### PR TITLE
performance can be improved by using intervalls and REQUEST_TIME

### DIFF
--- a/source/Application/Model/oxarticle.php
+++ b/source/Application/Model/oxarticle.php
@@ -576,8 +576,7 @@ class oxArticle extends oxI18n implements ArticleInterface, oxIUrl
 
         // enabled time range check ?
         if ($this->getConfig()->getConfigParam('blUseTimeCheck')) {
-            $sDate = date('Y-m-d H:i:s', oxRegistry::get("oxUtilsDate")->getTime());
-            $sQ = "( $sQ or ( $sTable.oxactivefrom < '$sDate' and $sTable.oxactiveto > '$sDate' ) ) ";
+            $sQ = $this->_addSqlActiveRangeSnippet($sQ,$sTable);
         }
 
         return $sQ;
@@ -608,12 +607,11 @@ class oxArticle extends oxI18n implements ArticleInterface, oxIUrl
             $sQ = " and ( $sTable.oxstockflag != 2 or ( $sTable.oxstock + $sTable.oxvarstock ) > 0  ) ";
             //V #M513: When Parent article is not purchasable, it's visibility should be displayed in shop only if any of Variants is available.
             if (!$myConfig->getConfigParam('blVariantParentBuyable')) {
-                $sTimeCheckQ = '';
+                $activeCheck = 'art.oxactive = 1';
                 if ($myConfig->getConfigParam('blUseTimeCheck')) {
-                    $sDate = date('Y-m-d H:i:s', oxRegistry::get("oxUtilsDate")->getTime());
-                    $sTimeCheckQ = " or ( art.oxactivefrom < '$sDate' and art.oxactiveto > '$sDate' )";
+                    $activeCheck = $this->_addSqlActiveRangeSnippet($activeCheck,'art');
                 }
-                $sQ = " $sQ and IF( $sTable.oxvarcount = 0, 1, ( select 1 from $sTable as art where art.oxparentid=$sTable.oxid and ( art.oxactive = 1 $sTimeCheckQ ) and ( art.oxstockflag != 2 or art.oxstock > 0 ) limit 1 ) ) ";
+                $sQ = " $sQ and IF( $sTable.oxvarcount = 0, 1, ( select 1 from $sTable as art where art.oxparentid=$sTable.oxid and $activeCheck and ( art.oxstockflag != 2 or art.oxstock > 0 ) limit 1 ) ) ";
             }
         }
 

--- a/source/Core/Base.php
+++ b/source/Core/Base.php
@@ -938,14 +938,14 @@ class Base extends \oxSuperCfg
 
         // has 'activefrom'/'activeto' fields ?
         if (isset($this->_aFieldNames['oxactivefrom']) && isset($this->_aFieldNames['oxactiveto'])) {
-            $sDate = date('Y-m-d H:i:s', oxRegistry::get('oxUtilsDate')->getTime());
+            $query = $this->_addSqlActiveRangeSnippet($query, $tableName);
 
-            $query = $query ? " $query or " : '';
-            $query = " ( $query ( $tableName.oxactivefrom < '$sDate' and $tableName.oxactiveto > '$sDate' ) ) ";
         }
 
         return $query;
     }
+
+
 
     /**
      * This function is triggered before the record is updated.
@@ -1540,5 +1540,38 @@ class Base extends \oxSuperCfg
     public function getLanguage()
     {
         return -1;
+    }
+
+    /**
+     * adds and activefrom/activeto to the query
+     * @param $query
+     * @param $tableName
+     *
+     * @return string
+     */
+    protected function _addSqlActiveRangeSnippet($query, $tableName)
+    {
+        $dateObj = oxRegistry::get('oxUtilsDate');
+        $sSecondsToRoundForQueryCache = $this->_getSecondsToRoundForQueryCache();
+        $databaseFormattedDate = $dateObj->getRoundedRequestDateDBFormatted($sSecondsToRoundForQueryCache);
+        $query = $query ? " $query or " : '';
+        $query = " ( $query ( $tableName.oxactivefrom < '$databaseFormattedDate' and $tableName.oxactiveto > '$databaseFormattedDate' ) ) ";
+
+        return $query;
+    }
+
+    /**
+     *  Return a number of seconds used to define a interval for rounding timestamps
+     *  e.g. this method returns the value 60 then it means timestamps should be rounded to full minutes
+     *  so the query may get an cache hit because it can be stable for an interval of one minute
+     *
+     *  it is a own method to allow overriding in child classes
+     *  @return int the amount of seconds
+     */
+    protected function _getSecondsToRoundForQueryCache()
+    {
+        //set default value cache time to 60 seconds
+        //because active from setting is based on minutes
+        return 60;
     }
 }

