### PR TITLE
Implemented a semantic HTML 5 layout structure

### DIFF
--- a/source/application/views/azure/tpl/layout/footer.tpl
+++ b/source/application/views/azure/tpl/layout/footer.tpl
@@ -1,7 +1,7 @@
 [{block name="footer_main"}]
     [{oxscript include="js/widgets/oxequalizer.js" priority=10}]
     [{oxscript add="$(function(){oxEqualizer.equalHeight($( '#panel dl' ));});"}]
-    <div id="footer">
+    <footer id="footer">
         <div id="panel" class="corners">
                 <div class="bar">
                     [{block name="footer_fblike"}]
@@ -44,7 +44,7 @@
                 [{$oCont->oxcontents__oxcontent->value}]
             [{/oxifcontent}]
         </div>
-    </div>
+    </footer>
 [{/block}]
 [{if $oView->isRootCatChanged()}]
     [{oxscript include="js/widgets/oxmodalpopup.js" priority=10}]

--- a/source/application/views/azure/tpl/layout/header.tpl
+++ b/source/application/views/azure/tpl/layout/header.tpl
@@ -4,7 +4,7 @@
 [{if $oViewConf->getTopActionClassName() != 'clearcookies' && $oViewConf->getTopActionClassName() != 'mallstart'}]
     [{oxid_include_widget cl="oxwCookieNote" _parent=$oView->getClassName() nocookie=1}]
 [{/if}]
-<div id="header" class="clear">
+<header id="header" class="clear">
     [{block name="layout_header_top"}]
         [{oxid_include_widget cl="oxwLanguageList" lang=$oViewConf->getActLanguageId() _parent=$oView->getClassName() nocookie=1 _navurlparams=$oViewConf->getNavUrlParams() anid=$oViewConf->getActArticleId()}]
         [{oxid_include_widget cl="oxwCurrencyList" cur=$oViewConf->getActCurrency() _parent=$oView->getClassName() nocookie=1 _navurlparams=$oViewConf->getNavUrlParams() anid=$oViewConf->getActArticleId()}]
@@ -39,7 +39,7 @@
         </div>
         [{include file="widget/header/search.tpl"}]
     [{/block}]
-</div>
+</header>
 [{if $oView->getClassName()=='start' && $oView->getBanners()|@count > 0}]
     <div class="oxSlider">
         [{include file="widget/promoslider.tpl"}]

--- a/source/application/views/azure/tpl/layout/page.tpl
+++ b/source/application/views/azure/tpl/layout/page.tpl
@@ -12,18 +12,18 @@
                [{include file="widget/breadcrumb.tpl"}]
             [{/block}]
         [{/if}]
-        <div id="content">
+        <section id="content">
             [{block name="content_main"}]
                 [{include file="message/errors.tpl"}]
                 [{foreach from=$oxidBlock_content item="_block"}]
                     [{$_block}]
                 [{/foreach}]
             [{/block}]
-        </div>
+        </section>
         [{if $sidebar}]
-            <div id="sidebar">
+            <aside id="sidebar">
                 [{include file="layout/sidebar.tpl"}]
-            </div>
+            </aside>
         [{/if}]
         [{include file="layout/footer.tpl"}]
     </div>
@@ -35,13 +35,13 @@
             [{if $oView->getTrustedShopId()}]
                 [{assign var="tsBadge" value="TsBadge"}]
             [{/if}]
-            <div id="incVatMessage[{$tsBadge}]">
+            <aside id="incVatMessage[{$tsBadge}]">
                 [{if $oView->isVatIncluded()}]
                     * <span class="deliveryInfo">[{oxmultilang ident="PLUS_SHIPPING"}]<a href="[{$oCont->getLink()}]" rel="nofollow">[{oxmultilang ident="PLUS_SHIPPING2"}]</a></span>
                 [{else}]
                     * <span class="deliveryInfo">[{oxmultilang ident="PLUS"}]<a href="[{$oCont->getLink()}]" rel="nofollow">[{oxmultilang ident="PLUS_SHIPPING2"}]</a></span>
                 [{/if}]
-            </div>
+            </aside>
         [{/oxifcontent}]
         [{/block}]
     [{/if}]

--- a/source/application/views/azure/tpl/layout/popup.tpl
+++ b/source/application/views/azure/tpl/layout/popup.tpl
@@ -1,8 +1,8 @@
 [{capture append="oxidBlock_pageBody"}]
     <div id="page">
-        <div id="content">
+        <section id="content">
             [{foreach from=$oxidBlock_content item="_block"}][{$_block}][{/foreach}]
-        </div>
+        </section>
     </div>
 [{/capture}]
 [{include file="layout/base.tpl"}]


### PR DESCRIPTION
Due to the HTML 5 doctype declaration, I implemented a semantic HTML 5 layout structure. This will add semantic meaning to all elements and improve search engine and screen reader handling.

According to some statistics, IE9 is already on the descending branch so I didn't implement html5shim to support HTML 5 tags in browsers older than IE9.