### PR TITLE
Use HTML5 type=email for email inputs

### DIFF
--- a/source/application/views/azure/tpl/form/contact.tpl
+++ b/source/application/views/azure/tpl/form/contact.tpl
@@ -35,7 +35,7 @@
         </li>
         <li [{if $aErrors.oxuser__oxusername}]class="oxInValid"[{/if}]>
             <label class="req">[{ oxmultilang ident="EMAIL" suffix="COLON" }]</label>
-            <input id="contactEmail" type="text" name="editval[oxuser__oxusername]"  size=70 maxlength=40 value="[{if $oxcmp_user && !$editval.oxuser__oxusername}][{$oxcmp_user->oxuser__oxusername->value}][{else}][{$editval.oxuser__oxusername}][{/if}]" class="js-oxValidate js-oxValidate_notEmpty js-oxValidate_email">
+            <input id="contactEmail" type="email" name="editval[oxuser__oxusername]"  size=70 maxlength=40 value="[{if $oxcmp_user && !$editval.oxuser__oxusername}][{$oxcmp_user->oxuser__oxusername->value}][{else}][{$editval.oxuser__oxusername}][{/if}]" class="js-oxValidate js-oxValidate_notEmpty js-oxValidate_email">
             <p class="oxValidateError">
                 <span class="js-oxError_notEmpty">[{ oxmultilang ident="ERROR_MESSAGE_INPUT_NOTALLFIELDS" }]</span>
                 <span class="js-oxError_email">[{ oxmultilang ident="ERROR_MESSAGE_INPUT_NOVALIDEMAIL" }]</span>

--- a/source/application/views/azure/tpl/form/fieldset/user_account.tpl
+++ b/source/application/views/azure/tpl/form/fieldset/user_account.tpl
@@ -1,7 +1,7 @@
     <li [{if $aErrors.oxuser__oxusername}]class="oxInValid"[{/if}]>
         [{block name="user_account_username"}]
         <label class="req">[{ oxmultilang ident="EMAIL_ADDRESS" suffix="COLON" }]</label>
-        <input id="userLoginName" class="js-oxValidate js-oxValidate_notEmpty js-oxValidate_email" type="text" name="lgn_usr" value="[{ $oView->getActiveUsername()}]" size="37" >
+        <input id="userLoginName" class="js-oxValidate js-oxValidate_notEmpty js-oxValidate_email" type="email" name="lgn_usr" value="[{ $oView->getActiveUsername()}]" size="37" >
         <p class="oxValidateError">
             <span class="js-oxError_notEmpty">[{ oxmultilang ident="ERROR_MESSAGE_INPUT_NOTALLFIELDS" }]</span>
             <span class="js-oxError_email">[{ oxmultilang ident="ERROR_MESSAGE_INPUT_NOVALIDEMAIL" }]</span>

--- a/source/application/views/azure/tpl/form/fieldset/user_email.tpl
+++ b/source/application/views/azure/tpl/form/fieldset/user_email.tpl
@@ -2,7 +2,7 @@
 [{oxscript add="$('.oxValidate_enterPass').oxEnterPassword();"}]
 <li [{if $aErrors.oxuser__oxusername}]class="oxInValid"[{/if}]>
     <label class="req">[{ oxmultilang ident="EMAIL_ADDRESS" suffix="COLON" }]</label>
-    <input class="js-oxValidate js-oxValidate_notEmpty js-oxValidate_email oxValidate_enterPass oxValidate_enterPassTarget[oxValidate_pwd] textbox" type="text" name="invadr[oxuser__oxusername]" value="[{if isset( $invadr.oxuser__oxusername ) }][{ $invadr.oxuser__oxusername }][{else }][{ $oxcmp_user->oxuser__oxusername->value }][{/if }]" size="37">
+    <input class="js-oxValidate js-oxValidate_notEmpty js-oxValidate_email oxValidate_enterPass oxValidate_enterPassTarget[oxValidate_pwd] textbox" type="email" name="invadr[oxuser__oxusername]" value="[{if isset( $invadr.oxuser__oxusername ) }][{ $invadr.oxuser__oxusername }][{else }][{ $oxcmp_user->oxuser__oxusername->value }][{/if }]" size="37">
     <p class="oxValidateError">
         <span class="js-oxError_notEmpty">[{ oxmultilang ident="ERROR_MESSAGE_INPUT_NOTALLFIELDS" }]</span>
         <span class="js-oxError_email">[{ oxmultilang ident="ERROR_MESSAGE_INPUT_NOVALIDEMAIL" }]</span>

