### PR TITLE
Fix vat calculation when percentaged voucher with article or category relation is applied (fixes #5795, #6204 and #6283)

### DIFF
--- a/source/application/models/oxbasket.php
+++ b/source/application/models/oxbasket.php
@@ -1110,11 +1110,7 @@ class oxBasket extends oxSuperCfg
 
                         if ($dVoucherdiscount > 0) {
 
-                            if ($oVoucher->getDiscountType() == 'absolute') {
-                                $dVatPart = ($dPrice - $dVoucherdiscount) / $dPrice * 100;
-                            } else {
-                                $dVatPart = 100 - $oVoucher->getDiscount();
-                            }
+                            $dVatPart = ($dPrice - $dVoucherdiscount) / $dPrice * 100;
 
                             if (!$this->_aDiscountedVats) {
                                 if ($oPriceList = $this->getDiscountProductsPrice()) {


### PR DESCRIPTION
When applying voucher discounts to all VAT rates OXID eShop doesn't consider vouchers article or category restrictions and therefore applies restricted and percentaged discounts to the whole VAT value instead of only reduce the VAT value by the percentage it reduced the article sum.

The root cause lies in an unnecessary differentiation between vouchers with absolute and percentaged discounts: https://github.com/OXID-eSales/oxideshop_ce/blob/f048d032435b8c668f5868ab5ed3b0d050a1fdb9/source/application/models/oxbasket.php#L1116
At this point the variable `$dVatPart` is calulcated to determine the percentage a discount has reduced the article sum to apply the same proportionally reduction to the VAT value. The calulation for absolute voucher discounts is correct since it only considers the actual percentaged reduction to the basket instead of examine the discount instructions (e.g. "reduce by 15%") and applying these to the VAT values without considering article or category restriction.

### Example
Based on the attached screenshots we have two articles in our basket:
- Article 1 (#1952) = **6,00 €**
- Article 2 (#2024) = **11,00 €**

We add a voucher with 10% discount which is restricted to article 2 (#2024).
- The total article sum including taxes amounts to **17,00 €**
- The voucher discount value amounts to **-1,10 €**
- OXID eShop calculates the VAT value (rate 19%) = **2,71 €**

#### Current calculation
- `$dVatPart` is evaluated (prev. linked line) = (100 - 10 = **90 %**) and reduces the VAT value considering this percentage (line 1127) = 2,71 * 90 / 100 = **2,44 €** (see screenshot no. 1) although the discount is only applied to article 2.

#### Fixed calculation
- `$dVatPart` for percentaged vouchers is calculated just as for absolute vouchers:
- `$dVatPart` = (17,00 - 1,10) / 17,00 * 100 = **93,53 %** (this is the actual percentage of the article sum left after the restricted discount has been applied).
- VAT values are reduced by this percentage = 2,71 * 93,53 / 100 = **2,54 €** (see screenshot no. 2)

### Related bug reports
As far as I know this bug was first reported 1 year and 7 months ago in 
- https://bugs.oxid-esales.com/view.php?id=5795

There are two duplicates:
- https://bugs.oxid-esales.com/view.php?id=6204
- https://bugs.oxid-esales.com/view.php?id=6283

The report 6210 linked in the affected 6204 is not related to this issue.

### Screenshots
#### No. 1
<img width="958" src="https://cloud.githubusercontent.com/assets/149483/12373334/61773a28-bc76-11e5-965e-b3cae5a2185a.png">
#### No. 2
<img width="953" src="https://cloud.githubusercontent.com/assets/149483/12373333/61740b6e-bc76-11e5-9d6f-8d5ad2606025.png">