### PR TITLE
OxNavigationTree::_loadFromFile() - fix iconv() fail leading to ommit…

### DIFF
--- a/source/Application/Controller/Admin/oxnavigationtree.php
+++ b/source/Application/Controller/Admin/oxnavigationtree.php
@@ -116,14 +116,17 @@ class OxNavigationTree extends oxSuperCfg
         } elseif (is_readable($sMenuFile) && ($sXml = @file_get_contents($sMenuFile))) {
 
             // looking for non supported character encoding
-            if (getStr()->preg_match("/encoding\=(.*)\?\>/", $sXml, $aMatches) !== 0) {
-                if (isset($aMatches[1])) {
-                    $sCurrEncoding = trim($aMatches[1], "\"");
-                    if (!in_array(strtolower($sCurrEncoding), $this->_aSupportedExpathXmlEncodings)) {
-                        $sXml = str_replace($aMatches[1], "\"UTF-8\"", $sXml);
-                        $sXml = iconv($sCurrEncoding, "UTF-8", $sXml);
-                    }
-                }
+            if ( getStr()->preg_match( '/\sencoding\="([^"]+)"\s*\?\s*\>/', $sXml, $aMatches ) !== 0 ) {
+               if ( isset( $aMatches[1] ) ) {
+                   $sCurrEncoding = trim( $aMatches[1] );
+                   if ( !in_array( strtolower( $sCurrEncoding ), $this->_aSupportedExpathXmlEncodings ) ) {
+                       $sXml = str_replace( $aMatches[1], 'UTF-8', $sXml );
+                       // fallback since $sCurrEncoding may be invalid and lead iconv to return FALSE 
+                       $sXml = iconv( $sCurrEncoding, 'UTF-8', $sXml ) !== false
+                             ? iconv( $sCurrEncoding, 'UTF-8', $sXml )
+                             : $sXml;
+                   }
+               }
             }
 
             // load XML as string


### PR DESCRIPTION
…ed menu.xml entry …

The original regex is too greedy and will match trailing whitespaces leading to a invalid `$sCurrEncoding` which will result in `iconv()` returning `false` … thus the menu items defined will never appear. A example xml (valid!) which triggers the error:
`<?xml version="1.0" encoding="ISO-8859-15" ?>` … `$sCurrEncoding` in this case would be `ISO-8859-15" ` …