### PR TITLE
bugfix: wrong parameter count used for checkEMail

### DIFF
--- a/source/Application/Model/oxuser.php
+++ b/source/Application/Model/oxuser.php
@@ -1061,7 +1061,7 @@ class oxUser extends oxBase
         $sLogin = $oInputValidator->checkLogin($this, $sLogin, $aInvAddress);
 
         // 2. checking email
-        $oInputValidator->checkEmail($this, $sLogin, $aInvAddress);
+        $oInputValidator->checkEmail($this, $sLogin);
 
         // 3. password
         $oInputValidator->checkPassword($this, $sPassword, $sPassword2, ((int) oxRegistry::getConfig()->getRequestParameter('option') == 3));


### PR DESCRIPTION
oxInputValidator->checkEmail only has 2 parameters (from which one is not even used), here 3 parameters were given