### PR TITLE
fixing current url matching in oxUtilsServer

### DIFF
--- a/source/core/oxutilsserver.php
+++ b/source/core/oxutilsserver.php
@@ -443,7 +443,7 @@ class oxUtilsServer extends oxSuperCfg
         $sCurrentHost = str_replace('/', '', $sCurrentHost);
         $sURL = str_replace('/', '', $sURL);
 
-        if ($sURL && $sCurrentHost && strpos($sURL, $sCurrentHost) !== false) {
+        if ($sURL && $sCurrentHost && strpos($sURL, $sServerHost) !== false) {
             //bug fix #0002991
             if ($sUrlHost == $sRealHost) {
                 return true;


### PR DESCRIPTION
The URL doesn't match if ```$this->getServerVar('SCRIPT_NAME')``` is set.

I have created a module and overwrite the "oxDynImgGenerator". Then I change the .htaccess like this:
```
RewriteCond %{REQUEST_URI} (\/out\/pictures\/generated\/)
RewriteCond %{REQUEST_FILENAME} !-f
RewriteCond %{REQUEST_FILENAME} !-d
RewriteRule (\.jpe?g|\.gif|\.png|\.svg)$ modules/example/getimg.php
```

In the enterprise version matches the oxbaseshop with shopid "1" everytime because the condition never matches.

So I get a redirect on the "mallshopstart" template.

I think it is a highly privileg hotfix and you should merge it in this version.

Cheers, Robin