### PR TITLE
php 7 - fix incorrect jpgraph php version check

### DIFF
--- a/source/core/jpgraph/jpgraph.php
+++ b/source/core/jpgraph/jpgraph.php
@@ -223,26 +223,9 @@ if (!defined('MBTTF_DIR')) {
 }
 
 //
-// Check minimum PHP version
-//
-function CheckPHPVersion($aMinVersion) {
-    list($majorC, $minorC, $editC) = preg_split('/[\/.-]/', PHP_VERSION);
-    list($majorR, $minorR, $editR) = preg_split('/[\/.-]/', $aMinVersion);
-
-    if ($majorC != $majorR) return false;
-    if ($majorC < $majorR) return false;
-    // same major - check minor
-    if ($minorC > $minorR) return true;
-    if ($minorC < $minorR) return false;
-    // and same minor
-    if ($editC  >= $editR)  return true;
-    return true;
-}
-
-//
 // Make sure PHP version is high enough
 //
-if( !CheckPHPVersion(MIN_PHPVERSION) ) {
+if(version_compare(PHP_VERSION, MIN_PHPVERSION, '<')) {
     JpGraphError::RaiseL(13,PHP_VERSION,MIN_PHPVERSION);
     die();
 }


### PR DESCRIPTION
The jpgraph library uses a custom function to check the php version requirement (>= 5.1.0) which can't handle php version numbers != 5.
Using the version_compare() function lets the corresponding unit test succeed. Graph generation still works in php 7.
This is the last necessary change to let the whole testsuite succeed with php 7 (in half the time and with just 50 percent memory usage compared to 5.x)