### PR TITLE
Use semantic HTML 5 for footer widgets

### DIFF
--- a/source/application/views/azure/tpl/widget/footer/categorylist.tpl
+++ b/source/application/views/azure/tpl/widget/footer/categorylist.tpl
@@ -1,22 +1,18 @@
 [{if $oxcmp_categories }]
     [{assign var="categories" value=$oxcmp_categories }]
     [{block name="footer_categories"}]
-    <dl class="categories" id="footerCategories">
-        <dt>[{oxmultilang ident="CATEGORIES" }]</dt>
-        <dd>
-            <ul class="list categories">
-                [{foreach from=$categories item=_cat}]
-                    [{if $_cat->getIsVisible() }]
-                        [{if $_cat->getContentCats() }]
-                            [{foreach from=$_cat->getContentCats() item=_oCont}]
-                            <li><a href="[{$_oCont->getLink()}]"><i></i>[{ $_oCont->oxcontents__oxtitle->value }]</a></li>
-                            [{/foreach}]
-                        [{/if }]
-                        <li><a href="[{$_cat->getLink()}]" [{if $_cat->expanded}]class="exp"[{/if}]>[{$_cat->oxcategories__oxtitle->value}] [{ if $oView->showCategoryArticlesCount() && ( $_cat->getNrOfArticles() > 0 )}] ([{$_cat->getNrOfArticles()}])[{/if}]</a></li>
-                    [{/if}]
-                [{/foreach}]
-            </ul>
-        </dd>
+    <dl class="list categories" id="footerCategories">
+        <dt class="list-header">[{oxmultilang ident="CATEGORIES" }]</dt>
+        [{foreach from=$categories item=_cat}]
+            [{if $_cat->getIsVisible() }]
+                [{if $_cat->getContentCats() }]
+                    [{foreach from=$_cat->getContentCats() item=_oCont}]
+                    <dd><a href="[{$_oCont->getLink()}]"><i></i>[{ $_oCont->oxcontents__oxtitle->value }]</a></dd>
+                    [{/foreach}]
+                [{/if }]
+                <dd><a href="[{$_cat->getLink()}]" [{if $_cat->expanded}]class="exp"[{/if}]>[{$_cat->oxcategories__oxtitle->value}] [{ if $oView->showCategoryArticlesCount() && ( $_cat->getNrOfArticles() > 0 )}] ([{$_cat->getNrOfArticles()}])[{/if}]</a></dd>
+            [{/if}]
+        [{/foreach}]
     </dl>
     [{/block}]
 [{/if}]

--- a/source/application/views/azure/tpl/widget/footer/info.tpl
+++ b/source/application/views/azure/tpl/widget/footer/info.tpl
@@ -1,17 +1,13 @@
 [{assign var="aServices" value=$oView->getServicesList()}]
 [{assign var="aServiceItems" value=$oView->getServicesKeys()}]
 [{block name="footer_information"}]
-    <dl id="footerInformation">
-        <dt>[{oxmultilang ident="INFORMATION" }]</dt>
-        <dd>
-            <ul class="list services">
-                [{foreach from=$aServiceItems item=sItem}]
-                    [{if isset($aServices.$sItem)}]
-                        <li><a href="[{$aServices.$sItem->getLink()}]">[{$aServices.$sItem->oxcontents__oxtitle->value}]</a></li>
-                    [{/if}]
-                [{/foreach}]
-                <li><a href="[{ oxgetseourl ident=$oViewConf->getSelfLink()|cat:"cl=newsletter" }]" rel="nofollow">[{ oxmultilang ident="NEWSLETTER" }]</a></li>
-            </ul>
-        </dd>
+    <dl id="footerInformation" class="list information">
+        <dt class="list-header">[{oxmultilang ident="INFORMATION" }]</dt>
+        [{foreach from=$aServiceItems item=sItem}]
+            [{if isset($aServices.$sItem)}]
+                <dd><a href="[{$aServices.$sItem->getLink()}]">[{$aServices.$sItem->oxcontents__oxtitle->value}]</a></dd>
+            [{/if}]
+        [{/foreach}]
+        <dd><a href="[{ oxgetseourl ident=$oViewConf->getSelfLink()|cat:"cl=newsletter" }]" rel="nofollow">[{ oxmultilang ident="NEWSLETTER" }]</a></dd>
     </dl>
 [{/block}]

