### PR TITLE
admin change: link from order to user for a better usability

### DIFF
--- a/source/Application/views/admin/tpl/navigation.tpl
+++ b/source/Application/views/admin/tpl/navigation.tpl
@@ -78,7 +78,7 @@
                         [{if $submenuitem->nodeType == XML_ELEMENT_NODE}]
                             [{assign var='sm' value=$sm+1}]
                             [{if $submenuitem->getAttribute('linkicon')}] [{assign var='linkicon' value=$submenuitem->getAttribute('linkicon')}][{/if}]
-                            <li class="[{if $submenuitem->getAttribute('active')}]act[{assign var='sNavActId' value="nav-`$mh`-`$mn`-`$sm`"}][{/if}]" id="nav-[{$mh}]-[{$mn}]-[{$sm}]">
+                            <li class="[{if $submenuitem->getAttribute('active')}]act[{assign var='sNavActId' value="nav-`$mh`-`$mn`-`$sm`"}][{/if}]" id="nav-[{$mh}]-[{$mn}]-[{$sm}]" name="nav_[{$submenuitem->getAttribute('cl')}]" rel="nav-[{$mh}]-[{$mn}]">
                                 <a href="[{if $submenuitem->getAttribute('url')}][{$submenuitem->getAttribute('url')}][{else}][{$submenuitem->getAttribute('link')}][{/if}]" onclick="_navAct(this);" target="basefrm" class="rc"><b>[{if $linkicon}]<span class="[{$linkicon}]">[{/if}][{oxmultilang ident=$submenuitem->getAttribute('name')|default:$submenuitem->getAttribute('id') noerror=true}][{if $linkicon}]</span>[{/if}]</b></a>
                             </li>
                             [{assign var='linkicon' value=''}]
@@ -183,6 +183,23 @@
             var _mna = _mnli.getElementsByTagName("a");
             if(_mna.length) {
                 _navExp(_mna[0]);
+            }
+        }
+    }
+
+    function _navExtExpActByName(sbid){
+        var sbid = "nav_" + sbid;
+        var _sbli = document.getElementsByName(sbid)[0];
+        if(_sbli) {
+            var mnid = _sbli.getAttribute("rel");
+            var _mnli = document.getElementById(mnid);
+            if(_mnli){
+                var _mna = _mnli.getElementsByTagName("a");
+                var _sba = _sbli.getElementsByTagName("a");
+                if(_mna.length && _sba.length) {
+                    _navExp(_mna[0]);
+                    _navAct(_sba[0]);
+                }
             }
         }
     }

--- a/source/Application/views/admin/tpl/order_overview.tpl
+++ b/source/Application/views/admin/tpl/order_overview.tpl
@@ -23,7 +23,7 @@
                 <br>
                 [{if $edit->oxorder__oxbillcompany->value}][{oxmultilang ident="GENERAL_COMPANY"}] [{$edit->oxorder__oxbillcompany->value}]<br>[{/if}]
                 [{if $edit->oxorder__oxbilladdinfo->value}][{$edit->oxorder__oxbilladdinfo->value}]<br>[{/if}]
-                [{$edit->oxorder__oxbillsal->value|oxmultilangsal}] [{$edit->oxorder__oxbillfname->value}] [{$edit->oxorder__oxbilllname->value}]<br>
+                <a class="jumplink" href="[{$oViewConf->getSelfLink()}]cl=admin_user&oxid=[{$edit->oxorder__oxuserid->value}]" target="basefrm" onclick="_homeExpActByName('admin_user');">[{$edit->oxorder__oxbillsal->value|oxmultilangsal}] [{$edit->oxorder__oxbillfname->value}] [{$edit->oxorder__oxbilllname->value}]</a><br>
                 [{$edit->oxorder__oxbillstreet->value}] [{$edit->oxorder__oxbillstreetnr->value}]<br>
                 [{$edit->oxorder__oxbillstateid->value}]
                 [{$edit->oxorder__oxbillzip->value}] [{$edit->oxorder__oxbillcity->value}]<br>
@@ -235,7 +235,7 @@
             [{/block}]
             [{block name="admin_order_overview_customer_number"}]
                 [{assign var="user" value=$edit->getOrderUser()}]
-                <b>[{oxmultilang ident="CUSTOMERNUM"}]: </b>[{$user->oxuser__oxcustnr->value}]<br>
+                <b>[{oxmultilang ident="CUSTOMERNUM"}]: </b><a class="jumplink" href="[{$oViewConf->getSelfLink()}]cl=admin_user&oxid=[{$edit->oxorder__oxuserid->value}]" target="basefrm" onclick="_homeExpActByName('admin_user');">[{$user->oxuser__oxcustnr->value}]</a><br>
             [{/block}]
             <br>
                 <form name="myedit" id="myedit" action="[{$oViewConf->getSelfLink()}]" method="post">

--- a/source/Application/views/admin/tpl/user_main.tpl
+++ b/source/Application/views/admin/tpl/user_main.tpl
@@ -237,9 +237,11 @@ function chkInsert()
     </td>
     <!-- Anfang rechte Seite -->
     <td valign="top" class="edittext vr" align="left" width="50%">
-    [{if $oxid != "-1"}]
-       <input [{$readonly}] type="button" value="[{oxmultilang ident="GENERAL_ASSIGNGROUPS"}]" class="edittext" onclick="JavaScript:showDialog('&cl=user_main&aoc=1&oxid=[{$oxid}]');">
-    [{/if}]
+        [{block name="admin_user_main_assign_groups"}]
+            [{if $oxid != "-1"}]
+               <input [{$readonly}] type="button" value="[{oxmultilang ident="GENERAL_ASSIGNGROUPS"}]" class="edittext" onclick="JavaScript:showDialog('&cl=user_main&aoc=1&oxid=[{$oxid}]');">
+            [{/if}]
+        [{/block}]
     </td>
     </tr>
 </table>

--- a/source/out/admin/src/main.css
+++ b/source/out/admin/src/main.css
@@ -500,3 +500,7 @@ a#linkToUpdate:hover,
 .assignmentContainer {
     width: 100%;
 }
+
+a.jumplink{
+    text-decoration: underline;
+}


### PR DESCRIPTION
In the order overview in the backend the name of the user and the customer number got a link, so you can jump from the order directly to the user (better usability). It is possible to install more links (for the articles for example) so you have more cross references and it is easier to navigate.