### PR TITLE
ESDEV-3502 Test and reimplement the method 'getAssoc'.

### DIFF
--- a/source/Core/Database/DatabaseInterface.php
+++ b/source/Core/Database/DatabaseInterface.php
@@ -122,13 +122,13 @@ interface DatabaseInterface
     public function select($query, $parameters = false, $executeOnSlave = true);
 
     /**
-     * Get values as an associative array.
+     * Get values as an associative array. The first column is taken as the key for the row.
      *
      * @param string     $query          The sql statement we want to execute.
      * @param array|bool $parameters     The parameters array.
      * @param bool       $executeOnSlave Execute this statement on the slave database. Only evaluated in a master - slave setup.
      *
-     * @return array
+     * @return array The rows for the corresponding sql select statement. The first column value is the key for the row.
      */
     public function getAssoc($query, $parameters = false, $executeOnSlave = true);
 

--- a/source/Core/Database/Doctrine.php
+++ b/source/Core/Database/Doctrine.php
@@ -462,6 +462,48 @@ class Doctrine extends oxLegacyDb implements DatabaseInterface, LoggerAwareInter
     }
 
     /**
+     * Get values as an associative array. The first column is taken as the key for the row.
+     *
+     * @param string     $query          The sql statement we want to execute.
+     * @param array|bool $parameters     The parameters array.
+     * @param bool       $executeOnSlave Execute this statement on the slave database. Only evaluated in a master - slave setup.
+     *
+     * @return array The rows for the corresponding sql select statement. The first column value is the key for the row.
+     */
+    public function getAssoc($query, $parameters = false, $executeOnSlave = true)
+    {
+        $preFetchMode = $this->interfaceFetchMode;
+
+        $this->setFetchMode(DatabaseInterface::FETCH_MODE_ASSOC);
+        $resultSet = $this->select($query, $parameters, $executeOnSlave);
+
+        $rows = $resultSet->getAll();
+
+        $this->setFetchMode($preFetchMode);
+
+        if (!$rows) {
+            return array();
+        }
+
+        $result = array();
+
+        foreach ($rows as $row) {
+            $firstColumn = array_keys($row)[0];
+            $key = $row[$firstColumn];
+
+            $values = array_values($row);
+
+            if (2 == count($values)) {
+                $values = $values[1];
+            }
+
+            $result[$key] = $values;
+        }
+
+        return $result;
+    }
+
+    /**
      * Get the values of a column.
      *
      * @param string     $query          The sql statement we want to execute.

--- a/tests/integration/core/Database/DatabaseInterfaceImplementationTest.php
+++ b/tests/integration/core/Database/DatabaseInterfaceImplementationTest.php
@@ -486,14 +486,69 @@ abstract class DatabaseInterfaceImplementationTest extends DatabaseInterfaceImpl
     }
 
     /**
+     * Test, that the method 'getAssoc' works without parameters and an empty table.
+     */
+    public function testGetAssocFromEmptyTable()
+    {
+        $result = $this->database->getAssoc('SELECT * FROM ' . self::TABLE_NAME);
+
+        $this->assertEmptyArray($result);
+    }
+
+    /**
+     * Test, that the method 'getAssoc' works without parameters and a non empty table.
+     */
+    public function testGetAssocFromNonEmptyTable()
+    {
+        $this->loadFixtureToTestTable();
+
+        $result = $this->database->getAssoc('SELECT * FROM ' . self::TABLE_NAME . ' ORDER BY oxid');
+
+        $expectedArray = array(
+            self::FIXTURE_OXID_1 => self::FIXTURE_OXUSERID_1,
+            self::FIXTURE_OXID_2 => self::FIXTURE_OXUSERID_2,
+            self::FIXTURE_OXID_3 => self::FIXTURE_OXUSERID_3
+        );
+        $this->assertEquals($expectedArray, $result);
+    }
+
+    /**
+     * Test, that the method 'getAssoc' works without parameters and a non empty table and reversed column order.
+     */
+    public function testGetAssocFromNonEmptyTableWithReversedColumns()
+    {
+        $this->loadFixtureToTestTable();
+        $result = $this->database->getAssoc('SELECT oxuserid, oxid FROM ' . self::TABLE_NAME . ' ORDER BY oxid');
+
+        $expectedArray = array(
+            self::FIXTURE_OXUSERID_1 => self::FIXTURE_OXID_1,
+            self::FIXTURE_OXUSERID_2 => self::FIXTURE_OXID_2,
+            self::FIXTURE_OXUSERID_3 => self::FIXTURE_OXID_3
+        );
+        $this->assertEquals($expectedArray, $result);
+    }
+
+    /**
+     * Test, that the method 'getAssoc' works with one parameter and a non empty table.
+     */
+    public function testGetAssocFromNonEmptyTableWithParameter()
+    {
+        $this->loadFixtureToTestTable();
+        $sqlSelect = 'SELECT * FROM ' . self::TABLE_NAME . " WHERE oxid = ? ORDER BY oxid";
+        $result = $this->database->getAssoc($sqlSelect, array(self::FIXTURE_OXID_2));
+
+        $expectedArray = array(self::FIXTURE_OXID_2 => self::FIXTURE_OXUSERID_2);
+        $this->assertEquals($expectedArray, $result);
+    }
+
+    /**
      * Test, that the method 'getCol' works without parameters and an empty result.
      */
     public function testGetColWithoutParametersEmptyResult()
     {
         $result = $this->database->getCol("SELECT OXID FROM " . self::TABLE_NAME);
 
-        $this->assertInternalType('array', $result);
-        $this->assertSame(0, count($result));
+        $this->assertEmptyArray($result);
     }
 
     /**
@@ -1010,5 +1065,16 @@ abstract class DatabaseInterfaceImplementationTest extends DatabaseInterfaceImpl
         $this->assertEmpty($resultSet->fields);
 
         $this->assertSame($this->getEmptyResultSetClassName(), get_class($resultSet));
+    }
+
+    /**
+     * Assert, that the given parameter is an empty array.
+     *
+     * @param mixed $parameter The hopefully empty array.
+     */
+    protected function assertEmptyArray($parameter)
+    {
+        $this->assertInternalType('array', $parameter);
+        $this->assertSame(0, count($parameter));
     }
 }


### PR DESCRIPTION
The doctrine database object must implement the behavior of the LegacyDatabase method 'getAssoc'.