### PR TITLE
PhpDoc: removed incorrect "@return null" from many constructors

### DIFF
--- a/source/application/controllers/admin/dynexportbase.php
+++ b/source/application/controllers/admin/dynexportbase.php
@@ -123,8 +123,6 @@ class DynExportBase extends oxAdminDetails
 
     /**
      * Calls parent costructor and initializes $this->_sFilePath parameter
-     *
-     * @return null
      */
     public function __construct()
     {

--- a/source/application/controllers/admin/voucherserie_export.php
+++ b/source/application/controllers/admin/voucherserie_export.php
@@ -56,8 +56,6 @@ class VoucherSerie_Export extends VoucherSerie_Main
 
     /**
      * Calls parent costructor and initializes $this->_sFilePath parameter
-     *
-     * @return null
      */
     public function __construct()
     {

--- a/source/application/models/oxaddress.php
+++ b/source/application/models/oxaddress.php
@@ -61,8 +61,6 @@ class oxAddress extends oxBase
 
     /**
      * Class constructor
-     *
-     * @return null
      */
     public function __construct()
     {

--- a/source/application/models/oxamountpricelist.php
+++ b/source/application/models/oxamountpricelist.php
@@ -63,8 +63,6 @@ class oxAmountPriceList extends oxList
 
     /**
      * Class constructor
-     *
-     * @return null
      */
     public function __construct()
     {

--- a/source/application/models/oxarticle.php
+++ b/source/application/models/oxarticle.php
@@ -471,8 +471,6 @@ class oxArticle extends oxI18n implements oxIArticle, oxIUrl
      * initiates parent constructor (parent::oxI18n()).
      *
      * @param array $aParams The array of names and values of oxArticle instance properties to be set on object instantiation
-     *
-     * @return null
      */
     public function __construct($aParams = null)
     {

--- a/source/application/models/oxcategorylist.php
+++ b/source/application/models/oxcategorylist.php
@@ -83,8 +83,6 @@ class oxCategoryList extends oxList
      * Class constructor, initiates parent constructor (parent::oxList()).
      *
      * @param string $sObjectsInListName optional parameter, the objects contained in the list, always oxCategory
-     *
-     * @return null
      */
     public function __construct($sObjectsInListName = 'oxcategory')
     {

--- a/source/application/models/oxcontentlist.php
+++ b/source/application/models/oxcontentlist.php
@@ -85,8 +85,6 @@ class oxContentList extends oxList
 
     /**
      * Class constructor, initiates parent constructor (parent::oxList()).
-     *
-     * @return null
      */
     public function __construct()
     {

--- a/source/application/models/oxcountrylist.php
+++ b/source/application/models/oxcountrylist.php
@@ -30,8 +30,6 @@ class oxCountryList extends oxList
 
     /**
      * Call parent class constructor
-     *
-     * @return null
      */
     public function __construct()
     {

--- a/source/application/models/oxdeliverylist.php
+++ b/source/application/models/oxdeliverylist.php
@@ -73,8 +73,6 @@ class oxDeliveryList extends oxList
 
     /**
      * Calls parent constructor and sets home country
-     *
-     * @return null
      */
     public function __construct()
     {

--- a/source/application/models/oxdeliverysetlist.php
+++ b/source/application/models/oxdeliverysetlist.php
@@ -57,8 +57,6 @@ class oxDeliverySetList extends oxList
 
     /**
      * Calls parent constructor and sets home country
-     *
-     * @return null
      */
     public function __construct()
     {

--- a/source/application/models/oxdiscountlist.php
+++ b/source/application/models/oxdiscountlist.php
@@ -52,8 +52,6 @@ class oxDiscountList extends oxList
 
     /**
      * Class Constructor
-     *
-     * @return null
      */
     public function __construct()
     {

--- a/source/application/models/oxmanufacturerlist.php
+++ b/source/application/models/oxmanufacturerlist.php
@@ -58,8 +58,6 @@ class oxManufacturerList extends oxList
 
     /**
      * Calls parent constructor and defines if Article vendor count is shown
-     *
-     * @return null
      */
     public function __construct()
     {

--- a/source/application/models/oxnews.php
+++ b/source/application/models/oxnews.php
@@ -45,8 +45,6 @@ class oxNews extends oxI18n
 
     /**
      * Class constructor, initiates parent constructor (parent::oxI18n()).
-     *
-     * @return null
      */
     public function __construct()
     {

--- a/source/application/models/oxpaymentlist.php
+++ b/source/application/models/oxpaymentlist.php
@@ -35,8 +35,6 @@ class oxPaymentList extends oxList
 
     /**
      * Class Constructor
-     *
-     * @return null
      */
     public function __construct()
     {

--- a/source/application/models/oxrecommlist.php
+++ b/source/application/models/oxrecommlist.php
@@ -57,8 +57,6 @@ class oxRecommList extends oxBase implements oxIUrl
 
     /**
      * Class constructor, initiates parent constructor (parent::oxBase()).
-     *
-     * @return null
      */
     public function __construct()
     {

--- a/source/application/models/oxremark.php
+++ b/source/application/models/oxremark.php
@@ -43,8 +43,6 @@ class oxRemark extends oxBase
 
     /**
      * Class constructor, initiates parent constructor (parent::oxBase()).
-     *
-     * @return null
      */
     public function __construct()
     {

--- a/source/application/models/oxsearch.php
+++ b/source/application/models/oxsearch.php
@@ -36,8 +36,6 @@ class oxSearch extends oxSuperCfg
 
     /**
      * Class constructor. Executes search lenguage setter
-     *
-     * @return null
      */
     public function __construct()
     {

--- a/source/application/models/oxselection.php
+++ b/source/application/models/oxselection.php
@@ -62,8 +62,6 @@ class oxSelection
      * @param string $sValue     selection value
      * @param string $blDisabled selection state - disabled/enabled
      * @param string $blActive   selection state - active/inactive
-     *
-     * @return null
      */
     public function __construct($sName, $sValue, $blDisabled, $blActive)
     {

--- a/source/application/models/oxselectlist.php
+++ b/source/application/models/oxselectlist.php
@@ -64,8 +64,6 @@ class oxSelectlist extends oxI18n implements oxISelectList
 
     /**
      * Calls parent constructor and initializes selection list
-     *
-     * @return null
      */
     public function __construct()
     {

--- a/source/application/models/oxshoplist.php
+++ b/source/application/models/oxshoplist.php
@@ -30,8 +30,6 @@ class oxShopList extends oxList
 
     /**
      * Calls parent constructor
-     *
-     * @return null
      */
     public function __construct()
     {

--- a/source/application/models/oxuser.php
+++ b/source/application/models/oxuser.php
@@ -183,8 +183,6 @@ class oxUser extends oxBase
 
     /**
      * Class constructor, initiates parent constructor (parent::oxBase()).
-     *
-     * @return null
      */
     public function __construct()
     {

--- a/source/application/models/oxuserbasket.php
+++ b/source/application/models/oxuserbasket.php
@@ -61,8 +61,6 @@ class oxUserBasket extends oxBase
 
     /**
      * Class constructor, initiates parent constructor (parent::oxBase()).
-     *
-     * @return null
      */
     public function __construct()
     {

--- a/source/application/models/oxuserlist.php
+++ b/source/application/models/oxuserlist.php
@@ -29,8 +29,6 @@ class oxUserList extends oxList
 
     /**
      * Class constructor
-     *
-     * @return null
      */
     public function __construct()
     {

--- a/source/application/models/oxvariantselectlist.php
+++ b/source/application/models/oxvariantselectlist.php
@@ -60,8 +60,6 @@ class oxVariantSelectList implements oxISelectList
      *
      * @param string $sLabel list label
      * @param int    $iIndex list index
-     *
-     * @return null
      */
     public function __construct($sLabel, $iIndex)
     {

--- a/source/application/models/oxvendorlist.php
+++ b/source/application/models/oxvendorlist.php
@@ -58,8 +58,6 @@ class oxVendorList extends oxList
 
     /**
      * Calls parent constructor and defines if Article vendor count is shown
-     *
-     * @return null
      */
     public function __construct()
     {

--- a/source/application/models/oxvoucherlist.php
+++ b/source/application/models/oxvoucherlist.php
@@ -29,8 +29,6 @@ class oxVoucherList extends oxList
 
     /**
      * Calls parent constructor
-     *
-     * @return null
      */
     public function __construct()
     {

--- a/source/application/models/oxwrapping.php
+++ b/source/application/models/oxwrapping.php
@@ -59,8 +59,6 @@ class oxWrapping extends oxI18n
     /**
      * Class constructor, initiates parent constructor (parent::oxBase()), loads
      * base shop objects.
-     *
-     * @return null
      */
     public function __construct()
     {


### PR DESCRIPTION
Many class constructors had a "@return null" annotation, which was wrong. (Returning null and not returning at all is not the same thing.)