### PR TITLE
Fix for bug #0005162 - voucher duscount calculation fix.

### DIFF
--- a/source/application/models/oxvoucher.php
+++ b/source/application/models/oxvoucher.php
@@ -720,7 +720,15 @@ class oxVoucher extends oxBase
         $oProductPrice  = oxNew('oxPrice');
         $oProductTotal  = oxNew('oxPrice');
 
+        // Is the voucher discount applied to at least one basket item
+        $blDiscountApplied = false;
+
         foreach ( $aBasketItems as $aBasketItem ) {
+
+            // If discount was already applied for the voucher to at least one basket items, then break
+            if ( $blDiscountApplied and !empty( $oSerie->oxvoucherseries__oxcalculateonce->value ) ) {
+                break;
+            }
 
             $oDiscountPrice->setPrice($aBasketItem['discount']);
             $oProductPrice->setPrice($aBasketItem['price']);
@@ -733,6 +741,10 @@ class oxVoucher extends oxBase
 
             $oVoucherPrice->add($oDiscountPrice->getBruttoPrice());
             $oProductTotal->add($oProductPrice->getBruttoPrice());
+
+            if ( !empty( $aBasketItem['discount'] ) ) {
+                $blDiscountApplied = true;
+            }
         }
 
         $dVoucher = $oVoucherPrice->getBruttoPrice();


### PR DESCRIPTION
Case is: voucher series with fixed discount amount assigned directly to product.

It makes voucher discount apply only once for all basket items.

Originally if You had several articles assigned to same voucher series and put those articles to basket and apply a code, then You got a discount value multiplied as many times as there are articles.

It limits discount only if "Calculate once" checkbox is set. (Originally this checkbox reacted only on amount of same articles, not on different articles from same series)
