### PR TITLE
refresh utilsobject modulvars on module install

### DIFF
--- a/source/Core/ModuleInstaller.php
+++ b/source/Core/ModuleInstaller.php
@@ -672,7 +672,6 @@ class ModuleInstaller extends \oxSuperCfg
         if ($this->getModuleCache()) {
             $this->getModuleCache()->resetCache();
         }
-        //clear utilsObject internal cache
-        UtilsObject::resetModuleVariables();        
+        ModuleVariablesLocator::resetModuleVariables();
     }
 }

--- a/source/Core/ModuleInstaller.php
+++ b/source/Core/ModuleInstaller.php
@@ -672,5 +672,7 @@ class ModuleInstaller extends \oxSuperCfg
         if ($this->getModuleCache()) {
             $this->getModuleCache()->resetCache();
         }
+        //clear utilsObject internal cache
+        UtilsObject::resetModuleVariables();        
     }
 }


### PR DESCRIPTION
fix ported from project, where module activation did not take affect because "moduleFiles" cache in oxUtilsObject was not refresh by moduleInstaller