### PR TITLE
backslash must also be escaped in javascript

### DIFF
--- a/source/Core/ViewHelper/JavaScriptRenderer.php
+++ b/source/Core/ViewHelper/JavaScriptRenderer.php
@@ -186,7 +186,7 @@ JS;
      */
     protected function sanitize($scripts)
     {
-        return strtr($scripts, array("'" => "\\'", "\r" => '', "\n" => '\n'));
+        return strtr($scripts, array('\\' => '\\\\', "'" => "\\'", "\r" => '', "\n" => '\n'));
     }
 
     /**


### PR DESCRIPTION
backslash must also be escaped, because the javascript may already include the escape character
(not yet tested, just ported from an recent fix from oxps async javascript module)