### PR TITLE
Updated install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ When checking out this repository or downloading the zip file from this place, c
 1. make sure composer (https://getcomposer.org/) is installed on your system
 2. $ git clone https://github.com/OXID-eSales/oxideshop_ce.git
 3. $ cd oxideshop_ce/source
-4. $ composer install
+4. $ composer dump-autoload --no-dev
 
 
 ### Useful links

--- a/README.md
+++ b/README.md
@@ -21,10 +21,10 @@ Please note: if you don't know what the following is about, please download the 
 
 When checking out this repository or downloading the zip file from this place, composer is required for setting up OXID eShop.
 
-1. make sure composer (https://getcomposer.org/) is installed on your system
-2. $ git clone https://github.com/OXID-eSales/oxideshop_ce.git
-3. $ cd oxideshop_ce/source
-4. $ composer dump-autoload --no-dev
+1. make sure [composer] (https://getcomposer.org/) is installed on your system
+2. `$ git clone https://github.com/OXID-eSales/oxideshop_ce.git`
+3. `$ cd oxideshop_ce/source`
+4. `$ composer dump-autoload --no-dev`
 
 
 ### Useful links


### PR DESCRIPTION
You actually don't have to run `composer install` which installs all dev-dependencies. To get a running shop you only need the `vendor/autoload.php` which can be generated using `composer dump-autoload`