### PR TITLE
Update oxsession.php and loads oxBasket through oxNew()

### DIFF
--- a/source/core/oxsession.php
+++ b/source/core/oxsession.php
@@ -684,11 +684,12 @@ class oxSession extends oxSuperCfg
             //init oxbasketitem class first
             //#1746
             oxNew('oxbasketitem');
-
+            
+            // init oxbasket through oxNew and not oxAutoload, Mantis-Bug #0004262
+            $oEmptyBasket = oxNew('oxbasket');
+            
             $oBasket = ( $sBasket && ( $oBasket = unserialize( $sBasket ) ) ) ? $oBasket : null;
 
-            //#3908
-            $oEmptyBasket = oxNew('oxbasket');
             if ( !$oBasket || ( get_class($oBasket) !== get_class($oEmptyBasket) ) ) {
                 $oBasket = $oEmptyBasket;
             }


### PR DESCRIPTION
The moved line "$oEmptyBasket = oxNew('oxbasket');" was an old design flaw. The old line leads to an intialization through oxAutoload because the unserialize() is called first, but normally, every class is initialized through oxNew(). This can break modules. (Broke mine many times!)
