### PR TITLE
Fixed browser detection in oxcompare.js

### DIFF
--- a/source/out/azure/src/js/widgets/oxcompare.js
+++ b/source/out/azure/src/js/widgets/oxcompare.js
@@ -20,68 +20,76 @@
  * @version OXID eShop CE
  * @version   SVN: $Id: oxcompare.js 35529 2011-05-23 07:31:20Z vilma $
  */
-( function ( $ ) {
+(function ( $ )
+{
 
     /**
      * Compare list
      */
     oxCompare = {
         options: {
-            browserMozzila  : "mozilla",
-            browserIE       : "msie",
-            propertyHeight  : "height",
-            classFirstCol   : ".js-firstCol",
-            idDataTable     : "#compareDataDiv",
-            elementTd       : "td",
-            idFirstTr       : "#firstTr"
+            browsers: {
+                chrome: "chrome",
+                mozilla: "mozilla",
+                msie: "msie",
+                safari: "safari"
+            },
+            propertyHeight: "height",
+            classFirstCol: ".js-firstCol",
+            idDataTable: "#compareDataDiv",
+            elementTd: "td",
+            idFirstTr: "#firstTr"
         },
 
-        _create: function() {
+        _create: function ()
+        {
 
             var self = this;
             var options = self.options;
             var iColumnCount = self.getColumnCount();
             var sBrowser = self.getBrowser();
 
-            self.alignRows(sBrowser, iColumnCount);
+            self.alignRows( sBrowser, iColumnCount );
 
-            if ( $( options.idDataTable ).length ) {
-                $( options.idDataTable ).jScrollPane({
+            if ( $( options.idDataTable ).length )
+            {
+                $( options.idDataTable ).jScrollPane( {
                     showArrows: true,
                     horizontalGutter: 0
-                });
+                } );
             }
         },
 
         /**
          * align first columns rows with data columns
-         *
-         * @return object
          */
-        alignRows: function(sBrowser, iColumnCount)
+        alignRows: function ( sBrowser, iColumnCount )
         {
             var iNumberOfRow = 0;
             var self = this;
-            var options = this.options;
 
-            $(self.options.classFirstCol).each(function(i){
+            $( self.options.classFirstCol ).each( function ()
+            {
 
-                  var oFirstColumn = $(this);
-                  var oOtherColumn = self.getOtherColumn(iColumnCount, iNumberOfRow);
+                var oFirstColumn = $( this );
+                var oOtherColumn = self.getOtherColumn( iColumnCount, iNumberOfRow );
 
-                  var firstColumnHeight = self.getColumnHeight(sBrowser, oFirstColumn);
-                  var otherColumnHeight = self.getColumnHeight(sBrowser, oOtherColumn);
+                var firstColumnHeight = self.getColumnHeight( sBrowser, oFirstColumn );
+                var otherColumnHeight = self.getColumnHeight( sBrowser, oOtherColumn );
 
-                  if(firstColumnHeight >  otherColumnHeight){
-                    self.setColumnHeight(oOtherColumn, firstColumnHeight );
-                    self.setColumnHeight(oFirstColumn, firstColumnHeight );
-                  }else{
-                    self.setColumnHeight(oFirstColumn, otherColumnHeight);
-                    self.setColumnHeight(oOtherColumn, otherColumnHeight );
-                  }
+                if ( firstColumnHeight > otherColumnHeight )
+                {
+                    self.setColumnHeight( oOtherColumn, firstColumnHeight );
+                    self.setColumnHeight( oFirstColumn, firstColumnHeight );
+                }
+                else
+                {
+                    self.setColumnHeight( oFirstColumn, otherColumnHeight );
+                    self.setColumnHeight( oOtherColumn, otherColumnHeight );
+                }
 
-                  iNumberOfRow++;
-          });
+                iNumberOfRow++;
+            } );
 
         },
 
@@ -90,15 +98,18 @@
          *
          * @return integer
          */
-        getColumnHeight: function(sBrowser, oColumn)
+        getColumnHeight: function ( sBrowser, oColumn )
         {
-            if(sBrowser == this.options.browserMozzila){
+            if ( sBrowser == this.options.browsers.mozilla || sBrowser == this.options.browsers.chrome )
+            {
                 return oColumn.outerHeight();
             }
-            else if(sBrowser == this.options.browserIE){
+            else if ( sBrowser == this.options.browsers.msie )
+            {
                 return oColumn.innerHeight();
             }
-            else {
+            else
+            {
                 return oColumn.height();
             }
         },
@@ -108,9 +119,9 @@
          *
          * @return object
          */
-        setColumnHeight: function(oColumn, iHeight)
+        setColumnHeight: function ( oColumn, iHeight )
         {
-            return $(oColumn).css(this.options.propertyHeight, iHeight);
+            return $( oColumn ).css( this.options.propertyHeight, iHeight );
         },
 
         /**
@@ -118,9 +129,9 @@
          *
          * @return object
          */
-        getOtherColumn: function(iColumnCount, iNumberOfRow)
+        getOtherColumn: function ( iColumnCount, iNumberOfRow )
         {
-            return $( this.options.idDataTable + ' ' + this.options.elementTd + ':eq(' + iColumnCount * iNumberOfRow + ')');
+            return $( this.options.idDataTable + ' ' + this.options.elementTd + ':eq(' + iColumnCount * iNumberOfRow + ')' );
         },
 
         /**
@@ -128,15 +139,20 @@
          *
          * @return object
          */
-        getBrowser: function(){
+        getBrowser: function ()
+        {
 
-            var sBrowser = this.options.browserMozzila;
+            var __this = this,
+                sBrowser = this.options.browsers.mozilla;
 
-            jQuery.each( jQuery.browser, function( i, val ) {
-                if ( val == true ){
-                   sBrowser = i.toString();
-                 }
-             });
+            jQuery.each( jQuery.browser, function ( i, val )
+            {
+                if ( typeof __this.options.browsers[ i ] != 'undefined' && val == true )
+                {
+                    sBrowser = i.toString();
+                    return true;
+                }
+            } );
 
             return sBrowser;
         },
@@ -146,15 +162,15 @@
          *
          * @return object
          */
-        getColumnCount: function()
+        getColumnCount: function ()
         {
-            return $( this.options.idFirstTr + '>' + this.options.elementTd).length;
+            return $( this.options.idFirstTr + '>' + this.options.elementTd ).length;
         }
     };
 
     /**
      * Compare list widget
      */
-    $.widget("ui.oxCompare", oxCompare );
+    $.widget( "ui.oxCompare", oxCompare );
 
 })( jQuery );


### PR DESCRIPTION
See #58

---

There was a problem with the height-calculation of columns in the compare table in some themes.
I've added modern browsers for detection and refactored them in an own object.
The column's height in Google Chrome is now calculated by the outerHeight, too.
## additional changes:
- removed inconsistent documented return tag
