### PR TITLE
clear internally cached seourl in oxarticle and oxcategory

### DIFF
--- a/source/Application/Model/oxarticle.php
+++ b/source/Application/Model/oxarticle.php
@@ -1092,6 +1092,9 @@ class oxArticle extends oxI18n implements ArticleInterface, oxIUrl
         // load object from database
         parent::assign($aRecord);
 
+        //clear seo urls
+        $this->_aSeoUrls = array();
+
         $this->oxarticles__oxnid = $this->oxarticles__oxid;
 
         // check for simple article.

--- a/source/Application/Model/oxcategory.php
+++ b/source/Application/Model/oxcategory.php
@@ -260,6 +260,9 @@ class oxCategory extends oxI18n implements oxIUrl
     {
         $this->_iNrOfArticles = null;
 
+        //clear seo urls
+        $this->_aSeoUrls = array();
+
         return parent::assign($dbRecord);
     }
 


### PR DESCRIPTION
when using load or assign method on the same object again the seourl you will get the wrong seo url.

pseudo code:
```
$obj = oxNew('oxArticle')
$obj->load('123');
print $obj->getLink(); # e.g. http://myshop/123.html
$obj->load('3');
print $obj->getLink(); # again http://myshop/123.html because first time the url is cached. 
#the correct output should be something like http://myshop/3.html

```