### PR TITLE
tiny bug causes wrong split of selvariant due to mismatching glue.

### DIFF
--- a/source/application/models/oxorderarticle.php
+++ b/source/application/models/oxorderarticle.php
@@ -413,7 +413,7 @@ class oxOrderArticle extends oxBase implements oxIArticle
             $aRet  = array();
 
             if ( $oArticle = $this->_getOrderArticle( $sArtId ) ) {
-                $aList = explode( ",", $sOrderArtSelList );
+                $aList = explode( ", ", $sOrderArtSelList );
                 $oStr = getStr();
 
                 $aArticleSelList = $oArticle->getSelectLists();


### PR DESCRIPTION
Hi,

oxorder.php _setOrderArticles() uses ", " as glue, but oxorderarticles getOrderArticleSelectList() uses ",". This ruined some of our selections that contain commas.

Regards,

H.
