### PR TITLE
fill netto and brutto price in amountPriceList in oxarticle

### DIFF
--- a/source/application/models/oxarticle.php
+++ b/source/application/models/oxarticle.php
@@ -3728,7 +3728,7 @@ class oxArticle extends oxI18n implements oxIArticle, oxIUrl
         // trying to find lowest price value
         foreach ($aAmPriceList as $sId => $oItem) {
 
-            $oItemPrice = $this->_getPriceObject();
+            $oItemPrice = $this->_getPriceObject(true);
             if ($oItem->oxprice2article__oxaddabs->value) {
 
                 $dBasePrice = $oItem->oxprice2article__oxaddabs->value;
@@ -3744,8 +3744,8 @@ class oxArticle extends oxI18n implements oxIArticle, oxIUrl
                 $oItemPrice->subtractPercent($oItem->oxprice2article__oxaddperc->value);
             }
 
-
-            $aAmPriceList[$sId]->fbrutprice = $oLang->formatCurrency($this->_getPriceForView($oItemPrice));
+            $aAmPriceList[$sId]->fbrutprice = $oLang->formatCurrency($oItemPrice->getBruttoPrice());
+            $aAmPriceList[$sId]->fnetprice = $oLang->formatCurrency($oItemPrice->getNettoPrice());
         }
 
         return $aAmPriceList;

--- a/source/application/views/azure/tpl/page/details/inc/priceinfo.tpl
+++ b/source/application/views/azure/tpl/page/details/inc/priceinfo.tpl
@@ -11,7 +11,12 @@
         [{if $priceItem->oxprice2article__oxaddperc->value}]
             [{$priceItem->oxprice2article__oxaddperc->value}] % [{oxmultilang ident="DISCOUNT"}]
         [{else}]
-            [{$priceItem->fbrutprice}] [{$currency->sign}]
+            [{if $oxcmp_basket->isPriceViewModeNetto()}]
+                [{$priceItem->fnetprice}]
+            [{else}]
+                [{$priceItem->fbrutprice}]
+            [{/if}]
+            [{$currency->sign}]
         [{/if}]
         </span>
     </li>


### PR DESCRIPTION
We need netto and brutto price in our theme for the amount Price List on the details page. (http://www.vkf-renzel.de/Namensschild-Querformat.html)

I thnik it would be great if you fill brutto and netto every time and use isPriceViewModeNetto in template to check if nettoMode is active.