### PR TITLE
remove duplicated slash from picture url

### DIFF
--- a/source/core/oxconfig.php
+++ b/source/core/oxconfig.php
@@ -1413,7 +1413,7 @@ class oxConfig extends oxSuperCfg
      */
     public function getPictureUrl($sFile, $blAdmin = false, $blSSL = null, $iLang = null, $iShopId = null, $sDefPic = "master/nopic.jpg")
     {
-        if ($sAltUrl = oxRegistry::get("oxPictureHandler")->getAltImageUrl('/', $sFile, $blSSL)) {
+        if ($sAltUrl = oxRegistry::get("oxPictureHandler")->getAltImageUrl('', $sFile, $blSSL)) {
             return $sAltUrl;
         }
 


### PR DESCRIPTION
seams like there are to many slashes in the picture URL if you configure an image server.