### PR TITLE
Added support for PSR0 and PSR4 autoloading.

### DIFF
--- a/source/core/oxfunctions.php
+++ b/source/core/oxfunctions.php
@@ -30,24 +30,24 @@
 function oxAutoload($sClass)
 {
     startProfile("oxAutoload");
-    $sClass = basename($sClass);
-    $sClass = strtolower($sClass);
-
-    static $sBasePath = null;
-    static $aClassDirs = null;
 
     // preventing infinite loop
     static $aTriedClasses = array();
 
-    //loading very base classes. We can do this as we know they exists,
-    //moreover even further method code could not execute without them
-    $sBaseClassLocation = null;
-    $aBaseClasses = array("oxutils", "oxsupercfg", "oxutilsobject");
-    if (in_array($sClass, $aBaseClasses)) {
-        $sFilename = getShopBasePath() . "core/" . $sClass . ".php";
-        include $sFilename;
+    $blNamespaceUsed = strpos($sClass,'\\',1);
+    if(! $blNamespaceUsed) {
+        $sClass = basename($sClass);
+        $sClass = strtolower($sClass);
 
-        return;
+        //loading very base classes. We can do this as we know they exists,
+        //moreover even further method code could not execute without them
+        $aBaseClasses = array("oxutils", "oxsupercfg", "oxutilsobject");
+        if (in_array($sClass, $aBaseClasses)) {
+            $sFilename = getShopBasePath() . "core/" . $sClass . ".php";
+            include $sFilename;
+
+            return;
+        }
     }
 
     static $aClassPaths;
@@ -59,8 +59,52 @@ function oxAutoload($sClass)
         return;
     }
 
+    static $sBasePath = null;
     $sBasePath = getShopBasePath();
 
+    // following block adds namespace support
+    if($blNamespaceUsed) {
+        $aNamespaceClassDirs = getNamespaceClassDirs();
+
+        $sNamespacePrefix = $sClass;
+        $sDirectorySeparator = '/';
+        $sNameSpaceSeparator = '\\';
+        $sClassAsPath =  str_replace($sNameSpaceSeparator, $sDirectorySeparator, $sClass);
+
+        while (false !== $pos = strrpos($sNamespacePrefix, $sNameSpaceSeparator)) {
+
+            $sNamespacePrefix = substr($sClass, 0, $pos);
+            $sRelativeClassWithoutPrefix = substr($sClassAsPath, $pos + 1);
+
+            $aPrefixDirs = $aNamespaceClassDirs[$sNamespacePrefix];
+            if($aPrefixDirs) {
+                // search in all directories configured for this namespace prefix
+                foreach ($aPrefixDirs as $sPrefixDir => $psr0OrPsr4) {
+                    // if PSR0 the path to the class inside the directory will include the prefix
+                    $sRelativeClass = NULL;
+                    if($psr0OrPsr4 === 'PSR0') {
+                        $sRelativeClass = $sClassAsPath;
+                    } else {
+                        $sRelativeClass = $sRelativeClassWithoutPrefix;
+                    }
+                    $sFilename = $sBasePath
+                        . $sPrefixDir . $sDirectorySeparator . $sRelativeClass . '.php';
+
+                    if (file_exists($sFilename)) {
+                        $aClassPaths[$sClass] = $sFilename;
+                        stopProfile("oxAutoload");
+                        include $sFilename;
+
+                        return;
+                    }
+                }
+            }
+        }
+
+        return;
+    }
+
+    static $aClassDirs = null;
 
     // initializing paths
     if ($aClassDirs == null) {
@@ -127,6 +171,17 @@ function oxAutoload($sClass)
 
     stopProfile("oxAutoload");
 }
+
+function getNamespaceClassDirs()
+{
+    return array(
+        //Namespace => array('subdirectory/in/shop/BasePath' => 'PSR0|PSR4' )
+        //PSR0: the directory structure in this path will map to the full qualified class name
+        //PSR4: the directory structure in this path will map to qualified class name without the prefix configured here
+        //e.g. 'Psr\Log' => array('core/log'=>'PSR0')
+    );
+}
+
 
 /**
  * Return array with classes paths.

--- a/source/core/oxutilsobject.php
+++ b/source/core/oxutilsobject.php
@@ -155,7 +155,11 @@ class oxUtilsObject
         array_shift($aArgs);
         $iArgCnt = count($aArgs);
         $blCacheObj = $iArgCnt < 2;
-        $sClassName = strtolower($sClassName);
+
+        // Case insensitive for class names in root namespace to be backward compatible
+        if(! strpos($sClassName,'\\',1)) {
+            $sClassName = strtolower($sClassName);
+        }
 
         if (isset(self::$_aClassInstances[$sClassName])) {
             return self::$_aClassInstances[$sClassName];


### PR DESCRIPTION
This brings support for namespaces and makes it possible to include other 3rd party libaries to core.

This pull request was designed to be backward compatible, so i tried not to change old code as much as possible
to lower the risc of breaking bc breaks or new bugs or unmasking bugs.

PSR3 Logger Interface and a Logger Implementation will be part of an other pull request,
also not included in this merge request is PSRR3/PSR4 autoloading support for modules.

Performance:
- negative impact should be ver low (hopyfully not mesureable),
- positve impact depends on usage of namespaces.

I am also thinking of caching $aClassPaths in the autoloader to make performance improvements but this would also be an other merge request.