### PR TITLE
Absolute instead of relative redirect

### DIFF
--- a/source/core/oxconfig.php
+++ b/source/core/oxconfig.php
@@ -440,7 +440,7 @@ class oxConfig extends oxSuperCfg
                 oxRegistry::getUtils()->showMessageAndExit( $oEx->getString() );
             } else {
                 header( "HTTP/1.1 500 Internal Server Error");
-                header( "Location: offline.html");
+                header( "Location: /offline.html");
                 header( "Connection: close");
             }
         } catch ( oxCookieException $oEx ) {


### PR DESCRIPTION
Redirecting to /offline.html instead of offline.html is needed when using SEO URLs for categories. Will not work if shop is not installed in base directory of domain.
