### PR TITLE
performance saving config variables

### DIFF
--- a/source/Core/oxconfig.php
+++ b/source/Core/oxconfig.php
@@ -1850,6 +1850,12 @@ class oxConfig extends oxSuperCfg
 
         // Update value only for current shop
         if ($sShopId == $this->getShopId()) {
+            if($this->getConfigParam($sVarName) === $sVarVal) {
+                //if the value is equal to the current value in the cache
+                //do not save it for performance reasons
+                //caller is responsible for not calling setConfigParam manually before calling this method
+                return;
+            }
             $this->setConfigParam($sVarName, $sVarVal);
         }
 


### PR DESCRIPTION
make sure no action is taken when trying save an value that was not changed

if the value is equal to the current value in the cache (class member (scope current request))
do not save it for performance reasons

but be aware caller is responsible for NOT calling setConfigParam manually before calling saveShopConfVar method, it sometimes done in 'old' modules.
So this is a very minor BC break for old modules but it is. So if someone likes to back port this for 5.x/4.x he/she should be aware of the fact that he/she will have to fix affected modules by not calling setConfigParam before saveShopConfVar.