### PR TITLE
always fresh config object

### DIFF
--- a/source/Core/SuperConfig.php
+++ b/source/Core/SuperConfig.php
@@ -39,7 +39,7 @@ class SuperConfig
      *
      * @var oxconfig
      */
-    protected static $_oConfig = null;
+    protected $_oConfig = null;
 
     /**
      * oxsession instance
@@ -110,11 +110,11 @@ class SuperConfig
      */
     public function getConfig()
     {
-        if (self::$_oConfig == null) {
-            self::$_oConfig = oxRegistry::getConfig();
+        if ($this->_oConfig == null) {
+            $this->_oConfig = oxRegistry::getConfig();
         }
 
-        return self::$_oConfig;
+        return $this->_oConfig;
     }
 
     /**
@@ -126,7 +126,7 @@ class SuperConfig
      */
     public function setConfig($config)
     {
-        self::$_oConfig = $config;
+        $this->_oConfig = $config;
     }
 
     /**


### PR DESCRIPTION
having the config not as static member makes it easier to change the configuration on the fly,
for example on cron jobs i often have the use case that  i need to switch the subshop within the cronjob.
but even after refreshing the config object in registry this class still holds the reference to the old config object.
this pull request should make that easier, because each object will fetch a fresh config object.

Please do some performance test before accepting this, i personally think the change is more important then performance impact,
but to be on the save side better measure before making such decision.