### PR TITLE
Email validation for new gTLDs

### DIFF
--- a/source/core/oxutils.php
+++ b/source/core/oxutils.php
@@ -341,7 +341,7 @@ class oxUtils extends oxSuperCfg
     {
         $blValid = true;
         if ( $sEmail != 'admin' ) {
-            $sEmailTpl = "/^([A-Za-z0-9_\-\.])+\@([A-Za-z0-9_\-\.])+\.([A-Za-z]{2,4})$/i";
+            $sEmailTpl = "/^([A-Za-z0-9_\-\.])+\@([A-Za-z0-9_\-\.])+\.([A-Za-z]{2,64})$/i";
             $blValid = ( getStr()->preg_match( $sEmailTpl, $sEmail ) != 0 );
         }
 


### PR DESCRIPTION
New gTLD can be more than 4 chars - update to a new maximum of 64. Maybe add check of smtp host later
