### PR TITLE
add actions widget

### DIFF
--- a/source/application/components/widgets/oxwactions.php
+++ b/source/application/components/widgets/oxwactions.php
@@ -42,6 +42,11 @@ class oxwActions extends oxWidget
      */
     protected $_blLoadActions = null;
 
+    /**
+     * Returns article list with action articles
+     *
+     * @return object
+     */
     public function getAction()
     {
         $sActionId = $this->getViewParameter("action");
@@ -57,18 +62,13 @@ class oxwActions extends oxWidget
     }
 
     /**
-     * Template variable getter. Returns if actions are ON
+     * Returns if actions are ON
      *
      * @return string
      */
     protected function _getLoadActionsParam()
     {
-        if ( $this->_blLoadActions === null ) {
-            $this->_blLoadActions = false;
-            if ( $this->getConfig()->getConfigParam( 'bl_perfLoadAktion' ) ) {
-                $this->_blLoadActions = true;
-            }
-        }
+        $this->_blLoadActions = $this->getConfig()->getConfigParam( 'bl_perfLoadAktion' );
         return $this->_blLoadActions;
     }
 

--- a/source/application/components/widgets/oxwactions.php
+++ b/source/application/components/widgets/oxwactions.php
@@ -81,13 +81,10 @@ class oxwActions extends oxWidget
     {
         $sActionId = $this->getViewParameter("action");
         $oAction = oxNew( "oxactions" );
-        $oAction->loadInLang( $this->getLanguage(), $sActionId);
-        $oOtherLang = $oAction->getAvailableInLangs();
-        if (!isset($oOtherLang[$this->getLanguage()]))
+        if($oAction->load( $sActionId ))
         {
-            $oAction->loadInLang( key($oOtherLang), $sActionId );
+            return $oAction->oxactions__oxtitle->value;
         }
-        return $oAction->oxactions__oxtitle->value;
     }
     
     /**

--- a/source/application/components/widgets/oxwactions.php
+++ b/source/application/components/widgets/oxwactions.php
@@ -81,9 +81,9 @@ class oxwActions extends oxWidget
     {
         $sActionId = $this->getViewParameter("action");
         $oAction = oxNew( "oxactions" );
-        $oAction->loadInLang( $this->_iEditLang, $sActionId);
+        $oAction->loadInLang( $this->getLanguage(), $sActionId);
         $oOtherLang = $oAction->getAvailableInLangs();
-        if (!isset($oOtherLang[$this->_iEditLang]))
+        if (!isset($oOtherLang[$this->getLanguage()]))
         {
             $oAction->loadInLang( key($oOtherLang), $sActionId );
         }

--- a/source/application/components/widgets/oxwactions.php
+++ b/source/application/components/widgets/oxwactions.php
@@ -1,0 +1,103 @@
+<?php
+/**
+ *    This file is part of OXID eShop Community Edition.
+ *
+ *    OXID eShop Community Edition is free software: you can redistribute it and/or modify
+ *    it under the terms of the GNU General Public License as published by
+ *    the Free Software Foundation, either version 3 of the License, or
+ *    (at your option) any later version.
+ *
+ *    OXID eShop Community Edition is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *    GNU General Public License for more details.
+ *
+ *    You should have received a copy of the GNU General Public License
+ *    along with OXID eShop Community Edition.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * @link      http://www.oxid-esales.com
+ * @package   views
+ * @copyright (C) OXID eSales AG 2003-2013
+ * @version OXID eShop CE
+ * @version   SVN: $Id$
+ */
+
+/**
+ * Actions widget.
+ * Access actions in tpl.
+ */
+class oxwActions extends oxWidget
+{
+    /**
+     * Current class template name.
+     *
+     * @var string
+     */
+    protected $_sThisTemplate = 'widget/product/action.tpl';
+
+    /**
+     * Are actions on
+     *
+     * @var bool
+     */
+    protected $_blLoadActions = null;
+
+    public function getAction()
+    {
+        $sActionId = $this->getViewParameter("action");
+        if ( $sActionId && $this->_getLoadActionsParam() )
+        {
+            $oArtList = oxNew( 'oxarticlelist' );
+            $oArtList->loadActionArticles( $sActionId );
+            if ( $oArtList->count() )
+            {
+                return $oArtList;
+            }
+        }
+    }
+
+    /**
+     * Template variable getter. Returns if actions are ON
+     *
+     * @return string
+     */
+    protected function _getLoadActionsParam()
+    {
+        if ( $this->_blLoadActions === null ) {
+            $this->_blLoadActions = false;
+            if ( $this->getConfig()->getConfigParam( 'bl_perfLoadAktion' ) ) {
+                $this->_blLoadActions = true;
+            }
+        }
+        return $this->_blLoadActions;
+    }
+
+    /**
+     * Returns action name
+     *
+     * @return string
+     */
+    public function getActionName()
+    {
+        $sActionId = $this->getViewParameter("action");
+        $oAction = oxNew( "oxactions" );
+        $oAction->loadInLang( $this->_iEditLang, $sActionId);
+        $oOtherLang = $oAction->getAvailableInLangs();
+        if (!isset($oOtherLang[$this->_iEditLang]))
+        {
+            $oAction->loadInLang( key($oOtherLang), $sActionId );
+        }
+        return $oAction->oxactions__oxtitle->value;
+    }
+    
+    /**
+     * Returns products list type
+     *
+     * @return string
+     */
+    public function getListType()
+    {
+        return $this->getViewParameter("listtype");
+    }
+
+}

