### PR TITLE
Update oxid.css

### DIFF
--- a/source/out/azure/src/css/oxid.css
+++ b/source/out/azure/src/css/oxid.css
@@ -3348,6 +3348,7 @@ h3.section button {
 
 .social span {
     float: left;
+    z-index: 66;
 }
 
 .fb_share_count_hidden {
@@ -3568,7 +3569,7 @@ a.fb_button_simple {
     top: 0;
     left: 0;
     display: none;
-    z-index: 99;
+    z-index: 33;
 }
 
 .marker img {


### PR DESCRIPTION
This is a pull request in b-dev-ce for this topic:
https://github.com/OXID-eSales/oxideshop_ce/pull/156
I had put it in the wrong branch.

It fixes a bug with the z-index of the facebook-like-button-flyout. It changes two z-indexes. It keeps the file cloudzoom.js unchanged. @Mantas, thank you for your help!
