### PR TITLE
Fix for disabled file access

### DIFF
--- a/source/.htaccess
+++ b/source/.htaccess
@@ -44,7 +44,7 @@ Redirect /config.inc.php /
 </IfModule>
 
 # disabling log file access from outside
-<FilesMatch "(EXCEPTION_LOG\.txt|\.log$|\.tpl$|pkg\.rev|\.ini|pkg\.info|\.pem$)">
+<FilesMatch "(EXCEPTION_LOG\.txt|\.log|\.tpl|pkg\.rev|\.ini|pkg\.info|\.pem)$">
 order allow,deny
 deny from all
 </FilesMatch>


### PR DESCRIPTION
The regex for disabled file access for log files and the like was too
greedy. The regex matched e.g. the file "op.init.php" which was needed
to be accessed from outside.
