### PR TITLE
Change getModuleUrl to return HTTPS hyperlink

### DIFF
--- a/source/core/oxviewconfig.php
+++ b/source/core/oxviewconfig.php
@@ -1362,6 +1362,10 @@ class oxViewConfig extends oxSuperCfg
             rtrim($this->getConfig()->getCurrentShopUrl(false), '/'),
             $this->getModulePath($sModule, $sFile)
         );
+        
+		if (($this->getConfig()->getConfigParam('sAdminSSLURL') != null) && ($this->isAdmin())){
+			$sUrl = str_replace('http:','https:',$sUrl);
+		}
 
         return $sUrl;
     }


### PR DESCRIPTION
Enables the method to return an HTTPS hyperlink for usage in admin modules. Important when the shop admin is configured to work with HTTPS.