### PR TITLE
0005597: Language setting by URL ?lang= parameter ignored for multilang ...

### DIFF
--- a/source/core/oxlang.php
+++ b/source/core/oxlang.php
@@ -154,13 +154,15 @@ class oxLang extends oxSuperCfg
             }
 
             //or determining by domain
-            $aLanguageUrls = $myConfig->getConfigParam( 'aLanguageURLs' );
+            if ( is_null( $this->_iBaseLanguageId ) ) {
+                $aLanguageUrls = $myConfig->getConfigParam( 'aLanguageURLs' );
 
-            if ( !$blAdmin && is_array( $aLanguageUrls ) ) {
-                foreach ( $aLanguageUrls as $iId => $sUrl ) {
-                    if ( $sUrl && $myConfig->isCurrentUrl( $sUrl ) ) {
-                        $this->_iBaseLanguageId = $iId;
-                        break;
+                if ( !$blAdmin && is_array( $aLanguageUrls ) ) {
+                    foreach ( $aLanguageUrls as $iId => $sUrl ) {
+                        if ( $sUrl && $myConfig->isCurrentUrl( $sUrl ) ) {
+                            $this->_iBaseLanguageId = $iId;
+                            break;
+                        }
                     }
                 }
             }


### PR DESCRIPTION
...environments with multiple non-ssl domains and single SSL domain.

Domain name took precedence over &lang= parameter; in multi-shop environments, this resulted in the inability to use a single SSL domain with multiple non-SSL domains: during checkout, upon redirecting to the SSL domain, the shop would switch back to the first language using the SSL domain.

An additional check in oxLang::getBaseLanguage() fixed this.
