### PR TITLE
Fix invalid HTML in setup by upgrading Doctype to HTML5

### DIFF
--- a/source/Setup/tpl/_header.php
+++ b/source/Setup/tpl/_header.php
@@ -22,7 +22,7 @@
 
 $editionSelector = new \OxidEsales\Eshop\Core\Edition\EditionSelector();
 ?>
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01//EN" "http://www.w3.org/TR/html4/strict.dtd">
+<!DOCTYPE html>
 <html>
 <head>
     <meta charset="utf-8"/>


### PR DESCRIPTION
The `/>` syntax is not allowed for void elements in HTML4. We should be using HTML5 anyway by now.