### PR TITLE
RDF Meta tags evaluation

### DIFF
--- a/source/application/views/azure/tpl/rdfa/details/details.tpl
+++ b/source/application/views/azure/tpl/rdfa/details/details.tpl
@@ -21,7 +21,8 @@
 [{oxhasrights ident="SHOWLONGDESCRIPTION"}]
 [{assign var="oLongdesc" value=$oProduct->getLongDescription()}]
 [{if $oLongdesc->value}]
-    <div property="gr:description" content="[{oxeval var=$oLongdesc->value|strip_tags|strip }]" [{if $oView->getActiveLangAbbr()}] xml:lang="[{$oView->getActiveLangAbbr()}]"[{/if}]></div>
+    [{capture assign="oLongdescEvaluated"}][{oxeval var=$oLongdesc->value}][{/capture}]
+    <div property="gr:description" content="[{oxeval var=$oLongdescEvaluated|strip_tags|strip }]" [{if $oView->getActiveLangAbbr()}] xml:lang="[{$oView->getActiveLangAbbr()}]"[{/if}]></div>
 [{/if}]
 [{if !$oProduct->oxarticles__oxbundleid->value}]
     <div property="gr:hasStockKeepingUnit" content="[{$oProduct->oxarticles__oxartnum->value}]" datatype="xsd:string"></div>

--- a/source/application/views/azure/tpl/rdfa/details/inc/object.tpl
+++ b/source/application/views/azure/tpl/rdfa/details/inc/object.tpl
@@ -10,7 +10,8 @@
                [{oxhasrights ident="SHOWLONGDESCRIPTION"}]
                [{assign var="oLongdesc" value=$oProduct->getLongDescription()}]
                [{if $oLongdesc->value}]
-                   <div property="gr:description" content="[{oxeval var=$oLongdesc->value|strip_tags|strip }]" [{if $oView->getActiveLangAbbr()}] xml:lang="[{$oView->getActiveLangAbbr()}]"[{/if}]></div>
+                   [{capture assign="oLongdescEvaluated"}][{oxeval var=$oLongdesc->value}][{/capture}]
+                   <div property="gr:description" content="[{oxeval var=$oLongdescEvaluated|strip_tags|strip }]" [{if $oView->getActiveLangAbbr()}] xml:lang="[{$oView->getActiveLangAbbr()}]"[{/if}]></div>
                [{/if}]
             [{/oxhasrights}]
             <div rel="foaf:depiction v:image" resource="[{$oView->getActPicture()}]"></div>


### PR DESCRIPTION
gr:description should first be evaluated, then tags should be stripped. 

otherwise, if the description contains `<img src="[{$oViewConf->getCurrentHomeDir()}]/some-file.png" />`, it fails to produce valid html code, as `->` seems to be counted as a closing tag. 