### PR TITLE
set html language regardless of performance settings

### DIFF
--- a/source/Application/Controller/BaseController.php
+++ b/source/Application/Controller/BaseController.php
@@ -1892,23 +1892,27 @@ class BaseController extends \oxView
 
     /**
      * Returns active lang suffix
-     *
+     * usally it used in html lang attr to allow the browser to interpret the page in the right language 
+     * e.g. to support hyphons
      * @return string
      */
     public function getActiveLangAbbr()
     {
-        // Performance
-        if (!$this->getConfig()->getConfigParam('bl_perfLoadLanguages')) {
-            return;
-        }
-
         if (!isset($this->_sActiveLangAbbr)) {
-            $languages = oxRegistry::getLang()->getLanguageArray();
-            while (list($key, $language) = each($languages)) {
-                if ($language->selected) {
-                    $this->_sActiveLangAbbr = $language->abbr;
-                    break;
+            $languageService = oxRegistry::getLang();
+            if ($this->getConfig()->getConfigParam('bl_perfLoadLanguages')) {
+                $languages = $languageService->getLanguageArray();
+                while (list($key, $language) = each($languages)) {
+                    if ($language->selected) {
+                        $this->_sActiveLangAbbr = $language->abbr;
+                        break;
+                    }
                 }
+            } else {
+                // Performance
+                // use oxid shop internal languageAbbr, this might be correct in the most cases but not guaranteed to be that
+                // configured in the admin backend for that language                
+                $this->_sActiveLangAbbr = $languageService->getLanguageAbbr();
             }
         }
 

--- a/tests/Unit/Application/Controller/UBaseTest.php
+++ b/tests/Unit/Application/Controller/UBaseTest.php
@@ -1269,8 +1269,10 @@ class UBaseTest extends \OxidTestCase
     public function testGetActiveLangAbbrWhenDisabledInConfig()
     {
         $this->setConfigParam('bl_perfLoadLanguages', false);
-        $oView = oxNew('oxUbase');
-        $this->assertNull($oView->getActiveLangAbbr());
+        //expect the same result like in testGetActiveLangAbbr
+        //the only difference is that for performance reasons with this setting the shop internal
+        //abbr is used and not the user defined settings from the database.
+        $this->testGetActiveLangAbbr();
     }
 
     public function testGetRequestParams()


### PR DESCRIPTION
set the language attribute in html is even if performance option to load languages is not enabled.
To do so i use the shop internal language abbr, that should be avail without loading the setting from the database,
so we will still have performance benefit but without loosing functionality to set html language
(in most cases, in special if internal language abbr matches the ISO 639-1 language abbr).