--- a/source/application/views/azure/tpl/widget/footer/manufacturerlist.tpl
+++ b/source/application/views/azure/tpl/widget/footer/manufacturerlist.tpl
@@ -2,21 +2,17 @@
 [{assign var="manufacturers" value=$oView->getManufacturerlist()}]
 [{if $manufacturers|count}]
     [{block name="footer_manufacturers"}]
-    <dl id="footerManufacturers">
-        <dt>[{oxmultilang ident="MANUFACTURERS" }]</dt>
-        <dd>
-        <ul class="list">
-            [{assign var="rootManufacturer" value=$oView->getRootManufacturer()}]
-            <li><a href="[{$rootManufacturer->getLink()}]">[{oxmultilang ident="ALL_BRANDS"}]</a></li>
-            [{foreach from=$manufacturers item=_mnf name=manufacturers}]
-                [{if $smarty.foreach.manufacturers.index < $iManufacturerLimit}]
-                    <li><a href="[{$_mnf->getLink()}]" [{if $_mnf->expanded}]class="exp"[{/if}]>[{$_mnf->oxmanufacturers__oxtitle->value}]</a></li>
-                [{elseif $smarty.foreach.manufacturers.index == $iManufacturerLimit}]
-                    <li><a href="[{$rootManufacturer->getLink()}]">[{oxmultilang ident="MORE"}]</a></li>
-                [{/if}]
-            [{/foreach}]
-        </ul>
-        </dd>
+    <dl id="footerManufacturers" class="list manufacturers">
+        <dt class="list-header">[{oxmultilang ident="MANUFACTURERS" }]</dt>
+        [{assign var="rootManufacturer" value=$oView->getRootManufacturer()}]
+        <dd><a href="[{$rootManufacturer->getLink()}]">[{oxmultilang ident="ALL_BRANDS"}]</a></dd>
+        [{foreach from=$manufacturers item=_mnf name=manufacturers}]
+            [{if $smarty.foreach.manufacturers.index < $iManufacturerLimit}]
+                <dd><a href="[{$_mnf->getLink()}]" [{if $_mnf->expanded}]class="exp"[{/if}]>[{$_mnf->oxmanufacturers__oxtitle->value}]</a></dd>
+            [{elseif $smarty.foreach.manufacturers.index == $iManufacturerLimit}]
+                <dd><a href="[{$rootManufacturer->getLink()}]">[{oxmultilang ident="MORE"}]</a></dd>
+            [{/if}]
+        [{/foreach}]
     </dl>
     [{/block}]
 [{/if}]

--- a/source/application/views/azure/tpl/widget/footer/services.tpl
+++ b/source/application/views/azure/tpl/widget/footer/services.tpl
@@ -1,46 +1,42 @@
 [{block name="footer_services"}]
