### PR TITLE
add full functional Travis CI configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,52 @@
+language: php
+
+notifications:
+  email: false
+
+php:
+  - "5.3"
+  - "5.4"
+  - "5.5"
+  - "5.6"
+
+# TRAVIS_ERROR_LEVEL = E_ALL & ~E_DEPRECATED & ~E_NOTICE & ~E_STRICT
+env: TRAVIS_ERROR_LEVEL=22519 oxINSTALLSHOP=0 oxSKIPSHOPSETUP=1 OXID_VERSION=CE OXID_EDITION=CE oxPATH="$TRAVIS_BUILD_DIR/source/"
+
+services: mysql
+
+before_install:
+  - echo 'Europe/Berlin' | sudo tee /etc/timezone
+  - sudo dpkg-reconfigure --frontend noninteractive tzdata
+
+before_script:
+  # apache setup (http://docs.travis-ci.com/user/languages/php/#Apache-%2B-PHP)
+  - sudo apt-get install apache2 libapache2-mod-fastcgi
+  # enable php-fpm
+  - sudo cp ~/.phpenv/versions/$(phpenv version-name)/etc/php-fpm.conf.default ~/.phpenv/versions/$(phpenv version-name)/etc/php-fpm.conf
+  - sudo a2enmod rewrite actions fastcgi alias
+  - echo "cgi.fix_pathinfo = 1" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini
+  - ~/.phpenv/versions/$(phpenv version-name)/sbin/php-fpm
+  # configure apache virtual host
+  - echo "$(curl -fsSL https://gist.githubusercontent.com/adriankirchner/197e3d13ccfb680f8942/raw/5b36cd3740cc05adb1c9d5c0568c851dd7700dcc/gistfile1.apacheconf)" | sudo tee /etc/apache2/sites-available/default > /dev/null
+  - sudo sed -e "s|%TRAVIS_BUILD_DIR%|$(pwd)/source|g" --in-place /etc/apache2/sites-available/default
+  - sudo service apache2 restart
+
+  # database setup
+  - sudo sed -e 's|utf8_unicode_ci|latin1_general_ci|g; s|utf8|latin1|g' --in-place /etc/mysql/my.cnf
+  - sudo service mysql restart
+  - mysql -e 'CREATE SCHEMA `oxidehop_ce` DEFAULT CHARACTER SET latin1 COLLATE latin1_general_ci;'
+  - mysql --default-character-set=latin1 oxidehop_ce < source/setup/sql/database.sql
+  - mysql --default-character-set=latin1 oxidehop_ce < tests/testsql/testdata.sql
+
+  # replace configuration values in config.inc.php
+  - sed -i 's|<dbHost_ce>|localhost|; s|<dbName_ce>|oxidehop_ce|; s|<dbUser_ce>|root|; s|<dbPwd_ce>||; s|<sShopURL_ce>|http://localhost|; s|<sShopDir_ce>|'$TRAVIS_BUILD_DIR'/source|; s|<sCompileDir_ce>|'$TRAVIS_BUILD_DIR'/source/tmp|; s|<iUtfMode>|0|; s|$this->iDebug = 0|$this->iDebug = 1|' source/config.inc.php
+
+  # fetching pictures from oxid latest
+  - wget http://download.oxid-esales.com/ -O oxidlatest.zip
+  - mkdir oxidlatest
+  - unzip oxidlatest.zip -d oxidlatest
+  - rsync -avz oxidlatest/out/pictures/ source/out/pictures/
+  - cp oxidlatest/pkg.* source/
+
+script: cd tests && phpunit --verbose --bootstrap bootstrap.php AllTestsUnit
+

--- a/tests/Library/test_config.inc.php
+++ b/tests/Library/test_config.inc.php
@@ -20,9 +20,11 @@
  * @version   OXID eShop CE
  */
 
