### PR TITLE
fixed annotation stating incorrect return type

### DIFF
--- a/source/Core/oxseoencoder.php
+++ b/source/Core/oxseoencoder.php
@@ -709,7 +709,7 @@ class oxSeoEncoder extends oxSuperCfg
      *
      * @access protected
      *
-     * @return void
+     * @return mixed
      */
     protected function _saveToDb($sType, $sObjectId, $sStdUrl, $sSeoUrl, $iLang, $iShopId = null, $blFixed = null, $sParams = null)
     {


### PR DESCRIPTION
maybe you want to make sure void is always returned instead, but this way, PHPStorm will no longer complain