-    <dl class="services" id="footerServices">
-        <dt>[{oxmultilang ident="SERVICES" }]</dt>
-        <dd>
-            <ul class="list services">
-                [{block name="footer_services_items"}]
-                    <li>
-                        <a href="[{ oxgetseourl ident=$oViewConf->getSelfLink()|cat:"cl=contact" }]">[{ oxmultilang ident="CONTACT" }]</a>
-                    </li>
-                    [{if $oViewConf->getHelpPageLink() }]
-                        <li><a href="[{ $oViewConf->getHelpPageLink() }]">[{ oxmultilang ident="HELP" }]</a></li>
-                    [{/if}]
-                    <li>
-                        <a href="[{ oxgetseourl ident=$oViewConf->getSelfLink()|cat:"cl=links" }]">[{ oxmultilang ident="LINKS" }]</a>
-                    </li>
-                    <li>
-                        <a href="[{ oxgetseourl ident=$oViewConf->getSelfLink()|cat:"cl=guestbook" }]">[{ oxmultilang ident="GUESTBOOK" }]</a>
-                    </li>
-                    [{if $oView->isActive('Invitations') }]
-                        <li><a href="[{ oxgetseourl ident=$oViewConf->getSelfLink()|cat:"cl=invite" }]"
-                               rel="nofollow">[{ oxmultilang ident="INVITE_YOUR_FRIENDS" }]</a></li>
-                    [{/if}]
-                    [{oxhasrights ident="TOBASKET"}]
-                        <li><a href="[{ oxgetseourl ident=$oViewConf->getBasketLink() }]"
-                               rel="nofollow">[{ oxmultilang ident="CART" }]</a></li>
-                    [{/oxhasrights}]
-                    <li><a href="[{ oxgetseourl ident=$oViewConf->getSelfLink()|cat:"cl=account" }]"
-                           rel="nofollow">[{ oxmultilang ident="ACCOUNT" }]</a></li>
-                    <li><a href="[{ oxgetseourl ident=$oViewConf->getSelfLink()|cat:"cl=account_noticelist" }]"
-                           rel="nofollow">[{ oxmultilang ident="WISH_LIST" }]</a></li>
-                    [{if $oViewConf->getShowWishlist()}]
-                        <li><a href="[{ oxgetseourl ident=$oViewConf->getSelfLink()|cat:"cl=account_wishlist" }]"
-                               rel="nofollow">[{ oxmultilang ident="MY_GIFT_REGISTRY" }]</a></li>
-                        <li>
-                            <a href="[{ oxgetseourl ident=$oViewConf->getSelfLink()|cat:"cl=wishlist" params="wishid="|cat:$oView->getWishlistUserId() }]"
-                               rel="nofollow">[{ oxmultilang ident="PUBLIC_GIFT_REGISTRIES" }]</a></li>
-                    [{/if}]
-                    [{if $oView->isEnabledDownloadableFiles()}]
-                        <li><a href="[{ oxgetseourl ident=$oViewConf->getSelfLink()|cat:"cl=account_downloads" }]"
-                               rel="nofollow">[{ oxmultilang ident="MY_DOWNLOADS" }]</a></li>
-                    [{/if}]
-                [{/block}]
-            </ul>
-        </dd>
+    <dl class="list services" id="footerServices">
+        <dt class="list-header">[{oxmultilang ident="SERVICES" }]</dt>
+        [{block name="footer_services_items"}]
+            <dd>
+                <a href="[{ oxgetseourl ident=$oViewConf->getSelfLink()|cat:"cl=contact" }]">[{ oxmultilang ident="CONTACT" }]</a>
+            </dd>
+            [{if $oViewConf->getHelpPageLink() }]
+                <dd><a href="[{ $oViewConf->getHelpPageLink() }]">[{ oxmultilang ident="HELP" }]</a></dd>
+            [{/if}]
+            <dd>
+                <a href="[{ oxgetseourl ident=$oViewConf->getSelfLink()|cat:"cl=links" }]">[{ oxmultilang ident="LINKS" }]</a>
+            </dd>
+            <dd>
+                <a href="[{ oxgetseourl ident=$oViewConf->getSelfLink()|cat:"cl=guestbook" }]">[{ oxmultilang ident="GUESTBOOK" }]</a>
+            </dd>
+            [{if $oView->isActive('Invitations') }]
+                <dd><a href="[{ oxgetseourl ident=$oViewConf->getSelfLink()|cat:"cl=invite" }]"
+                       rel="nofollow">[{ oxmultilang ident="INVITE_YOUR_FRIENDS" }]</a></dd>
+            [{/if}]
+            [{oxhasrights ident="TOBASKET"}]
+                <dd><a href="[{ oxgetseourl ident=$oViewConf->getBasketLink() }]"
+                       rel="nofollow">[{ oxmultilang ident="CART" }]</a></dd>
+            [{/oxhasrights}]
+            <dd><a href="[{ oxgetseourl ident=$oViewConf->getSelfLink()|cat:"cl=account" }]"
+                   rel="nofollow">[{ oxmultilang ident="ACCOUNT" }]</a></dd>
+            <dd><a href="[{ oxgetseourl ident=$oViewConf->getSelfLink()|cat:"cl=account_noticelist" }]"
+                   rel="nofollow">[{ oxmultilang ident="WISH_LIST" }]</a></dd>
+            [{if $oViewConf->getShowWishlist()}]
+                <dd><a href="[{ oxgetseourl ident=$oViewConf->getSelfLink()|cat:"cl=account_wishlist" }]"
+                       rel="nofollow">[{ oxmultilang ident="MY_GIFT_REGISTRY" }]</a></dd>
+                <dd>
+                    <a href="[{ oxgetseourl ident=$oViewConf->getSelfLink()|cat:"cl=wishlist" params="wishid="|cat:$oView->getWishlistUserId() }]"
+                       rel="nofollow">[{ oxmultilang ident="PUBLIC_GIFT_REGISTRIES" }]</a></dd>
+            [{/if}]
+            [{if $oView->isEnabledDownloadableFiles()}]
+                <dd><a href="[{ oxgetseourl ident=$oViewConf->getSelfLink()|cat:"cl=account_downloads" }]"
+                       rel="nofollow">[{ oxmultilang ident="MY_DOWNLOADS" }]</a></dd>
+            [{/if}]
+        [{/block}]
     </dl>
 [{/block}]

