### PR TITLE
oxarticlelist::loadIds -> optionally preserve the ordering of articles

### DIFF
--- a/source/application/models/oxarticlelist.php
+++ b/source/application/models/oxarticlelist.php
@@ -776,11 +776,12 @@ class oxArticleList extends oxList
     /**
      * Load the list by article ids
      *
-     * @param array $aIds Article ID array
+     * @param array $aIds               Article ID array
+     * @param bool  $blPreserveOrdering If true the ordering of the articles is preserved
      *
-     * @return null;
+     * @return null
      */
-    public function loadIds($aIds)
+    public function loadIds( $aIds, $blPreserveOrdering )
     {
         if (!count($aIds)) {
             $this->clear();
@@ -798,6 +799,10 @@ class oxArticleList extends oxList
         $sSelect  = "select $sArticleFields from $sArticleTable ";
         $sSelect .= "where $sArticleTable.oxid in ( '".implode("','", $aIds)."' ) and ";
         $sSelect .= $oBaseObject->getSqlActiveSnippet();
+
+        if ( $blPreserveOrdering ) {
+            $sSelect .= ' ORDER BY FIELD(`OXID`, \'' . implode('\',\'' , $aIds) . '\')';
+        }
 
         $this->selectString($sSelect);
     }


### PR DESCRIPTION
When retrieving a result list of article ids from external sources (Solr, etc. ) and afterwards you want to create a list of oxarticles via the oxarticlelist, you lose the ordering. oxArticleList::loadIds will return a list where the occurance of the articles is random (it depends on what ids the database finds first). 
Since the ordering is important, especially when using score algorithms based on tokens, hit counts in different fields or stemming, one wants to preserve it.
I've added an optional parameter to allow this. It is backwards compatible and shouldn't do any harm to other modules.
