### PR TITLE
Fix User::getSelectedAddress documentation

### DIFF
--- a/source/Application/Model/User.php
+++ b/source/Application/Model/User.php
@@ -432,7 +432,7 @@ class User extends \oxBase
 
     /**
      * Sets in the array oxuser::_aAddresses selected address.
-     * Returns user selected Address id.
+     * Returns user selected address object.
      *
      * @param bool $sWishId wishlist user id
      *


### PR DESCRIPTION
According to the documentation `User::getSelectedAddress` will return the id of the selected user address. This is not true since not the address identification but the hole address object will be returned.

Fixed documentation to reflect behaviour.