### PR TITLE
Use the order article price for already created orders instead of the current price of the product

### DIFF
--- a/source/application/models/oxorderarticle.php
+++ b/source/application/models/oxorderarticle.php
@@ -473,12 +473,17 @@ class oxOrderArticle extends oxBase implements oxIArticle
      */
     public function getBasketPrice($dAmount, $aSelList, $oBasket)
     {
-        $oArticle = $this->_getOrderArticle();
-        if ($oArticle) {
-            return $oArticle->getBasketPrice($dAmount, $aSelList, $oBasket);
-        } else {
-            return $this->getPrice();
+        $oPrice = $this->getPrice();
+
+        if ($oPrice->getBruttoPrice() <= 0) {
+            $oArticle = $this->_getOrderArticle();
+
+            if ($oArticle !== false) {
+                $oPrice = $oArticle->getBasketPrice($dAmount, $aSelList, $oBasket);
+            }
         }
+
+        return $oPrice;
     }
 
     /**


### PR DESCRIPTION
If we change a order afterwards the new prices of the products are taken instead of the one the user has seen to the time he order the products, which makes no sense because the prices of the products should used for the order articles information instead of the current ones. 
