### PR TITLE
enable to use oxNew during utilsobject bootstrap

### DIFF
--- a/source/Core/UtilsObject.php
+++ b/source/Core/UtilsObject.php
@@ -121,11 +121,12 @@ class UtilsObject
         }
 
         if (!self::$_instance instanceof UtilsObject) {
-            // allow modules
+            
             $oUtilsObject = new UtilsObject();
-
-            $classMapProvider = new ClassMapProvider(new EditionSelector());
-            $classNameProvider = new ClassNameProvider($classMapProvider->getOverridableClassMap());
+            // set the not overloaded(by modules) version early so oxnew can be used internally 
+            self::$_instance = $oUtilsObject;
+            // null for classNameProvider because it is generated in the constructor
+            $classNameProvider = null;
 
             $moduleVariablesCache = $oUtilsObject->oxNew('oxFileCache');
             $shopIdCalculator = $oUtilsObject->oxNew('oxShopIdCalculator', $moduleVariablesCache);
@@ -133,7 +134,8 @@ class UtilsObject
             $subShopSpecific = $oUtilsObject->oxNew('oxSubShopSpecificFileCache', $shopIdCalculator);
             $moduleVariablesLocator = $oUtilsObject->oxNew('oxModuleVariablesLocator', $subShopSpecific, $shopIdCalculator);
             $moduleChainsGenerator = $oUtilsObject->oxNew('oxModuleChainsGenerator', $moduleVariablesLocator);
-
+            
+            //generate UtilsObject again by oxnew to allow overloading by modules
             self::$_instance = $oUtilsObject->oxNew('oxUtilsObject', $classNameProvider, $moduleChainsGenerator, $shopIdCalculator);
         }
 


### PR DESCRIPTION
This is a minor improvement of the internal object creation process, 
that will help to simplify things by making it possible to use oxNew direcly or indirectly within the oxNew function.

technically: Set the not overloaded(by modules) version of UtilsObject as instance before creating the overloaded version.
- also some littel removement of duplicate code 
- some comments