--- a/source/application/views/azure/tpl/widget/footer/vendorlist.tpl
+++ b/source/application/views/azure/tpl/widget/footer/vendorlist.tpl
@@ -1,15 +1,11 @@
 [{assign var="vendors" value=$oView->getVendorlist()}]
 [{if $vendors->count()}]
     [{block name="footer_vendors"}]
-    <dl id="footerVendors">
-        <dt>[{oxmultilang ident="DISTRIBUTORS" }]</dt>
-        <dd>
-            <ul class="list">
-              [{foreach from=$vendors item=_vnd}]
-              <li><a href="[{$_vnd->getLink()}]" [{if $_vnd->expanded}]class="exp"[{/if}]>[{$_vnd->oxvendor__oxtitle->value}]</a></li>
-              [{/foreach}]
-            </ul>
-        </dd>
+    <dl id="footerVendors" class="list vendors">
+        <dt class="list-header">[{oxmultilang ident="DISTRIBUTORS" }]</dt>
+        [{foreach from=$vendors item=_vnd}]
+            <dd><a href="[{$_vnd->getLink()}]" [{if $_vnd->expanded}]class="exp"[{/if}]>[{$_vnd->oxvendor__oxtitle->value}]</a></dd>
+        [{/foreach}]
     </dl>
     [{/block}]
 [{/if}]

--- a/source/out/azure/src/css/oxid.css
+++ b/source/out/azure/src/css/oxid.css
@@ -1816,44 +1816,42 @@ div.searchBox input.textbox:focus {
 #footer .bar .deliveryinfo {float: right;}
 #footer .bar .deliveryinfo a {font-size:10px; color:#515353;}
 
-#footer dl {
-    float:left;
+#footer .list {
+    clear: none;
+    float: left;
     width: 233px;
-    margin:10px 0;
-    color:#465256;
-    height: auto;
+    margin: 10px 0;
+    color: #465256;
     border-right: 1px solid #3799b1;
     border-left: 1px solid #ffffff;
 }
 
-#footer dl.services {
-    border-left: none;
+#footer .list a {
+    line-height: 100%;
+    display: block;
+    padding: 4px 20px;
+    color: #29373c;
+    text-shadow: 0 1px 2px #fff;
 }
 
-#footer dl:last-child {
-    border-right: none;
-}
-
-#footer ul {
-    margin: 0;
-}
-
-#footer li {
-    list-style: none;
-    padding: 0;
-}
-
-#footer dl dt {
-    color:#29373C;
-    padding:2px 20px;
-    text-transform: uppercase;
-}
-
-#footer .list a  { line-height: 100%; display:block; padding:4px 20px; color: #29373c; text-shadow: 0 1px 2px #fff;}
 #footer .list a:hover  {
     text-decoration: none;
     color: #FFF;
     text-shadow: none;
+}
+
+#footer .list-header {
+    color: #29373C;
+    padding: 2px 20px;
+    text-transform: uppercase;
+}
+
+#footer .services {
+    border-left: 0;
+}
+
+#footer .categories {
+    border-right: 0;
 }
 
 #footer .tree ul {margin: 0; margin-left:10px;}


### PR DESCRIPTION
Each footer widget used a definition list with an encapsuled <ul> element to list all items for one section. According to HTML 5 Semantics, it makes more sense to define one definition term (for the section, e. g. "Services") and list each item as an <dd> element. The CSS was changed accordingly to create the same look and feel as before. I am using classes to have a better separation between the HTML structure and the CSS styles. 