### PR TITLE
Implement HTML 5 to sidebar widgets

### DIFF
--- a/source/application/views/azure/tpl/widget/sidebar/categorytree.tpl
+++ b/source/application/views/azure/tpl/widget/sidebar/categorytree.tpl
@@ -3,7 +3,7 @@
 [{assign var="act" value=$oxcmp_categories->getClickCat()}]
 [{if $categories}]
 [{assign var="deepLevel" value=$oView->getDeepLevel()}]
-<div class="categoryBox">
+<nav class="categoryBox">
     <ul class="tree" id="tree">
     [{defun name="tree" categories=$categories}]
         [{assign var="deepLevel" value=$deepLevel+1}]
@@ -32,6 +32,6 @@
     [{if $oView->showTags()}]
          [{oxid_include_widget cl="oxwTagCloud" nocookie=1 noscript=1}]
     [{/if}]
-</div>
+</nav>
 [{/if}]
 [{/if}]

--- a/source/application/views/azure/tpl/widget/sidebar/partners.tpl
+++ b/source/application/views/azure/tpl/widget/sidebar/partners.tpl
@@ -1,9 +1,8 @@
-<div class="box">
+<article class="box">
     <h3>[{oxmultilang ident="PARTNERS"}]</h3>
     <div class="content">
         [{block name="partner_logos"}]
             [{include file="widget/trustedshops/info.tpl"}]
         [{/block}]
     </div>
-
-</div>
+</article>

--- a/source/application/views/azure/tpl/widget/sidebar/recommendation.tpl
+++ b/source/application/views/azure/tpl/widget/sidebar/recommendation.tpl
@@ -13,7 +13,6 @@
     [{/if}]
     </h3>
 
-    <div>
     [{if $_oRecommendationList}]
         [{$_oRecommendationList->rewind()}]
 
@@ -49,7 +48,6 @@
             </li>
             [{/if}]
         </ul>
-    </div>
 </article>
 [{/if}]
 [{oxscript widget=$oView->getClassName()}]

--- a/source/application/views/azure/tpl/widget/sidebar/recommendation.tpl
+++ b/source/application/views/azure/tpl/widget/sidebar/recommendation.tpl
@@ -3,7 +3,7 @@
 [{assign var="oRecommList" value=$oView->getRecommList()}]
 
 [{if $_oRecommendationList || $oRecommList->getRecommSearch()}]
-<div class="box" id="recommendationsBox">
+<article class="box" id="recommendationsBox">
     <h3>[{oxmultilang ident="LISTMANIA"}]
     [{assign var='rsslinks' value=$oRecommList->getRssLinks()}]
     [{if $rsslinks.recommlists}]
@@ -50,6 +50,6 @@
             [{/if}]
         </ul>
     </div>
-</div>
+</article>
 [{/if}]
 [{oxscript widget=$oView->getClassName()}]

--- a/source/application/views/azure/tpl/widget/sidebar/tags.tpl
+++ b/source/application/views/azure/tpl/widget/sidebar/tags.tpl
@@ -2,11 +2,11 @@
 
     [{if $oView->displayInBox()}]
         [{* Display tags in separate box *}]
-        <div id="tagBox" class="box tagCloud">
+        <nav id="tagBox" class="box tagCloud">
             <h3>[{oxmultilang ident="TAGS"}]</h3>
             <div class="content">
     [{else}]
-        <div class="categoryTagsBox">
+        <nav class="categoryTagsBox">
             <h3>[{oxmultilang ident="TAGS"}]</h3>
             <div class="categoryTags">
     [{/if}]
@@ -20,5 +20,5 @@
         <a href="[{oxgetseourl ident=$oViewConf->getSelfLink()|cat:"cl=tags"}]" class="readMore">[{oxmultilang ident="MORE" suffix="ELLIPSIS"}]</a>
     [{/if}]
         </div>
-    </div>
+    </nav>
 [{/if}]


### PR DESCRIPTION
I implemented HTML 5 to all widgets contained in /tpl/widget/sidebar only to keep changes manageable. I also deleted an unnecessary (because without formats and so on) div element in the recommendations widget.

HTML 5 will add semantic meaning to the widgets, e. g. mark down the tagcloud and category tree as a navigation element. If browser support for Internet Explorer older than IE9 is required, html5shim must be implemented afterwards.