### PR TITLE
5720 - Use the method Utils::checkUrlEndingSlash instead of a hard coded slash

### DIFF
--- a/source/Core/PictureHandler.php
+++ b/source/Core/PictureHandler.php
@@ -305,7 +305,7 @@ class PictureHandler extends \oxSuperCfg
             }
 
             if (!is_null($sFile)) {
-                $sAltUrl .= '/' . $sFilePath . $sFile;
+                $sAltUrl = Registry::getUtils()->checkUrlEndingSlash($sAltUrl) . $sFilePath . $sFile;
             }
         }
 

--- a/tests/Unit/Core/PictureHandlerTest.php
+++ b/tests/Unit/Core/PictureHandlerTest.php
@@ -504,9 +504,12 @@ class PictureHandlerTest extends \OxidTestCase
      */
     public function testGetAltImageUrlNoDoubleSlashes()
     {
-        $this->setConfigParam('sAltImageUrl', 'https://example.com/');
         $oPicHandler = oxnew('oxPictureHandler');
 
+        $this->setConfigParam('sAltImageUrl', 'https://example.com');
+        $this->assertEquals('https://example.com/path/nopic.jpg', $oPicHandler->getAltImageUrl('path/', 'nopic.jpg'));
+
+        $this->setConfigParam('sAltImageUrl', 'https://example.com/');
         $this->assertEquals('https://example.com/path/nopic.jpg', $oPicHandler->getAltImageUrl('path/', 'nopic.jpg'));
     }
 

--- a/tests/Unit/Core/PictureHandlerTest.php
+++ b/tests/Unit/Core/PictureHandlerTest.php
@@ -499,6 +499,17 @@ class PictureHandlerTest extends \OxidTestCase
         $this->assertEquals(array('path' => false, 'url' => 'https://aqqa/master/product/nopic.jpg',), $oPicHandler->p_getPictureInfo('master/product/', 'nopic.jpg'));
     }
 
+    /**
+     * #5720
+     */
+    public function testGetAltImageUrlNoDoubleSlashes()
+    {
+        $this->setConfigParam('sAltImageUrl', 'https://example.com/');
+        $oPicHandler = oxnew('oxPictureHandler');
+
+        $this->assertEquals('https://example.com/path/nopic.jpg', $oPicHandler->getAltImageUrl('path/', 'nopic.jpg'));
+    }
+
     public function testGetPictureInfoNotFound()
     {
         $oCfg = $this->getMock('oxConfig', array('getPicturePath', 'getOutDir', 'getOutUrl'));


### PR DESCRIPTION
https://bugs.oxid-esales.com/view.php?id=5720