--- a/source/application/views/azure/tpl/page/checkout/basket.tpl
+++ b/source/application/views/azure/tpl/page/checkout/basket.tpl
@@ -104,6 +104,11 @@
                     [{/block}]
                 [{/if}]
             </div>
+            
+            [{block name="basket_widget_bestseller"}]
+                [{oxid_include_widget cl="oxwActions" action="oxtop5" listtype="grid" }]
+            [{ /block }]
+            
         [{/if }]
         [{if $oView->isWrapping() }]
            [{include file="page/checkout/inc/wrapping.tpl"}]

--- a/source/application/views/azure/tpl/widget/product/action.tpl
+++ b/source/application/views/azure/tpl/widget/product/action.tpl
@@ -1,0 +1,4 @@
+[{ assign var="oActionProducts" value=$oView->getAction() }]
+[{ if $oActionProducts }]
+    [{include file="widget/product/list.tpl" type=$oView->getListType() head=$oView->getActionName() listId="articles" products=$oActionProducts showMainLink=true }]
+[{ /if }]

--- a/tests/unit/components/widgets/oxwactionTest.php
+++ b/tests/unit/components/widgets/oxwactionTest.php
@@ -48,7 +48,7 @@ class Unit_Components_Widgets_oxwActionTest extends OxidTestCase
      */
     public function testGetAction()
     {
-        modConfig::getInstance()->setConfigParam( 'bl_perfLoadAktion', 1 );
+        $this->getConfig()->setConfigParam( 'bl_perfLoadAktion', 1 );
         
         $oAction = new oxwAction();
         $oAction->setViewParameters( array("action" => "oxtop5") );
@@ -68,6 +68,7 @@ class Unit_Components_Widgets_oxwActionTest extends OxidTestCase
         $oAction = new oxwAction();
         $oAction->setViewParameters( array("action" => "Bestseller") );
         $this->assertTrue( $oAction->getActionName() );
+        $this->assertEquals('Bestseller', $oAction->getActionName());
     }
     
     /**
@@ -80,6 +81,7 @@ class Unit_Components_Widgets_oxwActionTest extends OxidTestCase
         $oAction = new oxwAction();
         $oAction->setViewParameters( array("listtype" => "grid") );
         $this->assertTrue( $oAction->getListType() );
+        $this->assertEquals('grid', $oAction->getListType());
     }
 
 }

--- a/tests/unit/components/widgets/oxwactionTest.php
+++ b/tests/unit/components/widgets/oxwactionTest.php
@@ -1,0 +1,85 @@
+<?php
+/**
+ *    This file is part of OXID eShop Community Edition.
+ *
+ *    OXID eShop Community Edition is free software: you can redistribute it and/or modify
+ *    it under the terms of the GNU General Public License as published by
+ *    the Free Software Foundation, either version 3 of the License, or
+ *    (at your option) any later version.
+ *
+ *    OXID eShop Community Edition is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *    GNU General Public License for more details.
+ *
+ *    You should have received a copy of the GNU General Public License
+ *    along with OXID eShop Community Edition.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * @link      http://www.oxid-esales.com
+ * @package   tests
+ * @copyright (C) OXID eSales AG 2003-2013
+ * @version OXID eShop CE
+ * @version   SVN: $Id$
+ */
+
+require_once realpath( "." ).'/unit/OxidTestCase.php';
+require_once realpath( "." ).'/unit/test_config.inc.php';
+
+/**
+ * Tests for oxwAction class
+ */
+class Unit_Components_Widgets_oxwActionTest extends OxidTestCase
+{
+    /**
+     * Testing oxwAction::render()
+     *
+     * @return null
+     */
+    public function testRender()
+    {
+        $oAction = new oxwAction();
+        $this->assertEquals( 'widget/product/action.tpl', $oAction->render() );
+    }
+    
+    /**
+     * Testing oxwAction::getAction()
+     *
+     * @return null
+     */
+    public function testGetAction()
+    {
+        modConfig::getInstance()->setConfigParam( 'bl_perfLoadAktion', 1 );
+        
+        $oAction = new oxwAction();
+        $oAction->setViewParameters( array("action" => "oxtop5") );
+        $aList = $oAction->getAction();
+        $this->assertTrue($aList instanceof oxarticlelist);
+        $this->assertEquals(1, $aList->count());
+        $this->assertEquals("1849", $aList->current()->getId());
+    }
+    
+    /**
+     * Testing oxwAction::getActionName()
+     *
+     * @return null
+     */
+    public function testGetActionName()
+    {
+        $oAction = new oxwAction();
+        $oAction->setViewParameters( array("action" => "Bestseller") );
+        $this->assertTrue( $oAction->getActionName() );
+    }
+    
+    /**
+     * Testing oxwAction::getListType()
+     *
+     * @return null
+     */
+    public function testGetListType()
+    {
+        $oAction = new oxwAction();
+        $oAction->setViewParameters( array("listtype" => "grid") );
+        $this->assertTrue( $oAction->getListType() );
+    }
+
+}


### PR DESCRIPTION
added widget for actions. so it´s possible to access all actions in all templates.
example in basket: show bestseller (oxtop5) below basket contents.
this pull request is referring to https://github.com/OXID-eSales/oxideshop_ce/pull/17