### PR TITLE
Fix linting errors

### DIFF
--- a/source/out/azure/src/js/widgets/oxagbcheck.js
+++ b/source/out/azure/src/js/widgets/oxagbcheck.js
@@ -20,13 +20,12 @@
  */
 ( function( $ ) {
 
-    oxAGBCheck = {
+    var oxAGBCheck = {
 
         _create: function(){
 
             var self = this,
-                options = self.options,
-                el      = self.element;
+                el   = self.element;
 
              el.closest('form').submit(function() {
                 if( el.prop('checked') ){

--- a/source/out/azure/src/js/widgets/oxajax.js
+++ b/source/out/azure/src/js/widgets/oxajax.js
@@ -18,12 +18,12 @@
  * @copyright (C) OXID eSales AG 2003-2015
  * @version   OXID eShop CE
  */
-( function ( $ ) {
+( function ( $, window ) {
 
     /**
      * Ajax
      */
-    oxAjax = {
+    var oxAjax = {
 
         /**
          * Loading temporary screen when ajax call proceeds
@@ -217,9 +217,11 @@
          * @param e JS exception
          */
         reportJSError: function(e) {
+            /*eslint-disable no-console*/
             if (typeof console != 'undefined' && typeof console.error != 'undefined') {
                 console.error(e);
             }
+            /*eslint-enable no-console*/
         },
 
         /**
@@ -250,5 +252,6 @@
     };
 
     $.widget("ui.oxAjax", oxAjax );
+    window.oxAjax = oxAjax;
 
-})( jQuery );
+})( jQuery, window );

--- a/source/out/azure/src/js/widgets/oxamountpriceselect.js
+++ b/source/out/azure/src/js/widgets/oxamountpriceselect.js
@@ -27,8 +27,7 @@
         _create: function()
         {
             var self = this,
-                options = self.options,
-                el      = self.element;
+                el   = self.element;
 
             this.arrow             = this.element;
             this.arrowIcon         = this.arrow.children( 'img' );

--- a/source/out/azure/src/js/widgets/oxamountpriceselect.js
+++ b/source/out/azure/src/js/widgets/oxamountpriceselect.js
@@ -18,11 +18,11 @@
  * @copyright (C) OXID eSales AG 2003-2015
  * @version   OXID eShop CE
  */
-( function( $ ) {
+( function( $, window ) {
     /**
      * Details amount price selector
      */
-    oxAmountPriceSelect = {
+    var oxAmountPriceSelect = {
 
         _create: function()
         {
@@ -108,5 +108,6 @@
     };
 
     $.widget( "ui.oxAmountPriceSelect", oxAmountPriceSelect );
+    window.oxAmountPriceSelect = oxAmountPriceSelect;
 
-} )( jQuery );
+} )( jQuery, window );

--- a/source/out/azure/src/js/widgets/oxarticleactionlinksselect.js
+++ b/source/out/azure/src/js/widgets/oxarticleactionlinksselect.js
@@ -18,11 +18,11 @@
  * @copyright (C) OXID eSales AG 2003-2015
  * @version   OXID eShop CE
  */
-( function( $ ) {
+( function( $, window ) {
     /**
      * Details article action links selector
      */
-    oxArticleActionLinksSelect = {
+    var oxArticleActionLinksSelect = {
 
         _create: function()
         {
@@ -148,5 +148,6 @@
     };
 
     $.widget( "ui.oxArticleActionLinksSelect", oxArticleActionLinksSelect );
+    window.oxArticleActionLinksSelect = oxArticleActionLinksSelect;
 
-} )( jQuery );
+} )( jQuery, window );

--- a/source/out/azure/src/js/widgets/oxarticleactionlinksselect.js
+++ b/source/out/azure/src/js/widgets/oxarticleactionlinksselect.js
@@ -27,8 +27,7 @@
         _create: function()
         {
             var self = this,
-                options = self.options,
-                el      = self.element;
+                el   = self.element;
 
             var targetWidth  = $("span", el).width();
             var linkboxWidth = self.getLinkboxWidth( targetWidth, $("span", el));

--- a/source/out/azure/src/js/widgets/oxarticlebox.js
+++ b/source/out/azure/src/js/widgets/oxarticlebox.js
@@ -20,7 +20,7 @@
  */
 ( function( $ ) {
 
-    oxArticleBox = {
+    var oxArticleBox = {
 
         _create: function(){
             var oSelf         = this,
@@ -76,7 +76,7 @@
                     {
                         iTitleLength--;
                         $(this).html(sTitleText.substr(0, iTitleLength)+'&hellip;' + sTitleEnd);
-                        var iTitleWidth = $(this).width();
+                        iTitleWidth = $(this).width();
                     }
                     $(this).attr('title',sTitleText);
                 }

--- a/source/out/azure/src/js/widgets/oxarticlevariant.js
+++ b/source/out/azure/src/js/widgets/oxarticlevariant.js
@@ -18,8 +18,12 @@
  * @copyright (C) OXID eSales AG 2003-2015
  * @version   OXID eShop CE
  */
-( function ( $ ) {
+( function ( $, window ) {
 
+    var oxAjax = window.oxAjax;
+    var oxVariantSelections = window.oxVariantSelections;
+    var WidgetsHandler = window.WidgetsHandler;
+    
     var oxArticleVariant = {
 
         /**
@@ -77,7 +81,7 @@
      * Handles variant selection action
      * @returns {boolean}
      */
-    function variantSelectActionHandler( e ) {
+    function variantSelectActionHandler() {
         var obj = $( this );
         // resetting
         if ( obj.parents().hasClass("js-disabled") ) {
@@ -101,7 +105,7 @@
      * Handles variant reset action
      * @returns {boolean}
      */
-    function variantResetActionHandler( e ) {
+    function variantResetActionHandler() {
         resetVariantSelections();
         var form = $("form.js-oxWidgetReload");
         $('input[name=fnc]', form).val("");
@@ -154,4 +158,4 @@
 
     $.widget("ui.oxArticleVariant", oxArticleVariant );
 
-})( jQuery );
+})( jQuery, window );

--- a/source/out/azure/src/js/widgets/oxbasketchecks.js
+++ b/source/out/azure/src/js/widgets/oxbasketchecks.js
@@ -20,13 +20,12 @@
  */
 ( function( $ ) {
 
-    oxBasketChecks = {
+    var oxBasketChecks = {
 
         _create: function(){
 
             var self = this,
-                options = self.options,
-                el      = self.element;
+                el   = self.element;
 
             el.click(function(){
                 if(el.is('input')){

--- a/source/out/azure/src/js/widgets/oxbetanote.js
+++ b/source/out/azure/src/js/widgets/oxbetanote.js
@@ -23,7 +23,7 @@
     /**
      * Beta note handler
      */
-    oxBetaNote = {
+    var oxBetaNote = {
         options: {
             cookieName  : "hideBetaNote",
             closeButton : ".dismiss"

--- a/source/out/azure/src/js/widgets/oxblockdebug.js
+++ b/source/out/azure/src/js/widgets/oxblockdebug.js
@@ -20,7 +20,7 @@
  */
 ( function ( $ ) {
 
-    oxBlockDebug = {
+    var oxBlockDebug = {
 
         _create : function(){
 

--- a/source/out/azure/src/js/widgets/oxcenterelementonhover.js
+++ b/source/out/azure/src/js/widgets/oxcenterelementonhover.js
@@ -20,7 +20,7 @@
  */
 ( function( $ ) {
 
-    oxCenterElementOnHover = {
+    var oxCenterElementOnHover = {
 
         _create: function(){
 

--- a/source/out/azure/src/js/widgets/oxcompare.js
+++ b/source/out/azure/src/js/widgets/oxcompare.js
@@ -18,13 +18,13 @@
  * @copyright (C) OXID eSales AG 2003-2015
  * @version   OXID eShop CE
  */
-(function ( $ )
+(function ( $, window )
 {
 
     /**
      * Compare list
      */
-    oxCompare = {
+    var oxCompare = {
         options: {
             browsers: {
                 chrome: "chrome",
@@ -170,5 +170,6 @@
      * Compare list widget
      */
     $.widget( "ui.oxCompare", oxCompare );
-
-})( jQuery );
+    window.oxCompare = oxCompare;
+    
+})( jQuery, window );

--- a/source/out/azure/src/js/widgets/oxcomparelinks.js
+++ b/source/out/azure/src/js/widgets/oxcomparelinks.js
@@ -18,12 +18,12 @@
  * @copyright (C) OXID eSales AG 2003-2015
  * @version   OXID eShop CE
  */
-( function ( $ ) {
+( function ( $, window ) {
 
     /**
      * Beta note handler
      */
-    oxCompareLinks = {
+    var oxCompareLinks = {
 
         /**
          * Update compare links, hide add link and show remove link.
@@ -45,5 +45,6 @@
      * CompareLinks widget
      */
     $.widget("ui.oxCompareLinks", oxCompareLinks );
+    window.oxCompareLinks = oxCompareLinks;
 
-})( jQuery );
+})( jQuery, window );

--- a/source/out/azure/src/js/widgets/oxcookienote.js
+++ b/source/out/azure/src/js/widgets/oxcookienote.js
@@ -23,7 +23,7 @@
     /**
      * Cookie note handler
      */
-    oxCookieNote = {
+    var oxCookieNote = {
         options: {
             closeButton : ".dismiss"
         },

--- a/source/out/azure/src/js/widgets/oxcountrystateselect.js
+++ b/source/out/azure/src/js/widgets/oxcountrystateselect.js
@@ -18,9 +18,13 @@
  * @copyright (C) OXID eSales AG 2003-2015
  * @version   OXID eShop CE
  */
-( function( $ ) {
+( function( $, window ) {
+    
+    var allStates = window.allStates;
+    var allCountryIds = window.allCountryIds;
+    var allStateIds = window.allStateIds;
 
-   oxCountryStateSelect = {
+   var oxCountryStateSelect = {
         options: {
             listItem        : "li",
             select          : "select",
@@ -149,5 +153,6 @@
     };
 
     $.widget("ui.oxCountryStateSelect", oxCountryStateSelect );
+    window.oxCountryStateSelect = oxCountryStateSelect;
 
-} )( jQuery );
+} )( jQuery, window );

--- a/source/out/azure/src/js/widgets/oxcountrystateselect.js
+++ b/source/out/azure/src/js/widgets/oxcountrystateselect.js
@@ -77,7 +77,7 @@
          */
         getStateSelect: function(oCountrySelect)
         {
-            oOptions = this.options;
+            var oOptions = this.options;
             return     $( oCountrySelect ).parent(oOptions.listItem).next(oOptions.listItem).children(oOptions.span).children(oOptions.select);
         },
 
@@ -88,7 +88,7 @@
          */
         getStateSelectSpan: function(oStateSelect)
         {
-            oOptions = this.options;
+            var oOptions = this.options;
             return     $( oStateSelect ).parent(oOptions.span);
         },
 

--- a/source/out/azure/src/js/widgets/oxdropdown.js
+++ b/source/out/azure/src/js/widgets/oxdropdown.js
@@ -18,9 +18,9 @@
  * @copyright (C) OXID eSales AG 2003-2015
  * @version   OXID eShop CE
  */
-( function ( $ ) {
+( function ( $, window ) {
 
-    oxDropDown = {
+    var oxDropDown = {
 
         options: {
             sSubmitActionClass  : 'js-fnSubmit',
@@ -153,5 +153,6 @@
     };
 
    $.widget("ui.oxDropDown", oxDropDown );
+    window.oxDropDown = oxDropDown;
 
-})( jQuery );
+})( jQuery, window );

--- a/source/out/azure/src/js/widgets/oxenterpassword.js
+++ b/source/out/azure/src/js/widgets/oxenterpassword.js
@@ -18,11 +18,11 @@
  * @copyright (C) OXID eSales AG 2003-2015
  * @version   OXID eShop CE
  */
-( function( $ ) {
+( function( $, window ) {
     /**
      * Show password field if email will be changed
      */
-    oxEnterPassword = {
+    var oxEnterPassword = {
         options: {
             metodEnterPasswd      : "oxValidate_enterPass"
         },
@@ -62,5 +62,6 @@
     };
 
     $.widget( "ui.oxEnterPassword", oxEnterPassword );
+    window.oxEnterPassword = oxEnterPassword;
 
-} )( jQuery );
+} )( jQuery, window );

--- a/source/out/azure/src/js/widgets/oxequalizer.js
+++ b/source/out/azure/src/js/widgets/oxequalizer.js
@@ -18,14 +18,12 @@
  * @copyright (C) OXID eSales AG 2003-2015
  * @version   OXID eShop CE
  */
-( function ( $ ) {
+( function ( $, window ) {
 
     /**
      * Equalize columns
-     *
-     * TODO: This variable is used globally
      */
-    oxEqualizer = {
+    var oxEqualizer = {
 
         /**
          * Gets tallest element value
@@ -60,5 +58,7 @@
             });
         }
     };
+    
+    window.oxEqualizer = oxEqualizer;
 
-})( jQuery );
+})( jQuery, window );

--- a/source/out/azure/src/js/widgets/oxfacebook.js
+++ b/source/out/azure/src/js/widgets/oxfacebook.js
@@ -18,6 +18,10 @@
  * @copyright (C) OXID eSales AG 2003-2015
  * @version   OXID eShop CE
  */
+(function( $, window ) {
+    
+    var FB = window.FB;
+    
     /*
      * Facebook related scripts
      */
@@ -61,7 +65,7 @@
             window.fbAsyncInit = function() {
 
                 FB.init({appId: sFbAppId, status: true, cookie: true, xfbml: true, oauth: true});
-                FB.Event.subscribe('auth.login', function(response) {
+                FB.Event.subscribe('auth.login', function() {
                     // redirecting after successfull login
                     setTimeout(function(){oxFacebook.redirectPage(sLoginUrl);}, 0);
 
@@ -69,7 +73,7 @@
                           setTimeout(function(){FB.XFBML.Host.parseDomTree;}, 0 );
                 });
 
-                FB.Event.subscribe('auth.logout', function(response) {
+                FB.Event.subscribe('auth.logout', function() {
                     // redirecting after logout
                     setTimeout(function(){oxFacebook.redirectPage(sLogoutUrl);}, 0);
                 });
@@ -102,4 +106,7 @@
         }
 
     };
-
+    
+    window.oxFacebook = oxFacebook;
+    
+})( jQuery, window );

--- a/source/out/azure/src/js/widgets/oxfacebook.js
+++ b/source/out/azure/src/js/widgets/oxfacebook.js
@@ -21,7 +21,7 @@
     /*
      * Facebook related scripts
      */
-    oxFacebook = {
+    var oxFacebook = {
 
         /*
          * FB widgets/buttons array
@@ -37,7 +37,7 @@
             var self = this;
             self.key = null;
 
-            for ( key in this.buttons ) {
+            for ( var key in this.buttons ) {
                 if ( this.buttons[key].script ) {
                     self.key = key;
                     $.getScript( this.buttons[key].script, function () {

--- a/source/out/azure/src/js/widgets/oxflyoutbox.js
+++ b/source/out/azure/src/js/widgets/oxflyoutbox.js
@@ -20,19 +20,17 @@
  */
 ( function( $ ) {
 
-    oxFlyOutBox = {
+    var oxFlyOutBox = {
 
         _create: function(){
 
             var self = this,
-                options = self.options,
-                el      = self.element;
+                el   = self.element;
 
 
 
             $(document).click( function( e ){
-                if( $(e.target).parents("div").hasClass("topPopList") ){
-                }else{
+                if( !$(e.target).parents("div").hasClass("topPopList") ){
                     $("div.flyoutBox").hide();
                 }
             });

--- a/source/out/azure/src/js/widgets/oxinfopopup.js
+++ b/source/out/azure/src/js/widgets/oxinfopopup.js
@@ -20,7 +20,7 @@
  */
 ( function( $ ) {
 
-    oxInfoPopup = {
+    var oxInfoPopup = {
             options: {
                 width         : 300,
                 resizable     : true,
@@ -54,7 +54,7 @@
                         zIndex         : options.zIndex,
                         position     : [position.left + 30, position.top - 30],
 
-                        open: function(event, ui) {
+                        open: function() {
 
                         $('div.ui-dialog-titlebar').css("visibility", "hidden");
                     }

--- a/source/out/azure/src/js/widgets/oxinnerlabel.js
+++ b/source/out/azure/src/js/widgets/oxinnerlabel.js
@@ -18,9 +18,9 @@
  * @copyright (C) OXID eSales AG 2003-2015
  * @version   OXID eShop CE
  */
-( function( $ ) {
+( function( $, window ) {
 
-    oxInnerLabel = {
+    var oxInnerLabel = {
 
         options: {
                 sDefaultValue  : 'innerLabel',
@@ -67,5 +67,6 @@
     };
 
     $.widget( "ui.oxInnerLabel", oxInnerLabel );
+    window.oxInnerLabel = oxInnerLabel;
 
-} )( jQuery );
+} )( jQuery, window );

--- a/source/out/azure/src/js/widgets/oxinputvalidator.js
+++ b/source/out/azure/src/js/widgets/oxinputvalidator.js
@@ -18,9 +18,9 @@
  * @copyright (C) OXID eSales AG 2003-2015
  * @version   OXID eShop CE
  */
-( function( $ ) {
+( function( $, window ) {
 
-    oxInputValidator = {
+    var oxInputValidator = {
             options: {
                 classValid                 : "oxValid",
                 classInValid               : "oxInValid",
@@ -379,6 +379,6 @@
      * Form Items validator
      */
     $.widget("ui.oxInputValidator", oxInputValidator );
+    window.oxInputValidator = oxInputValidator;
 
-
-} )( jQuery );
+} )( jQuery, window );

--- a/source/out/azure/src/js/widgets/oxinputvalidator.js
+++ b/source/out/azure/src/js/widgets/oxinputvalidator.js
@@ -131,20 +131,20 @@
                     }
 
                     if ( $( oInput ).hasClass( oOptions.methodValidateDate ) ) {
-                        oDay   = $( oInput ).parent().children( '.oxDay' );
-                        oMonth = $( oInput ).parent().children( '.oxMonth' );
-                        oYear  = $( oInput ).parent().children( '.oxYear' );
+                        var oDay   = $( oInput ).parent().children( '.oxDay' );
+                        var oMonth = $( oInput ).parent().children( '.oxMonth' );
+                        var oYear  = $( oInput ).parent().children( '.oxYear' );
                         
                         if ( !( oDay.val() && oMonth.val() && oYear.val() ) && !( !oDay.val() && !oMonth.val() && !oYear.val() ) ) {
                             return oOptions.errorMessageNotEmpty;
                         } else if ( oDay.val() && oMonth.val() && oYear.val() ) {
-                            RE = /^\d+$/;
-                            blDayOnlyDigits  = RE.test( oDay.val() );
-                            blYearOnlyDigits = RE.test( oYear.val() );
+                            var RE = /^\d+$/;
+                            var blDayOnlyDigits  = RE.test( oDay.val() );
+                            var blYearOnlyDigits = RE.test( oYear.val() );
                             if ( !blDayOnlyDigits || !blYearOnlyDigits ) {
                                 return oOptions.errorMessageIncorrectDate;
                             } else {
-                                iMonthDays = new Date((new Date(oYear.val(), oMonth.val(), 1))-1).getDate();
+                                var iMonthDays = new Date((new Date(oYear.val(), oMonth.val(), 1))-1).getDate();
                                 
                                 if ( oDay.val() <= 0 || oYear.val() <= 0 || oDay.val() > iMonthDays ) {
                                     return oOptions.errorMessageIncorrectDate;
@@ -177,7 +177,7 @@
                 var self = this;
                 var oOptions = this.options;
 
-                $( "." + oOptions.methodValidate, oForm).each(    function(index) {
+                $( "." + oOptions.methodValidate, oForm).each( function() {
 
                     if ( $( this ).is(oOptions.visible) ) {
 
@@ -206,7 +206,7 @@
                 var blIsValid = true;
                 var self = this;
                 var oOptions = this.options;
-                $("." + oOptions.methodValidate + ":not(:focus)", oFieldSet).each( function(index) {
+                $("." + oOptions.methodValidate + ":not(:focus)", oFieldSet).each( function() {
 
                     if ( $( this ).is(oOptions.visible) ) {
                         var tmpblIsValid = self.inputValidation( this, blCanSetDefaultState );
@@ -297,15 +297,15 @@
              */
             setDefaultState: function ( oObject )
             {
-                var oObject = $( oObject ).parent();
+                oObject = $( oObject ).parent();
 
                 oObject.removeClass(this.options.classInValid);
                 oObject.removeClass(this.options.classValid);
                 oObject.children(this.options.errorParagraph).hide();
 
-                oOptions = this.options;
+                var oOptions = this.options;
 
-                $( this.options.span, oObject.children( this.options.errorParagraph ) ).each( function(index) {
+                $( this.options.span, oObject.children( this.options.errorParagraph ) ).each( function() {
                     oObject.children( oOptions.errorParagraph ).children( oOptions.span ).hide();
                 });
 
@@ -319,7 +319,7 @@
              */
             getLength: function(oObject){
 
-                oOptions = this.options;
+                var oOptions = this.options;
 
                 return $( oOptions.idPasswordLength , oObject).val();
             },

--- a/source/out/azure/src/js/widgets/oxlistremovebutton.js
+++ b/source/out/azure/src/js/widgets/oxlistremovebutton.js
@@ -20,7 +20,7 @@
  */
 ( function( $ ) {
 
-    oxListRemoveButton = {
+    var oxListRemoveButton = {
 
         _create: function(){
 

--- a/source/out/azure/src/js/widgets/oxloginbox.js
+++ b/source/out/azure/src/js/widgets/oxloginbox.js
@@ -20,13 +20,12 @@
  */
 ( function( $ ) {
 
-    oxLoginBox = {
+    var oxLoginBox = {
 
         _create: function(){
 
             var self = this,
-                options = self.options,
-                el      = self.element;
+                el   = self.element;
 
             el.click(function(){
                 $("#loginBox").show();

--- a/source/out/azure/src/js/widgets/oxmanufacturerslider.js
+++ b/source/out/azure/src/js/widgets/oxmanufacturerslider.js
@@ -20,7 +20,7 @@
  */
 ( function( $ ) {
 
-    oxManufacturerSlider = {
+    var oxManufacturerSlider = {
             options: {
                 classButtonNext    : '.nextItem',
                 classButtonPrev    : '.prevItem'

--- a/source/out/azure/src/js/widgets/oxminibasket.js
+++ b/source/out/azure/src/js/widgets/oxminibasket.js
@@ -18,15 +18,17 @@
  * @copyright (C) OXID eSales AG 2003-2015
  * @version   OXID eShop CE
  */
-( function( $ ) {
+( function( $, window ) {
 
+    var oxAjax = window.oxAjax;
+    var WidgetsHandler = window.WidgetsHandler;
+        
     var oxMiniBasket = {
 
         _create: function(){
 
             var self = this,
-                options = self.options,
-                el      = self.element;
+                el   = self.element;
 
             var timeout;
 
@@ -135,4 +137,4 @@
 
     $.widget( "ui.oxMiniBasket", oxMiniBasket );
 
-} )( jQuery );
+} )( jQuery, window );

--- a/source/out/azure/src/js/widgets/oxmodalpopup.js
+++ b/source/out/azure/src/js/widgets/oxmodalpopup.js
@@ -20,7 +20,7 @@
  */
 ( function( $ ) {
 
-     oxModalPopup = {
+     var oxModalPopup = {
             options: {
                 width        : 687,
                 height       : 'auto',
@@ -79,7 +79,7 @@
                     position  : options.position,
                     draggable : options.draggable,
 
-                    open: function(event, ui) {
+                    open: function() {
                         $('div.ui-dialog-titlebar').remove();
                     }
                 });

--- a/source/out/azure/src/js/widgets/oxmorepictures.js
+++ b/source/out/azure/src/js/widgets/oxmorepictures.js
@@ -20,7 +20,7 @@
  */
 ( function( $ ) {
 
-    oxMorePictures = {
+    var oxMorePictures = {
 
         options: {
             iDefaultIndex  : -1
@@ -29,7 +29,6 @@
         _create: function() {
 
             var self    = this,
-                options = self.options,
                 el      = self.element;
 
             $("li a", el).click(function() {

--- a/source/out/azure/src/js/widgets/oxpayment.js
+++ b/source/out/azure/src/js/widgets/oxpayment.js
@@ -19,10 +19,9 @@
  * @version   OXID eShop CE
  */
 ( function( $ ) {
-    oxPayment = {
+    var oxPayment = {
         _create: function(){
             var self = this,
-                options = self.options,
                 el = self.element;
 
             $("dl dt input[type=radio]", el).click(function(){

--- a/source/out/azure/src/js/widgets/oxrating.js
+++ b/source/out/azure/src/js/widgets/oxrating.js
@@ -18,9 +18,9 @@
  * @copyright (C) OXID eSales AG 2003-2015
  * @version   OXID eShop CE
  */
-( function( $ ) {
+( function( $, window ) {
 
-    oxRating = {
+    var oxRating = {
         options: {
             reviewButton         : "writeNewReview",
             articleRatingValue   : "productRating",
@@ -117,6 +117,6 @@
      * Rating widget
      */
     $.widget("ui.oxRating", oxRating );
+    window.oxRating = oxRating;
 
-
-} )( jQuery );
+} )( jQuery, window );

--- a/source/out/azure/src/js/widgets/oxreview.js
+++ b/source/out/azure/src/js/widgets/oxreview.js
@@ -20,7 +20,7 @@
  */
 ( function( $ ) {
 
-    oxReview = {
+    var oxReview = {
         options: {
             reviewButton : "#writeNewReview",
             reviewForm   : "#writeReview"
@@ -30,7 +30,6 @@
 
             var self    = this;
             var options = self.options;
-            var el      = self.element;
 
             $( options.reviewButton ).click(function(){
                 $( options.reviewForm ).slideToggle();

--- a/source/out/azure/src/js/widgets/oxslider.js
+++ b/source/out/azure/src/js/widgets/oxslider.js
@@ -18,9 +18,9 @@
  * @copyright (C) OXID eSales AG 2003-2015
  * @version   OXID eShop CE
  */
-( function( $ ) {
+( function( $, window ) {
 
-    oxSlider = {
+    var oxSlider = {
             options: {
                 width                : 940,
                 height               : 220,
@@ -250,5 +250,6 @@
     };
 
     $.widget("ui.oxSlider", oxSlider );
+    window.oxSlider = oxSlider;
 
-} )( jQuery );
+} )( jQuery, window );

--- a/source/out/azure/src/js/widgets/oxslider.js
+++ b/source/out/azure/src/js/widgets/oxslider.js
@@ -64,7 +64,7 @@
                         startStopped        : options.startStopped,
                         delay               : options.delay,
                         animationTime       : options.animationTime,
-                        navigationFormatter : function(i, panel){
+                        navigationFormatter : function(i){
                             return aNavigationTabs[i - 1];
                         }
                 });
@@ -155,7 +155,7 @@
              */
             showControlsWithOpacity: function(oElement, fOpacity){
 
-                oOptions = this.options;
+                var oOptions = this.options;
 
                 this.showControlWithOpacity(oElement, oOptions.classForwardArrow, fOpacity);
                 this.showControlWithOpacity(oElement, oOptions.classBackArrow, fOpacity);
@@ -206,7 +206,7 @@
              */
             hideControls: function(oElement){
 
-                oOptions = this.options;
+                var oOptions = this.options;
 
                 this.hideControl(oElement, oOptions.classStartStop);
                 this.hideControl(oElement, oOptions.classForwardArrow);

--- a/source/out/azure/src/js/widgets/oxtag.js
+++ b/source/out/azure/src/js/widgets/oxtag.js
@@ -18,9 +18,10 @@
  * @copyright (C) OXID eSales AG 2003-2015
  * @version   OXID eShop CE
  */
-( function ( $ ) {
+( function ( $, window ) {
 
-    oxTag = {
+    var oxAjax = window.oxAjax;
+    var oxTag = {
 
          highTag : function() {
 
@@ -33,7 +34,7 @@
                 {//targetEl, onSuccess, onError, additionalData
                     'targetEl' : $("#tags"),
                     'additionalData' : {'highTags' : oSelf.prev().text(), 'blAjax' : '1'},
-                    'onSuccess' : function(response, params) {
+                    'onSuccess' : function() {
                         oSelf.prev().addClass('taggedText');
                         oSelf.hide();
                     }
@@ -50,17 +51,18 @@
                 {//targetEl, onSuccess, onError, additionalData
                     'targetEl' : $("#tags"),
                     'additionalData' : {'blAjax' : '1'},
-                    'onSuccess' : function(response, params) {
+                    'onSuccess' : function(response) {
                         response = JSON.parse(response);
+                        var tagError;
                         if ( response.tags.length > 0 ) {
                             $(".tagCloud").append("<span class='taggedText'>, " + response.tags + "</span> ");
                         }
                         if ( response.invalid.length > 0 ) {
-                            var tagError = $("p.tagError.invalid").show();
+                            tagError = $("p.tagError.invalid").show();
                             $("span", tagError).text( response.invalid );
                         }
                         if ( response.inlist.length > 0 ) {
-                            var tagError = $("p.tagError.inlist").show();
+                            tagError = $("p.tagError.inlist").show();
                             $("span", tagError).text( response.inlist );
                         }
                     }
@@ -75,7 +77,7 @@
                 {//targetEl, onSuccess, onError, additionalData
                     'targetEl' : $("#tags"),
                     'additionalData' : {'blAjax' : '1', 'fnc' : 'cancelTags'},
-                    'onSuccess' : function(response, params) {
+                    'onSuccess' : function(response) {
                         if ( response ) {
                             $('#tags').html(response);
                             $("#tags #editTag").click(oxTag.editTag);
@@ -93,7 +95,7 @@
                 { //targetEl, onSuccess, onError, additionalData
                     'targetEl' : $("#tags"),
                     'additionalData' : {'blAjax' : '1'},
-                    'onSuccess' : function(response, params) {
+                    'onSuccess' : function(response) {
 
                         if ( response ) {
                             $('#tags').html(response);
@@ -111,4 +113,4 @@
 
     $.widget("ui.oxTag", oxTag );
 
-})( jQuery );
+})( jQuery, window );

--- a/source/out/azure/src/js/widgets/oxtopmenu.js
+++ b/source/out/azure/src/js/widgets/oxtopmenu.js
@@ -20,13 +20,12 @@
  */
 ( function( $ ) {
 
-    oxTopMenu = {
+    var oxTopMenu = {
 
         _create: function(){
 
             var self = this,
-                options = self.options,
-                el      = self.element;
+                el   = self.element;
 
 
             if ($.browser.msie) {
@@ -51,11 +50,11 @@
                     $('a:first', this.parent()).addClass($.fn.superfish.op.hoverClass);
 
                     // horizontally centering top navigation first level popup according its parent
-                    activeItem = this.parent()
+                    var activeItem = this.parent()
                     if ( activeItem.parent().hasClass('sf-menu') ) {
-                        liWidth = activeItem.width();
-                        ulWidth = $('ul:first', activeItem).width();
-                        marginWidth = (liWidth - ulWidth) / 2;
+                        var liWidth = activeItem.width();
+                        var ulWidth = $('ul:first', activeItem).width();
+                        var marginWidth = (liWidth - ulWidth) / 2;
 
                         var itemleft = activeItem.position().left + marginWidth;
                         if (itemleft < 0) marginWidth -= itemleft;

--- a/source/out/azure/src/js/widgets/oxusershippingaddressselect.js
+++ b/source/out/azure/src/js/widgets/oxusershippingaddressselect.js
@@ -22,11 +22,10 @@
     /**
      * User shipping address selector
      */
-    oxUserShippingAddressSelect = {
+    var oxUserShippingAddressSelect = {
         _create: function()
         {
             var self = this,
-                options = self.options,
                 el = self.element;
 
             el.change(function() {

--- a/source/out/azure/src/js/widgets/oxzoompictures.js
+++ b/source/out/azure/src/js/widgets/oxzoompictures.js
@@ -20,7 +20,7 @@
  */
 ( function( $ ) {
 
-    oxZoomPictures = {
+    var oxZoomPictures = {
 
         options: {
             sMorePicsContainerId     : "#morePicsContainer",
@@ -54,10 +54,9 @@
          */
         _beforeShow: function() {
             var self    = this,
-                options = self.options,
-                el      = self.element;
+                options = self.options;
 
-            iIndex = $(options.sMorePicsContainerId + " li a.selected").parent().index();
+            var iIndex = $(options.sMorePicsContainerId + " li a.selected").parent().index();
             $(options.sMoreZoomPicsContainerId).oxMorePictures({iDefaultIndex: iIndex});
         }
     };


### PR DESCRIPTION
This PR fixes lots of missing `var` keywords and prevents variables from leaking into the global scope by assigning them to the `window` object. This makes it easier to work with modern javascript bundlers like browserify or webpack.