### PR TITLE
oxnew parameters are serialized and so they can hit servers memorylimit

### DIFF
--- a/source/core/oxutilsobject.php
+++ b/source/core/oxutilsobject.php
@@ -157,6 +157,15 @@ class oxUtilsObject
         $blCacheObj = $iArgCnt < 2;
         $sClassName = strtolower($sClassName);
 
+        if($blCacheObj) {
+            foreach ($aArgs as $mArg) {
+                if (! ($mArg == null || is_scalar($mArg)) ) {
+                    $blCacheObj = false;
+                    break;
+                }
+            }
+        }
+
         if (isset(self::$_aClassInstances[$sClassName])) {
             return self::$_aClassInstances[$sClassName];
         }


### PR DESCRIPTION
this commit fixes a problem that happens if module-developers use oxNew with heavy constructor arguments (e.g. objects or arrays).
my modification checks the arguments first, only simple values (scalars/null) are accepted for cachable objects.

This commit does NOT fix the problem if someone uses a very big string as constructor argument,
but therefor strlen of the args could be checked additional.