### PR TITLE
6171 - fixed wrong pagination behavior

### DIFF
--- a/source/Application/Controller/BaseController.php
+++ b/source/Application/Controller/BaseController.php
@@ -2069,11 +2069,11 @@ class BaseController extends \oxView
             $startNo = 2;
             $finishNo = $pageNavigation->NrOfPages;
         } else {
-            $tmpVal = $positionCount - 3;
+            $tmpVal = $positionCount - 4;
             $tmpVal2 = floor(($positionCount - 4) / 2);
 
             // actual page is at the start
-            if ($pageNavigation->actPage <= $tmpVal) {
+            if ($pageNavigation->actPage < $tmpVal) {
                 $startNo = 2;
                 $finishNo = $tmpVal + 1;
                 // actual page is at the end


### PR DESCRIPTION
https://bugs.oxid-esales.com/view.php?id=6171

The listing of the last page numbers is different to the beginning. Please have a look at the bug entry because there is a screenshot attached which shows the behavior and explains it simply. I didn't use the provided solution as the source of the problem was a few lines above.

I tested it with the theme Azure, so I can't speak for the new theme, but in Azure the box "pageHead" increased its high size, because the words "zurück" and "weiter" made the colum to wide.