### PR TITLE
Javascript: Use on event handler instead of load

### DIFF
--- a/source/out/azure/src/js/libs/anythingslider.js
+++ b/source/out/azure/src/js/libs/anythingslider.js
@@ -192,7 +192,7 @@
 
 			base.$items = base.$el.find('> li').addClass('panel');
 			base.setDimensions();
-			if (!base.options.resizeContents) { $(window).load(function(){ base.setDimensions(); }); } // set dimensions after all images load
+			if (!base.options.resizeContents) { $(window).on('load', function(){ base.setDimensions(); }); } // set dimensions after all images load
 
 			if (base.currentPage > base.pages) {
 				base.currentPage = base.pages;

--- a/source/out/azure/src/js/libs/cloudzoom.js
+++ b/source/out/azure/src/js/libs/cloudzoom.js
@@ -334,13 +334,13 @@
         };
 
         img1 = new Image();
-        $(img1).load(function () {
+        $(img1).on('load', function () {
             ctx.init2(this, 0);
         });
         img1.src = sImg.attr('src');
 
         img2 = new Image();
-        $(img2).load(function () {
+        $(img2).on('load', function () {
             ctx.init2(this, 1);
         });
         img2.src = jWin.attr('href');

--- a/source/out/azure/src/js/widgets/oxmodalpopup.js
+++ b/source/out/azure/src/js/widgets/oxmodalpopup.js
@@ -44,7 +44,7 @@
                 if (options.openDialog) {
 
                     if (options.loadUrl){
-                        $(options.target).load(options.loadUrl);
+                        $(options.target).on('load', options.loadUrl);
                     }
 
                     self.openDialog(options.target, options);
@@ -54,7 +54,7 @@
                     el.click(function(){
 
                         if (options.loadUrl){
-                            $(options.target).load(options.loadUrl);
+                            $(options.target).on('load', options.loadUrl);
                         }
 
                         self.openDialog(options.target, options);


### PR DESCRIPTION
Load was deprecated long ago in jQuery 1.8 (august 2012)