### PR TITLE
Bugfix: wrong validation error field in checkCountries

### DIFF
--- a/source/core/oxinputvalidator.php
+++ b/source/core/oxinputvalidator.php
@@ -351,7 +351,7 @@ class oxInputValidator extends oxSuperCfg
                 $oEx = oxNew('oxUserException');
                 $oEx->setMessage(oxRegistry::getLang()->translateString('ERROR_MESSAGE_INPUT_NOTALLFIELDS'));
 
-                $this->_addValidationError("oxuser__oxpassword", $oEx);
+                $this->_addValidationError("oxuser__oxcountryid", $oEx);
             }
         }
     }


### PR DESCRIPTION
The function checkCountries in oxinputvalidator sets the validation error to the field oxpassword. But that is the wrong field. It has to be oxcountryid.