### PR TITLE
6083 - article sorting fields not verified against valid field from admin settings

### DIFF
--- a/source/Application/Controller/BaseController.php
+++ b/source/Application/Controller/BaseController.php
@@ -28,6 +28,9 @@ use oxCategory;
 use oxCategoryList;
 use oxContent;
 use oxDb;
+use OxidEsales\Eshop\Core\Registry;
+use OxidEsales\Eshop\Core\Request;
+use OxidEsales\Eshop\Core\Str;
 use oxManufacturer;
 use oxManufacturerList;
 use oxPrice;
@@ -919,22 +922,24 @@ class BaseController extends \oxView
     public function getUserSelectedSorting()
     {
         $sorting = null;
-        $stringModifier = getStr();
-        $config = oxRegistry::getConfig();
         $sortDirections = array('desc', 'asc');
 
-        $sortBy = $config->getRequestParameter($this->getSortOrderByParameterName());
-        $sortOrder = $config->getRequestParameter($this->getSortOrderParameterName());
+        $request = Registry::get(Request::class);
+        $sortBy = $request->getRequestParameter($this->getSortOrderByParameterName());
+        $sortOrder = $request->getRequestParameter($this->getSortOrderParameterName());
 
-        if ($sortBy && oxDb::getInstance()->isValidFieldName($sortBy) && $sortOrder &&
-            oxRegistry::getUtils()->isValidAlpha($sortOrder) && in_array($stringModifier->strtolower($sortOrder), $sortDirections)
+        if ($sortBy &&
+            oxDb::getInstance()->isValidFieldName($sortBy) &&
+            $sortOrder &&
+            Registry::getUtils()->isValidAlpha($sortOrder) &&
+            in_array(Str::getStr()->strtolower($sortOrder), $sortDirections) &&
+            in_array($sortBy, oxNew('oxArticle')->getFieldNames())
         ) {
             $sorting = array('sortby' => $sortBy, 'sortdir' => $sortOrder);
         }
 
         return $sorting;
     }
-
 
     /**
      * Returns sorting variable from session

--- a/tests/Unit/Application/Controller/UBaseTest.php
+++ b/tests/Unit/Application/Controller/UBaseTest.php
@@ -828,7 +828,7 @@ class UBaseTest extends \OxidTestCase
     public function testsRemoveDuplicatedWords()
     {
         $aIn = array("aaa ccc bbb ccc ddd ccc"                                                                       => "aaa, ccc, bbb, ddd",
-                     "kuyichi, t-shirt, tiger, bekleidung, fashion, ihn, shirts, &, co., shirt, tiger, organic, men" => "kuyichi, t-shirt, tiger, bekleidung, fashion, ihn, shirts, co, shirt, organic, men",
+            "kuyichi, t-shirt, tiger, bekleidung, fashion, ihn, shirts, &, co., shirt, tiger, organic, men" => "kuyichi, t-shirt, tiger, bekleidung, fashion, ihn, shirts, co, shirt, organic, men",
         );
 
         $oView = oxNew('oxubase');
@@ -1022,7 +1022,7 @@ class UBaseTest extends \OxidTestCase
 
         $this->assertEquals(
             array(
-                 0 => array('title' => 'test', 'link' => 'http://example.com/')), $a
+                0 => array('title' => 'test', 'link' => 'http://example.com/')), $a
         );
 
         $oView->addRssFeed('testd', 'http://example.com/?test=1', 'iknowthiskey');
@@ -1030,8 +1030,8 @@ class UBaseTest extends \OxidTestCase
         $a = $oView->getRssLinks();
         $this->assertEquals(
             array(
-                 0              => array('title' => 'test', 'link' => 'http://example.com/'),
-                 'iknowthiskey' => array('title' => 'testd', 'link' => 'http://example.com/?test=1')), $a
+                0              => array('title' => 'test', 'link' => 'http://example.com/'),
+                'iknowthiskey' => array('title' => 'testd', 'link' => 'http://example.com/?test=1')), $a
         );
     }
 
@@ -1296,8 +1296,8 @@ class UBaseTest extends \OxidTestCase
         $this->setRequestParameter('recommid', 'recid');
 
         $sExpUrl = 'cl=testclass&amp;fnc=testfunc&amp;cnid=catid&amp;mnid=manId&amp;anid=artid&amp;page=2&amp;tpl=test&amp;oxloadid=test&amp;pgNr=2' .
-                   '&amp;searchparam=test&amp;searchcnid=searchcat&amp;searchvendor=searchven' .
-                   '&amp;searchmanufacturer=searchman&amp;searchrecomm=searchrec&amp;searchtag=searchtag&amp;recommid=recid';
+            '&amp;searchparam=test&amp;searchcnid=searchcat&amp;searchvendor=searchven' .
+            '&amp;searchmanufacturer=searchman&amp;searchrecomm=searchrec&amp;searchtag=searchtag&amp;recommid=recid';
         $this->assertEquals($sExpUrl, $oView->UNITgetRequestParams());
     }
 
@@ -2215,16 +2215,16 @@ class UBaseTest extends \OxidTestCase
     public function testGetNavigationParams()
     {
         $aParams = array("cnid"               => "testCategory",
-                         "mnid"               => "testManufacturer",
-                         "listtype"           => "testType",
-                         "ldtype"             => "testDisplay",
-                         "recommid"           => "paramValue",
-                         "searchrecomm"       => "testRecommendation",
-                         "searchparam"        => "testSearchParam",
-                         "searchtag"          => "testTag",
-                         "searchvendor"       => "testVendor",
-                         "searchcnid"         => "testCategory",
-                         "searchmanufacturer" => "testManufacturer",
+            "mnid"               => "testManufacturer",
+            "listtype"           => "testType",
+            "ldtype"             => "testDisplay",
+            "recommid"           => "paramValue",
+            "searchrecomm"       => "testRecommendation",
+            "searchparam"        => "testSearchParam",
+            "searchtag"          => "testTag",
+            "searchvendor"       => "testVendor",
+            "searchcnid"         => "testCategory",
+            "searchmanufacturer" => "testManufacturer",
         );
         foreach ($aParams as $sKey => $sValue) {
             $this->setRequestParameter($sKey, $sValue);
@@ -2467,5 +2467,60 @@ class UBaseTest extends \OxidTestCase
         $oUBase->expects($this->any())->method('getTitlePageSuffix')->will($this->returnValue($aParts['pageSuffix']));
 
         $this->assertEquals($sTitle, $oUBase->getPageTitle());
+    }
+
+    /**
+     * test for getUserSelectedSorting
+     * @see https://bugs.oxid-esales.com/view.php?id=6083
+     */
+    public function testGetUserSelectedSortingValidSorting()
+    {
+        /** @var BaseController $baseController */
+        $baseController = oxNew('oxUBase');
+
+        $_GET[$baseController->getSortOrderByParameterName()] = 'oxid';
+        $_GET[$baseController->getSortOrderParameterName()] = 'asc';
+        $this->assertEquals(
+            array('sortby' => 'oxid', 'sortdir' => 'asc'),
+            $baseController->getUserSelectedSorting()
+        );
+
+        $_GET[$baseController->getSortOrderParameterName()] = 'desc';
+        $this->assertEquals(
+            array('sortby' => 'oxid', 'sortdir' => 'desc'),
+            $baseController->getUserSelectedSorting()
+        );
+    }
+
+    /**
+     * test for getUserSelectedSorting
+     * @see https://bugs.oxid-esales.com/view.php?id=6083
+     */
+    public function testGetUserSelectedSortingInvalidSorting()
+    {
+        /** @var BaseController $baseController */
+        $baseController = oxNew('oxUBase');
+
+        //not existing field name
+        $_GET[$baseController->getSortOrderByParameterName()] = 'foobar';
+        $_GET[$baseController->getSortOrderParameterName()] = 'asc';
+        $this->assertNull($baseController->getUserSelectedSorting());
+
+        //empty field name
+        $_GET[$baseController->getSortOrderByParameterName()] = '';
+        $this->assertNull($baseController->getUserSelectedSorting());
+
+        //invalid field name
+        $_GET[$baseController->getSortOrderByParameterName()] = '42';
+        $this->assertNull($baseController->getUserSelectedSorting());
+
+        //not existing order direction
+        $_GET[$baseController->getSortOrderByParameterName()] = 'oxid';
+        $_GET[$baseController->getSortOrderParameterName()] = 'foobar';
+        $this->assertNull($baseController->getUserSelectedSorting());
+
+        //empty order direction
+        $_GET[$baseController->getSortOrderParameterName()] = '';
+        $this->assertNull($baseController->getUserSelectedSorting());
     }
 }


### PR DESCRIPTION
[Fixed bug 6083](https://bugs.oxid-esales.com/view.php?id=6083) 
- Added a check if the given sort field name is existing
- Replaced deprecated calls in BaseController::getUserSelectedSorting
- Wrote tests.