--- a/source/application/views/azure/tpl/form/fieldset/user_noaccount.tpl
+++ b/source/application/views/azure/tpl/form/fieldset/user_noaccount.tpl
@@ -1,7 +1,7 @@
     <li [{if $aErrors.oxuser__oxusername}]class="oxInValid"[{/if}]>
         [{block name="user_noaccount_email"}]
         <label class="req">[{ oxmultilang ident="EMAIL_ADDRESS" suffix="COLON" }]</label>
-        <input id="userLoginName" class="js-oxValidate js-oxValidate_notEmpty js-oxValidate_email" type="text" name="lgn_usr" value="[{ $oView->getActiveUsername() }]" size="37" >
+        <input id="userLoginName" class="js-oxValidate js-oxValidate_notEmpty js-oxValidate_email" type="email" name="lgn_usr" value="[{ $oView->getActiveUsername() }]" size="37" >
         <p class="oxValidateError">
             <span class="js-oxError_notEmpty">[{ oxmultilang ident="ERROR_MESSAGE_INPUT_NOTALLFIELDS" }]</span>
             <span class="js-oxError_email">[{ oxmultilang ident="ERROR_MESSAGE_INPUT_NOVALIDEMAIL" }]</span>

--- a/source/application/views/azure/tpl/form/forgotpwd_email.tpl
+++ b/source/application/views/azure/tpl/form/forgotpwd_email.tpl
@@ -11,7 +11,7 @@
   <ul class="form clear">
     <li>
         <label>[{ oxmultilang ident="YOUR_EMAIL_ADDRESS" suffix="COLON" }]</label>
-        <input id="forgotPasswordUserLoginName[{$idPrefix}]" type="text" name="lgn_usr" value="[{$oView->getActiveUsername()}]" class="js-oxValidate js-oxValidate_notEmpty js-oxValidate_email">
+        <input id="forgotPasswordUserLoginName[{$idPrefix}]" type="email" name="lgn_usr" value="[{$oView->getActiveUsername()}]" class="js-oxValidate js-oxValidate_notEmpty js-oxValidate_email">
         <p class="oxValidateError">
             <span class="js-oxError_notEmpty">[{ oxmultilang ident="ERROR_MESSAGE_INPUT_NOTALLFIELDS" }]</span>
             <span class="js-oxError_email">[{ oxmultilang ident="ERROR_MESSAGE_INPUT_NOVALIDEMAIL" }]</span>

--- a/source/application/views/azure/tpl/form/login.tpl
+++ b/source/application/views/azure/tpl/form/login.tpl
@@ -9,7 +9,7 @@
             <input type="hidden" name="fnc" value="login_noredirect">
             <input type="hidden" name="cl" value="[{ $oViewConf->getActiveClassName() }]">
             <label class="short">[{ oxmultilang ident="EMAIL_ADDRESS" }]</label>
-            <input type="text" name="lgn_usr" class="textbox js-oxValidate js-oxValidate_notEmpty" data-fieldsize="pair-xsmall">
+            <input type="email" name="lgn_usr" class="textbox js-oxValidate js-oxValidate_notEmpty" data-fieldsize="pair-xsmall">
             <p class="underInput short oxValidateError">
                 <span class="js-oxError_notEmpty">[{ oxmultilang ident="ERROR_MESSAGE_INPUT_NOTALLFIELDS" }]</span>
             </p>

--- a/source/application/views/azure/tpl/form/login_account.tpl
+++ b/source/application/views/azure/tpl/form/login_account.tpl
@@ -24,7 +24,7 @@
         <ul class="form clear">
             <li [{if $aErrors}]class="oxInValid"[{/if}]>
                 <label class="req">[{ oxmultilang ident="EMAIL" suffix="COLON" }]</label>
-                <input id="loginUser" class="js-oxValidate js-oxValidate_notEmpty" type="text" name="lgn_usr" value="" size="37" >
+                <input id="loginUser" class="js-oxValidate js-oxValidate_notEmpty" type="email" name="lgn_usr" value="" size="37" >
                 <p class="oxValidateError">
                     <span class="js-oxError_notEmpty">[{ oxmultilang ident="ERROR_MESSAGE_INPUT_NOTALLFIELDS" }]</span>
                 </p>

--- a/source/application/views/azure/tpl/form/newsletter.tpl
+++ b/source/application/views/azure/tpl/form/newsletter.tpl
@@ -23,7 +23,7 @@
         </li>
         <li [{if $aErrors}]class="oxInValid"[{/if}]>
             <label class="req">[{ oxmultilang ident="EMAIL" }]</label>
