### PR TITLE
fixed problem with special umlauts in emos adapter

### DIFF
--- a/source/core/smarty/plugins/emos.php
+++ b/source/core/smarty/plugins/emos.php
@@ -572,7 +572,7 @@ class Emos
         $sStr = trim( $sStr );
 
         //2007-05-10 replace translated &nbsp; with spaces
-        $nbsp = chr(0xa0);
+        $nbsp = "\xc2\xa0"; // now compatible with UTF-8
         $sStr = str_replace( $nbsp, " ", $sStr );
         $sStr = str_replace( "\"", "", $sStr );
         $sStr = str_replace( "'", "", $sStr );


### PR DESCRIPTION
Old code didn’t work with special umlauts like in “BOÎTE À DÉSIR”

Detailed explanation:
The code wants to remove non breakable spaces. By replacing chr(0xa0) - which is nbsp for single-byte character sets - it destroys characters in multibyte character sets that are using that character for a multibyte character like À (which is composed by 0xc3 AND 0xa0).