### PR TITLE
Fixed access to target Category when loading products

### DIFF
--- a/source/application/controllers/alist.php
+++ b/source/application/controllers/alist.php
@@ -376,8 +376,8 @@ class aList extends oxUBase
         } else {
             $aSessionFilter = oxRegistry::getSession()->getVariable('session_attrfilter');
 
-            $sActCat = oxRegistry::getConfig()->getRequestParameter('cnid');
-            $this->_iAllArtCnt = $oArtList->loadCategoryArticles($sActCat, $aSessionFilter);
+            $sActCatId = $oCategory->getId();
+            $this->_iAllArtCnt = $oArtList->loadCategoryArticles($sActCatId, $aSessionFilter);
         }
 
         $this->_iCntPages = round($this->_iAllArtCnt / $iNrofCatArticles + 0.49);


### PR DESCRIPTION
Though a target category is given as function parameter, the "active category id" was loaded directly from Request in line 379. This did not make sense at all. The system does not behave as expected here, if the list controller is not used in standard (OXID-)case.

After some short tests, this change should not cause any problems.