### PR TITLE
Avoid warning if array is defined for settings in metadata

### DIFF
--- a/source/application/controllers/admin/module_config.php
+++ b/source/application/controllers/admin/module_config.php
@@ -117,10 +117,10 @@ class Module_Config extends Shop_Config
                 if (is_null($oConfig->getConfigParam($sName)) ) {
                     switch ($aValue["type"]){
                         case "arr":
-                            $sValue = $this->_arrayToMultiline( unserialize( $aValue["value"] ) );
+                            $sValue = $this->_arrayToMultiline( (is_array($aValue["value"])) ? $aValue["value"] : unserialize( $aValue["value"] ) );
                             break;
                         case "aarr":
-                            $sValue = $this->_aarrayToMultiline( unserialize( $aValue["value"] ) );
+                            $sValue = $this->_aarrayToMultiline( (is_array($aValue["value"])) ? $aValue["value"] : unserialize( $aValue["value"] ) );
                             break;
                     }
                     $sValue = getStr()->htmlentities( $sValue );


### PR DESCRIPTION
If metadata contains an Array like

``` php
  array('group' => 'foo', 'name' => 'bar',       'type' => 'aarr',    'value' => array('foo' => 'bar','baz' => 'foo'))
```

 in settings an warning will be shown:

> Warning: unserialize() expects parameter 1 to be string, array given

so here a quick fix to avoid this warning.
