### PR TITLE
0006032: SEO Suffix, Prefix and Title doesnt support multilingual

### DIFF
--- a/source/Application/Controller/Admin/shop_seo.php
+++ b/source/Application/Controller/Admin/shop_seo.php
@@ -100,8 +100,6 @@ class Shop_Seo extends Shop_Config
      */
     public function save()
     {
-        parent::save();
-
         // saving config params
         $this->saveConfVars();
 


### PR DESCRIPTION
It's as simple as deleting the call to the parent save()-method which is unnecessary because it is almost redundant, despite the fact that the edit language is not considered in the parent method.

For further information see https://bugs.oxid-esales.com/view.php?id=6032