### PR TITLE
Background for selected CMS Page categories in Navigation and in the Category tree

### DIFF
--- a/source/Application/Component/Widget/oxwcategorytree.php
+++ b/source/Application/Component/Widget/oxwcategorytree.php
@@ -72,4 +72,17 @@ class oxwCategoryTree extends oxWidget
     {
         return $this->getViewParameter("deepLevel");
     }
+
+    /**
+     * Content category getter
+     *
+     * @return bool|string
+     */
+    public function getContentCategory()
+    {
+        if (oxRegistry::getConfig()->getRequestParameter('oxcid')) {
+            return oxRegistry::getConfig()->getRequestParameter('oxcid');
+        }
+        return false;
+    }
 }

--- a/source/Application/views/azure/tpl/widget/header/categorylist.tpl
+++ b/source/Application/views/azure/tpl/widget/header/categorylist.tpl
@@ -14,11 +14,11 @@
         [{foreach from=$ocat->getContentCats() item=oTopCont name=MoreTopCms}]
             [{assign var="iCatCnt" value=$iCatCnt+1}]
             [{if $iCatCnt <= $oView->getTopNavigationCatCnt()}]
-                <li><a href="[{$oTopCont->getLink()}]">[{$oTopCont->oxcontents__oxtitle->value}]</a></li>
+                <li [{if $homeSelected == 'false' && $oTopCont->expanded}]class="current"[{/if}]><a [{if $homeSelected == 'false' && $oTopCont->expanded}]class="current"[{/if}] href="[{$oTopCont->getLink()}]">[{$oTopCont->oxcontents__oxtitle->value}]</a></li>
             [{else}]
                 [{assign var="blShowMore" value=true}]
                 [{capture append="moreLinks"}]
-                    <li><a href="[{$oTopCont->getLink()}]">[{$oTopCont->oxcontents__oxtitle->value}]</a></li>
+                    <li [{if $homeSelected == 'false' && $oTopCont->expanded}]class="current"[{/if}]><a [{if $homeSelected == 'false' && $oTopCont->expanded}]class="current"[{/if}] href="[{$oTopCont->getLink()}]">[{$oTopCont->oxcontents__oxtitle->value}]</a></li>
                 [{/capture}]
             [{/if}]
         [{/foreach}]

--- a/source/Application/views/azure/tpl/widget/sidebar/categorytree.tpl
+++ b/source/Application/views/azure/tpl/widget/sidebar/categorytree.tpl
@@ -13,7 +13,7 @@
                 [{* CMS category *}]
                 [{if $_cat->getContentCats() && $deepLevel > 1}]
                     [{foreach from=$_cat->getContentCats() item=_oCont}]
-                    <li class="[{if $oContentCat && $oContentCat->getId()==$_oCont->getId()}] active [{else}] end [{/if}]" >
+                    <li class="[{if $oContentCat==$_oCont->getId()}] active [{/if}] end" >
                         <a href="[{$_oCont->getLink()}]"><i></i>[{$_oCont->oxcontents__oxtitle->value}]</a>
                     </li>
                     [{/foreach}]


### PR DESCRIPTION
Category created from CMS Pages do not show the Selection as other categories. The fix will also change how the category gets displayed in the sidebar.