-            <input id="newsletterUserName" type="text" class="js-oxValidate js-oxValidate_notEmpty js-oxValidate_email" name="editval[oxuser__oxusername]" size=40 maxlength=40 value="[{if $aRegParams.oxuser__oxusername}][{$aRegParams.oxuser__oxusername}][{/if}]">
+            <input id="newsletterUserName" type="email" class="js-oxValidate js-oxValidate_notEmpty js-oxValidate_email" name="editval[oxuser__oxusername]" size=40 maxlength=40 value="[{if $aRegParams.oxuser__oxusername}][{$aRegParams.oxuser__oxusername}][{/if}]">
             <p class="oxValidateError">
                 <span class="js-oxError_notEmpty">[{ oxmultilang ident="ERROR_MESSAGE_INPUT_NOTALLFIELDS" }]</span>
                 <span class="js-oxError_email">[{ oxmultilang ident="ERROR_MESSAGE_INPUT_NOVALIDEMAIL" }]</span>

--- a/source/application/views/azure/tpl/form/pricealarm.tpl
+++ b/source/application/views/azure/tpl/form/pricealarm.tpl
@@ -24,7 +24,7 @@
         </li>
         <li>
             <label>[{ oxmultilang ident="EMAIL" suffix="COLON" }]</label>
-            <input class="js-oxValidate js-oxValidate_notEmpty js-oxValidate_email" type="text" name="pa[email]" value="[{ if $oxcmp_user }][{ $oxcmp_user->oxuser__oxusername->value }][{/if}]" size="20" maxlength="128">
+            <input class="js-oxValidate js-oxValidate_notEmpty js-oxValidate_email" type="email" name="pa[email]" value="[{ if $oxcmp_user }][{ $oxcmp_user->oxuser__oxusername->value }][{/if}]" size="20" maxlength="128">
             <p class="oxValidateError">
                 <span class="js-oxError_notEmpty">[{ oxmultilang ident="ERROR_MESSAGE_INPUT_NOTALLFIELDS" }]</span>
                 <span class="js-oxError_email">[{ oxmultilang ident="ERROR_MESSAGE_INPUT_NOVALIDEMAIL" }]</span>

--- a/source/application/views/azure/tpl/form/privatesales/invite.tpl
+++ b/source/application/views/azure/tpl/form/privatesales/invite.tpl
@@ -16,7 +16,7 @@
         <ul class="form">
             <li>
                 <label class="req">[{ oxmultilang ident="EMAIL" }] #1:</label>
-                <input type="text" class="js-oxValidate js-oxValidate_notEmpty js-oxValidate_email" name="editval[rec_email][1]" size="73" maxlength="73" value="[{$editval->rec_email.1}]">
+                <input type="email" class="js-oxValidate js-oxValidate_notEmpty js-oxValidate_email" name="editval[rec_email][1]" size="73" maxlength="73" value="[{$editval->rec_email.1}]">
                 <p class="oxValidateError">
                     <span class="js-oxError_notEmpty">[{ oxmultilang ident="ERROR_MESSAGE_INPUT_NOTALLFIELDS" }]</span>
                     <span class="js-oxError_email">[{ oxmultilang ident="ERROR_MESSAGE_INPUT_NOVALIDEMAIL" }]</span>
@@ -24,28 +24,28 @@
             </li>
             <li>
                 <label>[{ oxmultilang ident="EMAIL" }] #2:</label>
-                <input type="text" name="editval[rec_email][2]" size="73" maxlength="73" value="[{$editval->rec_email.2}]">
+                <input type="email" name="editval[rec_email][2]" size="73" maxlength="73" value="[{$editval->rec_email.2}]">
                 <p class="oxValidateError">
                     <span class="js-oxError_email">[{ oxmultilang ident="ERROR_MESSAGE_INPUT_NOVALIDEMAIL" }]</span>
                 </p>
             </li>
             <li>
                 <label>[{ oxmultilang ident="EMAIL" }] #3:</label>
-                <input type="text" name="editval[rec_email][3]" size="73" maxlength="73" value="[{$editval->rec_email.3}]">
+                <input type="email" name="editval[rec_email][3]" size="73" maxlength="73" value="[{$editval->rec_email.3}]">
                 <p class="oxValidateError">
                     <span class="js-oxError_email">[{ oxmultilang ident="ERROR_MESSAGE_INPUT_NOVALIDEMAIL" }]</span>
                 </p>
             </li>
             <li>
                 <label>[{ oxmultilang ident="EMAIL" }] #4:</label>
-                <input type="text" name="editval[rec_email][4]" size="73" maxlength="73" value="[{$editval->rec_email.4}]">
+                <input type="email" name="editval[rec_email][4]" size="73" maxlength="73" value="[{$editval->rec_email.4}]">
                 <p class="oxValidateError">
                     <span class="js-oxError_email">[{ oxmultilang ident="ERROR_MESSAGE_INPUT_NOVALIDEMAIL" }]</span>
                 </p>
             </li>
             <li>
                 <label>[{ oxmultilang ident="EMAIL" }] #5:</label>
