### PR TITLE
fix bug #6076 -  function oxViewConfig::isModuleActive returns false, if...

### DIFF
--- a/source/core/oxviewconfig.php
+++ b/source/core/oxviewconfig.php
@@ -1380,10 +1380,11 @@ class oxViewConfig extends oxSuperCfg
     {
         $blModuleIsActive = false;
 
-        $aModules = $this->getConfig()->getConfigParam('aModules');
+        // use aModuleVersions instead of aModules, because aModules gives only modules which extend oxid classes
+        $aModuleVersions = $this->getConfig()->getConfigParam('aModuleVersions');
 
-        if (is_array($aModules)) {
-            $blModuleIsActive = $this->_moduleExists($sModuleId, $aModules);
+        if (is_array($aModuleVersions)) {
+            $blModuleIsActive = $this->_moduleExists($sModuleId, $aModuleVersions);
 
             if ($blModuleIsActive) {
                 $blModuleIsActive = $this->_isModuleEnabled($sModuleId) && $this->_isModuleVersionCorrect($sModuleId, $sVersionFrom, $sVersionTo);
@@ -1524,19 +1525,18 @@ class oxViewConfig extends oxSuperCfg
      * Checks if module exists.
      *
      * @param string $sModuleId Module id
-     * @param array  $aModules  Modules
+     * @param array  $aModuleVersions  Modules from oxconfig 'aModuleVersions'
      *
      * @return bool
      */
-    private function _moduleExists($sModuleId, $aModules)
+    private function _moduleExists($sModuleId, $aModuleVersions)
     {
         $blModuleExists = false;
-        foreach ($aModules as $sExtendPath) {
-            if (false !== strpos($sExtendPath, '/' . $sModuleId . '/')) {
-                $blModuleExists = true;
-                break;
-            }
+
+        if (in_array($sModuleId, array_keys($aModuleVersions) )) {
+            $blModuleExists = true;
         }
+
         return $blModuleExists;
     }
 

--- a/tests/unit/views/oxviewconfigTest.php
+++ b/tests/unit/views/oxviewconfigTest.php
@@ -2560,7 +2560,7 @@ class Unit_Views_oxviewConfigTest extends OxidTestCase
     {
 
         $aModuleVersions = array(
-            'oepaypal1' => '2.0',
+            'oepaypal' => '2.0',
             'oepaypal2' => '5.0'
         );
 

--- a/tests/unit/views/oxviewconfigTest.php
+++ b/tests/unit/views/oxviewconfigTest.php
@@ -2545,10 +2545,10 @@ class Unit_Views_oxviewConfigTest extends OxidTestCase
     public function _dpIsModuleActive()
     {
         return array(
-            array(array('order' => 'oe/oepaypal/controllers/oepaypalorder'), array(), 'oepaypal', true),
-            array(array('order' => 'oe/oepaypal/controllers/oepaypalorder'), array(0 => 'oepaypal'), 'oepaypal', false),
-            array(array(), array(), 'oepaypal', false),
-            array(array(), array(0 => 'oepaypal'), 'oepaypal', false),
+            array(array('order' => 'oe/oepaypal/controllers/oepaypalorder'), array('oepaypal' => '2.0'), array(), 'oepaypal', true), // module activated
+            array(array('order' => 'oe/oepaypal/controllers/oepaypalorder'), array(), array(0 => 'oepaypal'), 'oepaypal', false),    // module disabled
+            array(array(), array(), array(), 'oepaypal', false),                                                                     // module never activated
+            array(array(), array('oepaypal' => '2.0'), array(0 => 'oepaypal'), 'oepaypal', false),                                   // module does not extend oxid-class and disabled
         );
     }
 
@@ -2556,13 +2556,8 @@ class Unit_Views_oxviewConfigTest extends OxidTestCase
      * oxViewConfig::oePayPalIsModuleActive()
      * @dataProvider _dpIsModuleActive
      */
-    public function testIsModuleActive($aModules, $aDisabledModules, $sModuleId, $blModuleIsActive)
+    public function testIsModuleActive($aModules, $aModuleVersions, $aDisabledModules, $sModuleId, $blModuleIsActive)
     {
-
-        $aModuleVersions = array(
-            'oepaypal' => '2.0',
-            'oepaypal2' => '5.0'
-        );
 
         $this->setConfigParam('aModules', $aModules);
         $this->setConfigParam('aDisabledModules', $aDisabledModules);

--- a/tests/unit/views/oxviewconfigTest.php
+++ b/tests/unit/views/oxviewconfigTest.php
@@ -2558,9 +2558,16 @@ class Unit_Views_oxviewConfigTest extends OxidTestCase
      */
     public function testIsModuleActive($aModules, $aDisabledModules, $sModuleId, $blModuleIsActive)
     {
+
+        $aModuleVersions = array(
+            'oepaypal' => '2.0',
+            'oepaypal2' => '5.0'
+        );
+
         $this->setConfigParam('aModules', $aModules);
         $this->setConfigParam('aDisabledModules', $aDisabledModules);
-
+        $this->setConfigParam('aModuleVersions', $aModuleVersions);
+        
         $oViewConf = new oxViewConfig();
         $blIsModuleActive = $oViewConf->isModuleActive($sModuleId);
 

--- a/tests/unit/views/oxviewconfigTest.php
+++ b/tests/unit/views/oxviewconfigTest.php
@@ -2560,7 +2560,7 @@ class Unit_Views_oxviewConfigTest extends OxidTestCase
     {
 
         $aModuleVersions = array(
-            'oepaypal' => '2.0',
+            'oepaypal1' => '2.0',
             'oepaypal2' => '5.0'
         );
 


### PR DESCRIPTION
... module has no vendor folder

function isModuleActive also returns false, if module does not extend any oxid class; therefore check uses wrong array

now uses 'aModuleVersions' instead of 'aModules' from oxconfig