### PR TITLE
nopic image file generation for unavailable png and gif files

### DIFF
--- a/source/Core/oxdynimggenerator.php
+++ b/source/Core/oxdynimggenerator.php
@@ -323,7 +323,7 @@ class oxDynImgGenerator
         $sPath = $this->_getShopBasePath() . $this->_getImageUri();
 
         // Correction for Bug:6291 - Changing the required nopic image format to the format of the requested image.
-        $sType = preg_replace("/.*\.(png|jp(e)?g|gif)$/", "\\1", $this->_getImageName());
+        $sType = $this->getImageType();
 
         return str_replace($this->_getImageName(), "nopic.".$sType, $sPath);
     }

--- a/source/Core/oxdynimggenerator.php
+++ b/source/Core/oxdynimggenerator.php
@@ -322,7 +322,10 @@ class oxDynImgGenerator
     {
         $sPath = $this->_getShopBasePath() . $this->_getImageUri();
 
-        return str_replace($this->_getImageName(), "nopic.jpg", $sPath);
+        // Correction for Bug:6291 - Changing the required nopic image format to the format of the requested image.
+        $sType = preg_replace("/.*\.(png|jp(e)?g|gif)$/", "\\1", $this->_getImageName());
+
+        return str_replace($this->_getImageName(), "nopic.".$sType, $sPath);
     }
 
     /**

--- a/source/Core/utils/oxpicgenerator.php
+++ b/source/Core/utils/oxpicgenerator.php
@@ -164,7 +164,19 @@ if (!function_exists("resizeGif")) {
         if (is_array($aResult)) {
             list($iNewWidth, $iNewHeight) = $aResult;
             $hDestinationImage = ($iGDVer == 1) ? imagecreate($iNewWidth, $iNewHeight) : imagecreatetruecolor($iNewWidth, $iNewHeight);
-            $hSourceImage = imagecreatefromgif($sSrc);
+            // Correction for Bug:6291 - When the source is not in GIF format, imagecreatefromgif will not work.
+            $sSrcType = preg_replace("/.*\.(png|jp(e)?g|gif)$/", "\\1", $sSrc);
+            switch ($sSrcType) {
+                case "png":
+                    $hSourceImage = imagecreatefrompng($sSrc);
+                    break;
+                case "jpg":
+                    $hSourceImage = imagecreatefromjpeg($sSrc);
+                    break;
+                case "gif":
+                    $hSourceImage = imagecreatefromgif($sSrc);
+                    break;
+            }
             $iTransparentColor = imagecolorresolve($hSourceImage, 255, 255, 255);
             $iFillColor = imagecolorresolve($hDestinationImage, 255, 255, 255);
             imagefill($hDestinationImage, 0, 0, $iFillColor);
@@ -208,7 +220,19 @@ if (!function_exists("resizePng")) {
             if ($hDestinationImage === null) {
                 $hDestinationImage = $iGdVer == 1 ? imagecreate($iNewWidth, $iNewHeight) : imagecreatetruecolor($iNewWidth, $iNewHeight);
             }
-            $hSourceImage = imagecreatefrompng($sSrc);
+            // Correction for Bug:6291 - When the source is not in PNG format, imagecreatefrompng will not work.
+            $sSrcType = preg_replace("/.*\.(png|jp(e)?g|gif)$/", "\\1", $sSrc);
+            switch ($sSrcType) {
+                case "png":
+                    $hSourceImage = imagecreatefrompng($sSrc);
+                    break;
+                case "jpg":
+                    $hSourceImage = imagecreatefromjpeg($sSrc);
+                    break;
+                case "gif":
+                    $hSourceImage = imagecreatefromgif($sSrc);
+                    break;
+            }
             if (!imageistruecolor($hSourceImage)) {
                 $hDestinationImage = imagecreate($iNewWidth, $iNewHeight);
                 // fix for transparent images sets image to transparent

--- a/source/Core/utils/oxpicgenerator.php
+++ b/source/Core/utils/oxpicgenerator.php
@@ -165,18 +165,7 @@ if (!function_exists("resizeGif")) {
             list($iNewWidth, $iNewHeight) = $aResult;
             $hDestinationImage = ($iGDVer == 1) ? imagecreate($iNewWidth, $iNewHeight) : imagecreatetruecolor($iNewWidth, $iNewHeight);
             // Correction for Bug:6291 - When the source is not in GIF format, imagecreatefromgif will not work.
-            $sSrcType = preg_replace("/.*\.(png|jp(e)?g|gif)$/", "\\1", $sSrc);
-            switch ($sSrcType) {
-                case "png":
-                    $hSourceImage = imagecreatefrompng($sSrc);
-                    break;
-                case "jpg":
-                    $hSourceImage = imagecreatefromjpeg($sSrc);
-                    break;
-                case "gif":
-                    $hSourceImage = imagecreatefromgif($sSrc);
-                    break;
-            }
+            $hSourceImage = imagecreatefromfile($sSrc);
             $iTransparentColor = imagecolorresolve($hSourceImage, 255, 255, 255);
             $iFillColor = imagecolorresolve($hDestinationImage, 255, 255, 255);
             imagefill($hDestinationImage, 0, 0, $iFillColor);
@@ -221,18 +210,7 @@ if (!function_exists("resizePng")) {
                 $hDestinationImage = $iGdVer == 1 ? imagecreate($iNewWidth, $iNewHeight) : imagecreatetruecolor($iNewWidth, $iNewHeight);
             }
             // Correction for Bug:6291 - When the source is not in PNG format, imagecreatefrompng will not work.
-            $sSrcType = preg_replace("/.*\.(png|jp(e)?g|gif)$/", "\\1", $sSrc);
-            switch ($sSrcType) {
-                case "png":
-                    $hSourceImage = imagecreatefrompng($sSrc);
-                    break;
-                case "jpg":
-                    $hSourceImage = imagecreatefromjpeg($sSrc);
-                    break;
-                case "gif":
-                    $hSourceImage = imagecreatefromgif($sSrc);
-                    break;
-            }
+            $hSourceImage = imagecreatefromfile($sSrc);
             if (!imageistruecolor($hSourceImage)) {
                 $hDestinationImage = imagecreate($iNewWidth, $iNewHeight);
                 // fix for transparent images sets image to transparent
@@ -280,7 +258,7 @@ if (!function_exists("resizeJpeg")) {
             if ($hDestinationImage === null) {
                 $hDestinationImage = $iGdVer == 1 ? imagecreate($iNewWidth, $iNewHeight) : imagecreatetruecolor($iNewWidth, $iNewHeight);
             }
-            $hSourceImage = imagecreatefromjpeg($sSrc);
+            $hSourceImage = imagecreatefromfile($sSrc);
             if (copyAlteredImage($hDestinationImage, $hSourceImage, $iNewWidth, $iNewHeight, $aImageInfo, $sTarget, $iGdVer)) {
                 imagejpeg($hDestinationImage, $sTarget, $iDefQuality);
                 imagedestroy($hDestinationImage);
@@ -289,5 +267,26 @@ if (!function_exists("resizeJpeg")) {
         }
 
         return makeReadable($sTarget);
+    }
+}
+if (!function_exists("imagecreatefromfile")) {
+    /**
+     * reads image
+     * @returns
+     */
+    function imagecreatefromfile($src) {
+        $sSrcType = preg_replace("/.*\.(png|jp(e)?g|gif)$/", "\\1", $sSrc);
+        switch ($sSrcType) {
+            case "png":
+                $hSourceImage = imagecreatefrompng($sSrc);
+                break;
+            case "jpg":
+                $hSourceImage = imagecreatefromjpeg($sSrc);
+                break;
+            case "gif":
+                $hSourceImage = imagecreatefromgif($sSrc);
+                break;
+            }
+            return $hSourceImage;
     }
 }


### PR DESCRIPTION
imagecreatefrompng was used to create the target image in the method OxPicGenerator::resizePng() without considering the source image format. Hence when a false image was requested in any format other than jpg(since nopic file currently present in jpg), no image gets printed. With this solution, if an unavailable png file is requested, a nopic.png is generated and output. The same goes for GIF images too.