-// DO NOT TOUCH THIS _ INSTEAD FIX NOTICES - DODGER
-error_reporting((E_ALL ^ E_NOTICE) | E_STRICT);
-ini_set('display_errors', true);
+if (!getenv('TRAVIS_ERROR_LEVEL')) {
+    // DO NOT TOUCH THIS _ INSTEAD FIX NOTICES - DODGER
+    error_reporting((E_ALL ^ E_NOTICE) | E_STRICT);
+    ini_set('display_errors', true);
+}
 
 define ('OXID_PHP_UNIT', true);
 

--- a/tests/Library/test_utils.php
+++ b/tests/Library/test_utils.php
@@ -205,7 +205,9 @@ class oxTestModules
             $sCode = " \$arg = func_get_args(); return call_user_func_array($func, \$arg);";
         }
 
-        $iErrorReportinc = error_reporting(E_ALL ^ E_NOTICE);
+        if (!getenv('TRAVIS_ERROR_LEVEL')) {
+            $iErrorReportinc = error_reporting(E_ALL ^ E_NOTICE);
+        }
 
         $aFncParams = array();
         if (strpos($fncName, '(') !== false) {
@@ -264,7 +266,9 @@ class oxTestModules
         eval ("class $name extends $last { function $fncName { $sCode }}");
         oxAddClassModule($name, $class);
 
-        error_reporting($iErrorReportinc);
+        if (!getenv('TRAVIS_ERROR_LEVEL')) {
+            error_reporting($iErrorReportinc);
+        }
 
         self::$_addedmods[$class][] = $name;
 

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -25,7 +25,12 @@
  * @version   SVN: $Id: $
  */
 
-error_reporting((E_ALL ^ E_NOTICE) | E_STRICT);
+if (getenv('TRAVIS_ERROR_LEVEL')) {
+    error_reporting((int)getenv('TRAVIS_ERROR_LEVEL'));
+} else {
+    error_reporting((E_ALL ^ E_NOTICE) | E_STRICT);
+}
+
 ini_set('display_errors', true);
 
 $sTestType = substr(getcwd(), strlen(__DIR__)+1);

--- a/tests/unit/OxidTestCase.php
+++ b/tests/unit/OxidTestCase.php
@@ -158,7 +158,13 @@ class OxidTestCase extends PHPUnit_Framework_TestCase
     protected function setUp()
     {
         parent::setUp();
-        error_reporting((E_ALL ^ E_NOTICE) | E_STRICT);
+
+        if (getenv('TRAVIS_ERROR_LEVEL')) {
+            error_reporting((int)getenv('TRAVIS_ERROR_LEVEL'));
+        } else {
+            error_reporting((E_ALL ^ E_NOTICE) | E_STRICT);
+        }
+
         ini_set('display_errors', true);
 
         $this->getConfig();
@@ -174,7 +180,12 @@ class OxidTestCase extends PHPUnit_Framework_TestCase
             $oTestModuleLoader->setModuleInformation();
         }
 
-        error_reporting((E_ALL ^ E_NOTICE) | E_STRICT);
+        if (getenv('TRAVIS_ERROR_LEVEL')) {
+            error_reporting((int)getenv('TRAVIS_ERROR_LEVEL'));
+        } else {
+            error_reporting((E_ALL ^ E_NOTICE) | E_STRICT);
+        }
+
         ini_set('display_errors', true);
     }
 

--- a/tests/unit/OxidTestCase.php
+++ b/tests/unit/OxidTestCase.php
@@ -245,7 +245,7 @@ class OxidTestCase extends PHPUnit_Framework_TestCase
         $oDbRestore = self::_getDbRestore();
         $oDbRestore->restoreDB();
 
-        if (function_exists('memory_get_usage')) {
+        if (function_exists('memory_get_usage') && !getenv('TRAVIS_ERROR_LEVEL')) {
             echo "\n" . round(memory_get_usage(1) / 1024 / 1024) . 'M (' . round(memory_get_peak_usage(1) / 1024 / 1024) . 'M)' . "\n";
         }
     }

