### PR TITLE
Prevent the redirect to the admin login page for logged in admin users.

### DIFF
--- a/source/core/oxshopcontrol.php
+++ b/source/core/oxshopcontrol.php
@@ -712,7 +712,9 @@ class oxShopControl extends oxSuperCfg
         $sClass = oxRegistry::getConfig()->getRequestParameter('cl');
 
         if (!$sClass) {
-            $sClass = $this->isAdmin() ? 'login' : $this->_getFrontendStartController();
+            $sClass = $this->isAdmin() ?
+                oxSession::getVar( "auth") ? 'admin_start' : 'login'
+                : $this->_getFrontendStartController();
             oxRegistry::getSession()->setVariable('cl', $sClass);
         }
 


### PR DESCRIPTION
This is important in cases when the browser call a broken link with the cl parameter missing.
That happen sometimes in the module area probably caused by some broken resources (e.g. css, images or something else)