### PR TITLE
Update genexport_do.php, fix mixed line endings on export

### DIFF
--- a/source/application/controllers/admin/genexport_do.php
+++ b/source/application/controllers/admin/genexport_do.php
@@ -93,6 +93,6 @@ class GenExport_Do extends DynExportBase
         $sLine = str_replace(array("\r\n", "\n"), "", $sLine);
         $sLine = str_replace("<br>", "\n", $sLine);
 
-        fwrite($this->fpFile, $sLine . "\r\n");
+        fwrite($this->fpFile, $sLine . "\n");
     }
 }


### PR DESCRIPTION
What sense does it make to first replace all line break chars with newline and then output everything with additional carriage return + newline? we should either simply stick to the newline we chose before or make this configurable.