### PR TITLE
Fix for bug #0005162 - voucher duscount calculation fix.

### DIFF
--- a/source/application/models/oxvoucher.php
+++ b/source/application/models/oxvoucher.php
@@ -721,7 +721,19 @@ class oxVoucher extends oxBase
         $oProductPrice  = oxNew('oxPrice');
         $oProductTotal  = oxNew('oxPrice');
 
+        // OXPS: Start
+        // Is the voucher discount applied to at least one basket item
+        $blDiscountApplied = false;
+        // OXPS: End
+
         foreach ( $aBasketItems as $aBasketItem ) {
+            
+            // OXPS: Start
+            // If discount was already applied for the voucher to at least one basket items, then break
+            if ( $blDiscountApplied and !empty( $oSerie->oxvoucherseries__oxcalculateonce->value ) ) {
+                break;
+            }
+            // OXPS: End
 
             $oDiscountPrice->setPrice($aBasketItem['discount']);
             $oProductPrice->setPrice($aBasketItem['price']);
@@ -734,6 +746,13 @@ class oxVoucher extends oxBase
 
             $oVoucherPrice->add($oDiscountPrice->getBruttoPrice());
             $oProductTotal->add($oProductPrice->getBruttoPrice());
+            
+            // OXPS: Start
+            // If basket item has a discount for the voucher, set discount as applied
+            if ( !empty( $aBasketItem['discount'] ) ) {
+                $blDiscountApplied = true;
+            }
+            // OXPS: End
         }
 
         $dVoucher = $oVoucherPrice->getBruttoPrice();


### PR DESCRIPTION
If voucher series has several articles assigned and those articles are in basket, then with one voucher user got discount multiplied to the number of different articles.

Note, that "Calculate once" option worked only for the amount of same article, but not for other articles assigned to save voucher series.

Current fix restricts discount calculation to one article only.

NOTE: Since now the discount applies only for ONE product in the cart related to entered voucher series, there are important things to notice:
    \* If article price is less than voucher discount, then user will get only the discount that equals article price.
    \* If several different articles related to same entered voucher series are in the cart, discount will apply to firs in the row.
    \* This new calculation restriction works, of course, only if "Calculate once" option is chosen
