### PR TITLE
Fixed a typo in documentation for cached article variant max price

### DIFF
--- a/source/application/models/oxarticle.php
+++ b/source/application/models/oxarticle.php
@@ -83,7 +83,7 @@ class oxArticle extends oxI18n implements oxIArticle, oxIUrl
     protected $_dVarMinPrice = null;
 
     /**
-     * cached article variant min price
+     * cached article variant max price
      *
      * @var double | null
      */


### PR DESCRIPTION
There was a typo in method documentation