### PR TITLE
Changed the setting of rating width

### DIFF
--- a/source/out/azure/src/js/widgets/oxrating.js
+++ b/source/out/azure/src/js/widgets/oxrating.js
@@ -79,7 +79,7 @@
          */
         setCurrentRating: function( oElement, value )
         {
-            oElement.width( value );
+            oElement.css('width', value);
             return oElement;
         },
 


### PR DESCRIPTION
.width() can make problems with special css rules, https://api.jquery.com/width/:

Note that .width("value") sets the content width of the box regardless of the value of the CSS box-sizing property.
