### PR TITLE
seoencoder creates entries with the wrong objectid because the object…

### DIFF
--- a/source/Core/oxseoencoder.php
+++ b/source/Core/oxseoencoder.php
@@ -768,7 +768,7 @@ class oxSeoEncoder extends oxSuperCfg
                 values
                     ( {$sQtedObjectId}, {$sQtedIdent}, {$iQtedShopId}, {$iLang}, {$sQtedStdUrl}, {$sQtedSeoUrl}, {$sQtedType}, '$blFixed', '0', {$sParams} )
                 on duplicate key update
-                    oxident = {$sQtedIdent}, oxstdurl = {$sQtedStdUrl}, oxseourl = {$sQtedSeoUrl}, oxfixed = '$blFixed', oxexpired = '0'";
+                    oxobjectid = {$sQtedObjectId}, oxident = {$sQtedIdent}, oxstdurl = {$sQtedStdUrl}, oxseourl = {$sQtedSeoUrl}, oxfixed = '$blFixed', oxexpired = '0'";
 
         return $oDb->execute($sQ);
     }

--- a/tests/Unit/Application/Model/SeoEncoderTest.php
+++ b/tests/Unit/Application/Model/SeoEncoderTest.php
@@ -1398,6 +1398,27 @@ class SeoEncoderTest extends \OxidTestCase
         $this->assertEquals(1, $oDb->affected_Rows());
     }
 
+    public function testSaveToDbKeyCollision()
+    {
+        $oEncoder = $this->getProxyClass('oxSeoEncoder');
+
+        //add entry
+        $oEncoder->UNITsaveToDb("static", 'test', 'http://std', 'http://seo', 0, 0);
+        //override entry by using the same url
+        $oEncoder->UNITsaveToDb("static", 'testOtherId', 'http://std', 'http://seo', 0, 0);
+
+        $oDb = oxDb::getDb();
+
+        $oDb->Execute('delete from oxseo where oxobjectid="test"');
+        //assert 0 rows to be found with oxobjectid = test because the entry was overridden
+        //by an other object with the same url
+        $this->assertEquals(0, $oDb->affected_Rows());
+
+        $oDb->Execute('delete from oxseo where oxobjectid="testOtherId"');
+        //assert 1 rows to be found with oxobjectid = testOtherId because the entry was saved
+        $this->assertEquals(1, $oDb->affected_Rows());
+    }
+    
     public function testTrimUrl()
     {
         $sBaseUrl = $this->getConfig()->getConfigParam("sShopURL");


### PR DESCRIPTION
…id is not refresh.

It happened on a database with hundreds of similar urls

same-title.html
same-title-oxid.html
same-title-oxid1.html
...

And i realized the expired flag was not updated(to 0) for an seourl of some articles.

From programming point of view oxobjectid bust be set in that sql statement because it is not part of the primary key.