### PR TITLE
configurable httponly flag in set cookie method

### DIFF
--- a/source/core/oxutilsserver.php
+++ b/source/core/oxutilsserver.php
@@ -56,10 +56,11 @@ class oxUtilsServer extends oxSuperCfg
      * @param string $sDomain     The domain that the cookie is available.
      * @param bool   $blToSession is true, records cookie information to session
      * @param bool   $blSecure    if true, transfer cookie only via SSL
+     * @param bool   $blHttponly  if true, only accessible via HTTP
      *
      * @return bool
      */
-    public function setOxCookie( $sName, $sValue = "", $iExpire = 0, $sPath = '/', $sDomain = null, $blToSession = true, $blSecure = false )
+    public function setOxCookie( $sName, $sValue = "", $iExpire = 0, $sPath = '/', $sDomain = null, $blToSession = true, $blSecure = false, $blHttponly = true )
     {
         //TODO: since setcookie takes more than just 4 params..
         // would be nice to have it sending through https only, if in https mode
@@ -82,7 +83,7 @@ class oxUtilsServer extends oxSuperCfg
             $this->_getCookiePath( $sPath ),
             $this->_getCookieDomain( $sDomain ),
             $blSecure,
-            true
+            $blHttponly
         );
     }
 


### PR DESCRIPTION
Made the last parameter of php's setcookie method configurable to set a cookie which can be accessed over Javascript with oxid API.