-                <input type="text" name="editval[rec_email][5]" size="73" maxlength="73" value="[{$editval->rec_email.5}]">
+                <input type="email" name="editval[rec_email][5]" size="73" maxlength="73" value="[{$editval->rec_email.5}]">
                 <p class="oxValidateError">
                     <span class="js-oxError_email">[{ oxmultilang ident="ERROR_MESSAGE_INPUT_NOVALIDEMAIL" }]</span>
                 </p>
@@ -64,7 +64,7 @@
             </li>
             <li>
                 <label class="req">[{ oxmultilang ident="SENDER_EMAIL" suffix="COLON" }]</label>
-                <input type="text" class="js-oxValidate js-oxValidate_notEmpty js-oxValidate_email" name="editval[send_email]" size=73 maxlength=73 value="[{$editval->send_email}]" >
+                <input type="email" class="js-oxValidate js-oxValidate_notEmpty js-oxValidate_email" name="editval[send_email]" size=73 maxlength=73 value="[{$editval->send_email}]" >
                 <p class="oxValidateError">
                     <span class="js-oxError_notEmpty">[{ oxmultilang ident="ERROR_MESSAGE_INPUT_NOTALLFIELDS" }]</span>
                     <span class="js-oxError_email">[{ oxmultilang ident="ERROR_MESSAGE_INPUT_NOVALIDEMAIL" }]</span>

--- a/source/application/views/azure/tpl/form/suggest.tpl
+++ b/source/application/views/azure/tpl/form/suggest.tpl
@@ -41,7 +41,7 @@
             </li>
             <li>
                 <label class="req">[{ oxmultilang ident="SENDER_EMAIL" suffix="COLON" }]</label>
-                <input class="js-oxValidate js-oxValidate_notEmpty js-oxValidate_email" type="text" name="editval[send_email]" size=73 maxlength=73 value="[{$editval->send_email}]" >
+                <input class="js-oxValidate js-oxValidate_notEmpty js-oxValidate_email" type="email" name="editval[send_email]" size=73 maxlength=73 value="[{$editval->send_email}]" >
                 <p class="oxValidateError">
                     <span class="js-oxError_notEmpty">[{ oxmultilang ident="ERROR_MESSAGE_INPUT_NOTALLFIELDS" }]</span>
                     <span class="js-oxError_email">[{ oxmultilang ident="ERROR_MESSAGE_INPUT_NOVALIDEMAIL" }]</span>

--- a/source/application/views/azure/tpl/widget/header/loginbox.tpl
+++ b/source/application/views/azure/tpl/widget/header/loginbox.tpl
@@ -35,7 +35,7 @@
                     [{oxscript include="js/widgets/oxinnerlabel.js" priority=10 }]
                     [{oxscript add="$( '#loginEmail' ).oxInnerLabel();"}]
                     <label for="loginEmail" class="innerLabel">[{ oxmultilang ident="EMAIL_ADDRESS" }]</label>
-                    <input id="loginEmail" type="text" name="lgn_usr" value="" class="textbox">
+                    <input id="loginEmail" type="email" name="lgn_usr" value="" class="textbox">
                 </p>
                 <p>
                     [{oxscript add="$( '#loginPasword' ).oxInnerLabel();"}]

--- a/source/out/azure/src/css/oxid.css
+++ b/source/out/azure/src/css/oxid.css
@@ -250,7 +250,7 @@ div.sidebarRight #sidebar {
     border-radius: 4px;
 }
 
-.input, .textbox, .pager .active, .lineBox, .areabox, input[type="text"] {
+.input, .textbox, .pager .active, .lineBox, .areabox, input[type="text"], input[type="email"] {
     -moz-border-radius: 2px;
     -webkit-border-radius: 2px;
     -khtml-border-radius: 2px;
@@ -1052,7 +1052,7 @@ a.viewAllHover,
     border: none;
 }
 
-.textbox, input[type="text"] {
+.textbox, input[type="text"], input[type="email"] {
     border: 1px solid #8c8989;
     background: #fff;
     padding: 1px 5px;
@@ -3951,7 +3951,8 @@ dl.review .param {
 }
 
 .form input[type="password"],
-.form input[type="text"] {
+.form input[type="text"],
+.form input[type="email"] {
     width: 190px;
 }
 


### PR DESCRIPTION
Use HTML5 input type="email" for email fields. Browsers which do not support email as an input type (IE9 and below) will fall back to using the "text" type.