### PR TITLE
0006304: oxseohistory is left untouched when deleting entities like oxArticle, oxCategory, oxContent, oxManufacturer, oxVendor

### DIFF
--- a/source/application/models/oxseoencoderarticle.php
+++ b/source/application/models/oxseoencoderarticle.php
@@ -645,6 +645,7 @@ class oxSeoEncoderArticle extends oxSeoEncoder
         $sIdQuoted = $oDb->quote($oArticle->getId());
         $oDb->execute("delete from oxseo where oxobjectid = $sIdQuoted and oxtype = 'oxarticle'");
         $oDb->execute("delete from oxobject2seodata where oxobjectid = $sIdQuoted");
+        $oDb->execute("delete from oxseohistory where oxobjectid = $sIdQuoted");
     }
 
     /**

--- a/source/application/models/oxseoencodercategory.php
+++ b/source/application/models/oxseoencodercategory.php
@@ -244,6 +244,7 @@ class oxSeoEncoderCategory extends oxSeoEncoder
         $oDb->execute("delete from oxseo where oxseo.oxtype = 'oxarticle' and oxseo.oxparams = $sIdQuoted");
         $oDb->execute("delete from oxseo where oxobjectid = $sIdQuoted and oxtype = 'oxcategory'");
         $oDb->execute("delete from oxobject2seodata where oxobjectid = $sIdQuoted");
+        $oDb->execute("delete from oxseohistory where oxobjectid = $sIdQuoted");
     }
 
     /**

--- a/source/application/models/oxseoencodercontent.php
+++ b/source/application/models/oxseoencodercontent.php
@@ -112,6 +112,7 @@ class oxSeoEncoderContent extends oxSeoEncoder
         $sIdQuoted = $oDb->quote($sId);
         $oDb->execute("delete from oxseo where oxobjectid = $sIdQuoted and oxtype = 'oxcontent'");
         $oDb->execute("delete from oxobject2seodata where oxobjectid = $sIdQuoted");
+        $oDb->execute("delete from oxseohistory where oxobjectid = $sIdQuoted");
     }
 
     /**

--- a/source/application/models/oxseoencodermanufacturer.php
+++ b/source/application/models/oxseoencodermanufacturer.php
@@ -143,6 +143,7 @@ class oxSeoEncoderManufacturer extends oxSeoEncoder
         $sIdQuoted = $oDb->quote($oManufacturer->getId());
         $oDb->execute("delete from oxseo where oxobjectid = $sIdQuoted and oxtype = 'oxmanufacturer'");
         $oDb->execute("delete from oxobject2seodata where oxobjectid = $sIdQuoted");
+        $oDb->execute("delete from oxseohistory where oxobjectid = $sIdQuoted");
     }
 
     /**

--- a/source/application/models/oxseoencodervendor.php
+++ b/source/application/models/oxseoencodervendor.php
@@ -143,6 +143,7 @@ class oxSeoEncoderVendor extends oxSeoEncoder
         $sIdQuoted = $oDb->quote($oVendor->getId());
         $oDb->execute("delete from oxseo where oxobjectid = $sIdQuoted and oxtype = 'oxvendor'");
         $oDb->execute("delete from oxobject2seodata where oxobjectid = $sIdQuoted");
+        $oDb->execute("delete from oxseohistory where oxobjectid = $sIdQuoted");
     }
 
     /**

--- a/tests/unit/models/oxseoencoderarticleTest.php
+++ b/tests/unit/models/oxseoencoderarticleTest.php
@@ -1201,8 +1201,12 @@ class Unit_Models_oxSeoEncoderArticleTest extends OxidTestCase
         $sQ = "insert into oxobject2seodata ( oxobjectid, oxshopid, oxlang ) values ( 'article_id', '{$sShopId}', '0' )";
         $oDb->execute($sQ);
 
+        $sQ = "insert into oxseohistory ( oxobjectid, oxident, oxshopid, oxlang ) values ( 'article_id', '132', '{$sShopId}', '0' )";
+        $oDb->execute($sQ);
+
         $this->assertTrue((bool) $oDb->getOne("select 1 from oxseo where oxobjectid = 'article_id'"));
         $this->assertTrue((bool) $oDb->getOne("select 1 from oxobject2seodata where oxobjectid = 'article_id'"));
+        $this->assertTrue((bool) $oDb->getOne("select 1 from oxseohistory where oxobjectid = 'article_id'"));
 
         $oArticle = new oxbase();
         $oArticle->setId('article_id');
@@ -1212,6 +1216,7 @@ class Unit_Models_oxSeoEncoderArticleTest extends OxidTestCase
 
         $this->assertFalse((bool) $oDb->getOne("select 1 from oxseo where oxobjectid = 'article_id'"));
         $this->assertFalse((bool) $oDb->getOne("select 1 from oxobject2seodata where oxobjectid = 'article_id'"));
+        $this->assertFalse((bool) $oDb->getOne("select 1 from oxseohistory where oxobjectid = 'article_id'"));
     }
 
     public function testCreateArticleCategoryUri()

--- a/tests/unit/models/oxseoencodercategoryTest.php
+++ b/tests/unit/models/oxseoencodercategoryTest.php
@@ -386,10 +386,13 @@ class Unit_Models_oxSeoEncoderCategoryTest extends OxidTestCase
         $oDb->execute($sQ);
         $sQ = "insert into oxobject2seodata ( oxobjectid, oxshopid, oxlang ) values ( 'obj_id', '{$sShopId}', '0' )";
         $oDb->execute($sQ);
+        $sQ = "insert into oxseohistory ( oxobjectid, oxident, oxshopid, oxlang ) values ( 'obj_id', '132', '{$sShopId}', '0' )";
+        $oDb->execute($sQ);
 
         $this->assertTrue((bool) $oDb->getOne("select 1 from oxseo where oxobjectid = 'obj_id'"));
         $this->assertTrue((bool) $oDb->getOne("select 1 from oxobject2seodata where oxobjectid = 'obj_id'"));
         $this->assertTrue((bool) $oDb->getOne("select 1 from oxseo where oxtype = 'oxarticle' and oxparams = 'obj_id' "));
+        $this->assertTrue((bool) $oDb->getOne("select 1 from oxseohistory where oxobjectid = 'obj_id'"));
 
         $oObj = new oxbase();
         $oObj->setId('obj_id');
@@ -400,5 +403,6 @@ class Unit_Models_oxSeoEncoderCategoryTest extends OxidTestCase
         $this->assertFalse((bool) $oDb->getOne("select 1 from oxseo where oxobjectid = 'obj_id'"));
         $this->assertFalse((bool) $oDb->getOne("select 1 from oxobject2seodata where oxobjectid = 'obj_id'"));
         $this->assertFalse((bool) $oDb->getOne("select 1 from oxseo where oxtype = 'oxarticle' and oxparams = 'obj_id' "));
+        $this->assertFalse((bool) $oDb->getOne("select 1 from oxseohistory where oxobjectid = 'obj_id'"));
     }
 }

--- a/tests/unit/models/oxseoencodercontentTest.php
+++ b/tests/unit/models/oxseoencodercontentTest.php
@@ -272,14 +272,19 @@ class Unit_Models_oxSeoEncoderContentTest extends OxidTestCase
         $sQ = "insert into oxobject2seodata ( oxobjectid, oxshopid, oxlang ) values ( 'oid', '{$sShopId}', '0' )";
         $oDb->execute($sQ);
 
+        $sQ = "insert into oxseohistory ( oxobjectid, oxident, oxshopid, oxlang ) values ( 'oid', '132', '{$sShopId}', '0' )";
+        $oDb->execute($sQ);
+
         $this->assertTrue((bool) $oDb->getOne("select 1 from oxseo where oxobjectid = 'oid'"));
         $this->assertTrue((bool) $oDb->getOne("select 1 from oxobject2seodata where oxobjectid = 'oid'"));
+        $this->assertTrue((bool) $oDb->getOne("select 1 from oxseohistory where oxobjectid = 'oid'"));
 
         $oEncoder = new oxSeoEncoderContent();
         $oEncoder->onDeleteContent('oid');
 
         $this->assertFalse((bool) $oDb->getOne("select 1 from oxseo where oxobjectid = 'oid'"));
         $this->assertFalse((bool) $oDb->getOne("select 1 from oxobject2seodata where oxobjectid = 'oid'"));
+        $this->assertFalse((bool) $oDb->getOne("select 1 from oxseohistory where oxobjectid = 'oid'"));
     }
 
 }

--- a/tests/unit/models/oxseoencodermanufacturerTest.php
+++ b/tests/unit/models/oxseoencodermanufacturerTest.php
@@ -307,8 +307,12 @@ class Unit_Models_oxSeoEncoderManufacturerTest extends OxidTestCase
         $sQ = "insert into oxobject2seodata ( oxobjectid, oxshopid, oxlang ) values ( 'oid', '{$sShopId}', '0' )";
         $oDb->execute($sQ);
 
+        $sQ = "insert into oxseohistory ( oxobjectid, oxident, oxshopid, oxlang ) values ( 'oid', '132', '{$sShopId}', '0' )";
+        $oDb->execute($sQ);
+
         $this->assertTrue((bool) $oDb->getOne("select 1 from oxseo where oxobjectid = 'oid'"));
         $this->assertTrue((bool) $oDb->getOne("select 1 from oxobject2seodata where oxobjectid = 'oid'"));
+        $this->assertTrue((bool) $oDb->getOne("select 1 from oxseohistory where oxobjectid = 'oid'"));
 
         $oObj = new oxbase();
         $oObj->setId('oid');
@@ -318,6 +322,7 @@ class Unit_Models_oxSeoEncoderManufacturerTest extends OxidTestCase
 
         $this->assertFalse((bool) $oDb->getOne("select 1 from oxseo where oxobjectid = 'oid'"));
         $this->assertFalse((bool) $oDb->getOne("select 1 from oxobject2seodata where oxobjectid = 'oid'"));
+        $this->assertFalse((bool) $oDb->getOne("select 1 from oxseohistory where oxobjectid = 'oid'"));
     }
 
 }

--- a/tests/unit/models/oxseoencodervendorTest.php
+++ b/tests/unit/models/oxseoencodervendorTest.php
@@ -289,8 +289,12 @@ class Unit_Models_oxSeoEncoderVendorTest extends OxidTestCase
         $sQ = "insert into oxobject2seodata ( oxobjectid, oxshopid, oxlang ) values ( 'oid', '{$sShopId}', '0' )";
         $oDb->execute($sQ);
 
+        $sQ = "insert into oxseohistory ( oxobjectid, oxident, oxshopid, oxlang ) values ( 'oid', '132', '{$sShopId}', '0' )";
+        $oDb->execute($sQ);
+
         $this->assertTrue((bool) $oDb->getOne("select 1 from oxseo where oxobjectid = 'oid'"));
         $this->assertTrue((bool) $oDb->getOne("select 1 from oxobject2seodata where oxobjectid = 'oid'"));
+        $this->assertTrue((bool) $oDb->getOne("select 1 from oxseohistory where oxobjectid = 'oid'"));
 
         $oObj = new oxbase();
         $oObj->setId('oid');
@@ -300,6 +304,7 @@ class Unit_Models_oxSeoEncoderVendorTest extends OxidTestCase
 
         $this->assertFalse((bool) $oDb->getOne("select 1 from oxseo where oxobjectid = 'oid'"));
         $this->assertFalse((bool) $oDb->getOne("select 1 from oxobject2seodata where oxobjectid = 'oid'"));
+        $this->assertFalse((bool) $oDb->getOne("select 1 from oxseohistory where oxobjectid = 'oid'"));
 
     }
 


### PR DESCRIPTION
For further information see https://bugs.oxid-esales.com/view.php?id=6304