### PR TITLE
bug #5576: fixing poor GIF image quality

### DIFF
--- a/source/core/utils/oxpicgenerator.php
+++ b/source/core/utils/oxpicgenerator.php
@@ -165,7 +165,7 @@ if ( !function_exists( "resizeGif" ) ) {
         $aResult = checkSizeAndCopy( $sSrc, $sTarget, $iWidth, $iHeight, $iOriginalWidth, $iOriginalHeigth );
         if ( is_array( $aResult ) ) {
             list( $iNewWidth, $iNewHeight ) = $aResult;
-            $hDestinationImage = imagecreate( $iNewWidth, $iNewHeight );
+            $hDestinationImage = $iGdVer == 1 ? imagecreate( $iNewWidth, $iNewHeight ) : imagecreatetruecolor( $iNewWidth, $iNewHeight );
             $hSourceImage = imagecreatefromgif( $sSrc );
             $iTransparentColor = imagecolorresolve( $hSourceImage, 255, 255, 255 );
             $iFillColor = imagecolorresolve( $hDestinationImage, 255, 255, 255 );


### PR DESCRIPTION
This is a bugfix for reported bug #5576:
created (resized) GIF images will look much nicer if "imagecreatetruecolor" is used instead of "imagecreate". The resulting images still are valid GIFs with only 255 colors (as mentioned in PHP docs).
