### PR TITLE
0005995: search with spaces only causes MySQL exception

### DIFF
--- a/source/application/controllers/search.php
+++ b/source/application/controllers/search.php
@@ -156,7 +156,7 @@ class Search extends oxUBase
 
         // #1184M - special char search
         $oConfig = oxRegistry::getConfig();
-        $sSearchParamForQuery = $oConfig->getRequestParameter('searchparam', true);
+        $sSearchParamForQuery = trim($oConfig->getRequestParameter('searchparam', true));
 
         // searching in category ?
         $sInitialSearchCat = $this->_sSearchCatId = rawurldecode($oConfig->getRequestParameter('searchcnid'));

--- a/tests/unit/views/searchTest.php
+++ b/tests/unit/views/searchTest.php
@@ -295,4 +295,20 @@ class Unit_Views_searchTest extends OxidTestCase
 
         $this->assertEquals('6 ' . oxRegistry::getLang()->translateString('HITS_FOR', oxRegistry::getLang()->getBaseLanguage(), false) . ' "searchStr"', $oView->getTitle());
     }
+
+    /**
+     * test for bug #5995
+     *
+     * @return null
+     */
+    public function testIsEmptySearchWithSpace()
+    {
+        oxTestModules::addFunction('oxUtilsServer', 'getServerVar', '{ if ( $aA[0] == "HTTP_HOST") { return "shop.com/"; } else { return "test.php";} }');
+
+        $oSearch = $this->getProxyClass('search');
+        modConfig::setRequestParameter('searchparam', ' ');
+        $oSearch->init();
+
+        $this->assertTrue($oSearch->isEmptySearch());
+    }
 }


### PR DESCRIPTION
This fix trims the `searchparam` parameter before checking conditions indicating empty searches.
For further information see https://bugs.oxid-esales.com/view.php?id=5995

Space-only values for the other search related parameters (`searchcnid`, `searchvendor`, `searchmanufacturer`) don't cause the same effect (MySQL exception).

The root cause for this bug lies in `oxSearch::_getWhere()` and may need further treatment. But because OXID eShop should handle space-only searchparam values like empty values and because of my assumption that the other call traces to this method don't involve user input I implemented the trim-call in the search controller and added an unit test for this case.
