### PR TITLE
UTF-8 should be the default option if possible

### DIFF
--- a/source/setup/tpl/dbinfo.php
+++ b/source/setup/tpl/dbinfo.php
@@ -27,7 +27,7 @@ $blMbStringOn = $this->getViewParam( "blMbStringOn" );
 $blUnicodeSupport = $this->getViewParam( "blUnicodeSupport" );
 
 $sChecked = '';
-if ( ( isset( $aDB['iUtfMode'] ) && $aDB['iUtfMode'] == 1 ) && $blMbStringOn > 1 && $blUnicodeSupport > 1 ) {
+if ( ( !isset( $aDB['iUtfMode'] ) || $aDB['iUtfMode'] == 1 ) && $blMbStringOn > 1 && $blUnicodeSupport > 1 ) {
     $sChecked = 'checked';
 }
 $sDisabled = ( $blMbStringOn > 1 && $blUnicodeSupport > 1 ) ? '' : 'disabled';


### PR DESCRIPTION
During the setup, utf-8 should be the default option for the database, if the server is possible to fullfil the requirements.
