### PR TITLE
allow CamelCase for class names in metadata extends area

### DIFF
--- a/source/Core/oxmodule.php
+++ b/source/Core/oxmodule.php
@@ -151,7 +151,11 @@ class oxModule extends oxSuperCfg
      */
     public function getExtensions()
     {
-        return isset($this->_aModule['extend']) ? $this->_aModule['extend'] : array();
+        $res = isset($this->_aModule['extend']) ? $this->_aModule['extend'] : array();
+        //convert class names (keys) to lower case because building extension chain is case sensitive and would fail
+        //if one module use CamelCase and the other not.
+        $res = array_change_key_case($res, CASE_LOWER);
+        return $res;
     }
 
     /**


### PR DESCRIPTION
CamelCase is currently not allowed in the extends area in metatadata of modules.
If an module does it anyway it may break other modules because then the module extension chain gets corrupted. This merge request does convert the module extends keys internally into lower case so modules can not cause this kind of problems anymore.