--- a/source/Core/oxutilsdate.php
+++ b/source/Core/oxutilsdate.php
@@ -548,13 +548,65 @@ class oxUtilsDate extends oxSuperCfg
     /**
      * Returns time according shop timezone configuration. Configures in
      * Admin -> Main menu -> Core Settings -> General
-     *
+     * @see getRequestTime
      * @return int current (modified according timezone) time
      */
     public function getTime()
     {
         return $this->shiftServerTime(time());
     }
+
+    /**
+     * Returns time wen the request was started according shop timezone configuration. Configures in
+     * Admin -> Main menu -> Core Settings -> General
+     * REQUEST TIME is faster because it is not an syscall like time
+     * @return int current (modified according timezone) time
+     */
+    public function getRequestTime()
+    {
+        return $this->shiftServerTime($_SERVER['REQUEST_TIME']);
+    }
+
+    /**
+     * Returns the the timestamp formatted as date string for the database
+     * @param $iTimestamp the timestamp to be formatted
+     *
+     * @return bool|string timestamp formatted as date string for the database, false on error
+     */
+    public function formatDBTimestamp($iTimestamp)
+    {
+        return date('Y-m-d H:i:s', $iTimestamp);
+    }
+
+    /**
+     * Returns the the timestamp formatted as date string for the database
+     * @param int $roundTo a amount of seconds to be rounded to e.g. 300 for rounding to 5 minutes
+     *
+     * @return bool|string  the data string formatted for the database (SQL), false on error
+     */
+    public function getRoundedRequestDateDBFormatted($roundTo)
+    {
+        $timestamp = $this->getRequestTime();
+        //round up x minutes so query cache can work
+        $timestamp = ceil($timestamp / $roundTo) * $roundTo;
+        //format date for sql query
+        $date = $this->formatDBTimestamp($timestamp);
+        return $date;
+    }
+
+
+
+
+    /**
+     * Returns the the request time formatted as date string for the database
+     *
+     * @return bool|string
+     */
+    public function getRequestTimeDBFormated()
+    {
+        return $this->formatDBTimestamp($this->getRequestTime());
+    }
+
 
     /**
      * Form time

--- a/tests/unit/core/I18nTest.php
+++ b/tests/unit/core/I18nTest.php
@@ -452,8 +452,8 @@ class Unit_Core_oxi18ntest extends OxidTestCase
 
     public function testGetSqlActiveSnippetForceCoreActiveMultilang()
     {
-        $iCurrTime = time();
-        oxTestModules::addFunction("oxUtilsDate", "getTime", "{ return $iCurrTime; }");
+        $iCurrTime = 1453734000; //some rounded timestamp
+        oxTestModules::addFunction("oxUtilsDate", "getRequestTime", "{ return $iCurrTime; }");
 
         $oI18n = $this->getMock('oxI18n', array('getViewName'));
         $oI18n->expects($this->once())->method('getViewName')->with($this->equalTo(null))->will($this->returnValue('oxi18n'));
@@ -476,8 +476,8 @@ class Unit_Core_oxi18ntest extends OxidTestCase
 
     public function testGetSqlActiveSnippet()
     {
-        $iCurrTime = time();
-        oxTestModules::addFunction("oxUtilsDate", "getTime", "{ return $iCurrTime; }");
+        $iCurrTime = 1453734000; //some rounded timestamp
+        oxTestModules::addFunction("oxUtilsDate", "getRequestTime", "{ return $iCurrTime; }");
 
         $sTable = 'oxi18n';
 

--- a/tests/unit/core/oxbaseTest.php
+++ b/tests/unit/core/oxbaseTest.php
@@ -2119,8 +2119,8 @@ class Unit_Core_oxbaseTest extends OxidTestCase
      */
     public function  testGetSqlActiveSnippet()
     {
-        $iCurrTime = time();
-        oxTestModules::addFunction("oxUtilsDate", "getTime", "{ return $iCurrTime; }");
+        $iCurrTime = 1453734000; //some rounded timestamp
+        oxTestModules::addFunction("oxUtilsDate", "getRequestTime", "{ return $iCurrTime; }");
 
         $aFields = array('oxactive' => 1, 'oxactivefrom' => 1, 'oxactiveto' => 1);
         $sDate = date('Y-m-d H:i:s', $iCurrTime);

--- a/tests/unit/models/oxactionlistTest.php
+++ b/tests/unit/models/oxactionlistTest.php
@@ -255,8 +255,8 @@ class Unit_Models_oxActionListTest extends OxidTestCase
      */
     public function testLoadBanners()
     {
-        oxTestModules::addFunction('oxUtilsDate', 'getTime', '{return ' . time() . ';}');
-        $sNow = (date('Y-m-d H:i:s', oxRegistry::get("oxUtilsDate")->getTime()));
+        oxTestModules::addFunction('oxUtilsDate', 'getRequestTime', '{return ' . (ceil(time() / 300) * 300) . ';}');
+        $sNow = (date('Y-m-d H:i:s', oxRegistry::get("oxUtilsDate")->getRequestTime()));
         $sShopId = $this->getConfig()->getShopId();
 
         $sView = getViewName('oxactions');

--- a/tests/unit/models/oxarticleTest.php
+++ b/tests/unit/models/oxarticleTest.php
@@ -349,13 +349,13 @@ class Unit_Models_oxArticleTest extends OxidTestCase
     public function testGetActiveCheckQuery()
     {
         $this->getConfig()->setConfigParam('blUseTimeCheck', true);
-        oxTestModules::addFunction("oxUtilsDate", "getTime", "{return 0;}");
-        $sDate = date('Y-m-d H:i:s', oxRegistry::get("oxUtilsDate")->getTime());
+        oxTestModules::addFunction("oxUtilsDate", "getRequestTime", "{return 0;}");
+        $sDate = date('Y-m-d H:i:s', oxRegistry::get("oxUtilsDate")->getRequestTime());
 
         $oArticle = oxNew('oxArticle');
         $sTable = $oArticle->getViewName();
 
-        $sQ = "(  $sTable.oxactive = 1  and $sTable.oxhidden = 0  or ( $sTable.oxactivefrom < '$sDate' and $sTable.oxactiveto > '$sDate' ) ) ";
+        $sQ = " (   $sTable.oxactive = 1  and $sTable.oxhidden = 0  or  ( $sTable.oxactivefrom < '$sDate' and $sTable.oxactiveto > '$sDate' ) ) ";
         $this->assertEquals($sQ, $oArticle->getActiveCheckQuery());
     }
 
@@ -369,8 +369,8 @@ class Unit_Models_oxArticleTest extends OxidTestCase
         $this->getConfig()->setConfigParam('blUseStock', true);
         $this->getConfig()->setConfigParam('blVariantParentBuyable', false);
         $this->getConfig()->setConfigParam('blUseTimeCheck', true);
-        oxTestModules::addFunction("oxUtilsDate", "getTime", "{return 0;}");
-        $sDate = date('Y-m-d H:i:s', oxRegistry::get("oxUtilsDate")->getTime());
+        oxTestModules::addFunction("oxUtilsDate", "getRequestTime", "{return 0;}");
+        $sDate = date('Y-m-d H:i:s', oxRegistry::get("oxUtilsDate")->getRequestTime());
 
         $oArticle = oxNew('oxArticle');
         $sTable = $oArticle->getViewName();
@@ -2136,7 +2136,7 @@ class Unit_Models_oxArticleTest extends OxidTestCase
         $oArticle->setAdminMode(true);
         $sInsert = "";
         if (!$this->getConfig()->getConfigParam('blVariantParentBuyable')) {
-            $sInsert = " and IF( $sTable.oxvarcount = 0, 1, ( select 1 from $sTable as art where art.oxparentid=$sTable.oxid and ( art.oxactive = 1  ) and ( art.oxstockflag != 2 or art.oxstock > 0 ) limit 1 ) ) ";
+            $sInsert = " and IF( $sTable.oxvarcount = 0, 1, ( select 1 from $sTable as art where art.oxparentid=$sTable.oxid and  art.oxactive = 1  and ( art.oxstockflag != 2 or art.oxstock > 0 ) limit 1 ) ) ";
         }
         $sExpSelect = "(  $sTable.oxactive = 1  and $sTable.oxhidden = 0  and ( $sTable.oxstockflag != 2 or ( $sTable.oxstock + $sTable.oxvarstock ) > 0  ) $sInsert ) ";
         $sSelect = $oArticle->getSqlActiveSnippet();
@@ -2150,15 +2150,15 @@ class Unit_Models_oxArticleTest extends OxidTestCase
      */
     public function testGetSqlActiveSnippetDontUseStock()
     {
-        $iCurrTime = time();
-        oxTestModules::addFunction("oxUtilsDate", "getTime", "{ return $iCurrTime; }");
+        $iCurrTime = 0;
+        oxTestModules::addFunction("oxUtilsDate", "getRequestTime", "{ return $iCurrTime; }");
 
         $this->getConfig()->setConfigParam('blUseStock', false);
         $oArticle = $this->_createArticle('_testArt');
         $oArticle->setAdminMode(true);
         $sTable = $oArticle->getViewName();
         $sDate = date('Y-m-d H:i:s', $iCurrTime);
-        $sExpSelect = "( (  $sTable.oxactive = 1  and $sTable.oxhidden = 0  or ( $sTable.oxactivefrom < '$sDate' and $sTable.oxactiveto > '$sDate' ) )  ) ";
+        $sExpSelect = "(  (   $sTable.oxactive = 1  and $sTable.oxhidden = 0  or  ( $sTable.oxactivefrom < '$sDate' and $sTable.oxactiveto > '$sDate' ) )  ) ";
         $sSelect = $oArticle->getSqlActiveSnippet();
         $this->assertEquals($sExpSelect, $sSelect);
     }

--- a/tests/unit/models/oxdiscountlistTest.php
+++ b/tests/unit/models/oxdiscountlistTest.php
@@ -187,8 +187,8 @@ class Unit_Models_oxDiscountlistTest extends OxidTestCase
     // no user
     public function testGetFilterSelectNoUser()
     {
-        $iCurrTime = time();
-        oxTestModules::addFunction("oxUtilsDate", "getTime", "{ return $iCurrTime; }");
+        $iCurrTime = 0;
+        oxTestModules::addFunction("oxUtilsDate", "getRequestTime", "{ return $iCurrTime; }");
         $sUserTable = getViewName('oxuser');
         $sGroupTable = getViewName('oxgroups');
         $sCountryTable = getViewName('oxcountry');

--- a/tests/unit/models/oxsearchTest.php
+++ b/tests/unit/models/oxsearchTest.php
@@ -761,8 +761,8 @@ class Unit_Models_oxsearchTest extends OxidTestCase
         $this->getConfig()->setConfigParam('aSearchCols', array('oxlongdesc'));
         $this->getConfig()->setConfigParam('blUseRightsRoles', 0);
 
-        $iCurrTime = time();
-        oxTestModules::addFunction("oxUtilsDate", "getTime", "{ return $iCurrTime; }");
+        $iCurrTime = 0;
+        oxTestModules::addFunction("oxUtilsDate", "getRequestTime", "{ return $iCurrTime; }");
 
         $sSearchDate = date('Y-m-d H:i:s', $iCurrTime);
         $sArticleTable = $sTable = getViewName('oxarticles');
@@ -796,10 +796,10 @@ class Unit_Models_oxsearchTest extends OxidTestCase
         $this->getConfig()->setConfigParam('blUseRightsRoles', 0);
 
         oxAddClassModule('modOxUtilsDate', 'oxUtilsDate');
-        oxRegistry::get("oxUtilsDate")->UNITSetTime(time());
+        oxRegistry::get("oxUtilsDate")->UNITSetTime(0);
 
-        $iCurrTime = time();
-        oxTestModules::addFunction("oxUtilsDate", "getTime", "{ return $iCurrTime; }");
+        $iCurrTime = 0;
+        oxTestModules::addFunction("oxUtilsDate", "getRequestTime", "{ return $iCurrTime; }");
 
         $sSearchDate = date('Y-m-d H:i:s', $iCurrTime);
         $sArticleTable = $sTable = getViewName('oxarticles');


### PR DESCRIPTION
by replacing the current time with a rounded request time it's possible for the query cache to hit the an cached sql query.

I used a 1 minutes interval for rounding so all queries can be cached(hit) for at least 1 minutes,

I did no performance test on this, would be great to get some feedback if it helps.
To test the "active from/to" stetting must be enabled, and you need high load situations on specific category pages.