### PR TITLE
#6411: Double slashes in request URI are replaced by single slash.

### DIFF
--- a/source/core/oxdynimggenerator.php
+++ b/source/core/oxdynimggenerator.php
@@ -253,6 +253,7 @@ class oxDynImgGenerator
 
 
             $sReqImg = isset($_SERVER["REQUEST_URI"]) ? urldecode($_SERVER["REQUEST_URI"]) : "";
+            $sReqImg = str_replace('//', '/', $sReqImg);
             if (($iPos = strpos($sReqImg, $sReqPath)) !== false) {
                 $this->_sImageUri = substr($sReqImg, $iPos);
             }

--- a/tests/unit/core/oxdynimggeneratorTest.php
+++ b/tests/unit/core/oxdynimggeneratorTest.php
@@ -36,6 +36,7 @@ class Unit_Core_oxDynImgGeneratorTest extends OxidTestCase
     public function testGetInstance()
     {
         $this->assertTrue(oxDynImgGenerator::getInstance() instanceof oxDynImgGenerator);
+        $this->assertInstanceOf('oxDynImgGenerator', oxDynImgGenerator::getInstance());
     }
 
     /**
@@ -47,6 +48,25 @@ class Unit_Core_oxDynImgGeneratorTest extends OxidTestCase
     {
         $oGen = new oxDynImgGenerator();
         $this->assertEquals(isset($_SERVER["REQUEST_URI"]) ? $_SERVER["REQUEST_URI"] : "", $oGen->UNITgetImageUri());
+    }
+
+    /**
+     * Testing image uri getter with double slashed URI
+     *
+     * @return null
+     */
+    public function testGetImageUriWithDoubleSlash()
+    {
+        $sRequestedImageUri = "/out/pictures//generated/path/to/test.jpg";
+        $sExpectedUri = "out/pictures/generated/path/to/test.jpg";
+
+        $sRequestUri = isset($_SERVER['REQUEST_URI']) ? $_SERVER['REQUEST_URI'] : null;
+        $_SERVER['REQUEST_URI'] = $sRequestedImageUri;
+
+        $oGen = new oxDynImgGenerator();
+        $this->assertEquals($sExpectedUri, $oGen->UNITgetImageUri());
+
+        $_SERVER['REQUEST_URI'] = $sRequestUri;
     }
 
     /**


### PR DESCRIPTION
This is the fix for ticket #6411 from OXID bug-tracker.
https://bugs.oxid-esales.com/view.php?id=6411