### PR TITLE
removed session ids from urls by default

### DIFF
--- a/source/Core/oxsession.php
+++ b/source/Core/oxsession.php
@@ -26,7 +26,6 @@
  * @deprecated on b-dev This class should not be used for direct extending. Please use parent class instead.
  *
  */
-
 class oxSession extends \OxidEsales\Eshop\Core\Session
 {
 }

--- a/source/config.inc.php.dist
+++ b/source/config.inc.php.dist
@@ -174,6 +174,15 @@
     $this->blSkipViewUsage = false;
 
     /**
+    * Allow session ids in urls
+    * Enable this only if you/your customers need it
+    * for security reasons it is not suggested to transfer/accept session ids in the url
+    * But you will need enable this option if you distinct https / http domains
+    */
+    $this->blAllowSidInUrl = false;
+
+
+    /**
      * Enterprise Edition related config options.
      * This options have no effect on Community/Professional Editions.
      */


### PR DESCRIPTION
it is not save anymore to transfer session id in urls.

on the other hand there are some valid usecases e.g.
 if you want to support user with disabled cookies,
 shops with extra ssl domain

but for this usecases i suggest to set
$this->blAllowSidInUrl = true in config.inc.php
and for default configuration the shop should pass the hardest security tests available