### PR TITLE
Disable xdebug for travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,7 @@ before_script:
   - sudo a2enmod rewrite actions fastcgi alias
   - echo "cgi.fix_pathinfo = 1" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini
   - ~/.phpenv/versions/$(phpenv version-name)/sbin/php-fpm
+  - phpenv config-rm xdebug.ini
   # configure apache virtual host
   - echo "$(curl -fsSL https://gist.githubusercontent.com/adriankirchner/197e3d13ccfb680f8942/raw/5b36cd3740cc05adb1c9d5c0568c851dd7700dcc/gistfile1.apacheconf)" | sudo tee /etc/apache2/sites-available/default > /dev/null
   - sudo sed -e "s|%TRAVIS_BUILD_DIR%|$(pwd)/source|g" --in-place /etc/apache2/sites-available/default


### PR DESCRIPTION
see https://docs.travis-ci.com/user/languages/php#Disabling-preinstalled-PHP-extensions and https://getcomposer.org/doc/articles/troubleshooting.md#xdebug-impact-on-composer
> Compared to a cli command run with "xdebug" enabled a speed improvement by a factor of up to 3 is not uncommon.