### PR TITLE
Cleanup JSDoc and JavaScript warnings

### DIFF
--- a/source/application/views/azure/tpl/form/fieldset/user_shipping.tpl
+++ b/source/application/views/azure/tpl/form/fieldset/user_shipping.tpl
@@ -4,8 +4,8 @@
 <li>
     <label>[{oxmultilang ident="ADDRESSES"}]</label>
     <input type="hidden" name="changeClass" value="[{$onChangeClass|default:'account_user'}]">
-    [{oxscript include="js/widgets/oxusershipingaddressselect.js" priority=10}]
-    [{oxscript add="$( '#addressId' ).oxUserShipingAddressSelect();"}]
+    [{oxscript include="js/widgets/oxusershippingaddressselect.js" priority=10}]
+    [{oxscript add="$( '#addressId' ).oxUserShippingAddressSelect();"}]
     [{block name="form_user_shipping_address_select"}]
         <select id="addressId" name="oxaddressid">
             <option value="-1">[{oxmultilang ident="NEW_ADDRESS"}]</option>

--- a/source/out/azure/src/js/widgets/oxagbcheck.js
+++ b/source/out/azure/src/js/widgets/oxagbcheck.js
@@ -20,15 +20,18 @@
  */
 ( function( $ ) {
 
-    oxAGBCheck = {
+    var oxAGBCheck = {
 
+        /**
+         * Initiating AGB Check
+         * @private
+         */
         _create: function(){
 
             var self = this,
-                options = self.options,
                 el      = self.element;
 
-             el.closest('form').submit(function() {
+            el.closest('form').submit(function() {
                 if( el.prop('checked') ){
                     return true;
                 } else {
@@ -47,7 +50,7 @@
                 }
             });
         }
-    }
+    };
 
     $.widget( "ui.oxAGBCheck", oxAGBCheck );
 

--- a/source/out/azure/src/js/widgets/oxajax.js
+++ b/source/out/azure/src/js/widgets/oxajax.js
@@ -23,22 +23,22 @@
     /**
      * Ajax
      */
-    oxAjax = {
+    var oxAjax = {
 
         /**
-         * Loading temporary screen when ajax call proseeds
+         * Loading temporary screen when ajax call proceeds
          */
         loadingScreen:  {
 
             /**
              * Starts load
              *
-             * @target - DOM element witch must be hide with the loading screen
-             * @iconPositionElement - element of a target on witch loaging icon is shown
+             * @param {HTMLElement} target - DOM element witch must be hide with the loading screen
+             * @param {jQuery} iconPositionElement - element of a target on witch loaging icon is shown
              */
             start : function (target, iconPositionElement) {
 
-                var loadingScreens = Array();
+                var loadingScreens = [];
                 $(target).each(function() {
                     var overlayKeeper = document.createElement("div");
                     overlayKeeper.innerHTML = '<div class="loadingfade"></div><div class="loadingicon"></div><div class="loadingiconbg"></div>';
@@ -82,30 +82,29 @@
                 return loadingScreens;
             },
 
-
             /**
              * Stops viewing loading screens
              *
-             * @loadingScreens - one or more showing screens
+             * @param {jQuery} loadingScreens - one or more showing screens
              */
             stop : function ( loadingScreens ) {
-              $.each(loadingScreens, function(i, el) {
-                  $('div', el).not('.loadingfade').remove();
-                  $('div.loadingfade', el)
-                      .stop(true, true)
-                      .animate({
-                          opacity: 0
-                      }, 100, function(){
-                          $(el).remove();
-                      });
-              });
+                $.each(loadingScreens, function(i, el) {
+                    $('div', el).not('.loadingfade').remove();
+                    $('div.loadingfade', el)
+                        .stop(true, true)
+                        .animate({
+                            opacity: 0
+                        }, 100, function(){
+                            $(el).remove();
+                        });
+                });
             }
         },
 
         /**
          * Updating errors on page
          *
-         * @errors - array of errors
+         * @param {Array} errors - array of errors
          */
         updatePageErrors : function(errors) {
             if (errors.length) {
@@ -131,8 +130,8 @@
         /**
          * Ajax call
          *
-         * @activator - link or form element that activates ajax call
-         * @params - call params: targetEl, iconPosEl, onSuccess, onError, additionalData
+         * @param {HTMLElement} activator - link or form element that activates ajax call
+         * @param {Array} params - call params: targetEl, iconPosEl, onSuccess, onError, additionalData
          */
         ajax : function(activator, params) {
             var self = this;
@@ -214,7 +213,7 @@
         /**
          * If it's possible report JS error
          *
-         * @param e JS exception
+         * @param {Object} e JS exception
          */
         reportJSError: function(e) {
             if (typeof console != 'undefined' && typeof console.error != 'undefined') {
@@ -225,7 +224,7 @@
         /**
          * Evals returned html and executes javascript after reload
          *
-         * @container - witch javascript must be restarted
+         * @param {jQuery} container - which javascript must be restarted
          */
         evalScripts : function(container){
             var self = this;

--- a/source/out/azure/src/js/widgets/oxamountpriceselect.js
+++ b/source/out/azure/src/js/widgets/oxamountpriceselect.js
@@ -22,8 +22,12 @@
     /**
      * Details amount price selector
      */
-    oxAmountPriceSelect = {
+    var oxAmountPriceSelect = {
 
+        /**
+         * Initiating details amount price selector
+         * @private
+         */
         _create: function()
         {
             var self = this,
@@ -54,8 +58,6 @@
 
         /**
          * Shows price list box
-         *
-         * @return null
          */
         showPriceList : function()
         {
@@ -66,8 +68,6 @@
 
         /**
          * Hides price list box
-         *
-         * @return null
          */
         hidePriceList : function()
         {
@@ -78,19 +78,16 @@
 
         /**
          * Hides all lists box
-         *
-         * @return null
          */
         hideAll : function()
         {
-            $('a.js-amountPriceSelector').next( 'ul' ).hide();
-            $('a.js-amountPriceSelector').removeClass('js-selected');
+            var priceSelect = $('a.js-amountPriceSelector');
+            priceSelect.next( 'ul' ).hide();
+            priceSelect.removeClass('js-selected');
         },
 
         /**
          * toggle list box
-         *
-         * @return null
          */
         togglePriceList : function ()
         {
@@ -108,13 +105,13 @@
         /**
          * returns state of list box
          *
-         * @return boolean
+         * @returns {boolean}
          */
         isOpened : function ()
         {
             return this.arrow.hasClass('js-selected');
         }
-    }
+    };
 
     $.widget( "ui.oxAmountPriceSelect", oxAmountPriceSelect );
 

--- a/source/out/azure/src/js/widgets/oxarticleactionlinksselect.js
+++ b/source/out/azure/src/js/widgets/oxarticleactionlinksselect.js
@@ -22,8 +22,12 @@
     /**
      * Details article action links selector
      */
-    oxArticleActionLinksSelect = {
+    var oxArticleActionLinksSelect = {
 
+        /**
+         * Initiating article action links select
+         * @private
+         */
         _create: function()
         {
             var self = this,
@@ -33,8 +37,9 @@
             var targetWidth  = $("span", el).width();
             var linkboxWidth = self.getLinkboxWidth( targetWidth, $("span", el));
             var targetHeight = $("span", el).height();
+            var actionlinks  = $("ul.actionLinks");
 
-            $("ul.actionLinks").css({
+            actionlinks.css({
                 "top": el.position().top - 7,
                 "left": el.position().left - 10,
                 "padding-top": targetHeight + 10,
@@ -42,9 +47,10 @@
             });
 
             var arrowSrc = $(".selector img").attr("src");
-            var arrow = $("#productLinks").children("img");
+            var productLinks = $("#productLinks");
+            var arrow = productLinks.children("img");
 
-            $("#productLinks").css({
+            productLinks.css({
                 "top": el.position().top - 3,
                 "left": targetWidth + el.position().left + 10
             }).click(function(){
@@ -56,14 +62,14 @@
                 return false;
             });
 
-            $("#productLinks").mouseenter(function() {
+            productLinks.mouseenter(function() {
                 if (! $(this).hasClass("selected") ) {
                     self.showLinks(arrow);
                 }
                 return false;
             });
 
-            $("ul.actionLinks").mouseleave( function() {
+            productLinks.mouseleave( function() {
                 self.hideLinks(arrow, arrowSrc);
                 return false;
             });
@@ -98,9 +104,7 @@
         /**
          * Shows action links list box in details
          *
-         * @param object arrow img object
-         *
-         * @return null
+         * @param {HTMLElement} arrow - img object
          */
         showLinks : function( arrow )
         {
@@ -114,10 +118,8 @@
         /**
          * Hides action links list box in details
          *
-         * @param object arrow    img object of selector
-         * @param object arrowSrc img object of product links
-         *
-         * @return null
+         * @param {HTMLElement} arrow - img object of selector
+         * @param {String} arrowSrc   - img object of product links
          */
         hideLinks : function( arrow, arrowSrc )
         {
@@ -137,10 +139,10 @@
         /**
          * Shows action links list box in details
          *
-         * @param integer iTargetWidth terget width
-         * @param object oObject      object to set width
+         * @param {Number} iTargetWidth - target width
+         * @param {jQuery} oObject      - object to set width
          *
-         * @return integer
+         * @returns {Number}
          */
         getLinkboxWidth : function( iTargetWidth, oObject )
         {
@@ -150,7 +152,7 @@
                 return 220;
             }
         }
-    }
+    };
 
     $.widget( "ui.oxArticleActionLinksSelect", oxArticleActionLinksSelect );
 

--- a/source/out/azure/src/js/widgets/oxarticlebox.js
+++ b/source/out/azure/src/js/widgets/oxarticlebox.js
@@ -20,8 +20,12 @@
  */
 ( function( $ ) {
 
-    oxArticleBox = {
+    var oxArticleBox = {
 
+        /**
+         * Initiating article box
+         * @private
+         */
         _create: function(){
             var oSelf         = this,
                 oElement      = oSelf.element,
@@ -51,7 +55,7 @@
                 }
             });
 
-            // triming titles to mach container width (if needed)
+            // trimming titles to mach container width (if needed)
             $( ".box h3 a", oElement ).each(function() {
                 var iTitleWidth = $(this).width(),
                     iContWidth  = $(this).parent().width(),
@@ -63,7 +67,7 @@
                     // checking if title has numbers at the end
                     var sTitleEnd	    = $.trim(sEndPattern.exec(sTitleText));
 
-                    // seperating the title from the numbers
+                    // separating the title from the numbers
                     if (sTitleEnd) {
                         sTitleEnd  = ' ' + sTitleEnd;
                         sTitleText = sTitlePattern.exec(sTitleText).pop();
@@ -76,13 +80,13 @@
                     {
                         iTitleLength--;
                         $(this).html(sTitleText.substr(0, iTitleLength)+'&hellip;' + sTitleEnd);
-                        var iTitleWidth = $(this).width();
+                        iTitleWidth = $(this).width();
                     }
                     $(this).attr('title',sTitleText);
                 }
             });
         }
-    }
+    };
 
     $.widget( "ui.oxArticleBox", oxArticleBox );
 

--- a/source/out/azure/src/js/widgets/oxarticlevariant.js
+++ b/source/out/azure/src/js/widgets/oxarticlevariant.js
@@ -71,7 +71,7 @@
         resetVariantSelections: function() {
             resetVariantSelections();
         }
-    }
+    };
 
     /**
      * Handles variant selection action

--- a/source/out/azure/src/js/widgets/oxbasketchecks.js
+++ b/source/out/azure/src/js/widgets/oxbasketchecks.js
@@ -20,8 +20,12 @@
  */
 ( function( $ ) {
 
-    oxBasketChecks = {
+    var oxBasketChecks = {
 
+        /**
+         * Initiating basket checks
+         * @private
+         */
         _create: function(){
 
             var self = this,
@@ -39,20 +43,29 @@
             });
         },
 
+        /**
+         * Toggle checkbox states
+         *
+         * @param {boolean} blChecked
+         */
         toggleChecks : function( blChecked ){
             $( ".basketitems .checkbox input" ).prop( "checked", blChecked );
         },
 
+        /**
+         * Toggle the main checkbox
+         *
+         * @returns {boolean}
+         */
         toggleMainCheck : function(){
-            if ( $( "#checkAll" ).prop( "checked" ) ) {
-                $( "#checkAll" ).prop( "checked", false );
-                return false;
-            } else {
-                $( "#checkAll" ).prop( "checked", true );
-                return true;
-            }
+            var checkAll = $( "#checkAll" );
+            var blChecked = checkAll.prop( "checked" );
+
+            checkAll.prop( "checked", !blChecked );
+
+            return !blChecked;
         }
-    }
+    };
 
     $.widget( "ui.oxBasketChecks", oxBasketChecks );
 

--- a/source/out/azure/src/js/widgets/oxbetanote.js
+++ b/source/out/azure/src/js/widgets/oxbetanote.js
@@ -23,7 +23,7 @@
     /**
      * Beta note handler
      */
-    oxBetaNote = {
+    var oxBetaNote = {
         options: {
             cookieName  : "hideBetaNote",
             closeButton : ".dismiss"
@@ -31,8 +31,7 @@
 
         /**
          * Enable beta note dismiss and set cookie to keep it hidden on next pages
-         *
-         * @return integer
+         * @private
          */
         _create: function() {
             

--- a/source/out/azure/src/js/widgets/oxblockdebug.js
+++ b/source/out/azure/src/js/widgets/oxblockdebug.js
@@ -20,8 +20,12 @@
  */
 ( function ( $ ) {
 
-    oxBlockDebug = {
+    var oxBlockDebug = {
 
+        /**
+         * Init block debug
+         * @private
+         */
         _create : function(){
 
             $("hr.debugBlocksStart").each(function(){
@@ -113,7 +117,7 @@
                 })
             );
         }
-    }
+    };
 
     /**
      * Compare list widget

--- a/source/out/azure/src/js/widgets/oxcenterelementonhover.js
+++ b/source/out/azure/src/js/widgets/oxcenterelementonhover.js
@@ -20,8 +20,12 @@
  */
 ( function( $ ) {
 
-    oxCenterElementOnHover = {
+    var oxCenterElementOnHover = {
 
+        /**
+         * Center element on hover
+         * @private
+         */
         _create: function(){
 
             var self = this;
@@ -38,7 +42,7 @@
                   $(".viewAllHover", el).hide();
               });
         }
-    }
+    };
 
     $.widget( "ui.oxCenterElementOnHover", oxCenterElementOnHover );
 

--- a/source/out/azure/src/js/widgets/oxcompare.js
+++ b/source/out/azure/src/js/widgets/oxcompare.js
@@ -24,7 +24,7 @@
     /**
      * Compare list
      */
-    oxCompare = {
+    var oxCompare = {
         options: {
             browsers: {
                 chrome: "chrome",
@@ -39,6 +39,10 @@
             idFirstTr: "#firstTr"
         },
 
+        /**
+         * Init compare list
+         * @private
+         */
         _create: function ()
         {
 
@@ -60,6 +64,9 @@
 
         /**
          * align first columns rows with data columns
+         *
+         * @param sBrowser
+         * @param {Number} iColumnCount
          */
         alignRows: function ( sBrowser, iColumnCount )
         {
@@ -92,9 +99,9 @@
         },
 
         /**
-         * get colummns rows hight
+         * Get column row height
          *
-         * @return integer
+         * @returns {Number}
          */
         getColumnHeight: function ( sBrowser, oColumn )
         {
@@ -113,9 +120,9 @@
         },
 
         /**
-         * set colummns rows hight
+         * Set column row height
          *
-         * @return object
+         * @returns {jQuery}
          */
         setColumnHeight: function ( oColumn, iHeight )
         {
@@ -123,9 +130,9 @@
         },
 
         /**
-         * get colummns
+         * Get Columns
          *
-         * @return object
+         * @returns {jQuery}
          */
         getOtherColumn: function ( iColumnCount, iNumberOfRow )
         {
@@ -133,13 +140,12 @@
         },
 
         /**
-         * get browser
+         * Get Browser
          *
-         * @return object
+         * @returns {String} - The browser
          */
         getBrowser: function ()
         {
-
             var __this = this,
                 sBrowser = this.options.browsers.mozilla;
 
@@ -156,9 +162,9 @@
         },
 
         /**
-         * get column Count
+         * Get column Count
          *
-         * @return object
+         * @returns {Number}
          */
         getColumnCount: function ()
         {

--- a/source/out/azure/src/js/widgets/oxcomparelinks.js
+++ b/source/out/azure/src/js/widgets/oxcomparelinks.js
@@ -23,15 +23,12 @@
     /**
      * Beta note handler
      */
-    oxCompareLinks = {
+    var oxCompareLinks = {
 
         /**
          * Update compare links, hide add link and show remove link.
          *
-         * @param id
-         * @param state 1=hide add, 0=hide remove
-         *
-         * @return void
+         * @param {jQuery} list
          */
         updateLinks: function(list)
         {

--- a/source/out/azure/src/js/widgets/oxcookienote.js
+++ b/source/out/azure/src/js/widgets/oxcookienote.js
@@ -23,14 +23,15 @@
     /**
      * Cookie note handler
      */
-    oxCookieNote = {
+    var oxCookieNote = {
         options: {
             closeButton : ".dismiss"
         },
         /**
          * Enable cookie note dismiss
          *
-         * @return false
+         * @returns {boolean} false
+         * @private
          */
         _create: function() {
             var self = this;

--- a/source/out/azure/src/js/widgets/oxcountrystateselect.js
+++ b/source/out/azure/src/js/widgets/oxcountrystateselect.js
@@ -20,7 +20,7 @@
  */
 ( function( $ ) {
 
-   oxCountryStateSelect = {
+    var oxCountryStateSelect = {
         options: {
             listItem        : "li",
             select          : "select",
@@ -28,6 +28,10 @@
             selectedStateId : "selectedStateId"
         },
 
+       /**
+        * Init country state select
+        * @private
+        */
         _create: function() {
             var self = this,
             options = self.options,
@@ -51,7 +55,11 @@
         /**
          * show / hide select add/remove options
          *
-         * @return object
+         * @param oSelect
+         * @param aStates
+         * @param aStatesValues
+         * @param selectedStateId
+         * @returns object
          */
         manageStateSelect: function(oSelect, aStates, aStatesValues, selectedStateId)
         {
@@ -73,28 +81,34 @@
         /**
          * get state select
          *
-         * @return object
+         * @param {HTMLElement} oCountrySelect
+         * @returns {jQuery}
          */
         getStateSelect: function(oCountrySelect)
         {
-            oOptions = this.options;
-            return     $( oCountrySelect ).parent(oOptions.listItem).next(oOptions.listItem).children(oOptions.span).children(oOptions.select);
+            var oOptions = this.options;
+            return $( oCountrySelect ).parent(oOptions.listItem)
+                .next(oOptions.listItem).children(oOptions.span).children(oOptions.select);
         },
 
         /**
          * get state select span
          *
-         * @return object
+         * @param {HTMLElement} oStateSelect
+         * @returns {jQuery}
          */
         getStateSelectSpan: function(oStateSelect)
         {
-            oOptions = this.options;
-            return     $( oStateSelect ).parent(oOptions.span);
+            return $( oStateSelect ).parent(this.options.span);
         },
 
         /**
          * add options
          *
+         * @param oSelect
+         * @param aValues
+         * @param aLables
+         * @param selectedStateId
          * @return object
          */
         addSelectOptions: function(oSelect, aValues, aLables, selectedStateId)
@@ -118,7 +132,7 @@
         /**
          * remove all select options except first list promt string
          *
-         * @return object
+         * @returns {jQuery}
          */
         removeSelectOptions: function(oSelect)
         {
@@ -129,7 +143,7 @@
         /**
          * get Country state names
          *
-         * @return array
+         * @returns {Array}
          */
         getStates: function(sCountry, allStates, allCountryIds)
         {
@@ -139,7 +153,7 @@
         /**
          * get Country state ids
          *
-         * @return array
+         * @returns {Array}
          */
         getStatesValues: function(sCountry, allStatesIds, allCountryIds)
         {

--- a/source/out/azure/src/js/widgets/oxdropdown.js
+++ b/source/out/azure/src/js/widgets/oxdropdown.js
@@ -20,7 +20,7 @@
  */
 ( function ( $ ) {
 
-    oxDropDown = {
+    var oxDropDown = {
 
         options: {
             sSubmitActionClass  : 'js-fnSubmit',
@@ -28,7 +28,11 @@
             sDisabledClass      : 'js-disabled'
         },
 
-         _create: function(){
+        /**
+         * Init dropdown
+         * @private
+         */
+        _create: function(){
 
             var self = this,
                 options = self.options;
@@ -64,7 +68,7 @@
         /**
          * execute action after select: do nothing, submit, go link
          *
-         * @return boolean
+         * @returns {boolean}
          */
         action : function(){
 
@@ -86,7 +90,7 @@
         /**
          * set selected value
          *
-         * @return null
+         * @param {jQuery} oSelectLink
          */
         select : function( oSelectLink ) {
             this.selectedValue.val( oSelectLink.attr('data-selection-id') );
@@ -97,8 +101,6 @@
 
         /**
          * toggle oxDropDown
-         *
-         * @return null
          */
         toggleDropDown : function() {
             if ( !this.isDisabled() ) {
@@ -113,8 +115,6 @@
 
         /**
          * show value list
-         *
-         * @return null
          */
         showDropDown : function (){
 
@@ -134,8 +134,6 @@
 
         /**
          * hide values list
-         *
-         * @return null
          */
         hideDropDown : function() {
             this.valueList.hide();
@@ -143,9 +141,7 @@
         },
 
         /**
-         * hide all opend oxDropDown
-         *
-         * @return null
+         * hide all opened oxDropDown
          */
         hideAll : function() {
             $("li.value").remove();
@@ -155,13 +151,13 @@
         /**
          * check is dropdown disabled
          *
-         * @return boolean
+         * @returns {boolean}
          */
         isDisabled : function() {
             return this.head.hasClass( this.options.sDisabledClass );
         }
-    }
+    };
 
-   $.widget("ui.oxDropDown", oxDropDown );
+    $.widget("ui.oxDropDown", oxDropDown );
 
 })( jQuery );

--- a/source/out/azure/src/js/widgets/oxenterpassword.js
+++ b/source/out/azure/src/js/widgets/oxenterpassword.js
@@ -22,11 +22,15 @@
     /**
      * Show password field if email will be changed
      */
-    oxEnterPassword = {
+    var oxEnterPassword = {
         options: {
-            metodEnterPasswd      : "oxValidate_enterPass"
+            methodEnterPasswd : "oxValidate_enterPass"
         },
 
+        /**
+         * Init enter password
+         * @private
+         */
         _create: function()
         {
             var self    = this,
@@ -34,7 +38,7 @@
             el      = self.element;
 
             el.bind ( "keyup", function() {
-                self.showInput( el, el.val() != el.prop( "defaultValue" ), options.metodEnterPasswd );
+                self.showInput( el, el.val() != el.prop( "defaultValue" ), options.methodEnterPasswd );
             });
         },
 
@@ -59,7 +63,7 @@
             }
         }
 
-    }
+    };
 
     $.widget( "ui.oxEnterPassword", oxEnterPassword );
 

--- a/source/out/azure/src/js/widgets/oxequalizer.js
+++ b/source/out/azure/src/js/widgets/oxequalizer.js
@@ -23,19 +23,21 @@
     /**
      * Equalize columns
      */
-    oxEqualizer = {
+    var oxEqualizer = {
 
         /**
          * Gets tallest element value
          *
-         * @return integer
+         * @param group
+         * @param target
+         * @returns {Number} - The tallest height
          */
         equalHeight: function(group, target)
         {
-            var self    = this,
-                newh    = 0,
-                tallest = 0,
-                elementh = 0;
+            var self     = this,
+                newH     = 0,
+                tallest  = 0,
+                elementH = 0;
 
             if ( target ) {
                 if (group.height() < target.height()){
@@ -45,16 +47,16 @@
                 tallest = self.getTallest( group );
             }
 
-            if( tallest ) {
+            if ( tallest ) {
                 group.each(function(){
                     if($(this).hasClass('oxEqualized')) {
                         $(this).css('height','');
                         $(this).removeClass('oxEqualized');
                     }
-                    elementh = $(this).outerHeight();
-                    if (elementh < tallest) {
-                        newh = tallest - (elementh - $(this).height());
-                        $(this).height(newh).addClass('oxEqualized');
+                    elementH = $(this).outerHeight();
+                    if (elementH < tallest) {
+                        newH = tallest - (elementH - $(this).height());
+                        $(this).height(newH).addClass('oxEqualized');
                     }
                 });
             }
@@ -63,7 +65,7 @@
         /**
          * Gets tallest element value
          *
-         * @return integer
+         * @returns {Number} - The tallest height
          */
         getTallest: function(el)
         {

--- a/source/out/azure/src/js/widgets/oxfacebook.js
+++ b/source/out/azure/src/js/widgets/oxfacebook.js
@@ -18,88 +18,95 @@
  * @copyright (C) OXID eSales AG 2003-2015
  * @version   OXID eShop CE
  */
-    /*
-     * Facebook related scripts
+
+/**
+ * Facebook related scripts
+ */
+var oxFacebook = {
+
+    /**
+     * FB widgets/buttons array
      */
-    oxFacebook = {
+    buttons: {
+    },
 
-        /*
-         * FB widgets/buttons array
-         */
-        buttons: {
-        },
+    /**
+     * Enables FB widgets
+     * @param {String} sFbAppId
+     * @param sLocale
+     * @param {String} sLoginUrl
+     * @param {String} sLogoutUrl
+     */
+    showFbWidgets: function ( sFbAppId, sLocale, sLoginUrl, sLogoutUrl ) {
 
-        /*
-         * Enables FB widgets
-         */
-        showFbWidgets: function ( sFbAppId, sLocale, sLoginUrl, sLogoutUrl ) {
+        var self = this;
+        self.key = null;
 
-            var self = this;
-            self.key = null;
-
-            for ( key in this.buttons ) {
-                if ( this.buttons[key].script ) {
-                    self.key = key;
-                    $.getScript( this.buttons[key].script, function () {
-                        $( self.key ).html( unescape( self.buttons[self.key].html ) );
-                    } );
-                } else {
-                    $( key ).html( unescape( this.buttons[key].html ) );
-                }
-            }
-
-            $.cookie( 'fbwidgetson',1, {path: '/'});
-            this.fbInit( sFbAppId, sLocale, sLoginUrl, sLogoutUrl );
-        },
-
-        /*
-         * Initing Facebook API
-         *
-         */
-        fbInit: function ( sFbAppId, sLocale, sLoginUrl, sLogoutUrl ) {
-
-            window.fbAsyncInit = function() {
-
-                FB.init({appId: sFbAppId, status: true, cookie: true, xfbml: true, oauth: true});
-                FB.Event.subscribe('auth.login', function(response) {
-                    // redirecting after successfull login
-                    setTimeout(function(){oxFacebook.redirectPage(sLoginUrl);}, 0);
-
-                    if ( FB.XFBML.Host !== undefined && FB.XFBML.Host.parseDomTree )
-                          setTimeout(function(){FB.XFBML.Host.parseDomTree;}, 0 );
-                });
-
-                FB.Event.subscribe('auth.logout', function(response) {
-                    // redirecting after logout
-                    setTimeout(function(){oxFacebook.redirectPage(sLogoutUrl);}, 0);
-                });
-            };
-
-            // loading FB script file
-            var e   = document.createElement('script');
-            e.type  = 'text/javascript';
-            e.async = true;
-            e.src   = document.location.protocol + '//connect.facebook.net/' + sLocale + '/all.js';
-            $('#fb-root').append(e);
-        },
-
-        /*
-         * Redicrecting page to given url
-         */
-        redirectPage: function ( sUrl ) {
-
-           sUrl = sUrl.toString().replace(/&amp;/g,"&");
-           document.location.href = sUrl;
-        },
-
-        /*
-         * Add scripts from tpl
-         */
-        initDetailsPagePartial : function () {
-            if (window.fbAsyncInit) {
-                window.fbAsyncInit();
+        for ( var key in this.buttons ) {
+            if ( this.buttons[key].script ) {
+                self.key = key;
+                $.getScript( this.buttons[key].script, function () {
+                    $( self.key ).html( unescape( self.buttons[self.key].html ) );
+                } );
+            } else {
+                $( key ).html( unescape( this.buttons[key].html ) );
             }
         }
 
-    };
+        $.cookie( 'fbwidgetson',1, {path: '/'});
+        this.fbInit( sFbAppId, sLocale, sLoginUrl, sLogoutUrl );
+    },
+
+    /**
+     * Init Facebook API
+     * @param {String} sFbAppId
+     * @param sLocale
+     * @param {String} sLoginUrl
+     * @param {String} sLogoutUrl
+     */
+    fbInit: function ( sFbAppId, sLocale, sLoginUrl, sLogoutUrl ) {
+
+        window.fbAsyncInit = function() {
+
+            FB.init({appId: sFbAppId, status: true, cookie: true, xfbml: true, oauth: true});
+            FB.Event.subscribe('auth.login', function(response) {
+                // redirecting after successful login
+                setTimeout(function(){oxFacebook.redirectPage(sLoginUrl);}, 0);
+
+                if ( FB.XFBML.Host !== undefined && FB.XFBML.Host.parseDomTree )
+                      setTimeout(function(){FB.XFBML.Host.parseDomTree;}, 0 );
+            });
+
+            FB.Event.subscribe('auth.logout', function(response) {
+                // redirecting after logout
+                setTimeout(function(){oxFacebook.redirectPage(sLogoutUrl);}, 0);
+            });
+        };
+
+        // loading FB script file
+        var e   = document.createElement('script');
+        e.type  = 'text/javascript';
+        e.async = true;
+        e.src   = document.location.protocol + '//connect.facebook.net/' + sLocale + '/all.js';
+        $('#fb-root').append(e);
+    },
+
+    /**
+     * Redirecting page to given url
+     */
+    redirectPage: function ( sUrl ) {
+       sUrl = sUrl.toString().replace(/&amp;/g,"&");
+       document.location.href = sUrl;
+    },
+
+    /**
+     * Add scripts from tpl
+     */
+    initDetailsPagePartial : function () {
+        if (window.fbAsyncInit) {
+            window.fbAsyncInit();
+        }
+    }
+
+};
 

--- a/source/out/azure/src/js/widgets/oxflyoutbox.js
+++ b/source/out/azure/src/js/widgets/oxflyoutbox.js
@@ -20,15 +20,16 @@
  */
 ( function( $ ) {
 
-    oxFlyOutBox = {
+    var oxFlyOutBox = {
 
+        /**
+         * Init fly out box
+         * @private
+         */
         _create: function(){
-
             var self = this,
                 options = self.options,
                 el      = self.element;
-
-
 
             $(document).click( function( e ){
                 if( $(e.target).parents("div").hasClass("topPopList") ){
@@ -50,7 +51,7 @@
             });
 
         }
-    }
+    };
 
     $.widget( "ui.oxFlyOutBox", oxFlyOutBox );
 

--- a/source/out/azure/src/js/widgets/oxinfopopup.js
+++ b/source/out/azure/src/js/widgets/oxinfopopup.js
@@ -20,46 +20,51 @@
  */
 ( function( $ ) {
 
-    oxInfoPopup = {
-            options: {
-                width         : 300,
-                resizable     : true,
-                zIndex         : 10000,
-                target         : '#popup'
-            },
+    var oxInfoPopup = {
+        options: {
+            width     : 300,
+            resizable : true,
+            zIndex    : 10000,
+            target    : '#popup'
+        },
 
-            _create: function() {
+        /**
+         * Init info popup
+         * @private
+         */
+        _create: function() {
+            var self = this,
+            options  = self.options,
+            el       = self.element;
 
-                var self = this,
-                options = self.options,
-                el      = self.element;
+            var position = el.position();
 
-                var position = el.position();
+            el.click(function(){
+                self.openDialog(options.target, options, position);
 
-                el.click(function(){
+                return false;
+            });
+        },
 
-                    self.openDialog(options.target, options, position);
-
-                    return false;
-                });
-            },
-
-             openDialog: function (target, options, position) {
-
-                $(target).dialog({
-
-                        width         : options.width,
-                        modal         : false,
-                        resizable     : options.resizable,
-                        zIndex         : options.zIndex,
-                        position     : [position.left + 30, position.top - 30],
-
-                        open: function(event, ui) {
-
-                        $('div.ui-dialog-titlebar').css("visibility", "hidden");
-                    }
-                });
-             }
+        /**
+         * Opens the info popup
+         *
+         * @param {String} target - jQuery Selector
+         * @param {Object} options
+         * @param {Object} position
+         */
+        openDialog: function (target, options, position) {
+            $(target).dialog({
+                width     : options.width,
+                modal     : false,
+                resizable : options.resizable,
+                zIndex    : options.zIndex,
+                position  : [position.left + 30, position.top - 30],
+                open: function(event, ui) {
+                    $('div.ui-dialog-titlebar').css("visibility", "hidden");
+                }
+            });
+        }
     };
 
     $.widget("ui.oxInfoPopup", oxInfoPopup );

--- a/source/out/azure/src/js/widgets/oxinnerlabel.js
+++ b/source/out/azure/src/js/widgets/oxinnerlabel.js
@@ -20,15 +20,18 @@
  */
 ( function( $ ) {
 
-    oxInnerLabel = {
+    var oxInnerLabel = {
 
         options: {
                 sDefaultValue  : 'innerLabel',
                 sReloadElement : ''
         },
 
+        /**
+         * Init inner label
+         * @private
+         */
         _create: function(){
-
             var self = this,
                 options = self.options,
                 input = self.element,
@@ -58,13 +61,19 @@
             $(options.sReloadElement).click(function() {
                 setTimeout(function(){ self._reload( self.element, label ); }, 100);
             });
-       },
-       
-       _reload : function( input, label ){
-           var pos = input.position();
-           label.css( { "left": (pos.left) + "px", "top":(pos.top) + "px" } );
-       }
-    }
+        },
+
+        /**
+         * Refresh the position
+         * @param {jQuery} input
+         * @param {jQuery} label
+         * @private
+         */
+        _reload : function( input, label ){
+            var pos = input.position();
+            label.css( { "left": (pos.left) + "px", "top":(pos.top) + "px" } );
+        }
+    };
 
     $.widget( "ui.oxInnerLabel", oxInnerLabel );
 

--- a/source/out/azure/src/js/widgets/oxinputvalidator.js
+++ b/source/out/azure/src/js/widgets/oxinputvalidator.js
@@ -20,361 +20,362 @@
  */
 ( function( $ ) {
 
-    oxInputValidator = {
-            options: {
-                classValid                 : "oxValid",
-                classInValid               : "oxInValid",
-                errorParagraph              : "p.oxValidateError",
-                errorMessageNotEmpty       : "js-oxError_notEmpty",
-                errorMessageNotEmail       : "js-oxError_email",
-                errorMessageShort          : "js-oxError_length",
-                errorMessageNotEqual       : "js-oxError_match",
-                errorMessageIncorrectDate  : "js-oxError_incorrectDate",
-                methodValidate              : "js-oxValidate",
-                methodValidateEmail         : "js-oxValidate_email",
-                methodValidateNotEmpty      : "js-oxValidate_notEmpty",
-                methodValidateLength        : "js-oxValidate_length",
-                methodValidateMatch         : "js-oxValidate_match",
-                methodValidateDate          : "js-oxValidate_date",
-                idPasswordLength           : "#passwordLength",
-                listItem                   : "li",
-                list                       : "ul",
-                paragraph                   : "p",
-                span                       : "span",
-                form                       : "form",
-                visible                    : ":visible"
-            },
+    var oxInputValidator = {
+        options: {
+            classValid                 : "oxValid",
+            classInValid               : "oxInValid",
+            errorParagraph             : "p.oxValidateError",
+            errorMessageNotEmpty       : "js-oxError_notEmpty",
+            errorMessageNotEmail       : "js-oxError_email",
+            errorMessageShort          : "js-oxError_length",
+            errorMessageNotEqual       : "js-oxError_match",
+            errorMessageIncorrectDate  : "js-oxError_incorrectDate",
+            methodValidate             : "js-oxValidate",
+            methodValidateEmail        : "js-oxValidate_email",
+            methodValidateNotEmpty     : "js-oxValidate_notEmpty",
+            methodValidateLength       : "js-oxValidate_length",
+            methodValidateMatch        : "js-oxValidate_match",
+            methodValidateDate         : "js-oxValidate_date",
+            idPasswordLength           : "#passwordLength",
+            listItem                   : "li",
+            list                       : "ul",
+            paragraph                  : "p",
+            span                       : "span",
+            form                       : "form",
+            visible                    : ":visible"
+        },
 
-            _create: function() {
+        /**
+         * Init input validator
+         * @private
+         */
+        _create: function() {
 
-                var self    = this,
-                    options = self.options,
-                    el      = self.element;
+            var self    = this,
+                options = self.options,
+                el      = self.element;
 
-                el.delegate("."+options.methodValidate, "blur", function() {
-                    var oTrigger = this;
-                    // the element who caused the event
-                    // adding a timeout to delay the callback from modifying the form
-                    // this allows other events like CLICK to be called before the blur event
-                    // this happens only on some browsers where blur has higher priority than click
-                    setTimeout(function(){
-                        if ( $( oTrigger ).is(options.visible) ) {
-                            var oFieldSet = self.getFieldSet( oTrigger );
-                            if ( oFieldSet.children( '.'+options.methodValidateDate ).length >= 0  ) {
-                                var blIsValid = self.isFieldSetValid( oFieldSet, true );
-                                self.hideErrorMessage( oFieldSet );
-                                if ( blIsValid != true ) {
-                                    self.showErrorMessage( oFieldSet, blIsValid );
-                                }
-                            }
-                        }
-                    }, 50);
-                });
-
-                el.bind( "submit", function() {
-                    return self.submitValidation(this);
-                });
-            },
-
-            /**
-             * Validate form element, return forms true - valid, false - not valid
-             *
-             * @return boolean
-             */
-            inputValidation: function( oInput, blCanSetDefaultState )
-            {
-                var oOptions = this.options;
-                var self = this;
-                var blValidInput = true;
-
-                    if ( $( oInput ).hasClass( oOptions.methodValidateNotEmpty ) && blValidInput ) {
-                        if (! $.trim( $( oInput ).val()) ){
-                            return oOptions.errorMessageNotEmpty;
-                        }
-                    }
-
-                    if ( $( oInput ).hasClass( oOptions.methodValidateEmail ) && blValidInput ) {
-
-                        if( $( oInput ).val()  ) {
-
-                            if ( !self.isEmail( $( oInput ).val() ) ){
-                                return oOptions.errorMessageNotEmail;
+            el.delegate("."+options.methodValidate, "blur", function() {
+                var oTrigger = this;
+                // the element who caused the event
+                // adding a timeout to delay the callback from modifying the form
+                // this allows other events like CLICK to be called before the blur event
+                // this happens only on some browsers where blur has higher priority than click
+                setTimeout(function(){
+                    if ( $( oTrigger ).is(options.visible) ) {
+                        var oFieldSet = self.getFieldSet( oTrigger );
+                        if ( oFieldSet.children( '.'+options.methodValidateDate ).length >= 0  ) {
+                            var blIsValid = self.isFieldSetValid( oFieldSet, true );
+                            self.hideErrorMessage( oFieldSet );
+                            if ( blIsValid != true ) {
+                                self.showErrorMessage( oFieldSet, blIsValid );
                             }
                         }
                     }
-                    if ( $( oInput ).hasClass( oOptions.methodValidateLength ) && blValidInput ) {
+                }, 50);
+            });
 
-                        var iLength = self.getLength( $( oInput ).closest(oOptions.form ));
-                        if( $( oInput ).val() ) {
-                            if ( !self.hasLength( $( oInput ).val(), iLength ) ) {
-                                return  oOptions.errorMessageShort;
-                            }
+            el.bind( "submit", function() {
+                return self.submitValidation(this);
+            });
+        },
+
+        /**
+         * Validate form element, return forms true - valid, false - not valid
+         *
+         * @param {jQuery} oInput - The input to validate
+         * @param {boolean} blCanSetDefaultState
+         * @returns {boolean|String} - true if valid, returns an error message if invalid
+         */
+        inputValidation: function( oInput, blCanSetDefaultState )
+        {
+            var oOptions = this.options;
+            var self = this;
+            var blValidInput = true;
+
+                if ( $( oInput ).hasClass( oOptions.methodValidateNotEmpty ) && blValidInput ) {
+                    if (! $.trim( $( oInput ).val()) ){
+                        return oOptions.errorMessageNotEmpty;
+                    }
+                }
+
+                if ( $( oInput ).hasClass( oOptions.methodValidateEmail ) && blValidInput ) {
+
+                    if( $( oInput ).val()  ) {
+
+                        if ( !self.isEmail( $( oInput ).val() ) ){
+                            return oOptions.errorMessageNotEmail;
                         }
                     }
+                }
+                if ( $( oInput ).hasClass( oOptions.methodValidateLength ) && blValidInput ) {
 
-                    if ( $( oInput ).hasClass( oOptions.methodValidateMatch ) && blValidInput ) {
-
-                        var inputs = new Array();
-
-                        var oForm = $( oInput ).closest(oOptions.form);
-
-                        $( "." + oOptions.methodValidateMatch, oForm).each( function(index) {
-                            inputs[index] = this;
-                        });
-
-                        if( $(inputs[0]).val() && $(inputs[1]).val() ) {
-
-                            if( !self.isEqual($(inputs[0]).val(), $(inputs[1]).val()) ) {
-                                return oOptions.errorMessageNotEqual;
-                            }
+                    var iLength = self.getLength( $( oInput ).closest(oOptions.form ));
+                    if( $( oInput ).val() ) {
+                        if ( !self.hasLength( $( oInput ).val(), iLength ) ) {
+                            return oOptions.errorMessageShort;
                         }
                     }
+                }
 
-                    if ( $( oInput ).hasClass( oOptions.methodValidateDate ) ) {
-                        oDay   = $( oInput ).parent().children( '.oxDay' );
-                        oMonth = $( oInput ).parent().children( '.oxMonth' );
-                        oYear  = $( oInput ).parent().children( '.oxYear' );
-                        
-                        if ( !( oDay.val() && oMonth.val() && oYear.val() ) && !( !oDay.val() && !oMonth.val() && !oYear.val() ) ) {
-                            return oOptions.errorMessageNotEmpty;
-                        } else if ( oDay.val() && oMonth.val() && oYear.val() ) {
-                            RE = /^\d+$/;
-                            blDayOnlyDigits  = RE.test( oDay.val() );
-                            blYearOnlyDigits = RE.test( oYear.val() );
-                            if ( !blDayOnlyDigits || !blYearOnlyDigits ) {
+                if ( $( oInput ).hasClass( oOptions.methodValidateMatch ) && blValidInput ) {
+
+                    var inputs = [];
+                    var oForm = $( oInput ).closest(oOptions.form);
+
+                    $( "." + oOptions.methodValidateMatch, oForm).each( function(index) {
+                        inputs[index] = this;
+                    });
+
+                    if( $(inputs[0]).val() && $(inputs[1]).val() ) {
+
+                        if( !self.isEqual($(inputs[0]).val(), $(inputs[1]).val()) ) {
+                            return oOptions.errorMessageNotEqual;
+                        }
+                    }
+                }
+
+                if ( $( oInput ).hasClass( oOptions.methodValidateDate ) ) {
+                    var oParent = $( oInput ).parent();
+                    var oDay    = oParent.children( '.oxDay' );
+                    var oMonth  = oParent.children( '.oxMonth' );
+                    var oYear   = oParent.children( '.oxYear' );
+
+                    if ( !( oDay.val() && oMonth.val() && oYear.val() ) && !( !oDay.val() && !oMonth.val() && !oYear.val() ) ) {
+                        return oOptions.errorMessageNotEmpty;
+                    } else if ( oDay.val() && oMonth.val() && oYear.val() ) {
+                        var RE = /^\d+$/;
+                        var blDayOnlyDigits  = RE.test( oDay.val() );
+                        var blYearOnlyDigits = RE.test( oYear.val() );
+                        if ( !blDayOnlyDigits || !blYearOnlyDigits ) {
+                            return oOptions.errorMessageIncorrectDate;
+                        } else {
+                            var iMonthDays = new Date((new Date(oYear.val(), oMonth.val(), 1))-1).getDate();
+
+                            if ( oDay.val() <= 0 || oYear.val() <= 0 || oDay.val() > iMonthDays ) {
                                 return oOptions.errorMessageIncorrectDate;
-                            } else {
-                                iMonthDays = new Date((new Date(oYear.val(), oMonth.val(), 1))-1).getDate();
-                                
-                                if ( oDay.val() <= 0 || oYear.val() <= 0 || oDay.val() > iMonthDays ) {
-                                    return oOptions.errorMessageIncorrectDate;
-                                }
                             }
                         }
                     }
+                }
 
-                    if ( $( oInput ).hasClass( oOptions.methodValidate ) && blCanSetDefaultState) {
+                if ( $( oInput ).hasClass( oOptions.methodValidate ) && blCanSetDefaultState) {
 
-                        if( !$( oInput ).val()){
-                            self.setDefaultState( oInput );
-                            return true;
+                    if( !$( oInput ).val()){
+                        self.setDefaultState( oInput );
+                        return true;
+                    }
+                }
+
+            return blValidInput;
+        },
+
+        /**
+         * On submit validate required form elements,
+         * return true - if all filled correctly, false - if not
+         *
+         * @param {jQuery} oForm
+         * @returns {boolean}
+         */
+        submitValidation: function( oForm )
+        {
+            var blValid = true;
+            var oFirstNotValidElement = null;
+            var self = this;
+            var oOptions = this.options;
+
+            $( "." + oOptions.methodValidate, oForm).each(    function(index) {
+
+                if ( $( this ).is(oOptions.visible) ) {
+
+                    var oFieldSet = self.getFieldSet(this);
+                    self.hideErrorMessage( oFieldSet );
+                    var blIsValid = self.isFieldSetValid( oFieldSet, false );
+                    if ( blIsValid != true ){
+                        self.showErrorMessage( oFieldSet, blIsValid );
+                        blValid = false;
+                        if( oFirstNotValidElement == null ) {
+                            oFirstNotValidElement = this;
                         }
                     }
-
-                return blValidInput;
-            },
-
-            /**
-             * On submit validate required form elements,
-             * return true - if all filled correctly, false - if not
-             *
-             * @return boolean
-             */
-            submitValidation: function( oForm )
-            {
-                var blValid = true;
-                var oFirstNotValidElement = null;
-                var self = this;
-                var oOptions = this.options;
-
-                $( "." + oOptions.methodValidate, oForm).each(    function(index) {
-
-                    if ( $( this ).is(oOptions.visible) ) {
-
-                        var oFieldSet = self.getFieldSet(this);
-                        self.hideErrorMessage( oFieldSet );
-                        var blIsValid = self.isFieldSetValid( oFieldSet, false );
-                        if ( blIsValid != true ){
-                            self.showErrorMessage( oFieldSet, blIsValid );
-                            blValid = false;
-                            if( oFirstNotValidElement == null ) {
-                                oFirstNotValidElement = this;
-                            }
-                        }
-                    }
-                });
-
-                if( oFirstNotValidElement != null ) {
-                    $( oFirstNotValidElement ).focus();
                 }
+            });
 
-                return blValid;
-            },
-
-            isFieldSetValid: function ( oFieldSet, blCanSetDefaultState ) {
-
-                var blIsValid = true;
-                var self = this;
-                var oOptions = this.options;
-                $("." + oOptions.methodValidate + ":not(:focus)", oFieldSet).each( function(index) {
-
-                    if ( $( this ).is(oOptions.visible) ) {
-                        var tmpblIsValid = self.inputValidation( this, blCanSetDefaultState );
-
-                        if( tmpblIsValid != true){
-                            blIsValid = tmpblIsValid;
-                        }
-                    }
-                });
-
-                return blIsValid;
-            },
-
-            /**
-             * returns li element
-             *
-             *
-             * @return object
-             */
-            getFieldSet: function( oField ){
-
-               var oFieldSet =  $( oField ).parent();
-
-               return oFieldSet;
-            },
-
-            /**
-             * Show error messages
-             *
-             * @return object
-             */
-            showErrorMessage: function ( oObject, messageType )
-            {
-                oObject.removeClass(this.options.classValid);
-                oObject.addClass(this.options.classInValid);
-                oObject.children(this.options.errorParagraph).children( this.options.span + "." + messageType ).show();
-                oObject.children(this.options.errorParagraph).show();
-
-                return oObject;
-            },
-
-            /**
-             * Hide error messages
-             *
-             * @return object
-             */
-            hideErrorMessage: function ( oObject )
-            {
-                this.hideMatchMessages( oObject );
-
-                oObject.removeClass(this.options.classInValid);
-                oObject.addClass(this.options.classValid);
-                oObject.children(this.options.errorParagraph).children( this.options.span ).hide();
-                oObject.children(this.options.errorParagraph).hide();
-
-                return oObject;
-            },
-
-            /**
-             * has match error messages
-             *
-             * @return boolean
-             */
-            hasOpenMatchMessage: function ( oObject )
-            {
-                return $( '.'+this.options.errorMessageNotEqual, oObject ).is( this.options.visible )
-            },
-
-            /**
-             * Hide match error messages
-             *
-             * @return object
-             */
-            hideMatchMessages: function ( oObject )
-            {
-                if ( this.hasOpenMatchMessage( oObject.next(this.options.listItem) ) ){
-                    this.hideErrorMessage( oObject.next(this.options.listItem) );
-                }
-
-                if ( this.hasOpenMatchMessage( oObject.prev(this.options.listItem) ) ){
-                    this.hideErrorMessage( oObject.prev(this.options.listItem) );
-                }
-            },
-
-            /**
-             * Set default look of form list element
-             *
-             * @return object
-             */
-            setDefaultState: function ( oObject )
-            {
-                var oObject = $( oObject ).parent();
-
-                oObject.removeClass(this.options.classInValid);
-                oObject.removeClass(this.options.classValid);
-                oObject.children(this.options.errorParagraph).hide();
-
-                oOptions = this.options;
-
-                $( this.options.span, oObject.children( this.options.errorParagraph ) ).each( function(index) {
-                    oObject.children( oOptions.errorParagraph ).children( oOptions.span ).hide();
-                });
-
-                return oObject;
-            },
-
-            /**
-             * gets required length from form
-             *
-             * @return boolean
-             */
-            getLength: function(oObject){
-
-                oOptions = this.options;
-
-                return $( oOptions.idPasswordLength , oObject).val();
-            },
-            /**
-             * Checks length
-             *
-             * @return boolean
-             */
-            hasLength: function( stValue, length )
-            {
-                stValue = jQuery.trim( stValue );
-
-                if( stValue.length >= length ) {
-                    return true;
-                }
-
-                return false;
-            },
-
-            /**
-             * Checks mails validation
-             *
-             * @return boolean
-             */
-            isEmail: function( email )
-            {
-                email = jQuery.trim(email);
-
-                var reg = /^(.+?)\@(.+)\.(.+)$/;
-
-                if(reg.test(email) == false) {
-                    return false;
-                }
-
-                return true;
-            },
-
-            /**
-             * Checks is string equal
-             *
-             * @return boolean
-             */
-            isEqual: function( stValue1, stValue2 )
-            {
-                stValue1 = jQuery.trim(stValue1);
-                stValue2 = jQuery.trim(stValue2);
-
-                if (stValue1 == stValue2){
-                    return true;
-                }
-
-                return false;
+            if( oFirstNotValidElement != null ) {
+                $( oFirstNotValidElement ).focus();
             }
-        };
+
+            return blValid;
+        },
+
+
+        /**
+         * Validates a field
+         *
+         * @param {jQuery} oFieldSet
+         * @param {boolean} blCanSetDefaultState
+         * @returns {boolean}
+         */
+        isFieldSetValid: function ( oFieldSet, blCanSetDefaultState ) {
+
+            var blIsValid = true;
+            var self = this;
+            var oOptions = this.options;
+            $("." + oOptions.methodValidate + ":not(:focus)", oFieldSet).each( function(index) {
+
+                if ( $( this ).is(oOptions.visible) ) {
+                    var tmpblIsValid = self.inputValidation( this, blCanSetDefaultState );
+
+                    if( tmpblIsValid != true){
+                        blIsValid = tmpblIsValid;
+                    }
+                }
+            });
+
+            return blIsValid;
+        },
+
+        /**
+         * returns li element
+         *
+         * @param {jQuery} oField
+         * @returns {jQuery}
+         */
+        getFieldSet: function( oField ){
+           return $(oField).parent();
+        },
+
+        /**
+         * Show error messages
+         *
+         * @param {jQuery} oObject
+         * @param {String} messageType
+         * @returns {jQuery}
+         */
+        showErrorMessage: function ( oObject, messageType )
+        {
+            oObject.removeClass(this.options.classValid);
+            oObject.addClass(this.options.classInValid);
+            oObject.children(this.options.errorParagraph).children( this.options.span + "." + messageType ).show();
+            oObject.children(this.options.errorParagraph).show();
+
+            return oObject;
+        },
+
+        /**
+         * Hide error messages
+         *
+         * @param {jQuery} oObject
+         * @returns {jQuery}
+         */
+        hideErrorMessage: function ( oObject )
+        {
+            this.hideMatchMessages( oObject );
+
+            oObject.removeClass(this.options.classInValid);
+            oObject.addClass(this.options.classValid);
+            oObject.children(this.options.errorParagraph).children( this.options.span ).hide();
+            oObject.children(this.options.errorParagraph).hide();
+
+            return oObject;
+        },
+
+        /**
+         * has match error messages
+         *
+         * @returns {boolean}
+         */
+        hasOpenMatchMessage: function ( oObject )
+        {
+            return $( '.'+this.options.errorMessageNotEqual, oObject ).is( this.options.visible )
+        },
+
+        /**
+         * Hide match error messages
+         *
+         * @param {jQuery} oObject
+         */
+        hideMatchMessages: function ( oObject )
+        {
+            if ( this.hasOpenMatchMessage( oObject.next(this.options.listItem) ) ){
+                this.hideErrorMessage( oObject.next(this.options.listItem) );
+            }
+
+            if ( this.hasOpenMatchMessage( oObject.prev(this.options.listItem) ) ){
+                this.hideErrorMessage( oObject.prev(this.options.listItem) );
+            }
+        },
+
+        /**
+         * Set default look of form list element
+         *
+         * @param {jQuery} oObject
+         * @returns {jQuery}
+         */
+        setDefaultState: function ( oObject )
+        {
+            oObject = $( oObject ).parent();
+
+            oObject.removeClass(this.options.classInValid);
+            oObject.removeClass(this.options.classValid);
+            oObject.children(this.options.errorParagraph).hide();
+
+            var oOptions = this.options;
+
+            $( this.options.span, oObject.children( this.options.errorParagraph ) ).each( function(index) {
+                oObject.children( oOptions.errorParagraph ).children( oOptions.span ).hide();
+            });
+
+            return oObject;
+        },
+
+        /**
+         * gets required length from form
+         *
+         * @return boolean
+         */
+        getLength: function(oObject){
+            return $( this.options.idPasswordLength , oObject).val();
+        },
+
+        /**
+         * Checks length
+         *
+         * @return boolean
+         */
+        hasLength: function( stValue, length )
+        {
+            stValue = jQuery.trim( stValue );
+
+            return stValue.length >= length;
+        },
+
+        /**
+         * Checks mails validation
+         *
+         * @return boolean
+         */
+        isEmail: function( email )
+        {
+            email = jQuery.trim(email);
+            var reg = /^(.+?)\@(.+)\.(.+)$/;
+
+            return reg.test(email) != false;
+        },
+
+        /**
+         * Checks is string equal
+         *
+         * @return boolean
+         */
+        isEqual: function( stValue1, stValue2 )
+        {
+            stValue1 = jQuery.trim(stValue1);
+            stValue2 = jQuery.trim(stValue2);
+
+            return stValue1 == stValue2;
+        }
+    };
 
     /**
      * Form Items validator

--- a/source/out/azure/src/js/widgets/oxlistremovebutton.js
+++ b/source/out/azure/src/js/widgets/oxlistremovebutton.js
@@ -20,8 +20,12 @@
  */
 ( function( $ ) {
 
-    oxListRemoveButton = {
+    var oxListRemoveButton = {
 
+        /**
+         * Init list remove button
+         * @private
+         */
         _create: function(){
 
             var self = this;
@@ -34,7 +38,7 @@
             });
 
         }
-    }
+    };
 
     $.widget( "ui.oxListRemoveButton", oxListRemoveButton );
 

--- a/source/out/azure/src/js/widgets/oxloginbox.js
+++ b/source/out/azure/src/js/widgets/oxloginbox.js
@@ -20,8 +20,12 @@
  */
 ( function( $ ) {
 
-    oxLoginBox = {
+    var oxLoginBox = {
 
+        /**
+         * Init Login Box
+         * @private
+         */
         _create: function(){
 
             var self = this,
@@ -49,7 +53,7 @@
                }
             });
         }
-    }
+    };
 
     $.widget( "ui.oxLoginBox", oxLoginBox );
 

--- a/source/out/azure/src/js/widgets/oxmanufacturerslider.js
+++ b/source/out/azure/src/js/widgets/oxmanufacturerslider.js
@@ -20,25 +20,28 @@
  */
 ( function( $ ) {
 
-    oxManufacturerSlider = {
-            options: {
-                classButtonNext    : '.nextItem',
-                classButtonPrev    : '.prevItem'
-            },
+    var oxManufacturerSlider = {
+        options: {
+            classButtonNext : '.nextItem',
+            classButtonPrev : '.prevItem'
+        },
 
-            _create: function() {
+        /**
+         * Init Manufacturer Slider
+         * @private
+         */
+        _create: function() {
+            var self = this,
+            options  = self.options,
+            el       = self.element;
 
-                var self = this,
-                options = self.options,
-                el         = self.element;
-
-                 el.jCarouselLite({
-                     btnNext: options.classButtonNext,
-                     btnPrev: options.classButtonPrev,
-                   visible: 6,
-                   scroll: 1
-                });
-            }
+            el.jCarouselLite({
+               btnNext: options.classButtonNext,
+               btnPrev: options.classButtonPrev,
+               visible: 6,
+               scroll: 1
+            });
+        }
     };
 
     $.widget("ui.oxManufacturerSlider", oxManufacturerSlider );

--- a/source/out/azure/src/js/widgets/oxminibasket.js
+++ b/source/out/azure/src/js/widgets/oxminibasket.js
@@ -22,8 +22,11 @@
 
     var oxMiniBasket = {
 
+        /**
+         * Init Mini Basket
+         * @private
+         */
         _create: function(){
-
             var self = this,
                 options = self.options,
                 el      = self.element;
@@ -62,22 +65,27 @@
              });
 
             // show / hide added article message
-            if($("#newItemMsg").length > 0){
-                $("#countValue").hide();
-                $("#newItemMsg").delay(3000).fadeTo("fast", 0, function(){
-                    $("#countValue").fadeTo("fast", 1);
-                    $("#newItemMsg").remove()
+            var newItemMsg = $("#newItemMsg");
+            if(newItemMsg.length > 0){
+                var countVal = $("#countValue");
+
+                countVal.hide();
+                newItemMsg.delay(3000).fadeTo("fast", 0, function(){
+                    countVal.fadeTo("fast", 1);
+                    newItemMsg.remove()
                 });
             }
 
             $("#countdown").countdown(
                 function(count, element, container) {
                     if (count <= 1) {
+
                         //closing and emptying the basket
                         $(element).parents("#basketFlyout").hide();
                         $("#countValue").parent('span').remove();
                         $("#basketFlyout").remove();
-                        $("#miniBasket #minibasketIcon").unbind('mouseenter mouseleave');
+                        $("#minibasketIcon").unbind('mouseenter mouseleave');
+
                         // refresh mini basket widget
                         $( "form.js-oxWidgetReload-miniBasket" ).submit();
                         return container.not(element);
@@ -88,11 +96,15 @@
 
         },
 
+        /**
+         * Show the mini basket
+         */
         showMiniBasket : function(){
             $("#basketFlyout").show();
 
-            if ($(".scrollable .scrollbarBox").length > 0) {
-                $('.scrollable .scrollbarBox').jScrollPane({
+            var box = $(".scrollable .scrollbarBox");
+            if (box.length > 0) {
+                box.jScrollPane({
                     showArrows: true,
                     verticalArrowPositions: 'split'
                 });
@@ -121,7 +133,7 @@
             );
             return false;
         }
-    }
+    };
 
     /**
      * Handles form submit

--- a/source/out/azure/src/js/widgets/oxmodalpopup.js
+++ b/source/out/azure/src/js/widgets/oxmodalpopup.js
@@ -20,28 +20,42 @@
  */
 ( function( $ ) {
 
-     oxModalPopup = {
-            options: {
-                width        : 687,
-                height       : 'auto',
-                modal        : true,
-                resizable    : true,
-                zIndex       : 10000,
-                position     : 'center',
-                draggable    : true,
-                target       : '#popup',
-                openDialog   : false,
-                loadUrl      : false,
-                closeButton  : "img.closePop, button.closePop"
-            },
+    var oxModalPopup = {
+        options: {
+            width        : 687,
+            height       : 'auto',
+            modal        : true,
+            resizable    : true,
+            zIndex       : 10000,
+            position     : 'center',
+            draggable    : true,
+            target       : '#popup',
+            openDialog   : false,
+            loadUrl      : false,
+            closeButton  : "img.closePop, button.closePop"
+        },
 
-            _create: function() {
+        /**
+         * Init Modal Popup
+         * @private
+         */
+        _create: function() {
 
-                var self = this,
-                options = self.options,
-                el      = self.element;
+            var self = this,
+            options = self.options,
+            el      = self.element;
 
-                if (options.openDialog) {
+            if (options.openDialog) {
+
+                if (options.loadUrl){
+                    $(options.target).load(options.loadUrl);
+                }
+
+                self.openDialog(options.target, options);
+
+            } else {
+
+                el.click(function(){
 
                     if (options.loadUrl){
                         $(options.target).load(options.loadUrl);
@@ -49,41 +63,37 @@
 
                     self.openDialog(options.target, options);
 
-                } else {
-
-                    el.click(function(){
-
-                        if (options.loadUrl){
-                            $(options.target).load(options.loadUrl);
-                        }
-
-                        self.openDialog(options.target, options);
-
-                        return false;
-                    });
-                }
-
-                $(self.options.closeButton, $( options.target ) ).click(function(){
-                    $( options.target ).dialog("close");
                     return false;
                 });
-            },
-
-            openDialog: function (target, options) {
-                $(target).dialog({
-                    width     : options.width,
-                    height    : options.height,
-                    modal     : options.modal,
-                    resizable : options.resizable,
-                    zIndex    : options.zIndex,
-                    position  : options.position,
-                    draggable : options.draggable,
-
-                    open: function(event, ui) {
-                        $('div.ui-dialog-titlebar').remove();
-                    }
-                });
             }
+
+            $(self.options.closeButton, $( options.target ) ).click(function(){
+                $( options.target ).dialog("close");
+                return false;
+            });
+        },
+
+        /**
+         * Opens the dialog
+         *
+         * @param {String} target - jQuery selector
+         * @param {Object} options
+         */
+        openDialog: function (target, options) {
+            $(target).dialog({
+                width     : options.width,
+                height    : options.height,
+                modal     : options.modal,
+                resizable : options.resizable,
+                zIndex    : options.zIndex,
+                position  : options.position,
+                draggable : options.draggable,
+
+                open: function(event, ui) {
+                    $('div.ui-dialog-titlebar').remove();
+                }
+            });
+        }
     };
 
     $.widget("ui.oxModalPopup", oxModalPopup );

--- a/source/out/azure/src/js/widgets/oxmorepictures.js
+++ b/source/out/azure/src/js/widgets/oxmorepictures.js
@@ -20,12 +20,16 @@
  */
 ( function( $ ) {
 
-    oxMorePictures = {
+    var oxMorePictures = {
 
         options: {
             iDefaultIndex  : -1
         },
 
+        /**
+         * Init More Pictures
+         * @private
+         */
         _create: function() {
 
             var self    = this,
@@ -41,6 +45,10 @@
             });
         },
 
+        /**
+         * Init More Pictures
+         * @private
+         */
         _init: function() {
             var self    = this,
                 options = self.options,
@@ -51,7 +59,7 @@
                 $("li a:eq("+ options.iDefaultIndex +")", el).trigger("click");
             }
         }
-    }
+    };
 
     $.widget( "ui.oxMorePictures", oxMorePictures );
 

--- a/source/out/azure/src/js/widgets/oxpayment.js
+++ b/source/out/azure/src/js/widgets/oxpayment.js
@@ -19,7 +19,12 @@
  * @version   OXID eShop CE
  */
 ( function( $ ) {
-    oxPayment = {
+    var oxPayment = {
+
+        /**
+         * Init Payment
+         * @private
+         */
         _create: function(){
             var self = this,
                 options = self.options,
@@ -30,7 +35,7 @@
                 $(this).parents("dl").children("dd").toggle();
             });
         }
-    }
+    };
 
     $.widget( "ui.oxPayment", oxPayment );
 

--- a/source/out/azure/src/js/widgets/oxrating.js
+++ b/source/out/azure/src/js/widgets/oxrating.js
@@ -20,7 +20,7 @@
  */
 ( function( $ ) {
 
-    oxRating = {
+    var oxRating = {
         options: {
             reviewButton         : "writeNewReview",
             articleRatingValue   : "productRating",
@@ -33,9 +33,13 @@
             ratingElement        : "a.ox-write-review"
         },
 
+        /**
+         * Init Rating
+         * @private
+         */
         _create: function() {
 
-            var self     = this;
+            var self    = this;
             var options = self.options;
             var el      = self.element;
 
@@ -64,7 +68,9 @@
         /**
          * set rating value on form element
          *
-         * @return object
+         * @param {jQuery} oElement
+         * @param value
+         * @returns {jQuery}
          */
         setRatingValue: function( oElement, value )
         {
@@ -75,7 +81,9 @@
         /**
          * set rating value on stars
          *
-         * @return object
+         * @param {jQuery} oElement
+         * @param value
+         * @returns {jQuery}
          */
         setCurrentRating: function( oElement, value )
         {
@@ -87,7 +95,8 @@
         /**
          * hide review button
          *
-         * @return object
+         * @param {jQuery} oButton
+         * @returns {jQuery}
          */
         hideReviewButton: function( oButton )
         {
@@ -98,7 +107,8 @@
         /**
          * open review form
          *
-         * @return object
+         * @param {jQuery} oForm
+         * @returns {jQuery}
          */
         openReviewForm: function( oForm )
         {

--- a/source/out/azure/src/js/widgets/oxreview.js
+++ b/source/out/azure/src/js/widgets/oxreview.js
@@ -20,14 +20,17 @@
  */
 ( function( $ ) {
 
-    oxReview = {
+    var oxReview = {
         options: {
             reviewButton : "#writeNewReview",
             reviewForm   : "#writeReview"
         },
 
+        /**
+         * Init Review
+         * @private
+         */
         _create: function() {
-
             var self    = this;
             var options = self.options;
             var el      = self.element;
@@ -44,6 +47,5 @@
      * Review widget
      */
     $.widget("ui.oxReview", oxReview );
-
 
 } )( jQuery );

--- a/source/out/azure/src/js/widgets/oxslider.js
+++ b/source/out/azure/src/js/widgets/oxslider.js
@@ -20,232 +20,218 @@
  */
 ( function( $ ) {
 
-    oxSlider = {
-            options: {
-                width                : 940,
-                height               : 220,
-                autoPlay             : true,
-                delay				 : 6700,
-                animationTime 		 : 2700,
-                startStopped		 : false,
-                classPanel           : '.panel',
-                classStartStop       : '.start-stop',
-                classPromotionText   : '.promoBox',
-                classNavigation      : '.thumbNav',
-                classForwardArrow    : '.forward',
-                classBackArrow       	: '.back',
-                classAnythingSlider  	: '.anythingSlider',
-                classThumbNav        	: '.thumbNav',
-                classAnythingControls	: '.anythingControls',
-                elementLi             : 'li',
-                eventMouseover        : "mouseover",
-                eventMouseout        : "mouseout",
-                opacity70            : 0.7,
-                opacity100            : 1,
-                opacity0            : 0
+    var oxSlider = {
+        options: {
+            width                 : 940,
+            height                : 220,
+            autoPlay              : true,
+            delay				  : 6700,
+            animationTime 		  : 2700,
+            startStopped		  : false,
+            classPanel            : '.panel',
+            classStartStop        : '.start-stop',
+            classPromotionText    : '.promoBox',
+            classNavigation       : '.thumbNav',
+            classForwardArrow     : '.forward',
+            classBackArrow        : '.back',
+            classAnythingSlider   : '.anythingSlider',
+            classThumbNav         : '.thumbNav',
+            classAnythingControls : '.anythingControls',
+            elementLi             : 'li',
+            eventMouseover        : "mouseover",
+            eventMouseout         : "mouseout",
+            opacity70             : 0.7,
+            opacity100            : 1,
+            opacity0              : 0
+        },
 
-            },
+        /**
+         * Init Slider
+         * @private
+         */
+        _create: function() {
 
-            _create: function() {
+            var self = this,
+            options  = self.options,
+            el       = self.element;
+            var oAnythingSlider;
 
-                var self = this,
-                options = self.options,
-                el         = self.element;
-                var oAnythingSlider;
+            var aNavigationTabs = self.getNavigationTabsArray(el, options.elementLi);
 
-                var aNavigationTabs = new Array();
+            el.anythingSlider({
+                width               : options.width,
+                height              : options.height,
+                autoPlay            : options.autoPlay,
+                startStopped        : options.startStopped,
+                delay               : options.delay,
+                animationTime       : options.animationTime,
+                navigationFormatter : function(i, panel){
+                    return aNavigationTabs[i - 1];
+                }
+            });
 
-                aNavigationTabs = self.getNavigationTabsArray(el, options.elementLi);
+            oAnythingSlider = $(options.classAnythingSlider);
 
-                el.anythingSlider({
-                        width               : options.width,
-                        height              : options.height,
-                        autoPlay            : options.autoPlay,
-                        startStopped        : options.startStopped,
-                        delay               : options.delay,
-                        animationTime       : options.animationTime,
-                        navigationFormatter : function(i, panel){
-                            return aNavigationTabs[i - 1];
-                        }
-                });
+            $(options.classAnythingControls, oAnythingSlider).css("left", (options.width - $(options.classThumbNav, oAnythingSlider).innerWidth() ) / 2);
 
-                oAnythingSlider = $(options.classAnythingSlider);
+            self.hideControls(oAnythingSlider);
 
-                $(options.classAnythingControls, oAnythingSlider).css("left", (options.width - $(options.classThumbNav, oAnythingSlider).innerWidth() ) / 2);
+            $("a[class^='panel']", oAnythingSlider).attr("rel", 'nofollow');
 
-                self.hideControls(oAnythingSlider);
+            var blOnNav = false;
 
-                $("a[class^='panel']", oAnythingSlider).attr("rel", 'nofollow');
-
-                var blOnNav = false;
-
-                $(options.classPromotionText, el).each(function(){
-                    var targetObj = $(this).children(".promoPrice");
-                    var targetObjHeight = targetObj.nextAll("strong").height();
-                    targetObj.css({
-                        "height" : targetObjHeight,
-                        "line-height" : targetObjHeight + "px"
-                    });
-                });
-
-
-                oAnythingSlider.mouseover( function() {
-                    self.showTextSpan(el, options.classPromotionText);
-                    if ( ! blOnNav ){
-                        self.showControlsWithOpacity(oAnythingSlider, options.opacity70);
-                    }
-
-                });
-
-                $(options.classNavigation, oAnythingSlider).mouseover(function() {
-
-                    self.showControlsWithOpacity(oAnythingSlider, options.opacity70);
-                    self.showControlWithOpacity(oAnythingSlider, options.classNavigation, options.opacity100);
-                      blOnNav = true;
-
-                });
-
-                $(options.classBackArrow, oAnythingSlider).mouseover(function() {
-
-                    self.showControlsWithOpacity(oAnythingSlider, options.opacity70);
-                    self.showControlWithOpacity(oAnythingSlider, options.classBackArrow, options.opacity100);
-                      blOnNav = true;
-
-                });
-
-                $(options.classForwardArrow, oAnythingSlider).mouseover(function() {
-
-                    self.showControlsWithOpacity(oAnythingSlider, options.opacity70);
-                    self.showControlWithOpacity(oAnythingSlider, options.classForwardArrow, options.opacity100);
-                      blOnNav = true;
-
-                });
-
-                oAnythingSlider.mouseout( function() {
-
-                   self.hideTextSpan(el, options.classPromotionText);
-                   self.showControlWithOpacity(oAnythingSlider, options.classNavigation, options.opacity0);
-                   self.hideControls(oAnythingSlider);
-                   blOnNav = false;
-
-                });
-
-            },
-
-            /**
-             * generate slider navigation array
-             *
-             * @return array
-             */
-            getNavigationTabsArray: function(oElement, stElementType){
-
-                var aTabs = new Array();
-
-                $( stElementType, oElement ).each( function( index ) {
-                    aTabs[index] = index + 1;
-                });
-
-                return aTabs;
-            },
-
-            /**
-             * shows controls with opacity (navigation, start-stop button, etc.)
-             *
-             * @return object
-             */
-            showControlsWithOpacity: function(oElement, fOpacity){
-
-                oOptions = this.options;
-
-                this.showControlWithOpacity(oElement, oOptions.classForwardArrow, fOpacity);
-                this.showControlWithOpacity(oElement, oOptions.classBackArrow, fOpacity);
-                this.showControlWithOpacity(oElement, oOptions.classNavigation, fOpacity);
-
-            },
-
-            /**
-             * shows control with opacity (navigation, start-stop button, etc.)
-             *
-             * @return object
-             */
-            showControlWithOpacity: function(oElement, stClass, fOpacity){
-
-                oElement = $(stClass, oElement).fadeTo(0, fOpacity);
-                return oElement;
-
-            },
-
-            /**
-             * Show control (navigation, start-stop button, etc.)
-             *
-             * @return object
-             */
-            showControl: function(oElement, stClass){
-
-                oElement = $(stClass, oElement).show();
-                return oElement;
-
-            },
-
-            /**
-             * hide control (navigation, start-stop button, etc.)
-             *
-             * @return object
-             */
-            hideControl: function(oElement, stClass ){
-
-                oElement = $(stClass, oElement).hide();
-                return oElement;
-
-            },
-
-            /**
-             * hides controla (navigation, start-stop button, etc.)
-             *
-             * @return object
-             */
-            hideControls: function(oElement){
-
-                oOptions = this.options;
-
-                this.hideControl(oElement, oOptions.classStartStop);
-                this.hideControl(oElement, oOptions.classForwardArrow);
-                this.hideControl(oElement, oOptions.classBackArrow);
-                this.hideControl(oElement, oOptions.classNavigation);
-            },
-
-            /**
-             * hides texts spans
-             *
-             * @return object
-             */
-            hideTextSpan: function(oElement, stClass ){
-
-                oElement = $(stClass, oElement).css("visibility", "hidden");
-
-                return oElement;
-            },
-
-            /**
-             * shows texts spans
-             *
-             * @return object
-             */
-            showTextSpan: function(oElement, stClass ){
-
-                oElement = $( stClass, oElement );
-                oElement.css("visibility", "visible");
-
-                /*var targetObj = oElement.children(".promoPrice");
+            $(options.classPromotionText, el).each(function(){
+                var targetObj = $(this).children(".promoPrice");
                 var targetObjHeight = targetObj.nextAll("strong").height();
-
                 targetObj.css({
                     "height" : targetObjHeight,
                     "line-height" : targetObjHeight + "px"
-                });*/
+                });
+            });
 
-                return oElement;
-            }
+            oAnythingSlider.mouseover( function() {
+                self.showTextSpan(el, options.classPromotionText);
+                if ( ! blOnNav ){
+                    self.showControlsWithOpacity(oAnythingSlider, options.opacity70);
+                }
+            });
+
+            $(options.classNavigation, oAnythingSlider).mouseover(function() {
+                self.showControlsWithOpacity(oAnythingSlider, options.opacity70);
+                self.showControlWithOpacity(oAnythingSlider, options.classNavigation, options.opacity100);
+                blOnNav = true;
+            });
+
+            $(options.classBackArrow, oAnythingSlider).mouseover(function() {
+                self.showControlsWithOpacity(oAnythingSlider, options.opacity70);
+                self.showControlWithOpacity(oAnythingSlider, options.classBackArrow, options.opacity100);
+                blOnNav = true;
+            });
+
+            $(options.classForwardArrow, oAnythingSlider).mouseover(function() {
+                self.showControlsWithOpacity(oAnythingSlider, options.opacity70);
+                self.showControlWithOpacity(oAnythingSlider, options.classForwardArrow, options.opacity100);
+                blOnNav = true;
+            });
+
+            oAnythingSlider.mouseout( function() {
+               self.hideTextSpan(el, options.classPromotionText);
+               self.showControlWithOpacity(oAnythingSlider, options.classNavigation, options.opacity0);
+               self.hideControls(oAnythingSlider);
+               blOnNav = false;
+            });
+
+        },
+
+        /**
+         * generate slider navigation array
+         *
+         * @param {jQuery} oElement
+         * @param {String} stElementType
+         * @returns {Array}
+         */
+        getNavigationTabsArray: function(oElement, stElementType){
+            var aTabs = [];
+
+            $( stElementType, oElement ).each( function( index ) {
+                aTabs[index] = index + 1;
+            });
+
+            return aTabs;
+        },
+
+        /**
+         * shows controls with opacity (navigation, start-stop button, etc.)
+         *
+         * @param {jQuery} oElement
+         * @param fOpacity
+         */
+        showControlsWithOpacity: function(oElement, fOpacity){
+            var oOptions = this.options;
+
+            this.showControlWithOpacity(oElement, oOptions.classForwardArrow, fOpacity);
+            this.showControlWithOpacity(oElement, oOptions.classBackArrow, fOpacity);
+            this.showControlWithOpacity(oElement, oOptions.classNavigation, fOpacity);
+        },
+
+        /**
+         * shows control with opacity (navigation, start-stop button, etc.)
+         *
+         * @param {jQuery} oElement
+         * @param {String} stClass
+         * @param fOpacity
+         * @returns {jQuery}
+         */
+        showControlWithOpacity: function(oElement, stClass, fOpacity){
+            oElement = $(stClass, oElement).fadeTo(0, fOpacity);
+            return oElement;
+        },
+
+        /**
+         * Show control (navigation, start-stop button, etc.)
+         *
+         * @param {jQuery} oElement
+         * @param {String} stClass
+         * @returns {jQuery} object
+         */
+        showControl: function(oElement, stClass){
+            oElement = $(stClass, oElement).show();
+            return oElement;
+        },
+
+        /**
+         * hide control (navigation, start-stop button, etc.)
+         *
+         * @param {jQuery} oElement
+         * @param {String} stClass
+         * @returns {jQuery}
+         */
+        hideControl: function(oElement, stClass ){
+
+            oElement = $(stClass, oElement).hide();
+            return oElement;
+
+        },
+
+        /**
+         * hides controls (navigation, start-stop button, etc.)
+         *
+         * @param {jQuery} oElement
+         */
+        hideControls: function(oElement){
+            var oOptions = this.options;
+
+            this.hideControl(oElement, oOptions.classStartStop);
+            this.hideControl(oElement, oOptions.classForwardArrow);
+            this.hideControl(oElement, oOptions.classBackArrow);
+            this.hideControl(oElement, oOptions.classNavigation);
+        },
+
+        /**
+         * hides texts spans
+         *
+         * @param {jQuery} oElement
+         * @param {String} stClass
+         * @returns {jQuery}
+         */
+        hideTextSpan: function(oElement, stClass ){
+            oElement = $(stClass, oElement).css("visibility", "hidden");
+            return oElement;
+        },
+
+        /**
+         * shows texts spans
+         *
+         * @param {jQuery} oElement
+         * @param {String} stClass
+         * @returns {jQuery}
+         */
+        showTextSpan: function(oElement, stClass ){
+            oElement = $( stClass, oElement );
+            oElement.css("visibility", "visible");
+
+            return oElement;
+        }
 
     };
 

--- a/source/out/azure/src/js/widgets/oxtag.js
+++ b/source/out/azure/src/js/widgets/oxtag.js
@@ -18,12 +18,11 @@
  * @copyright (C) OXID eSales AG 2003-2015
  * @version   OXID eShop CE
  */
-( function ( $ ) {
+( function ( $, oxAjax ) {
 
-    oxTag = {
+    var oxTag = {
 
-         highTag : function() {
-
+        highTag : function() {
             var oSelf = $(this);
 
             $("p.tagError").hide();
@@ -55,12 +54,14 @@
                         if ( response.tags.length > 0 ) {
                             $(".tagCloud").append("<span class='taggedText'>, " + response.tags + "</span> ");
                         }
+
+                        var tagError;
                         if ( response.invalid.length > 0 ) {
-                            var tagError = $("p.tagError.invalid").show();
+                            tagError = $("p.tagError.invalid").show();
                             $("span", tagError).text( response.invalid );
                         }
                         if ( response.inlist.length > 0 ) {
-                            var tagError = $("p.tagError.inlist").show();
+                            tagError = $("p.tagError.inlist").show();
                             $("span", tagError).text( response.inlist );
                         }
                     }
@@ -78,7 +79,7 @@
                     'onSuccess' : function(response, params) {
                         if ( response ) {
                             $('#tags').html(response);
-                            $("#tags #editTag").click(oxTag.editTag);
+                            $("#editTag").click(oxTag.editTag);
                         }
                     }
                 }
@@ -94,12 +95,12 @@
                     'targetEl' : $("#tags"),
                     'additionalData' : {'blAjax' : '1'},
                     'onSuccess' : function(response, params) {
-
                         if ( response ) {
-                            $('#tags').html(response);
-                            $("#tags .tagText").click(oxTag.highTag);
-                            $('#tags #saveTag').click(oxTag.saveTag);
-                            $('#tags #cancelTag').click(oxTag.cancelTag);
+                            var tags = $('#tags');
+                            tags.html(response);
+                            tags.find(".tagText").click(oxTag.highTag);
+                            $('#saveTag').click(oxTag.saveTag);
+                            $('#cancelTag').click(oxTag.cancelTag);
                         }
                     }
                 }
@@ -107,8 +108,8 @@
 
             return false;
         }
-    }
+    };
 
     $.widget("ui.oxTag", oxTag );
 
-})( jQuery );
+})( jQuery, oxAjax );

--- a/source/out/azure/src/js/widgets/oxtopmenu.js
+++ b/source/out/azure/src/js/widgets/oxtopmenu.js
@@ -20,14 +20,16 @@
  */
 ( function( $ ) {
 
-    oxTopMenu = {
+    var oxTopMenu = {
 
+        /**
+         * Init top menu
+         * @private
+         */
         _create: function(){
-
-            var self = this,
+            var self    = this,
                 options = self.options,
                 el      = self.element;
-
 
             if ($.browser.msie) {
                 $("li:not(:has(ul))", el).hover(function(){
@@ -44,18 +46,18 @@
                 extraWidth:  1     // extra width can ensure lines don't sometimes turn over
                                    // due to slight rounding differences and font-family
             }).superfish( {
-                 delay : 500,
-                 dropShadows : false,
-                 onBeforeShow : function() {
+                delay : 500,
+                dropShadows : false,
+                onBeforeShow : function() {
                     //adding hover class for active <A> elements
                     $('a:first', this.parent()).addClass($.fn.superfish.op.hoverClass);
 
-                    // horizontaly centering top navigation first level popup accoring its parent
-                    activeItem = this.parent()
+                    // horizontally centering top navigation first level popup according its parent
+                    var activeItem = this.parent()
                     if ( activeItem.parent().hasClass('sf-menu') ) {
-                        liWidth = activeItem.width();
-                        ulWidth = $('ul:first', activeItem).width();
-                        marginWidth = (liWidth - ulWidth) / 2;
+                        var liWidth = activeItem.width();
+                        var ulWidth = $('ul:first', activeItem).width();
+                        var marginWidth = (liWidth - ulWidth) / 2;
 
                         var itemleft = activeItem.position().left + marginWidth;
                         if (itemleft < 0) marginWidth -= itemleft;
@@ -72,7 +74,7 @@
                 }
             });
         }
-    }
+    };
 
     $.widget( "ui.oxTopMenu", oxTopMenu );
 

--- a/source/out/azure/src/js/widgets/oxtsbadge.js
+++ b/source/out/azure/src/js/widgets/oxtsbadge.js
@@ -20,14 +20,17 @@
  */
 ( function( $ ) {
 
-    oxTsBadge = {
+    var oxTsBadge = {
 
         options: {
             trustedShopId : "trustedShopId"
         },
 
+        /**
+         * Init Trusted Shop Badge
+         * @private
+         */
         _create: function(){
-
             var self = this,
                 options = self.options;
 
@@ -39,9 +42,8 @@
 
             var __ts = document.getElementsByTagName('script')[0];
             __ts.parentNode.insertBefore(_ts, __ts);
-
         }
-    }
+    };
 
     $.widget( "ui.oxTsBadge", oxTsBadge );
 

--- a/source/out/azure/src/js/widgets/oxusershipingaddressselect.js
+++ b/source/out/azure/src/js/widgets/oxusershipingaddressselect.js
@@ -22,7 +22,12 @@
     /**
      * User shipping address selector
      */
-    oxUserShipingAddressSelect = {
+    var oxUserShippingAddressSelect = {
+
+        /**
+         * Init shipping address select
+         * @private
+         */
         _create: function()
         {
             var self = this,
@@ -30,11 +35,12 @@
                 el = self.element;
 
             el.change(function() {
-                var selectValue = $(this).val();
-
-                if ($("input[name=reloadaddress]")) {
-                    $("input[name=reloadaddress]").val(self.getReloadValue(selectValue));
+                var selectValue   = $(this).val();
+                var reloadAddress = $("input[name=reloadaddress]");
+                if (reloadAddress) {
+                    reloadAddress.val(self.getReloadValue(selectValue));
                 }
+
                 if (selectValue !== '-1') {
                     $( ".js-oxValidate" ).unbind('submit');
                     self.submitForm();
@@ -46,8 +52,6 @@
 
         /**
          * Clears all shipping address input fields
-         *
-         * @return null
          */
         emptyInputFields : function()
         {
@@ -62,8 +66,6 @@
 
         /**
          * Sets some form values and submits it
-         *
-         * @return null
          */
         submitForm : function()
         {
@@ -75,7 +77,8 @@
         /**
          * Returns reloadaddress value
          *
-         * @return integer
+         * @param {String} selectValue
+         * @returns {String}
          */
         getReloadValue : function( selectValue )
         {
@@ -85,8 +88,8 @@
                 return '2';
             }
         }
-    }
+    };
 
-    $.widget( "ui.oxUserShipingAddressSelect", oxUserShipingAddressSelect );
+    $.widget( "ui.oxUserShippingAddressSelect", oxUserShippingAddressSelect );
 
 } )( jQuery );

--- a/source/out/azure/src/js/widgets/oxwidgetshandler.js
+++ b/source/out/azure/src/js/widgets/oxwidgetshandler.js
@@ -5,8 +5,8 @@ var WidgetsHandler = (function() {
         /**
          * Registers function if it was not already registered
          *
-         * @param sFunction function text
-         * @param sWidget widget name
+         * @param {String} sFunction - function text
+         * @param {String} sWidget widget - name
          */
         registerFunction: function( sFunction, sWidget ) {
             _register( oRegister, sFunction, 'functions' );
@@ -17,8 +17,8 @@ var WidgetsHandler = (function() {
         /**
          * Registers files if it was not already registered
          *
-         * @param sFile file name
-         * @param sWidget widget name
+         * @param {String} sFile - file name
+         * @param {String} sWidget - widget name
          */
         registerFile: function( sFile, sWidget ) {
             _register( oRegister, sFile, 'files' );
@@ -36,16 +36,16 @@ var WidgetsHandler = (function() {
         /**
          * Loads all registered functions
          *
-         * @param sWidget widget name
+         * @param {String} sWidget widget name
          */
         reloadWidget: function( sWidget ) {
             _loadWidget( sWidget );
         }
-    }
+    };
 
     /**
      * Initiates widget
-     * @param sWidget
+     * @param {String} sWidget
      * @private
      */
     function _initWidget( sWidget )
@@ -58,9 +58,9 @@ var WidgetsHandler = (function() {
     /**
      * Registers given value to given register
      *
-     * @param oRegister
-     * @param sValue
-     * @param sGroup
+     * @param {Object} oRegister
+     * @param {String} sValue
+     * @param {String} sGroup
      */
     function _register( oRegister, sValue, sGroup ) {
         if ( !_isRegistered( oRegister[ sGroup ], sValue ) ) {
@@ -71,8 +71,8 @@ var WidgetsHandler = (function() {
     /**
      * Checks whether given needle is registered in given register
      *
-     * @param oRegister
-     * @param sNeedle
+     * @param {Object} oRegister
+     * @param {String} sNeedle
      * @returns {boolean}
      */
     function _isRegistered( oRegister, sNeedle ) {
@@ -98,6 +98,7 @@ var WidgetsHandler = (function() {
     /**
      * Loads all widget functions and files from register
      *
+     * @param {String} sWidget
      * @private
      */
     function _loadWidget( sWidget ) {
@@ -107,8 +108,9 @@ var WidgetsHandler = (function() {
     }
 
     /**
+     * Loads everything
      *
-     * @param oRegister
+     * @param {Object} oRegister
      * @private
      */
     function _load( oRegister ) {
@@ -129,6 +131,7 @@ var WidgetsHandler = (function() {
     /**
      * Loads widget functions from register
      *
+     * @param {Object} oRegister
      * @private
      */
     function _loadFunctions( oRegister ) {

--- a/source/out/azure/src/js/widgets/oxzoompictures.js
+++ b/source/out/azure/src/js/widgets/oxzoompictures.js
@@ -20,7 +20,7 @@
  */
 ( function( $ ) {
 
-    oxZoomPictures = {
+    var oxZoomPictures = {
 
         options: {
             sMorePicsContainerId     : "#morePicsContainer",
@@ -29,8 +29,11 @@
             sZoomTriggerButtonId     : "#zoomTrigger"
         },
 
+        /**
+         * Init ox zoom pictures
+         * @private
+         */
         _create: function() {
-
             var self    = this,
                 options = self.options,
                 el      = self.element;
@@ -45,10 +48,9 @@
              $(options.sZoomTriggerButtonId).click(function() {
                  self._beforeShow();
              } );
-
         },
 
-        /*
+        /**
          * Checking which picture was selected in product details view
          * and zooming this selected picture
          */
@@ -57,10 +59,10 @@
                 options = self.options,
                 el      = self.element;
 
-            iIndex = $(options.sMorePicsContainerId + " li a.selected").parent().index();
+            var iIndex = $(options.sMorePicsContainerId + " li a.selected").parent().index();
             $(options.sMoreZoomPicsContainerId).oxMorePictures({iDefaultIndex: iIndex});
         }
-    }
+    };
 
     $.widget( "ui.oxZoomPictures", oxZoomPictures );
 


### PR DESCRIPTION
+ Add JSDoc where it was missing.
+ Remove unnecessary global variables because of missing `var` keyword.
+ Use `[]`-assignment for arrays instead of `new Array()`.
+ Cache obvious jQuery object usage.
+ Simplify some return statements (those that PHPStorm automatically gets right).
+ Fixed indention of some files