### PR TITLE
oxactive filter missing in DB fetch in OxContent.php

### DIFF
--- a/source/Application/Model/Content.php
+++ b/source/Application/Model/Content.php
@@ -181,14 +181,15 @@ class Content extends \oxI18n implements \oxIUrl
      * Loads Content by using field oxloadid instead of oxid.
      *
      * @param string $sLoadId content load ID
+     * @param string $blActive selection state - active/inactive
      *
      * @return bool
      */
-    public function loadByIdent($sLoadId)
+    public function loadByIdent($sLoadId, $blActive = false)
     {
         $aData = $this->_loadFromDb($sLoadId);
 
-        if ($aData) {
+        if ($aData && (!$blActive || ($blActive && $aData['OXACTIVE']) == '1')) {
             $this->assign($aData);
             return true;
         }

--- a/source/Core/ViewConfig.php
+++ b/source/Core/ViewConfig.php
@@ -224,7 +224,7 @@ class ViewConfig extends \oxSuperCfg
             $aContentIdents = $this->_getHelpContentIdents();
             $oContent = oxNew("oxContent");
             foreach ($aContentIdents as $sIdent) {
-                if ($oContent->loadByIdent($sIdent)) {
+                if ($oContent->loadByIdent($sIdent, true)) {
                     $this->_sHelpPageLink = $oContent->getLink();
                     break;
                 }

--- a/tests/Unit/Application/Model/ContentTest.php
+++ b/tests/Unit/Application/Model/ContentTest.php
@@ -150,6 +150,21 @@ class ContentTest extends \OxidTestCase
         $this->assertFalse($oObj->loadByIdent('noSuchLoadId'));
     }
 
+    /*
+     * Test loading active/inactive content
+     */
+    public function testLoadByIdentInactiveContent()
+    {
+        $oObj = oxNew('oxContent');
+        $this->assertTrue($oObj->loadByIdent('_testLoadId'), 'can not load oxcontent by ident');
+        $oObj->oxcontents__oxactive = new oxField('0', oxField::T_RAW);
+        $oObj->save();
+        $this->assertFalse($oObj->loadByIdent('_testLoadId', true));
+        $oObj->oxcontents__oxactive = new oxField('1', oxField::T_RAW);
+        $oObj->save();
+        $this->assertTrue($oObj->loadByIdent('_testLoadId', true));
+    }
+
     public function test_setFieldData()
     {
         $oObj = $this->getProxyClass('oxcontent');


### PR DESCRIPTION
Applied oxactive filter to DB Fetch from oxcontent. Now Help Page link in footer is displayed according to the oxhelpdefault CMS Page.
