### PR TITLE
Adding checkbox for configurable performance check in dashboard

### DIFF
--- a/source/application/controllers/admin/navigation.php
+++ b/source/application/controllers/admin/navigation.php
@@ -204,9 +204,15 @@ class Navigation extends oxAdminView
     { // #661
         $aMessage = array();
 
-        // check if system reguirements are ok
-        $oSysReq = new oxSysRequirements();
-        if (!$oSysReq->getSysReqStatus()) {
+        if ($this->getConfig()->getConfigParam('blCheckSysReq')) {
+            // check if system reguirements are ok
+            $oSysReq = new oxSysRequirements();
+            if (!$oSysReq->getSysReqStatus()) {
+                $aMessage['warning'] = oxRegistry::getLang()->translateString('NAVIGATION_SYSREQ_MESSAGE_INACTIVE');
+                $aMessage['warning'] .= '<a href="?cl=sysreq&amp;stoken=' . $this->getSession()->getSessionChallengeToken() . '" target="basefrm">';
+                $aMessage['warning'] .= oxRegistry::getLang()->translateString('NAVIGATION_SYSREQ_MESSAGE2') . '</a>';
+            }
+        } else {
             $aMessage['warning'] = oxRegistry::getLang()->translateString('NAVIGATION_SYSREQ_MESSAGE');
             $aMessage['warning'] .= '<a href="?cl=sysreq&amp;stoken=' . $this->getSession()->getSessionChallengeToken() . '" target="basefrm">';
             $aMessage['warning'] .= oxRegistry::getLang()->translateString('NAVIGATION_SYSREQ_MESSAGE2') . '</a>';
@@ -218,7 +224,6 @@ class Navigation extends oxAdminView
                 $aMessage['message'] .= $sVersionNotice;
             }
         }
-
 
         // check if setup dir is deleted
         if (file_exists($this->getConfig()->getConfigParam('sShopDir') . '/setup/index.php')) {

--- a/source/application/views/admin/de/lang.php
+++ b/source/application/views/admin/de/lang.php
@@ -848,8 +848,9 @@ $aLang = array(
 'FAVORITES_DESC'                                           => 'Beschreibung der Favoriten ...',
 'NAVIGATION_HISTORY'                                       => 'History',
 'NAVIGATION_SYSREQ_MESSAGE'                                => "Die Systemgesundheit dieses Shops ist gefährdet. Möglicherweise verhält sich Ihr OXID eShop in einigen Bereichen unerwartet. Bitte stellen Sie sicher, dass die Servereinstellungen korrekt vorgenommen werden. Unterstützung finden Sie in der ",
-'NAVIGATION_SYSREQ_MESSAGE2'                               => "Systemgesundheitsprüfung.",
-'NAVIGATION_SHOPFRONT'                                     => "Startseite des Shops",
+'NAVIGATION_SYSREQ_MESSAGE2'                               => 'Systemgesundheitsprüfung.',
+'NAVIGATION_SYSREQ_MESSAGE_INACTIVE'                       => 'Die System Gesundheitspr&uuml;fung ist auf der Startseite inaktiv. Sie k&ouml;nnen diese unter Grundeinstellungen -> Perform. aktivieren oder direkt aufrufen ',
+'NAVIGATION_SHOPFRONT'                                     => 'Startseite des Shops',
 
 'NEWSLETTER_DONE_NEWSSEND'                                 => 'Ihr Newsletter wurde versendet.',
 'NEWSLETTER_DONE_GOTONEWSLETTER'                           => 'gehen Sie zu Newsletter',
@@ -2000,6 +2001,7 @@ $aLang = array(
 'NEWSLETTER_SUBJECT'                                       => 'Betreff',
 
 'SHOP_PERF_SEO_CACHE'                                      => 'SEO Cache aktivieren',
+'SHOP_PERF_SYSREQ_CHECK'                                   => 'System Gesundheitspr&uuml;fung auf der Startseite des Admins aktivieren',
 'INFO_MODULES_MOVED_TO_EXTENSIONS'                         => 'Die Einstellungen für Themes und Module finden Sie im neuen Menü "Erweiterungen"',
 'EXCEPTION_THEME_SHOULD_BE_ONLY_IN_DATABASE'               => 'Theme darf nicht in config.inc.php definiert sein',
 'EMAIL_PRICEALARM_CUSTOMER_PRICEALARMIN'                   => 'Preisalarm im ',

--- a/source/application/views/admin/en/lang.php
+++ b/source/application/views/admin/en/lang.php
@@ -851,6 +851,7 @@ $aLang = array(
 'NAVIGATION_HISTORY'                                       => 'History',
 'NAVIGATION_SYSREQ_MESSAGE'                                => "System healthcheck shows setup/server setup of this OXID eShop might be broken. Probably this OXID eShop behaves strange in some cases. Please fix this as soon as possible. Support for fixing find in ",
 'NAVIGATION_SYSREQ_MESSAGE2'                               => "system healthcheck.",
+'NAVIGATION_SYSREQ_MESSAGE_INACTIVE'                       => "system healthcheck is in dashboard inactive. You can activate it in Core Settings -> Perform. or click on this link ",
 'NAVIGATION_SHOPFRONT'                                     => "Shop's start page",
 
 'NEWSLETTER_DONE_NEWSSEND'                                 => 'Your Newsletter has been sent.',
@@ -1999,6 +2000,7 @@ $aLang = array(
 'NEWSLETTER_SUBJECT'                                       => 'Subject',
 
 'SHOP_PERF_SEO_CACHE'                                      => 'Enable SEO cache',
+'SHOP_PERF_SYSREQ_CHECK'                                   => 'Enable system health check on dashboard',
 'INFO_MODULES_MOVED_TO_EXTENSIONS'                         => 'Themes and modules handling moved to new menu "Extensions"',
 'EXCEPTION_THEME_SHOULD_BE_ONLY_IN_DATABASE'               => 'Theme should not be defined in config.inc.php',
 'EMAIL_PRICEALARM_CUSTOMER_PRICEALARMIN'                      => 'Price Alert in ',

--- a/source/application/views/admin/tpl/shop_performance.tpl
+++ b/source/application/views/admin/tpl/shop_performance.tpl
@@ -121,6 +121,16 @@
            		[{ oxmultilang ident="SHOP_PERF_SEO_CACHE" }]
          	</td>
         	</tr>
+            <tr class="conftext[{cycle}]">
+                <td valign="top">
+                    <input type="hidden" name="confbools[blCheckSysReq]" value="true">
+                    <input type="checkbox" class="confinput" name="confbools[blCheckSysReq]" value="false"  [{if (!$confbools.blCheckSysReq)}]checked[{/if}] [{ $readonly }]>
+                    [{ oxinputhelp ident="HELP_SHOP_PERF_SYSREQ_CHECK" }]
+                </td>
+                <td valign="top" width="100%" >
+                    [{ oxmultilang ident="SHOP_PERF_SYSREQ_CHECK" }]
+                </td>
+            </tr>
         [{/block}]
     </table>
     <br>


### PR DESCRIPTION
We have 17 languages and 32 shops in our Shop. If we login to admin panel, the admin checks the collations on nearly every klick. This makes a high workload for the backend and the backend is very sluggish.

I think it would be a good idea to add a configurable checkbox in performance settings for systemrequirement check in dashboard.