### PR TITLE
WIP: removed code that force a session if http request uses POST method.

### DIFF
--- a/source/Core/Config.php
+++ b/source/Core/Config.php
@@ -463,7 +463,7 @@ class Config extends SuperConfig
     protected function initializeShop()
     {
         $this->_processSeoCall();
-        $this->getSession()->start();
+        $this->getSession()->start(false);
     }
 
     /**
@@ -2260,9 +2260,6 @@ class Config extends SuperConfig
     protected function _handleCookieException($oEx)
     {
         $this->_processSeoCall();
-
-        //starting up the session
-        $this->getSession()->start();
 
         // redirect to start page and display the error
         oxRegistry::get("oxUtilsView")->addErrorToDisplay($oEx);

--- a/source/Core/UtilsView.php
+++ b/source/Core/UtilsView.php
@@ -161,7 +161,6 @@ class UtilsView extends \oxSuperCfg
         //messages are stored in session
         $session = $this->getSession();
         if (!$session->getId() && !$session->isHeaderSent()) {
-            $session->setForceNewSession();
             $session->start();
         }
 

--- a/tests/Unit/Core/SessionTest.php
+++ b/tests/Unit/Core/SessionTest.php
@@ -1454,12 +1454,12 @@ class SessionTest extends \OxidTestCase
     }
 
     /**
-     * check if forces session on POST request
+     * check if session is not forced on every POST/GET request
      */
     function testIsSessionRequiredActionOnPost()
     {
         $oSess = $this->getMock('oxSession', array('_getRequireSessionWithParams'));
-        $oSess->expects($this->exactly(2))->method('_getRequireSessionWithParams')
+        $oSess->expects($this->any())->method('_getRequireSessionWithParams')
             ->will(
                 $this->returnValue(
                     array()
@@ -1471,7 +1471,7 @@ class SessionTest extends \OxidTestCase
             $_SERVER['REQUEST_METHOD'] = 'GET';
             $this->assertEquals(false, $oSess->UNITisSessionRequiredAction());
             $_SERVER['REQUEST_METHOD'] = 'POST';
-            $this->assertEquals(true, $oSess->UNITisSessionRequiredAction());
+            $this->assertEquals(false, $oSess->UNITisSessionRequiredAction());
         } catch (Exception $e) {
         }
         $_SERVER['REQUEST_METHOD'] = $sInitial;


### PR DESCRIPTION
Forcing a php session for http post requests makes trouble in several projects, because sessions may created on ajax request or form submits.
It is not gernnerall true that an POST request will need a session, the only thing "POST" does is storing data on the server and this can be independet from the current session.

On the other hand, forcing the session on POST requests may simplify other places and i am not sure what it may break.