### PR TITLE
Bug/log curl exceptions

### DIFF
--- a/source/application/views/admin/de/lang.php
+++ b/source/application/views/admin/de/lang.php
@@ -737,6 +737,7 @@ $aLang = array(
 'EXCEPTION_USER_USEREXISTS'                                => 'Dieser Benutzer existiert bereits!',
 'EXCEPTION_CONNECTION_NODB'                                => 'Keine Verbindung zur Datenbank möglich!',
 'EXCEPTION_ACCESSRIGHT_ACCESSDENIED'                       => 'Zugriff verweigert, keine ausreichende Rechte!',
+'EXCEPTION_CURL_ERROR'                                     => 'cURL Fehler: %s',
 'EXCEPTION_DELETING_VALID_FILE'                            => 'Sie können diese Datei nicht löschen, solange es dafür gültige Downloads gibt',
 'EXCEPTION_NOFILE'                                         => 'Keine Dateien hochgeladen',
 'EXCEPTION_FILENAMEINVALIDCHARS'                           => 'Ungültige Zeichen im Dateinamne',

--- a/source/application/views/admin/en/lang.php
+++ b/source/application/views/admin/en/lang.php
@@ -739,6 +739,7 @@ $aLang = array(
 'EXCEPTION_USER_USEREXISTS'                                => 'This user allready exists!',
 'EXCEPTION_CONNECTION_NODB'                                => 'No connection to database!',
 'EXCEPTION_ACCESSRIGHT_ACCESSDENIED'                       => 'Access denied, no sufficient rights!',
+'EXCEPTION_CURL_ERROR'                                     => 'cURL error: %s',
 'EXCEPTION_DELETING_VALID_FILE'                            => 'You cannot delete this file, as long as it has valid downloads',
 'EXCEPTION_NOFILE'                                         => 'No uploaded file',
 'EXCEPTION_FILENAMEINVALIDCHARS'                           => 'Invalid chars in file name',

--- a/source/core/oxonlinecaller.php
+++ b/source/core/oxonlinecaller.php
@@ -100,6 +100,7 @@ abstract class oxOnlineCaller
             }
             $this->_resetFailedCallsCount($iFailedCallsCount);
         } catch (Exception $oEx) {
+            $this->_castExceptionAndWriteToLog($oEx);
             if ($iFailedCallsCount > self::ALLOWED_HTTP_FAILED_CALLS_COUNT) {
                 $sXml = $this->_formEmail($oRequest);
                 $this->_sendEmail($sXml);
@@ -110,6 +111,22 @@ abstract class oxOnlineCaller
         }
 
         return $sOutputXml;
+    }
+	
+    /*
+     * Depending on the type of exception, first cast the exception and then write it to log.
+     *
+     * @param Exception $oEx
+     */
+    protected function _castExceptionAndWriteToLog(Exception $oEx)
+    {
+        if(!($oEx instanceof oxException)){
+            $oOxException = oxNew("oxException");
+            $oOxException->setMessage($oEx->getMessage());
+            $oOxException->debugOut();
+        } else {
+            $oEx->debugOut();
+        }
     }
 
     /**


### PR DESCRIPTION
cUrl error codes (Online License Check) disappear as they are not written to a log file or shown. If this bug is fixed, the second bug can be seen on the file EXCEPTION_LOG.log: If a exception is thrown for a cUrl error, the translation string EXCEPTION_CURL_ERROR gets not translated as this string is not present in admin translation files.