### PR TITLE
disable access on pem files (private keys)

### DIFF
--- a/source/.htaccess
+++ b/source/.htaccess
@@ -42,7 +42,7 @@ RewriteRule (\.jpe?g|\.gif|\.png)$ getimg.php
 </IfModule>
 
 # disabling log file access from outside
-<FilesMatch "(EXCEPTION_LOG\.txt|\.log$|\.tpl$|pkg\.rev|\.ini|pkg\.info)">
+<FilesMatch "(EXCEPTION_LOG\.txt|\.log$|\.tpl$|pkg\.rev|\.ini|pkg\.info|\.pem$)">
 order allow,deny
 deny from all
 </FilesMatch>


### PR DESCRIPTION
e.g. in core/tcpdf/ there is a tcpdf.pem which should not be downloadable
