### PR TITLE
Use array literals for assignments instead of 'new Array()' in JavaSc…

### DIFF
--- a/source/out/azure/src/js/widgets/oxajax.js
+++ b/source/out/azure/src/js/widgets/oxajax.js
@@ -38,7 +38,7 @@
              */
             start : function (target, iconPositionElement) {
 
-                var loadingScreens = Array();
+                var loadingScreens = [];
                 $(target).each(function() {
                     var overlayKeeper = document.createElement("div");
                     overlayKeeper.innerHTML = '<div class="loadingfade"></div><div class="loadingicon"></div><div class="loadingiconbg"></div>';
@@ -156,7 +156,7 @@
 
             // sorting array to pass parameters alphabetically
             var aInputs = {};
-            var keys = Array();
+            var keys = [];
             for ( var key in inputs ) {
                 if ( inputs.hasOwnProperty( key ) ) {
                     keys.push( key );

--- a/source/out/azure/src/js/widgets/oxinputvalidator.js
+++ b/source/out/azure/src/js/widgets/oxinputvalidator.js
@@ -114,7 +114,7 @@
 
                     if ( $( oInput ).hasClass( oOptions.methodValidateMatch ) && blValidInput ) {
 
-                        var inputs = new Array();
+                        var inputs = [];
 
                         var oForm = $( oInput ).closest(oOptions.form);
 

--- a/source/out/azure/src/js/widgets/oxslider.js
+++ b/source/out/azure/src/js/widgets/oxslider.js
@@ -53,7 +53,7 @@
                 el         = self.element;
                 var oAnythingSlider;
 
-                var aNavigationTabs = new Array();
+                var aNavigationTabs = [];
 
                 aNavigationTabs = self.getNavigationTabsArray(el, options.elementLi);
 
@@ -139,7 +139,7 @@
              */
             getNavigationTabsArray: function(oElement, stElementType){
 
-                var aTabs = new Array();
+                var aTabs = [];
 
                 $( stElementType, oElement ).each( function( index ) {
                     aTabs[index] = index + 1;


### PR DESCRIPTION
Using `var foo = [];` is more common than `var foo = new Array();` and has the benefit of being shorter. There is no difference in behavior between the two.