### PR TITLE
0006398: Payment type charges are not deleted changed back to a type with no costs

### DIFF
--- a/source/Application/Model/Payment.php
+++ b/source/Application/Model/Payment.php
@@ -315,6 +315,11 @@ class Payment extends \oxI18n
             }
 
             $this->_oPrice = $oPrice;
+        } else {
+            // no payment costs
+            $oPrice = oxNew('oxPrice');
+            $oPrice->setPrice(0);
+            $this->_oPrice = $oPrice;
         }
 
     }

--- a/tests/Unit/Application/Model/OrderTest.php
+++ b/tests/Unit/Application/Model/OrderTest.php
@@ -1101,7 +1101,7 @@ class OrderTest extends \OxidTestCase
         $oOrder->oxorder__oxpaymenttype->setValue("oxidinvoice");
         $oOrder->recalculateOrder();
 
-        $this->assertEquals('7.5', $oOrder->oxorder__oxpaycost->value);
+        $this->assertEquals('0.0', $oOrder->oxorder__oxpaycost->value);
     }
 
     //#M429: Total amounts are not recalculated when Shipping is changed for order in the admin


### PR DESCRIPTION
Problem are the following lines:
`$dPrice = $this->getPaymentValue($this->getBaseBasketPriceForPaymentCostCalc($oBasket));`
`if ($dPrice) {`
`...`

If there is no price it does nothing. This is no problem for the first order. But if you change it from a payment type which costs money to zero it will not remove it because of the if-statement. I added an else to explicitly set the costs to 0 if there are none.

https://bugs.oxid-esales.com/view.php?id=6398