### PR TITLE
Prevent the redirect to the admin login page for logged in admin users.

### DIFF
--- a/source/application/controllers/admin/oxadminview.php
+++ b/source/application/controllers/admin/oxadminview.php
@@ -160,7 +160,7 @@ class oxAdminView extends oxView
 
         // authorization check
         if (!$this->_authorize()) {
-            oxRegistry::getUtils()->redirect('index.php', true, 302);
+            oxRegistry::getUtils()->redirect('index.php?cl=login', true, 302);
             exit;
         }
 

--- a/source/core/oxshopcontrol.php
+++ b/source/core/oxshopcontrol.php
@@ -712,8 +712,13 @@ class oxShopControl extends oxSuperCfg
         $sClass = oxRegistry::getConfig()->getRequestParameter('cl');
 
         if (!$sClass) {
-            $sClass = $this->isAdmin() ? 'login' : $this->_getFrontendStartController();
-            oxRegistry::getSession()->setVariable('cl', $sClass);
+            $oSession = oxRegistry::getSession();
+            if($this->isAdmin()){
+                $sClass = $oSession->getVariable("auth") ? 'admin_start' : 'login';
+            }else{
+                $sClass = $this->_getFrontendStartController();
+            }
+            $oSession->setVariable('cl', $sClass);
         }
 
         return $sClass;


### PR DESCRIPTION
This is important in cases when the browser call a broken link with the cl parameter missing.
That happen sometimes in the module area probably caused by some broken resources (e.g. css, images or something else)