### PR TITLE
Replace preg_match by stripos

### DIFF
--- a/source/core/oxfunctions.php
+++ b/source/core/oxfunctions.php
@@ -115,7 +115,7 @@ function oxAutoload( $sClass )
         $myUtilsObject = oxUtilsObject::getInstance();
         foreach ( $aModules as $sParentName => $sModuleName ) {
             // looking for module parent class
-            if (  preg_match('/\b'.$sClass.'($|\&)/i', $sModuleName )  ) {
+             if ( stripos($sModuleName, $sClass) !== false) {
                 $myUtilsObject->getClassName( $sParentName );
                 break;
             }


### PR DESCRIPTION
The preg_match should be replaced with stripos like mentioned in the php docs (http://php.net/manual/en/function.preg-match.php#refsect1-function.preg-match-notes)

Also preg_match could cause issues with namespaces.
