### PR TITLE
0005143: Apply innodb status patch to mysqli driver

### DIFF
--- a/source/core/adodblite/adodbSQL_drivers/mysqli/mysqli_perfmon_module.inc
+++ b/source/core/adodblite/adodbSQL_drivers/mysqli/mysqli_perfmon_module.inc
@@ -295,7 +295,7 @@ class mysqli_perfmon_ADOConnection extends mysqli_perfmon_EXTENDER
         $save = $ADODB_FETCH_MODE;
         $ADODB_FETCH_MODE = ADODB_FETCH_NUM;
 
-        $rs = $this->Execute('show innodb status');
+        $rs = $this->Execute('show engine innodb status');
 ;
         $ADODB_FETCH_MODE = $save;
 


### PR DESCRIPTION
This PR applies the patch for [1] and [2] to the adodb mysql**i** driver.


[1] https://bugs.oxid-esales.com/view.php?id=5143
[2] https://bugs.oxid-esales.com/view.php?id=5622