--- a/tests/unit/core/oxemailAzureTplTest.php
+++ b/tests/unit/core/oxemailAzureTplTest.php
@@ -1027,7 +1027,10 @@ class Unit_Core_oxemailAzureTplTest extends OxidTestCase
      */
     public function testSendPriceAlarmNotification()
     {
-        $iErrorReporting = error_reporting(E_ALL ^ E_NOTICE);
+        if (!getenv('TRAVIS_ERROR_LEVEL')) {
+            $iErrorReporting = error_reporting(E_ALL ^ E_NOTICE);
+        }
+
         $e = null;
 
         try {
@@ -1068,7 +1071,10 @@ class Unit_Core_oxemailAzureTplTest extends OxidTestCase
         } catch (Exception $e) {
         }
 
-        error_reporting($iErrorReporting);
+        if (!getenv('TRAVIS_ERROR_LEVEL')) {
+            error_reporting($iErrorReporting);
+        }
+
         if ($e) {
             throw $e;
         }

--- a/tests/unit/core/oxnewsTest.php
+++ b/tests/unit/core/oxnewsTest.php
@@ -174,7 +174,10 @@ class Unit_Core_oxnewsTest extends OxidTestCase
      */
     public function testIsInGroup()
     {
-        $iErrorReporting = error_reporting(E_ALL ^ E_NOTICE);
+        if (!getenv('TRAVIS_ERROR_LEVEL')) {
+            $iErrorReporting = error_reporting(E_ALL ^ E_NOTICE);
+        }
+
         $e = null;
         try {
             $oTestNews = oxNew('oxnews');
@@ -182,7 +185,11 @@ class Unit_Core_oxnewsTest extends OxidTestCase
             $this->assertTrue($oTestNews->inGroup('oxidnewcustomer'));
         } catch (Exception $e) {
         }
-        error_reporting($iErrorReporting);
+
+        if (!getenv('TRAVIS_ERROR_LEVEL')) {
+            error_reporting($iErrorReporting);
+        }
+
         if ($e) {
             throw $e;
         }
@@ -193,7 +200,10 @@ class Unit_Core_oxnewsTest extends OxidTestCase
      */
     public function testIsNotInGroup()
     {
-        $iErrorReporting = error_reporting(E_ALL ^ E_NOTICE);
+        if (!getenv('TRAVIS_ERROR_LEVEL')) {
+            $iErrorReporting = error_reporting(E_ALL ^ E_NOTICE);
+        }
+
         $e = null;
         try {
             $oTestNews = oxNew('oxnews');
@@ -201,7 +211,11 @@ class Unit_Core_oxnewsTest extends OxidTestCase
             $this->assertFalse($oTestNews->inGroup('xxx'));
         } catch (Exception $e) {
         }
-        error_reporting($iErrorReporting);
+
+        if (!getenv('TRAVIS_ERROR_LEVEL')) {
+            error_reporting($iErrorReporting);
+        }
+
         if ($e) {
             throw $e;
         }
@@ -212,7 +226,10 @@ class Unit_Core_oxnewsTest extends OxidTestCase
      */
     public function testInsert()
     {
-        $iErrorReporting = error_reporting(E_ALL ^ E_NOTICE);
+        if (!getenv('TRAVIS_ERROR_LEVEL')) {
+            $iErrorReporting = error_reporting(E_ALL ^ E_NOTICE);
+        }
+
         $e = null;
         try {
             $oTestNews = oxNew('oxnews');
@@ -228,7 +245,10 @@ class Unit_Core_oxnewsTest extends OxidTestCase
         } catch (Exception $e) {
         }
 
-        error_reporting($iErrorReporting);
+        if (!getenv('TRAVIS_ERROR_LEVEL')) {
+            error_reporting($iErrorReporting);
+        }
+
         if ($e) {
             throw $e;
         }
@@ -239,7 +259,10 @@ class Unit_Core_oxnewsTest extends OxidTestCase
      */
     public function testInsert_dateIsZero()
     {
-        $iErrorReporting = error_reporting(E_ALL ^ E_NOTICE);
+        if (!getenv('TRAVIS_ERROR_LEVEL')) {
+            $iErrorReporting = error_reporting(E_ALL ^ E_NOTICE);
+        }
+
         $e = null;
         try {
             $oTestNews = oxNew('oxnews');
@@ -255,7 +278,10 @@ class Unit_Core_oxnewsTest extends OxidTestCase
         } catch (Exception $e) {
         }
 
-        error_reporting($iErrorReporting);
+        if (!getenv('TRAVIS_ERROR_LEVEL')) {
+            error_reporting($iErrorReporting);
+        }
+
         if ($e) {
             throw $e;
         }
@@ -266,7 +292,10 @@ class Unit_Core_oxnewsTest extends OxidTestCase
      */
     public function testInsert_dateNotEntered()
     {
-        $iErrorReporting = error_reporting(E_ALL ^ E_NOTICE);
+        if (!getenv('TRAVIS_ERROR_LEVEL')) {
+            $iErrorReporting = error_reporting(E_ALL ^ E_NOTICE);
+        }
+
         $e = null;
         try {
             $oTestNews = oxNew('oxnews');
@@ -281,7 +310,9 @@ class Unit_Core_oxnewsTest extends OxidTestCase
         } catch (Exception $e) {
         }
 
-        error_reporting($iErrorReporting);
+        if (!getenv('TRAVIS_ERROR_LEVEL')) {
+            error_reporting($iErrorReporting);
+        }
     }
 
     /**


### PR DESCRIPTION
When looking through previous pull requests you may notice that very few of them ship with unittests. I think one reason for this is the lack of configuration documentation about the environment you need to successfully execute the whole OXID eShop testsuite and another reason may be the effort you need to invest to configure the required software stack (with PHP version matrix) including all dependencies.

I'm aware of the repository tomasliubinas/vagrant-oxideshop but this requires the contributor to install a bunch of additional software packages besides the fact that the chef recipes don't work with current versions of chef and Sebastian Bergmann did shutdown the corresponding pear channel. Testsuite execution over different versions of PHP is also not possible with this solution.

I'm aware of the pull request OXID-eSales/oxideshop_ce#148 and the fact that you rejected it. In contrast to the referenced pull request the Travis CI configuration in my pull request is fully functional so the whole latin1 testsuite is executed across all four supported PHP versions without errors (see [1]). Furthermore you pointed out:
> [..] Have the feeling that we have to do that from scratch, a modular way, using our internal infrastructure and put much more effort in it than we could do now (as the focus is presently somewhere else) [..]

I respect your dedication to do things from scratch and in a modular way. But for us external contributors, without access to your internal infrastructure, Travis CI is the perfect solution with nearly no overhead and direct availability not just in the (maybe far) future.
Simply don't see Travis CI as a part of your internal test and release process but as a nice and quick feedback for external contributors as well as a first check for incoming pull requests.
I separated the very minor changes to the existing codebase into different commits so you can quickly determine that there is no impact of any execution outside of the Travis CI environment. Knowing that, you will see that there is nothing to do for you if you merge this pull request.

With the need of signing your OCA (which is inevitable) before contributing, there is already a barrier which is uncommon in the opensource world (at GitHub). It should be in your interest to lower contribution barriers.

I expect this setup to be as stable as a setup with that much software and configuration dependencies could be. However, should any problems occur in the future or the development of OXID-eSales/testing_library results in necessary modifications, feel free to ping me and I'll have a look into it.

After merging this pull request, you only need to sign in at Travis CI with a GitHub account that has access to this repository. Remember to enable the checkbox `Build only if .travis.yml is present` in the project settings. 

[1] https://travis-ci.org/adriankirchner/oxideshop_ce