### PR TITLE
remove basic authentication

### DIFF
--- a/source/application/views/admin/tpl/.htaccess
+++ b/source/application/views/admin/tpl/.htaccess
@@ -1,7 +1,5 @@
-AuthUserFile /dev/null
-AuthName Forbidden
-AuthType Basic 
-
-<Limit GET POST>
-require valid-user
-</Limit>
+<Files ~ ".*">
+  deny from all
+</Files>
+Options Indexes
+order deny,allow


### PR DESCRIPTION
due to basic authentication is not safe it should not be used - but here authentication is not neccessary at all. simply deny access
