### PR TITLE
skip empty vouchers gerneration

### DIFF
--- a/source/application/controllers/admin/voucherserie_main.php
+++ b/source/application/controllers/admin/voucherserie_main.php
@@ -148,6 +148,14 @@ class VoucherSerie_Main extends DynExportBase
      */
     public function start()
     {
+        $sVoucherNr = oxRegistry::getConfig()->getRequestParameter("voucherNr");
+        $bRandomNr = oxRegistry::getConfig()->getRequestParameter("randomVoucherNr");
+        $sClass = oxRegistry::getConfig()->getRequestParameter("cl");
+
+        if ($sClass == 'voucherserie_generate' && !$bRandomNr && empty($sVoucherNr)) {
+            return;
+        }
+        
         $this->_aViewData['refresh'] = 0;
         $this->_aViewData['iStart'] = 0;
         $iEnd = $this->prepareExport();
@@ -157,8 +165,8 @@ class VoucherSerie_Main extends DynExportBase
         // saving export info
         oxRegistry::getSession()->setVariable("voucherid", oxRegistry::getConfig()->getRequestParameter("voucherid"));
         oxRegistry::getSession()->setVariable("voucherAmount", abs((int) oxRegistry::getConfig()->getRequestParameter("voucherAmount")));
-        oxRegistry::getSession()->setVariable("randomVoucherNr", oxRegistry::getConfig()->getRequestParameter("randomVoucherNr"));
-        oxRegistry::getSession()->setVariable("voucherNr", oxRegistry::getConfig()->getRequestParameter("voucherNr"));
+        oxRegistry::getSession()->setVariable("randomVoucherNr", $bRandomNr);
+        oxRegistry::getSession()->setVariable("voucherNr", $sVoucherNr);
     }
 
     /**

--- a/source/application/controllers/admin/voucherserie_main.php
+++ b/source/application/controllers/admin/voucherserie_main.php
@@ -148,7 +148,7 @@ class VoucherSerie_Main extends DynExportBase
      */
     public function start()
     {
-        $sVoucherNr = oxRegistry::getConfig()->getRequestParameter("voucherNr");
+        $sVoucherNr = trim(oxRegistry::getConfig()->getRequestParameter("voucherNr"));
         $bRandomNr = oxRegistry::getConfig()->getRequestParameter("randomVoucherNr");
         $sClass = oxRegistry::getConfig()->getRequestParameter("cl");
 

--- a/source/application/models/oxvoucher.php
+++ b/source/application/models/oxvoucher.php
@@ -67,7 +67,7 @@ class oxVoucher extends oxBase
     public function getVoucherByNr($sVoucherNr, $aVouchers = array(), $blCheckavalability = false)
     {
         $oRet = null;
-        if (!is_null($sVoucherNr)) {
+        if (!empty($sVoucherNr)) {
 
             $sViewName = $this->getViewName();
             $sSeriesViewName = getViewName('oxvoucherseries');


### PR DESCRIPTION
Its possible in Oxid Admin Backend to generate empty voucher codes in Admin Backend. Choose custom code and set an amout of codes and click generate.

This codes are not useable cause javascript frontend validation requiered a value.

This fix skip generation of empty codes.