### PR TITLE
some code cleanup in oxdynimggenerator.php

### DIFF
--- a/source/Core/oxdynimggenerator.php
+++ b/source/Core/oxdynimggenerator.php
@@ -594,7 +594,7 @@ class oxDynImgGenerator
         $sLockName = $this->_getLockName($sSource);
 
         // creating lock file
-        $this->_hLockHandle = @fopen($this->_getLockName($sSource), "w");
+        $this->_hLockHandle = @fopen($sLockName, "w");
         if (is_resource($this->_hLockHandle)) {
             if (!($blLocked = flock($this->_hLockHandle, LOCK_EX))) {
                 // on failure - closing
@@ -606,8 +606,8 @@ class oxDynImgGenerator
         // in case system does not support file lockings
         if (!$blLocked) {
             // start a blank file to inform other processes we are dealing with it.
-            if (!(file_exists($this->_getLockName($sSource)) && abs(time() - filectime($this->_getLockName($sSource)) < 40))) {
-                if ($this->_hLockHandle = @fopen($this->_getLockName($sSource), "w")) {
+            if (!(file_exists($sLockName) && abs(time() - filectime($sLockName) < 40))) {
+                if ($this->_hLockHandle = @fopen($sLockName, "w")) {
                     $blLocked = true;
                 }
             }


### PR DESCRIPTION
reused $sLockName because it was
1. unused,
2. because you should not call methods more then once if you can hold the value within the same method (e.g. performance, DRY)
3. using variable names may help to document the code