### PR TITLE
this change prevents the shop from disabling modules or going into an…

### DIFF
--- a/source/Core/UtilsObject.php
+++ b/source/Core/UtilsObject.php
@@ -115,10 +115,7 @@ class UtilsObject
      */
     public static function getInstance()
     {
-        // disable caching for test modules
-        if (defined('OXID_PHP_UNIT')) {
-            self::$_instance = null;
-        }
+        
 
         if (!self::$_instance instanceof UtilsObject) {
             // allow modules
@@ -135,6 +132,11 @@ class UtilsObject
             $moduleChainsGenerator = $oUtilsObject->oxNew('oxModuleChainsGenerator', $moduleVariablesLocator);
 
             self::$_instance = $oUtilsObject->oxNew('oxUtilsObject', $classNameProvider, $moduleChainsGenerator, $shopIdCalculator);
+        }
+
+        // disable caching for test modules
+        if (defined('OXID_PHP_UNIT')) {
+            self::$_instance->_aClassNameCache = [];
         }
 
         return self::$_instance;

--- a/source/config.inc.php.dist
+++ b/source/config.inc.php.dist
@@ -169,6 +169,13 @@
     $this->blDoNotDisableModuleOnError = false;
 
     /**
+     * If class from extension path does not exist, ignore it and try to continue
+     * The exception will be logged but not thrown, module will not be deactivate
+     * regardless of the blDoNotDisableModuleOnError setting
+     */
+    $this->blIgnoreModuleExtensionError = true;
+
+    /**
      * Enable temporarily in case you can't access the backend due to broken views
      */
     $this->blSkipViewUsage = false;


### PR DESCRIPTION
… unrecoverable state if modules are broken

we already have that blDoNotDisableModuleOnError configuration option, that give us some control how the shop should behave on module errors,
but in projects it has shown, that the current behavior is not a good default no matter how you set this variable.

If you set
blDoNotDisableModuleOnError to true, the shop may disable modules that you need only because of an temporary error.
and if you set blDoNotDisableModuleOnError to false, an module error may bring the shop in an unrecoverable state where you can not fix the module anymore.

So i introduced a new default that ignores errors, and tries to continue. You will still see the exception in logfiles, and maybe the broken module will may stop some areas of the shop from working,
but it's likely that will be able to fix the problem by module internals or by activating/deactivating the module in the backend.