### PR TITLE
fix broken javascript in combination with varnish

### DIFF
--- a/source/core/smarty/plugins/function.oxscript.php
+++ b/source/core/smarty/plugins/function.oxscript.php
@@ -186,7 +186,7 @@ function _oxscript_execute( $aScript, $sWidget, $blAjaxRequest )
     if (count($aScript)) {
         foreach ($aScript as $sScriptToken) {
             if ( $sWidget && !$blAjaxRequest ) {
-                $sScriptTokenSanitized = str_replace( '"', '\"', $sScriptToken );
+                $sScriptTokenSanitized = _oxscript_sanitize($sScriptToken);
                 $sOutput .= 'WidgetsHandler.registerFunction( "'. $sScriptTokenSanitized . '", "'.$sWidget.'");'. PHP_EOL ;
             } else {
                 $sOutput .= $sScriptToken. PHP_EOL;
@@ -195,6 +195,12 @@ function _oxscript_execute( $aScript, $sWidget, $blAjaxRequest )
     }
 
     return $sOutput;
+}
+
+function _oxscript_sanitize($sScripts)
+{
+    $sScriptTokenSanitized = strtr($sScripts,array('"' => '\"',"\r" =>'',"\n"=>'\n'));
+    return $sScriptTokenSanitized;
 }
 
 /**


### PR DESCRIPTION
oxscript must pack some javascript into a string to execute it in a global scope, for that

some characters must be replace to generate a valid string.

In the old version it does only replace quotes but newlines are also problematic and must be escaped.

Without that fix you will get javascript errors in combination with varnish in some situations, please contact me if you need to reproduce that.

Implementation details: i used a extra method, which i copied from a async javascript support module that we are using in projects.