### PR TITLE
simplify return statements

### DIFF
--- a/source/Application/Component/UserComponent.php
+++ b/source/Application/Component/UserComponent.php
@@ -179,7 +179,6 @@ class UserComponent extends \oxView
 
         // TODO: move this to a proper place
         if ($oUser->isLoadedFromCookie() && !$myConfig->getConfigParam('blPerfNoBasketSaving')) {
-
             if ($oBasket = $this->getSession()->getBasket()) {
                 $oBasket->load();
                 $oBasket->onUpdate();
@@ -335,7 +334,6 @@ class UserComponent extends \oxView
         $oUser = oxNew('oxuser');
 
         if ($oUser->logout()) {
-
             $this->setLoginStatus(USER_LOGOUT);
 
             // finalizing ..
@@ -372,13 +370,7 @@ class UserComponent extends \oxView
      */
     public function changeUser()
     {
-        $blUserRegistered = $this->_changeUser_noRedirect();
-
-        if ($blUserRegistered === true) {
-            return 'payment';
-        } else {
-            return $blUserRegistered;
-        }
+        return ($this->_changeUser_noRedirect() === true) ? 'payment' : false;
     }
 
     /**
@@ -449,7 +441,6 @@ class UserComponent extends \oxView
         $oUser = oxNew('oxuser');
 
         try {
-
             $oUser->checkValues($sUser, $sPassword, $sPassword2, $aInvAdress, $aDelAdress);
 
             $iActState = $blActiveLogin ? 0 : 1;
@@ -511,7 +502,6 @@ class UserComponent extends \oxView
         }
 
         if (!$blActiveLogin) {
-
             oxRegistry::getSession()->setVariable('usr', $oUser->getId());
             $this->_afterLogin($oUser);
 

--- a/source/Application/Component/Widget/ArticleDetails.php
+++ b/source/Application/Component/Widget/ArticleDetails.php
@@ -300,11 +300,9 @@ class ArticleDetails extends \oxWidget
     public function canRate()
     {
         if ($this->_blCanRate === null) {
-
             $this->_blCanRate = false;
 
             if ($this->ratingIsActive() && $oUser = $this->getUser()) {
-
                 $oRating = oxNew('oxrating');
                 $this->_blCanRate = $oRating->allowRating($oUser->getId(), 'oxarticle', $this->getProduct()->getId());
             }
@@ -322,12 +320,7 @@ class ArticleDetails extends \oxWidget
      */
     public function canChangeTags()
     {
-        if ($oUser = $this->getUser()) {
-
-            return true;
-        }
-
-        return false;
+        return (bool) $this->getUser();
     }
 
     /**
@@ -922,7 +915,6 @@ class ArticleDetails extends \oxWidget
         $myUtils = oxRegistry::getUtils();
 
         if ($this->_oProduct === null) {
-
             if ($this->getViewParameter('_object')) {
                 $this->_oProduct = $this->getViewParameter('_object');
             } else {

--- a/source/Application/Component/Widget/CookieNote.php
+++ b/source/Application/Component/Widget/CookieNote.php
@@ -55,10 +55,6 @@ class CookieNote extends \oxWidget
      */
     public function isEnabled()
     {
-        if ($this->getConfig()->getConfigParam('blShowCookiesNotification')) {
-            return true;
-        }
-
-        return false;
+        return (bool) $this->getConfig()->getConfigParam('blShowCookiesNotification');
     }
 }

--- a/source/Application/Component/Widget/Recommendation.php
+++ b/source/Application/Component/Widget/Recommendation.php
@@ -57,9 +57,8 @@ class Recommendation extends \oxWidget
         $aArticleIds = $this->getViewParameter("aArticleIds");
 
         $oRecommList = oxNew('oxrecommlist');
-        $aRecommList = $oRecommList->getRecommListsByIds($aArticleIds);
 
-        return $aRecommList;
+        return $oRecommList->getRecommListsByIds($aArticleIds);
     }
 
     /**
@@ -69,8 +68,6 @@ class Recommendation extends \oxWidget
      */
     public function getRecommList()
     {
-        $oRecommList = oxNew('recommlist');
-
-        return $oRecommList;
+        return oxNew('recommlist');
     }
 }

--- a/source/Application/Component/Widget/ServiceMenu.php
+++ b/source/Application/Component/Widget/ServiceMenu.php
@@ -53,9 +53,7 @@ class ServiceMenu extends \oxWidget
     public function getCompareItemsCnt()
     {
         $oCompare = oxNew("compare");
-        $iCompItemsCnt = $oCompare->getCompareItemsCnt();
-
-        return $iCompItemsCnt;
+        return $oCompare->getCompareItemsCnt();
     }
 
     /**

--- a/source/Application/Controller/Admin/ActionsGroupsAjax.php
+++ b/source/Application/Controller/Admin/ActionsGroupsAjax.php
@@ -124,6 +124,7 @@ class ActionsGroupsAjax extends \ajaxListComponent
                 $oObject2Promotion->oxobject2action__oxclass = new oxField("oxgroups");
                 $oObject2Promotion->save();
             }
+
             $promotionAdded = true;
         }
 

--- a/source/Application/Controller/Admin/ActionsMainAjax.php
+++ b/source/Application/Controller/Admin/ActionsMainAjax.php
@@ -89,7 +89,6 @@ class ActionsMainAjax extends \ajaxListComponent
         } else {
             // selected category ?
             if ($sSynchSelId && $sSelId != $sSynchSelId) {
-
                 $sQAdd = " from {$sView} left join $sArtTable on ";
                 $blVariantsSelectionParameter = $myConfig->getConfigParam('blVariantsSelection');
                 $sSqlIfTrue = " ( $sArtTable.oxid={$sView}.oxobjectid or $sArtTable.oxparentid={$sView}.oxobjectid) ";
@@ -97,7 +96,6 @@ class ActionsMainAjax extends \ajaxListComponent
                 $sQAdd .= $blVariantsSelectionParameter ? $sSqlIfTrue : $sSqlIfFalse;
                 $sQAdd .= " where {$sView}.oxcatnid = " . $oDb->quote($sSelId);
             } else {
-
                 $sQAdd = " from {$sArtTable} left join oxactions2article " .
                          "on {$sArtTable}.oxid=oxactions2article.oxartid " .
                          " where oxactions2article.oxactionid = " . $oDb->quote($sSelId) .
@@ -135,7 +133,6 @@ class ActionsMainAjax extends \ajaxListComponent
             }
         }
 
-        //echo $sQ;
         return $sQ;
     }
 
@@ -254,7 +251,6 @@ class ActionsMainAjax extends \ajaxListComponent
         if (($iKey = array_search(oxRegistry::getConfig()->getRequestParameter('sortoxid'), $aIdx2Id)) !== false) {
             $iDir = (oxRegistry::getConfig()->getRequestParameter('direction') == 'up') ? ($iKey - 1) : ($iKey + 1);
             if (isset($aIdx2Id[$iDir])) {
-
                 // exchanging indexes
                 $oDir1 = $oList->offsetGet($aIdx2Id[$iDir]);
                 $oDir2 = $oList->offsetGet($aIdx2Id[$iKey]);
@@ -285,5 +281,4 @@ class ActionsMainAjax extends \ajaxListComponent
     {
         return oxNew('oxRssFeed');
     }
-
 }

--- a/source/Application/Controller/Admin/ActionsOrderAjax.php
+++ b/source/Application/Controller/Admin/ActionsOrderAjax.php
@@ -55,10 +55,8 @@ class ActionsOrderAjax extends \ajaxListComponent
         $sSelTable = $this->_getViewName('oxselectlist');
         $sArtId = oxRegistry::getConfig()->getRequestParameter('oxid');
 
-        $sQAdd = " from $sSelTable left join oxobject2selectlist on oxobject2selectlist.oxselnid = $sSelTable.oxid " .
+        return " from $sSelTable left join oxobject2selectlist on oxobject2selectlist.oxselnid = $sSelTable.oxid " .
                  "where oxobjectid = " . oxDb::getDb()->quote($sArtId) . "  ";
-
-        return $sQAdd;
     }
 
     /**
@@ -88,7 +86,6 @@ class ActionsOrderAjax extends \ajaxListComponent
         $iSelCnt = 0;
         $aIdx2Id = array();
         foreach ($oList as $sKey => $oSel) {
-
             if ($oSel->oxobject2selectlist__oxsort->value != $iSelCnt) {
                 $oSel->oxobject2selectlist__oxsort->setValue($iSelCnt);
 

--- a/source/Application/Controller/Admin/AdminDetails.php
+++ b/source/Application/Controller/Admin/AdminDetails.php
@@ -70,13 +70,9 @@ class AdminDetails extends \oxAdminView
     protected function getDocumentationLanguageId()
     {
         $language = oxRegistry::getLang();
-        $languageId = 1;
         $languageAbbr = $language->getLanguageAbbr($language->getTplLanguage());
-        if ($languageAbbr === "de") {
-            $languageId = 0;
-        }
 
-        return $languageId;
+        return $languageAbbr === "de" ? 0 : 1;
     }
 
     /**
@@ -104,7 +100,6 @@ class AdminDetails extends \oxAdminView
     {
         $sEditObjectValue = '';
         if ($oObject && $sField && isset($oObject->$sField)) {
-
             if ($oObject->$sField instanceof oxField) {
                 $sEditObjectValue = $oObject->$sField->getRawValue();
             } else {
@@ -324,7 +319,6 @@ class AdminDetails extends \oxAdminView
     {
         // navigation according to class
         if ($sNode) {
-
             $myAdminNavig = $this->getNavigation();
 
             // default tab

--- a/source/Application/Controller/Admin/AdminList.php
+++ b/source/Application/Controller/Admin/AdminList.php
@@ -318,7 +318,6 @@ class AdminList extends \oxAdminView
         $sortFields = $this->getListSorting();
 
         if (is_array($sortFields) && count($sortFields)) {
-
             // only add order by at full sql not for count(*)
             $query .= ' order by ';
             $addSeparator = false;
@@ -330,10 +329,8 @@ class AdminList extends \oxAdminView
             $descending = $descending !== null ? (bool)$descending : $this->_blDesc;
 
             foreach ($sortFields as $table => $fieldData) {
-
                 $table = $table ? (getViewName($table, $languageId) . '.') : '';
                 foreach ($fieldData as $column => $sortDirectory) {
-
                     $field = $table . $column;
 
                     //add table name to column name if no table name found attached to column name
@@ -414,15 +411,7 @@ class AdminList extends \oxAdminView
      */
     protected function _isSearchValue($fieldValue)
     {
-        //check if this is search string (contains % sign at beginning and end of string)
-        $isSearchValue = false;
-        $stringModifier = getStr();
-        if ($stringModifier->preg_match('/^%/', $fieldValue) && $stringModifier->preg_match('/%$/', $fieldValue)) {
-            $isSearchValue = true;
-        }
-
-        //removing % symbols
-        return $isSearchValue;
+        return (getStr()->preg_match('/^%/', $fieldValue) && getStr()->preg_match('/%$/', $fieldValue));
     }
 
     /**
@@ -507,11 +496,9 @@ class AdminList extends \oxAdminView
     public function buildWhere()
     {
         if ($this->_aWhere === null && ($list = $this->getItemList())) {
-
             $this->_aWhere = array();
             $filter = $this->getListFilter();
             if (is_array($filter)) {
-
                 $listItem = $this->getItemListBaseObject();
                 $languageId = $listItem->isMultilang() ? $listItem->getLanguage() : oxRegistry::getLang()->getBaseLanguage();
                 $localDateFormat = $this->getConfig()->getConfigParam('sLocalDateFormat');
@@ -519,7 +506,6 @@ class AdminList extends \oxAdminView
                 foreach ($filter as $table => $filterData) {
                     foreach ($filterData as $name => $value) {
                         if ($value || '0' === ( string )$value) {
-
                             $field = "{$table}__{$name}";
 
                             // if no table name attached to field name, add it
@@ -668,8 +654,10 @@ class AdminList extends \oxAdminView
             // yes, we need to build the navigation object
             $pageNavigation = new stdClass();
             $pageNavigation->pages = round((($this->_iListSize - 1) / $adminListSize) + 0.5, 0);
-            $pageNavigation->actpage = ($pageNavigation->actpage > $pageNavigation->pages) ? $pageNavigation->pages : round(($this->_iCurrListPos / $adminListSize) + 0.5,
-                0);
+            $pageNavigation->actpage = ($pageNavigation->actpage > $pageNavigation->pages) ? $pageNavigation->pages : round(
+                ($this->_iCurrListPos / $adminListSize) + 0.5,
+                0
+            );
             $pageNavigation->lastlink = ($pageNavigation->pages - 1) * $adminListSize;
             $pageNavigation->nextlink = null;
             $pageNavigation->backlink = null;
@@ -746,7 +734,6 @@ class AdminList extends \oxAdminView
     {
         // navigation according to class
         if ($node) {
-
             $adminNavigation = $this->getNavigation();
 
             $objectId = $this->getEditObjectId();
@@ -782,7 +769,6 @@ class AdminList extends \oxAdminView
     public function getItemList()
     {
         if ($this->_oList === null && $this->_sListClass) {
-
             $this->_oList = oxNew($this->_sListType);
             $this->_oList->clear();
             $this->_oList->init($this->_sListClass);

--- a/source/Application/Controller/Admin/AdminView.php
+++ b/source/Application/Controller/Admin/AdminView.php
@@ -252,7 +252,6 @@ class AdminView extends \oxView
     public function getServiceUrl($sLangAbbr = null)
     {
         if ($this->_sServiceUrl === null) {
-
             $sProtocol = $this->_getServiceProtocol();
 
             $editionSelector = new EditionSelector();
@@ -289,9 +288,7 @@ class AdminView extends \oxView
             $sVersion = oxDb::getDb()->getOne($sQ, false, false);
         }
 
-        $sVersion = preg_replace("/(^[^0-9]+)(.+)$/", "$2", $sVersion);
-
-        return trim($sVersion);
+        return trim(preg_replace("/(^[^0-9]+)(.+)$/", "$2", $sVersion));
     }
 
     /**
@@ -303,7 +300,6 @@ class AdminView extends \oxView
     {
         // navigation according to class
         if ($sNode) {
-
             $myAdminNavig = $this->getNavigation();
 
             // active tab

--- a/source/Application/Controller/Admin/ArticleFiles.php
+++ b/source/Application/Controller/Admin/ArticleFiles.php
@@ -119,9 +119,8 @@ class ArticleFiles extends \oxAdminDetails
 
         $oProduct = oxNew('oxArticle');
         $oProduct->load($sProductId);
-        $this->_oArticle = $oProduct;
 
-        return $this->_oArticle;
+        return $this->_oArticle = $oProduct;
     }
 
     /**
@@ -211,9 +210,7 @@ class ArticleFiles extends \oxAdminDetails
      */
     public function getConfigOptionValue($iOption)
     {
-        $iOption = ($iOption < 0) ? "" : $iOption;
-
-        return $iOption;
+        return ($iOption < 0) ? "" : $iOption;
     }
 
     /**

--- a/source/Application/Controller/Admin/ArticleMain.php
+++ b/source/Application/Controller/Admin/ArticleMain.php
@@ -298,7 +298,6 @@ class ArticleMain extends \oxAdminDetails
         $oArticle = oxNew('oxBase');
         $oArticle->init('oxarticles');
         if ($oArticle->load($sOldId)) {
-
             if ($myConfig->getConfigParam('blDisableDublArtOnCopy')) {
                 $oArticle->oxarticles__oxactive->setValue(0);
                 $oArticle->oxarticles__oxactivefrom->setValue(0);
@@ -362,7 +361,6 @@ class ArticleMain extends \oxAdminDetails
 
             // only for top articles
             if (!$sParentId) {
-
                 $this->setEditObjectId($oArticle->getId());
 
                 //article number handling, warns for artnum duplicates
@@ -451,7 +449,6 @@ class ArticleMain extends \oxAdminDetails
         $oRs = $oDb->execute($sQ);
         if ($oRs !== false && $oRs->recordCount() > 0) {
             while (!$oRs->EOF) {
-
                 $oFile = oxNew("oxfile");
                 $oFile->setId($myUtilsObject->generateUID());
                 $oFile->oxfiles__oxartid = new oxField($sNewId);
@@ -726,11 +723,9 @@ class ArticleMain extends \oxAdminDetails
     protected function formQueryForCopyingToCategory($newArticleId, $sUid, $sCatId, $sTime)
     {
         $oDb = oxDb::getDb();
-        $sql = "insert into oxobject2category (oxid, oxobjectid, oxcatnid, oxtime) " .
+        return "insert into oxobject2category (oxid, oxobjectid, oxcatnid, oxtime) " .
             "VALUES (" . $oDb->quote($sUid) . ", " . $oDb->quote($newArticleId) . ", " .
             $oDb->quote($sCatId) . ", " . $oDb->quote($sTime) . ") ";
-
-        return $sql;
     }
 
     /**

--- a/source/Application/Controller/Admin/ArticleOverview.php
+++ b/source/Application/Controller/Admin/ArticleOverview.php
@@ -128,12 +128,10 @@ class ArticleOverview extends \oxAdminDetails
      */
     protected function formSoldOutAmountQuery($oxId)
     {
-        $query = "select sum(oxorderarticles.oxamount) from  oxorderarticles, oxorder " .
+        return "select sum(oxorderarticles.oxamount) from  oxorderarticles, oxorder " .
             "where (oxorder.oxpaid>0 or oxorder.oxsenddate > 0) and oxorderarticles.oxstorno != '1' " .
             "and oxorderarticles.oxartid=" . $this->getDatabase()->quote($oxId) .
             "and oxorder.oxid =oxorderarticles.oxorderid";
-
-        return $query;
     }
 
     /**
@@ -145,10 +143,8 @@ class ArticleOverview extends \oxAdminDetails
      */
     protected function formCanceledAmountQuery($soxId)
     {
-        $query = "select sum(oxamount) from oxorderarticles where oxstorno = '1' " .
+        return "select sum(oxamount) from oxorderarticles where oxstorno = '1' " .
             "and oxartid=" . $this->getDatabase()->quote($soxId);
-
-        return $query;
     }
 
     /**

--- a/source/Application/Controller/Admin/ArticleSeo.php
+++ b/source/Application/Controller/Admin/ArticleSeo.php
@@ -96,7 +96,7 @@ class ArticleSeo extends \Object_Seo
     /**
      * Returns active category (manufacturer/vendor) id
      *
-     * @return string
+     * @return false|string
      */
     public function getActCatId()
     {
@@ -107,9 +107,11 @@ class ArticleSeo extends \Object_Seo
             $iStartPos = $oStr->strpos($aData["oxparams"], "#");
             $iEndPos = $oStr->strpos($aData["oxparams"], "#", $iStartPos + 1);
             $iLen = $oStr->strlen($aData["oxparams"]);
+
             $sId = $oStr->substr($aData["oxparams"], $iStartPos + 1, $iEndPos - $iLen);
         } elseif ($aList = $this->getSelectionList()) {
             $oItem = reset($aList[$this->getActCatType()][$this->getActCatLang()]);
+
             $sId = $oItem->getId();
         }
 
@@ -223,7 +225,6 @@ class ArticleSeo extends \Object_Seo
             }
         }
     }
-
 
     /**
      * Returns active category object, used for seo url getter
@@ -373,9 +374,7 @@ class ArticleSeo extends \Object_Seo
      */
     protected function _getSaveObjectId()
     {
-        $sId = $this->getEditObjectId();
-
-        return $sId;
+        return $this->getEditObjectId();
     }
 
     /**

--- a/source/Application/Controller/Admin/AttributeOrderAjax.php
+++ b/source/Application/Controller/Admin/AttributeOrderAjax.php
@@ -53,10 +53,8 @@ class AttributeOrderAjax extends \ajaxListComponent
         $sSelTable = $this->_getViewName('oxattribute');
         $sArtId = oxRegistry::getConfig()->getRequestParameter('oxid');
 
-        $sQAdd = " from $sSelTable left join oxcategory2attribute on oxcategory2attribute.oxattrid = $sSelTable.oxid " .
+        return " from $sSelTable left join oxcategory2attribute on oxcategory2attribute.oxattrid = $sSelTable.oxid " .
                  "where oxobjectid = " . oxDb::getDb()->quote($sArtId) . " ";
-
-        return $sQAdd;
     }
 
     /**

--- a/source/Application/Controller/Admin/CategoryMain.php
+++ b/source/Application/Controller/Admin/CategoryMain.php
@@ -368,8 +368,7 @@ class CategoryMain extends \oxAdminDetails
         $category->setLanguage($this->_iEditLang);
 
         $utilsFile = oxRegistry::get("oxUtilsFile");
-        $category = $utilsFile->processFiles($category);
 
-        return $category;
+        return $utilsFile->processFiles($category);
     }
 }

--- a/source/Application/Controller/Admin/DynamicExportBaseController.php
+++ b/source/Application/Controller/Admin/DynamicExportBaseController.php
@@ -610,7 +610,6 @@ class DynamicExportBaseController extends \oxAdminDetails
     protected function _createHeapTable($sHeapTable, $sTableCharset)
     {
         $blDone = false;
-
         $oDB = oxDb::getDb();
         $sQ = "CREATE TABLE IF NOT EXISTS {$sHeapTable} ( `oxid` CHAR(32) NOT NULL default '' ) ENGINE=InnoDB {$sTableCharset}";
         if (($oDB->execute($sQ)) !== false) {
@@ -710,7 +709,6 @@ class DynamicExportBaseController extends \oxAdminDetails
     protected function _removeParentArticles($sHeapTable)
     {
         if (!(oxRegistry::getConfig()->getRequestParameter("blExportMainVars"))) {
-
             $oDB = oxDb::getDb();
             $sArticleTable = getViewName('oxarticles');
 
@@ -892,7 +890,6 @@ class DynamicExportBaseController extends \oxAdminDetails
                 // check price
                 $dMinPrice = oxRegistry::getConfig()->getRequestParameter("sExportMinPrice");
                 if (!isset($dMinPrice) || (isset($dMinPrice) && ($oArticle->getPrice()->getBruttoPrice() >= $dMinPrice))) {
-
                     //Saulius: variant title added
                     $sTitle = $oArticle->oxarticles__oxvarselect->value ? " " . $oArticle->oxarticles__oxvarselect->value : "";
                     $oArticle->oxarticles__oxtitle->setValue($oArticle->oxarticles__oxtitle->value . $sTitle);

--- a/source/Application/Controller/Admin/GenericImportMain.php
+++ b/source/Application/Controller/Admin/GenericImportMain.php
@@ -264,7 +264,8 @@ class GenericImportMain extends oxAdminDetails
                 $oEx = oxNew("oxExceptionToDisplay");
                 $oEx->setMessage('GENIMPORT_ERRORUPLOADINGFILE');
                 oxRegistry::get("oxUtilsView")->addErrorToDisplay($oEx, false, true, 'genimport');
-                $iNavStep = 1;
+
+                return 1;
             }
         }
 
@@ -282,7 +283,8 @@ class GenericImportMain extends oxAdminDetails
                 $oEx = oxNew("oxExceptionToDisplay");
                 $oEx->setMessage('GENIMPORT_ERRORASSIGNINGFIELDS');
                 oxRegistry::get("oxUtilsView")->addErrorToDisplay($oEx, false, true, 'genimport');
-                $iNavStep = 2;
+
+                return 2;
             }
         }
 

--- a/source/Application/Controller/Admin/LanguageMain.php
+++ b/source/Application/Controller/Admin/LanguageMain.php
@@ -257,9 +257,7 @@ class LanguageMain extends \oxAdminDetails
     protected function _updateAbbervation($sOldId, $sNewId)
     {
         foreach (array_keys($this->_aLangData) as $sTypeKey) {
-
             if (is_array($this->_aLangData[$sTypeKey]) && count($this->_aLangData[$sTypeKey]) > 0) {
-
                 if ($sTypeKey == 'urls' || $sTypeKey == 'sslUrls') {
                     continue;
                 }
@@ -440,11 +438,7 @@ class LanguageMain extends \oxAdminDetails
         $myConfig = $this->getConfig();
         $aAbbrs = array_keys($this->_aLangData['lang']);
 
-        if (in_array($sAbbr, $aAbbrs)) {
-            return true;
-        }
-
-        return false;
+        return in_array($sAbbr, $aAbbrs);
     }
 
     /**
@@ -475,7 +469,7 @@ class LanguageMain extends \oxAdminDetails
 
         // if creating new language, checking if language already exists with
         // entered language abbreviation
-        if ( ($oxid == -1) && $this->_checkLangExists($parameters['abbr']) ) {
+        if (($oxid == -1) && $this->_checkLangExists($parameters['abbr'])) {
             $this->addDisplayException('LANGUAGE_ALREADYEXISTS_ERROR');
             $result = false;
         }
@@ -503,15 +497,19 @@ class LanguageMain extends \oxAdminDetails
      *
      * @param string $abbreviation language abbreviation
      *
+     * @throws RegExException if pattern does not match
+     *
      * @return bool
      */
     protected function checkAbbreviationAllowedCharacters($abbreviation)
     {
-        $return = false;
-        if (preg_match('/^[a-zA-Z0-9_]*$/', $abbreviation)) {
-            $return = true;
+        $pattern = '/^[a-zA-Z0-9_]*$/';
+        $result = preg_match($pattern, $abbreviation);
+        if ($result === false) {
+            throw new RegExException(preg_last_error(), $pattern, $abbreviation);
         }
-        return $return;
+
+        return (bool) $result;
     }
 
     /**

--- a/source/Application/Controller/Admin/ListComponentAjax.php
+++ b/source/Application/Controller/Admin/ListComponentAjax.php
@@ -328,13 +328,9 @@ class ListComponentAjax extends \oxSuperCfg
      */
     protected function _isExtendedColumn($sColumn)
     {
-        $blBuild = false;
         $blVariantsSelectionParameter = oxRegistry::getConfig()->getConfigParam('blVariantsSelection');
-        if ($this->_blAllowExtColumns && $blVariantsSelectionParameter && $sColumn == 'oxtitle') {
-            $blBuild = true;
-        }
 
-        return $blBuild;
+        return $this->_blAllowExtColumns && $blVariantsSelectionParameter && $sColumn == 'oxtitle';
     }
 
     /**
@@ -352,11 +348,9 @@ class ListComponentAjax extends \oxSuperCfg
         // multilanguage
         $sVarSelect = "$sViewTable.oxvarselect";
 
-        $sSql = " IF( {$sViewTable}.{$sColumn} != '', {$sViewTable}.{$sColumn}, CONCAT((select oxart.{$sColumn} " .
+        return " IF( {$sViewTable}.{$sColumn} != '', {$sViewTable}.{$sColumn}, CONCAT((select oxart.{$sColumn} " .
                 "from {$sViewTable} as oxart " .
                 "where oxart.oxid = {$sViewTable}.oxparentid),', ',{$sVarSelect})) as _{$iCnt}";
-
-        return $sSql;
     }
 
     /**
@@ -404,7 +398,6 @@ class ListComponentAjax extends \oxSuperCfg
             $sCharset = $oLang->translateString("charset");
 
             foreach ($aFilter as $sCol => $sValue) {
-
                 // skipping empty filters
                 if ($sValue === '') {
                     continue;

--- a/source/Application/Controller/Admin/ManufacturerMainAjax.php
+++ b/source/Application/Controller/Admin/ManufacturerMainAjax.php
@@ -190,11 +190,10 @@ class ManufacturerMainAjax extends \ajaxListComponent
     protected function formArticleToManufacturerAdditionQuery($manufacturerId, $articlesToAdd)
     {
         $database = oxDb::getDb();
-        $query = "
+
+        return "
             UPDATE oxarticles
             SET oxmanufacturerid = " . $database->quote($manufacturerId) . "
             WHERE oxid IN ( " . implode(", ", $database->quoteArray($articlesToAdd)) . " )";
-
-        return $query;
     }
 }

--- a/source/Application/Controller/Admin/ModuleConfiguration.php
+++ b/source/Application/Controller/Admin/ModuleConfiguration.php
@@ -121,7 +121,6 @@ class ModuleConfiguration extends \Shop_Config
         $aDbVariables = $this->loadConfVars($oConfig->getShopId(), $this->_getModuleForConfigVars());
 
         if (is_array($aModuleSettings)) {
-
             foreach ($aModuleSettings as $aValue) {
                 $sName = $aValue["name"];
                 $sType = $aValue["type"];
@@ -215,11 +214,6 @@ class ModuleConfiguration extends \Shop_Config
      */
     private function _getDbConfigTypeName($sType)
     {
-        $sDbType = $sType;
-        if ($sType === 'password') {
-            $sDbType = 'str';
-        }
-
-        return $sDbType;
+        return $sType === 'password' ? 'str' : $sType;
     }
 }

--- a/source/Application/Controller/Admin/NavigationTree.php
+++ b/source/Application/Controller/Admin/NavigationTree.php
@@ -727,7 +727,6 @@ class NavigationTree extends \oxSuperCfg
      */
     public function getListUrl($id)
     {
-        $url = null;
         $xPath = new DOMXPath($this->getDomXml());
         $nodeList = $xPath->query("//SUBMENU[@cl='{$id}']");
         if ($nodeList->length && ($node = $nodeList->item(0))) {
@@ -737,10 +736,8 @@ class NavigationTree extends \oxSuperCfg
             $params = $node->getAttribute('listparam');
             $params = $params ? "&$params" : '';
 
-            $url = "{$cl}{$params}";
+            return "{$cl}{$params}";
         }
-
-        return $url;
     }
 
     /**
@@ -753,7 +750,6 @@ class NavigationTree extends \oxSuperCfg
      */
     public function getEditUrl($id, $actTab)
     {
-        $url = null;
         $xPath = new DOMXPath($this->getDomXml());
         $nodeList = $xPath->query("//SUBMENU[@cl='{$id}']/TAB");
 
@@ -761,19 +757,16 @@ class NavigationTree extends \oxSuperCfg
         if ($nodeList->length && ($actTab = $nodeList->item($actTab))) {
             // special case for external resources
             if ($actTab->getAttribute('external')) {
-                $url = $actTab->getAttribute('location');
-            } else {
-                $cl = $actTab->getAttribute('cl');
-                $cl = $cl ? "cl={$cl}" : '';
-
-                $params = $actTab->getAttribute('clparam');
-                $params = $params ? "&{$params}" : '';
-
-                $url = "{$cl}{$params}";
+                return $actTab->getAttribute('location');
             }
-        }
+            $cl = $actTab->getAttribute('cl');
+            $cl = $cl ? "cl={$cl}" : '';
 
-        return $url;
+            $params = $actTab->getAttribute('clparam');
+            $params = $params ? "&{$params}" : '';
+
+            return "{$cl}{$params}";
+        }
     }
 
     /**
@@ -827,15 +820,11 @@ class NavigationTree extends \oxSuperCfg
      */
     public function getClassId($className)
     {
-        $classId = null;
-
         $xPath = new DOMXPath($this->_getInitialDom());
         $nodeList = $xPath->query("//*[@cl='{$className}' or @list='{$className}']");
         if ($nodeList->length && ($firstItem = $nodeList->item(0))) {
-            $classId = $firstItem->getAttribute('id');
+            return $firstItem->getAttribute('id');
         }
-
-        return $classId;
     }
 
 
@@ -854,14 +843,13 @@ class NavigationTree extends \oxSuperCfg
         if (!$loadDynContents) {
             // getting dyn info from oxid server is off, so getting local menu path
             $fullAdminDir = getShopBasePath() . 'Application/views/admin';
-            $url = $fullAdminDir . "/dynscreen_local.xml";
-        } else {
-            $adminView = oxNew('oxadminview');
-            $this->_sDynIncludeUrl = $adminView->getServiceUrl($lang);
-            $url = $this->_sDynIncludeUrl . "menue/dynscreen.xml";
-        }
 
-        return $url;
+            return $fullAdminDir . "/dynscreen_local.xml";
+        }
+        $adminView = oxNew('oxadminview');
+        $this->_sDynIncludeUrl = $adminView->getServiceUrl($lang);
+
+        return $this->_sDynIncludeUrl . "menue/dynscreen.xml";
     }
 
     /**
@@ -879,9 +867,7 @@ class NavigationTree extends \oxSuperCfg
         $dynLang = $myConfig->getConfigParam('iDynInterfaceLanguage');
         $dynLang = isset($dynLang) ? $dynLang : ($lang->getTplLanguage());
 
-        $languages = $lang->getLanguageArray();
-
-        return $languages[$dynLang]->abbr;
+        return $lang->getLanguageArray()[$dynLang]->abbr;
     }
 
     /**

--- a/source/Application/Controller/Admin/SelectListOrderAjax.php
+++ b/source/Application/Controller/Admin/SelectListOrderAjax.php
@@ -54,10 +54,8 @@ class SelectListOrderAjax extends \ajaxListComponent
         $sSelTable = $this->_getViewName('oxselectlist');
         $sArtId = oxRegistry::getConfig()->getRequestParameter('oxid');
 
-        $sQAdd = " from $sSelTable left join oxobject2selectlist on oxobject2selectlist.oxselnid = $sSelTable.oxid " .
+        return " from $sSelTable left join oxobject2selectlist on oxobject2selectlist.oxselnid = $sSelTable.oxid " .
                  "where oxobjectid = '$sArtId' ";
-
-        return $sQAdd;
     }
 
     /**
@@ -86,7 +84,6 @@ class SelectListOrderAjax extends \ajaxListComponent
         $iSelCnt = 0;
         $aIdx2Id = array();
         foreach ($oList as $sKey => $oSel) {
-
             if ($oSel->oxobject2selectlist__oxsort->value != $iSelCnt) {
                 $oSel->oxobject2selectlist__oxsort->setValue($iSelCnt);
 

--- a/source/Application/Controller/Admin/ShopConfiguration.php
+++ b/source/Application/Controller/Admin/ShopConfiguration.php
@@ -381,12 +381,7 @@ class ShopConfiguration extends oxAdminDetails
      */
     protected function _arrayToMultiline($aInput)
     {
-        $sVal = '';
-        if (is_array($aInput)) {
-            $sVal = implode("\n", $aInput);
-        }
-
-        return $sVal;
+        return implode("\n", (array) $aInput);
     }
 
     /**
@@ -469,8 +464,8 @@ class ShopConfiguration extends oxAdminDetails
         $sEditId = parent::getEditObjectId();
         if (!$sEditId) {
             return $this->getConfig()->getShopId();
-        } else {
-            return $sEditId;
         }
+
+        return $sEditId;
     }
 }

--- a/source/Application/Controller/Admin/ShopLicense.php
+++ b/source/Application/Controller/Admin/ShopLicense.php
@@ -125,8 +125,7 @@ class ShopLicense extends \Shop_Config
             $sUpdateLink = oxRegistry::getLang()->translateString("VERSION_UPDATE_LINK");
             $aResult[5] = "<a id='linkToUpdate' href='$sUpdateLink' target='_blank'>" . $aResult[5] . "</a>";
         }
-        $sOutput = implode("<br>", $aResult);
 
-        return $sOutput;
+        return implode("<br>", $aResult);
     }
 }

--- a/source/Application/Controller/Admin/ShopMain.php
+++ b/source/Application/Controller/Admin/ShopMain.php
@@ -228,7 +228,6 @@ class ShopMain extends \oxAdminDetails
      */
     protected function renderNewShop()
     {
-
         return '';
     }
 
@@ -265,6 +264,7 @@ class ShopMain extends \oxAdminDetails
     protected function updateParameters($parameters)
     {
         $parameters['oxshops__oxid'] = null;
+
         return $parameters;
     }
 

--- a/source/Application/Controller/Admin/ShopRdfa.php
+++ b/source/Application/Controller/Admin/ShopRdfa.php
@@ -65,6 +65,7 @@ class ShopRdfa extends \Shop_Config
                                     AND OXLOADID IN ('oxagb', 'oxdeliveryinfo', 'oximpressum', 'oxrightofwithdrawal')
                                     AND OXSHOPID = '" . oxRegistry::getConfig()->getRequestParameter("oxid") . "'"
         ); // $this->getEditObjectId()
+
         return $oContentList;
     }
 

--- a/source/Application/Controller/Admin/SystemInfoController.php
+++ b/source/Application/Controller/Admin/SystemInfoController.php
@@ -91,16 +91,13 @@ class SystemInfoController extends \oxAdminView
      */
     protected function isClassVariableVisible($varName)
     {
-        $skipNames = array(
+        return !in_array($varName, [
             'oDB',
             'dbUser',
             'dbPwd',
             'oSerial',
             'aSerials',
             'sSerialNr'
-        );
-        $result = !in_array($varName, $skipNames);
-
-        return $result;
+        ]);
     }
 }

--- a/source/Application/Controller/Admin/SystemRequirementsMain.php
+++ b/source/Application/Controller/Admin/SystemRequirementsMain.php
@@ -85,9 +85,8 @@ class SystemRequirementsMain extends \oxAdminDetails
     public function getReqInfoUrl($sIdent)
     {
         $oSysReq = new oxSysRequirements();
-        $sUrl = $oSysReq->getReqInfoUrl($sIdent);
 
-        return $sUrl;
+        return $oSysReq->getReqInfoUrl($sIdent);
     }
 
     /**

--- a/source/Application/Controller/Admin/ThemeMain.php
+++ b/source/Application/Controller/Admin/ThemeMain.php
@@ -76,11 +76,7 @@ class ThemeMain extends \oxAdminDetails
         $blThemeSet = isset($this->getConfig()->sTheme);
         $blCustomThemeSet = isset($this->getConfig()->sCustomTheme);
 
-        if ($blThemeSet || $blCustomThemeSet) {
-            return true;
-        }
-
-        return false;
+        return ($blThemeSet || $blCustomThemeSet);
     }
 
 

--- a/source/Application/Controller/Admin/UserList.php
+++ b/source/Application/Controller/Admin/UserList.php
@@ -90,6 +90,7 @@ class UserList extends \oxAdminList
     {
         if ($this->_allowAdminEdit($this->getEditObjectId())) {
             $this->_oList = null;
+
             return parent::deleteEntry();
         }
     }

--- a/source/Application/Controller/Admin/UserPayment.php
+++ b/source/Application/Controller/Admin/UserPayment.php
@@ -94,7 +94,6 @@ class UserPayment extends \oxAdminDetails
             $this->_aViewData['readonly'] = true;
         }
 
-
         return "user_payment.tpl";
     }
 
@@ -107,7 +106,6 @@ class UserPayment extends \oxAdminDetails
 
         $soxId = $this->getEditObjectId();
         if ($this->_allowAdminEdit($soxId)) {
-
             $aParams = oxRegistry::getConfig()->getRequestParameter("editval");
             $aDynvalues = oxRegistry::getConfig()->getRequestParameter("dynvalue");
 
@@ -196,7 +194,6 @@ class UserPayment extends \oxAdminDetails
     public function getPaymentTypes()
     {
         if ($this->_oPaymentTypes == null) {
-
             // all paymenttypes
             $this->_oPaymentTypes = oxNew("oxlist");
             $this->_oPaymentTypes->init("oxpayment");

--- a/source/Application/Controller/Admin/VendorMainAjax.php
+++ b/source/Application/Controller/Admin/VendorMainAjax.php
@@ -174,8 +174,7 @@ class VendorMainAjax extends \ajaxListComponent
      */
     protected function onVendorActionArticleUpdateConditions($articleIds)
     {
-        $database = oxDb::getDb();;
-        return 'oxid in (' . implode(", ", $database->quoteArray($articleIds)) . ')';
+        return 'oxid in (' . implode(", ", oxDb::getDb()->quoteArray($articleIds)) . ')';
     }
 
     /**

--- a/source/Application/Controller/ArticleDetailsController.php
+++ b/source/Application/Controller/ArticleDetailsController.php
@@ -471,7 +471,6 @@ class ArticleDetailsController extends \oxUBase
         }
     }
 
-
     /**
      * Returns current product
      *
@@ -640,9 +639,7 @@ class ArticleDetailsController extends \oxUBase
      */
     public function getActPictureId()
     {
-        $picturesGallery = $this->getPictureGallery();
-
-        return $picturesGallery['ActPicID'];
+        return $this->getPictureGallery()['ActPicID'];
     }
 
     /**
@@ -652,9 +649,7 @@ class ArticleDetailsController extends \oxUBase
      */
     public function getActPicture()
     {
-        $picturesGallery = $this->getPictureGallery();
-
-        return $picturesGallery['ActPic'];
+        return $this->getPictureGallery()['ActPic'];
     }
 
     /**
@@ -664,9 +659,7 @@ class ArticleDetailsController extends \oxUBase
      */
     public function getPictures()
     {
-        $picturesGallery = $this->getPictureGallery();
-
-        return $picturesGallery['Pics'];
+        return $this->getPictureGallery()['Pics'];
     }
 
     /**
@@ -678,9 +671,7 @@ class ArticleDetailsController extends \oxUBase
      */
     public function getArtPic($pictureNumber)
     {
-        $picturesGallery = $this->getPictureGallery();
-
-        return $picturesGallery['Pics'][$pictureNumber];
+        return $this->getPictureGallery()['Pics'][$pictureNumber];
     }
 
     /**
@@ -887,7 +878,8 @@ class ArticleDetailsController extends \oxUBase
             $variantSelectionId = $article->oxarticles__oxvarselect->value;
 
             $variantSelectionValue = $variantSelectionId ? ' ' . $variantSelectionId : '';
-            return $articleTitle . $variantSelectionValue ;
+
+            return $articleTitle . $variantSelectionValue;
         }
     }
 
@@ -1256,9 +1248,7 @@ class ArticleDetailsController extends \oxUBase
      */
     public function showZoomPics()
     {
-        $pictureGallery = $this->getPictureGallery();
-
-        return $pictureGallery['ZoomPic'];
+        return $this->getPictureGallery()['ZoomPic'];
     }
 
     /**

--- a/source/Application/Controller/BaseController.php
+++ b/source/Application/Controller/BaseController.php
@@ -901,7 +901,6 @@ class BaseController extends \oxView
      */
     public function getUserSelectedSorting()
     {
-        $sorting = null;
         $sortDirections = array('desc', 'asc');
 
         $request = Registry::get(Request::class);
@@ -915,10 +914,8 @@ class BaseController extends \oxView
             in_array(Str::getStr()->strtolower($sortOrder), $sortDirections) &&
             in_array($sortBy, oxNew('oxArticle')->getFieldNames())
         ) {
-            $sorting = array('sortby' => $sortBy, 'sortdir' => $sortOrder);
+            return array('sortby' => $sortBy, 'sortdir' => $sortOrder);
         }
-
-        return $sorting;
     }
 
     /**
@@ -1467,8 +1464,6 @@ class BaseController extends \oxView
      */
     public function getPageTitle()
     {
-        $title = '';
-
         $titleParts = array();
         $titleParts[] = $this->getTitlePrefix();
         $titleParts[] = $this->getTitle();
@@ -1477,12 +1472,7 @@ class BaseController extends \oxView
 
         $titleParts = array_filter($titleParts);
 
-        if (count($titleParts)) {
-            $title = implode(' | ', $titleParts);
-        }
-
-
-        return $title;
+        return implode(' | ', $titleParts);
     }
 
 
@@ -1740,12 +1730,7 @@ class BaseController extends \oxView
      */
     public function showSearch()
     {
-        $show = true;
-        if ($this->getConfig()->getConfigParam('blDisableNavBars') && $this->getIsOrderStep()) {
-            $show = false;
-        }
-
-        return (int) $show;
+        return !($this->getConfig()->getConfigParam('blDisableNavBars') && $this->getIsOrderStep());
     }
 
     /**
@@ -2005,9 +1990,7 @@ class BaseController extends \oxView
      */
     public function getPageNavigationLimitedTop($positionCount = 7)
     {
-        $this->_oPageNavigation = $this->generatePageNavigation($positionCount);
-
-        return $this->_oPageNavigation;
+        return $this->_oPageNavigation = $this->generatePageNavigation($positionCount);
     }
 
     /**
@@ -2019,9 +2002,7 @@ class BaseController extends \oxView
      */
     public function getPageNavigationLimitedBottom($positionCount = 11)
     {
-        $this->_oPageNavigation = $this->generatePageNavigation($positionCount);
-
-        return $this->_oPageNavigation;
+        return $this->_oPageNavigation = $this->generatePageNavigation($positionCount);
     }
 
     /**
@@ -2107,7 +2088,6 @@ class BaseController extends \oxView
         parent::render();
 
         if ($this->getIsOrderStep()) {
-
             // disabling navigation during order ...
             if ($this->getConfig()->getConfigParam('blDisableNavBars')) {
                 $this->_iNewsRealStatus = 1;
@@ -2201,7 +2181,6 @@ class BaseController extends \oxView
         // this may be useful when category component was unable to load active Manufacturer
         // and we still need some object to mount navigation info
         if ($this->_oActManufacturer === null) {
-
             $this->_oActManufacturer = false;
             $manufacturerId = $this->getConfig()->getRequestParameter('mnid');
             $manufacturer = oxNew('oxManufacturer');
@@ -2585,13 +2564,7 @@ class BaseController extends \oxView
      */
     public function isFieldRequired($field)
     {
-        if ($mustFillFields = $this->getMustFillFields()) {
-            if (isset($mustFillFields[$field])) {
-                return true;
-            }
-        }
-
-        return false;
+        return isset($this->getMustFillFields()[$field]);
     }
 
     /**
@@ -2921,7 +2894,6 @@ class BaseController extends \oxView
      */
     public function isVatIncluded()
     {
-        $result = true;
         $config = $this->getConfig();
         $user = $this->getUser();
 
@@ -2949,10 +2921,10 @@ class BaseController extends \oxView
             $config->getConfigParam('bl_perfCalcVatOnlyForBasketOrder') ||
             $countryBillsNotVat
         ) {
-            $result = false;
+            return false;
         }
 
-        return $result;
+        return true;
     }
 
     /**

--- a/source/Application/Controller/BasketController.php
+++ b/source/Application/Controller/BasketController.php
@@ -388,9 +388,7 @@ class BasketController extends \oxUBase
     public function getBasketContentMarkGenerator()
     {
         /** @var oxBasketContentMarkGenerator $oBasketContentMarkGenerator */
-        $oBasketContentMarkGenerator = oxNew('oxBasketContentMarkGenerator', $this->getSession()->getBasket());
-
-        return $oBasketContentMarkGenerator;
+        return oxNew('oxBasketContentMarkGenerator', $this->getSession()->getBasket());
     }
 
     /**

--- a/source/Application/Controller/ContentController.php
+++ b/source/Application/Controller/ContentController.php
@@ -183,14 +183,9 @@ class ContentController extends \oxUBase
      */
     protected function _canShowContent($sContentIdent)
     {
-        $blCan = true;
-        if ($this->isEnabledPrivateSales() &&
+        return !($this->isEnabledPrivateSales() &&
             !$this->getUser() && !in_array($sContentIdent, $this->_aPsAllowedContents)
-        ) {
-            $blCan = false;
-        }
-
-        return $blCan;
+        );
     }
 
     /**
@@ -288,7 +283,6 @@ class ContentController extends \oxUBase
     public function getContentId()
     {
         if ($this->_sContentId === null) {
-
             $sContentId = oxRegistry::getConfig()->getRequestParameter('oxcid');
             $sLoadId = oxRegistry::getConfig()->getRequestParameter('oxloadid');
 

--- a/source/Application/Controller/ForgotPasswordController.php
+++ b/source/Application/Controller/ForgotPasswordController.php
@@ -115,7 +115,6 @@ class ForgotPasswordController extends \oxUBase
 
         // passwords are fine - updating and loggin user in
         if ($oUser->loadUserByUpdateId($this->getUpdateId())) {
-
             // setting new pass ..
             $oUser->setPassword($sNewPass);
 

--- a/source/Application/Controller/InviteController.php
+++ b/source/Application/Controller/InviteController.php
@@ -204,12 +204,7 @@ class InviteController extends \oxUBase
      */
     public function getInviteSendStatus()
     {
-        //checking if email was sent
-        if ($this->_iMailStatus == 1) {
-            return true;
-        }
-
-        return false;
+        return ($this->_iMailStatus == 1);
     }
 
     /**

--- a/source/Application/Controller/ManufacturerListController.php
+++ b/source/Application/Controller/ManufacturerListController.php
@@ -178,12 +178,9 @@ class ManufacturerListController extends \AList
      */
     protected function _getSeoObjectId()
     {
-        $sId = null;
         if (($oManufacturer = $this->getActManufacturer())) {
-            $sId = $oManufacturer->getId();
+            return $oManufacturer->getId();
         }
-
-        return $sId;
     }
 
     /**
@@ -201,13 +198,11 @@ class ManufacturerListController extends \AList
         if (oxRegistry::getUtils()->seoIsActive() && ($oManufacturer = $this->getActManufacturer())) {
             if ($iPage) {
                 // only if page number > 0
-                $sUrl = $oManufacturer->getBaseSeoLink($iLang, $iPage);
+                return $oManufacturer->getBaseSeoLink($iLang, $iPage);
             }
-        } else {
-            $sUrl = parent::_addPageNrParam($sUrl, $iPage, $iLang);
         }
 
-        return $sUrl;
+        return parent::_addPageNrParam($sUrl, $iPage, $iLang);
     }
 
     /**
@@ -309,12 +304,9 @@ class ManufacturerListController extends \AList
      */
     public function getTreePath()
     {
-        $aPath = null;
         if ($oManufacturerTree = $this->getManufacturerTree()) {
-            $aPath = $oManufacturerTree->getPath();
+            return $oManufacturerTree->getPath();
         }
-
-        return $aPath;
     }
 
     /**
@@ -360,12 +352,9 @@ class ManufacturerListController extends \AList
      */
     public function getTitleSuffix()
     {
-        $sSuffix = null;
         if ($this->getActManufacturer()->oxmanufacturers__oxshowsuffix->value) {
-            $sSuffix = $this->getConfig()->getActiveShop()->oxshops__oxtitlesuffix->value;
+            return $this->getConfig()->getActiveShop()->oxshops__oxtitlesuffix->value;
         }
-
-        return $sSuffix;
     }
 
     /**

--- a/source/Application/Controller/OrderController.php
+++ b/source/Application/Controller/OrderController.php
@@ -251,7 +251,6 @@ class OrderController extends \oxUBase
         // get basket contents
         $oBasket = $this->getSession()->getBasket();
         if ($oBasket->getProductsCount()) {
-
             try {
                 $oOrder = oxNew('oxorder');
 
@@ -556,10 +555,7 @@ class OrderController extends \oxUBase
      */
     public function getBasketContentMarkGenerator()
     {
-        /** @var oxBasketContentMarkGenerator $oBasketContentMarkGenerator */
-        $oBasketContentMarkGenerator = oxNew('oxBasketContentMarkGenerator', $this->getBasket());
-
-        return $oBasketContentMarkGenerator;
+        return oxNew('oxBasketContentMarkGenerator', $this->getBasket());
     }
 
     /**

--- a/source/Application/Controller/PaymentController.php
+++ b/source/Application/Controller/PaymentController.php
@@ -175,7 +175,6 @@ class PaymentController extends \oxUBase
         $blAlreadyRedirected = oxRegistry::getConfig()->getRequestParameter('sslredirect') == 'forced';
 
         if ($this->getIsOrderStep()) {
-
             //additional check if we really really have a user now
             //and the basket is not empty
             $oBasket = $this->getSession()->getBasket();

--- a/source/Application/Controller/RecommListController.php
+++ b/source/Application/Controller/RecommListController.php
@@ -220,7 +220,6 @@ class RecommListController extends \AList
         if ($this->canAcceptFormData() &&
             ($oRecommList = $this->getActiveRecommList()) && ($oUser = $this->getUser())
         ) {
-
             //save rating
             $dRating = oxRegistry::getConfig()->getRequestParameter('recommlistrating');
             if ($dRating !== null) {
@@ -487,12 +486,10 @@ class RecommListController extends \AList
     public function generatePageNavigationUrl()
     {
         if ((oxRegistry::getUtils()->seoIsActive() && ($oRecomm = $this->getActiveRecommList()))) {
-            $sUrl = $oRecomm->getLink();
-        } else {
-            $sUrl = oxUBase::generatePageNavigationUrl();
+            return $oRecomm->getLink();
         }
 
-        return $sUrl;
+        return oxUBase::generatePageNavigationUrl();
     }
 
     /**
@@ -590,13 +587,12 @@ class RecommListController extends \AList
             $sTranslatedString = $oLang->translateString('LIST_BY', $oLang->getBaseLanguage(), false);
             $sTitleField = 'oxrecommlists__oxtitle';
             $sAuthorField = 'oxrecommlists__oxauthor';
-            $sTitle = $aActiveList->$sTitleField->value . ' (' . $sTranslatedString . ' ' .
-                      $aActiveList->$sAuthorField->value . ')';
-        } else {
-            $sTranslatedString = $oLang->translateString('HITS_FOR', $oLang->getBaseLanguage(), false);
-            $sTitle = $this->getArticleCount() . ' ' . $sTranslatedString . ' "' . $this->getSearchForHtml() . '"';
-        }
 
-        return $sTitle;
+            return $aActiveList->$sTitleField->value . ' (' . $sTranslatedString . ' ' .
+                      $aActiveList->$sAuthorField->value . ')';
+        }
+        $sTranslatedString = $oLang->translateString('HITS_FOR', $oLang->getBaseLanguage(), false);
+
+        return $this->getArticleCount() . ' ' . $sTranslatedString . ' "' . $this->getSearchForHtml() . '"';
     }
 }

--- a/source/Application/Controller/RegisterController.php
+++ b/source/Application/Controller/RegisterController.php
@@ -118,13 +118,7 @@ class RegisterController extends \User
      */
     public function isFieldRequired($sField)
     {
-        if ($aMustFillFields = $this->getMustFillFields()) {
-            if (isset($aMustFillFields[$sField])) {
-                return true;
-            }
-        }
-
-        return false;
+        return isset($this->getMustFillFields()[$sField]);
     }
 
     /**
@@ -138,7 +132,6 @@ class RegisterController extends \User
     {
         $oUser = oxNew('oxuser');
         if ($oUser->loadUserByUpdateId($this->getUpdateId())) {
-
             // resetting update key parameter
             $oUser->setUpdateKey(true);
 

--- a/source/Application/Controller/ReviewController.php
+++ b/source/Application/Controller/ReviewController.php
@@ -180,7 +180,6 @@ class ReviewController extends \Details
         if (!($this->getReviewUser())) {
             $this->_sThisTemplate = $this->_sThisLoginTemplate;
         } else {
-
             // @deprecated since v5.3 (2016-06-17); Listmania will be moved to an own module.
             $oActiveRecommList = $this->getActiveRecommList();
             $oList = $this->getActiveRecommItems();
@@ -212,9 +211,7 @@ class ReviewController extends \Details
         }
 
         if (($oRevUser = $this->getReviewUser()) && $this->canAcceptFormData()) {
-
             if (($oActObject = $this->_getActiveObject()) && ($sType = $this->_getActiveType())) {
-
                 if (($dRating = oxRegistry::getConfig()->getRequestParameter('rating')) === null) {
                     $dRating = oxRegistry::getConfig()->getRequestParameter('artrating');
                 }
@@ -320,16 +317,13 @@ class ReviewController extends \Details
      */
     protected function _getActiveType()
     {
-        $sType = null;
         if ($this->getProduct()) {
-            $sType = 'oxarticle';
+            return 'oxarticle';
             // @deprecated since v5.3 (2016-06-17); Listmania will be moved to an own module.
         } elseif ($this->getActiveRecommList()) {
-            $sType = 'oxrecommlist';
+            return 'oxrecommlist';
             // END deprecated
         }
-
-        return $sType;
     }
 
     /**

--- a/source/Application/Controller/WishListController.php
+++ b/source/Application/Controller/WishListController.php
@@ -90,7 +90,6 @@ class WishListController extends oxUBase
             if ($sUserId) {
                 $oUser = oxNew('oxuser');
                 if ($oUser->load($sUserId)) {
-
                     // passing wishlist information
                     $this->_oWishUser = $oUser;
 
@@ -115,7 +114,6 @@ class WishListController extends oxUBase
 
             // passing wishlist information
             if ($oUser = $this->getWishUser()) {
-
                 $oWishlistBasket = $oUser->getBasket('wishlist');
                 $this->_oWishList = $oWishlistBasket->getArticles();
 
@@ -141,7 +139,6 @@ class WishListController extends oxUBase
     public function searchForWishList()
     {
         if ($sSearch = oxRegistry::getConfig()->getRequestParameter('search')) {
-
             // search for baskets
             $oUserList = oxNew('oxuserlist');
             $oUserList->loadWishlistUsers($sSearch);
@@ -204,11 +201,9 @@ class WishListController extends oxUBase
             $sFirstnameField = 'oxuser__oxfname';
             $sLastnameField = 'oxuser__oxlname';
 
-            $sTitle = $sTranslatedString . ' ' . $oUser->$sFirstnameField->value . ' ' . $oUser->$sLastnameField->value;
-        } else {
-            $sTitle = $oLang->translateString('PUBLIC_GIFT_REGISTRIES', $oLang->getBaseLanguage(), false);
+            return $sTranslatedString . ' ' . $oUser->$sFirstnameField->value . ' ' . $oUser->$sLastnameField->value;
         }
 
-        return $sTitle;
+        return $oLang->translateString('PUBLIC_GIFT_REGISTRIES', $oLang->getBaseLanguage(), false);
     }
 }

--- a/source/Application/Model/ActionList.php
+++ b/source/Application/Model/ActionList.php
@@ -143,14 +143,12 @@ class ActionList extends \oxList
         }
 
         $sGroupSql = count($aIds) ? "EXISTS(select oxobject2action.oxid from oxobject2action where oxobject2action.oxactionid=$sTable.OXID and oxobject2action.oxclass='oxgroups' and oxobject2action.OXOBJECTID in (" . implode(', ', oxDb::getInstance()->quoteArray($aIds)) . ") )" : '0';
-        $sQ = " and (
+        return " and (
             select
                 if(EXISTS(select 1 from oxobject2action, $sGroupTable where $sGroupTable.oxid=oxobject2action.oxobjectid and oxobject2action.oxactionid=$sTable.OXID and oxobject2action.oxclass='oxgroups' LIMIT 1),
                     $sGroupSql,
                     1)
             ) ";
-
-        return $sQ;
     }
 
     /**

--- a/source/Application/Model/Address.php
+++ b/source/Application/Model/Address.php
@@ -100,9 +100,7 @@ class Address extends \oxBase
         }
         $sAddress .= "$sStreet $sStreetNr, $sCity";
 
-        $sAddress = trim($sAddress);
-
-        return $sAddress;
+        return trim($sAddress);
     }
 
     /**

--- a/source/Application/Model/AmountPriceList.php
+++ b/source/Application/Model/AmountPriceList.php
@@ -108,8 +108,6 @@ class AmountPriceList extends \oxList
 
         $sSql = "SELECT * FROM `oxprice2article` WHERE `oxartid` = " . oxDb::getDb()->quote($sArticleId) . " AND $sShopSelect ORDER BY `oxamount` ";
 
-        $aData = oxDb::getDb(oxDb::FETCH_MODE_ASSOC)->getAll($sSql);
-
-        return $aData;
+        return oxDb::getDb(oxDb::FETCH_MODE_ASSOC)->getAll($sSql);
     }
 }

--- a/source/Application/Model/Article.php
+++ b/source/Application/Model/Article.php
@@ -585,7 +585,7 @@ class Article extends \oxI18n implements ArticleInterface, \oxIUrl
 
         // enabled time range check ?
         if ($this->getConfig()->getConfigParam('blUseTimeCheck')) {
-            $sQ = $this->addSqlActiveRangeSnippet($sQ,$sTable);
+            $sQ = $this->addSqlActiveRangeSnippet($sQ, $sTable);
         }
 
         return $sQ;
@@ -618,7 +618,7 @@ class Article extends \oxI18n implements ArticleInterface, \oxIUrl
             if (!$myConfig->getConfigParam('blVariantParentBuyable')) {
                 $activeCheck = 'art.oxactive = 1';
                 if ($myConfig->getConfigParam('blUseTimeCheck')) {
-                    $activeCheck = $this->addSqlActiveRangeSnippet($activeCheck,'art');
+                    $activeCheck = $this->addSqlActiveRangeSnippet($activeCheck, 'art');
                 }
                 $sQ = " $sQ and IF( $sTable.oxvarcount = 0, 1, ( select 1 from $sTable as art where art.oxparentid=$sTable.oxid and $activeCheck and ( art.oxstockflag != 2 or art.oxstock > 0 ) limit 1 ) ) ";
             }
@@ -672,11 +672,9 @@ class Article extends \oxI18n implements ArticleInterface, \oxIUrl
      */
     public function getSize()
     {
-        $dSize = $this->oxarticles__oxlength->value *
+        return $this->oxarticles__oxlength->value *
                  $this->oxarticles__oxwidth->value *
                  $this->oxarticles__oxheight->value;
-
-        return $dSize;
     }
 
     /**
@@ -698,9 +696,7 @@ class Article extends \oxI18n implements ArticleInterface, \oxIUrl
      */
     public function getSqlActiveSnippet($blForceCoreTable = null)
     {
-        $sQ = $this->_createSqlActiveSnippet($blForceCoreTable);
-
-        return "( $sQ ) ";
+        return "( {$this->_createSqlActiveSnippet($blForceCoreTable)} ) ";
     }
 
     /**
@@ -784,11 +780,7 @@ class Article extends \oxI18n implements ArticleInterface, \oxIUrl
      */
     public function isBuyable()
     {
-        if ($this->_blNotBuyableParent) {
-            return false;
-        }
-
-        return !$this->_blNotBuyable;
+        return !($this->_blNotBuyableParent || $this->_blNotBuyable);
     }
 
     /**
@@ -1364,7 +1356,7 @@ class Article extends \oxI18n implements ArticleInterface, \oxIUrl
         }
 
         // Check configured number of similar products (bug #6062)
-        if($myConfig->getConfigParam('iNrofSimilarArticles') < 1) {
+        if ($myConfig->getConfigParam('iNrofSimilarArticles') < 1) {
             return;
         }
 
@@ -1381,7 +1373,7 @@ class Article extends \oxI18n implements ArticleInterface, \oxIUrl
         $aList = $this->_getSimList($sAttribs, $iCnt);
 
         if (count($aList)) {
-            uasort($aList, function($a, $b) {
+            uasort($aList, function ($a, $b) {
                 if ($a->cnt == $b->cnt) {
                     return 0;
                 }
@@ -1552,8 +1544,13 @@ class Article extends \oxI18n implements ArticleInterface, \oxIUrl
             $aVariantSelections = false;
             if ($this->oxarticles__oxvarcount->value) {
                 $oVariants = $this->getVariants(false);
-                $aVariantSelections = oxNew("oxVariantHandler")->buildVariantSelections($this->oxarticles__oxvarname->getRawValue(),
-                    $oVariants, $aFilterIds, $sActVariantId, $iLimit);
+                $aVariantSelections = oxNew("oxVariantHandler")->buildVariantSelections(
+                    $this->oxarticles__oxvarname->getRawValue(),
+                    $oVariants,
+                    $aFilterIds,
+                    $sActVariantId,
+                    $iLimit
+                );
 
                 if (!empty($oVariants) && empty($aVariantSelections['rawselections'])) {
                     $aVariantSelections = false;
@@ -1577,7 +1574,6 @@ class Article extends \oxI18n implements ArticleInterface, \oxIUrl
     {
         $sId = $this->getId() . ((int) $iLimit);
         if (!array_key_exists($sId, self::$_aSelections)) {
-
             $oDb = oxDb::getDb();
             $sSLViewName = getViewName('oxselectlist');
 
@@ -1676,7 +1672,6 @@ class Article extends \oxI18n implements ArticleInterface, \oxIUrl
     {
         $oVariants = oxNew('oxArticleList');
         if (($sId = $this->getId())) {
-
             $oBaseObj = $oVariants->getBaseObject();
 
             if (is_null($sLanguage)) {
@@ -1723,12 +1718,13 @@ class Article extends \oxI18n implements ArticleInterface, \oxIUrl
                 $oStr = getStr();
                 $sWhere = $oCategory->getSqlActiveSnippet();
                 $sSelect = $this->_generateSearchStr($sOXID);
-                $sSelect .= ($oStr->strstr($sSelect,
-                        'where') ? ' and ' : ' where ') . $sWhere . " order by oxobject2category.oxtime limit 1";
+                $sSelect .= ($oStr->strstr(
+                    $sSelect,
+                    'where'
+                ) ? ' and ' : ' where ') . $sWhere . " order by oxobject2category.oxtime limit 1";
 
                 // category not found ?
                 if (!$oCategory->assignRecord($sSelect)) {
-
                     $sSelect = $this->_generateSearchStr($sOXID, true);
                     $sSelect .= ($oStr->strstr($sSelect, 'where') ? ' and ' : ' where ') . $sWhere . " limit 1";
 
@@ -1762,7 +1758,6 @@ class Article extends \oxI18n implements ArticleInterface, \oxIUrl
         $sArticleId = $this->getId();
 
         if (!isset(self::$_aArticleCats[$sArticleId]) || $blSkipCache) {
-
             $sSql = $this->_getCategoryIdsSelect($blActCats);
             $aCategoryIds = $this->_selectCategoryIds($sSql, 'oxcatnid');
 
@@ -1794,7 +1789,6 @@ class Article extends \oxI18n implements ArticleInterface, \oxIUrl
             $sVendorId = $this->oxarticles__oxvendorid->value;
         }
         if ($sVendorId && $oVendor && $oVendor->load($sVendorId) && $oVendor->oxvendor__oxactive->value) {
-
             return $oVendor;
         }
 
@@ -1835,12 +1829,7 @@ class Article extends \oxI18n implements ArticleInterface, \oxIUrl
      */
     public function getManufacturerId()
     {
-        $sManufacturerId = false;
-        if ($this->oxarticles__oxmanufacturerid->value) {
-            $sManufacturerId = $this->oxarticles__oxmanufacturerid->value;
-        }
-
-        return $sManufacturerId;
+        return $this->oxarticles__oxmanufacturerid->value ?: false;
     }
 
     /**
@@ -2044,9 +2033,7 @@ class Article extends \oxI18n implements ArticleInterface, \oxIUrl
      */
     protected function _getModifiedAmountPrice($amount)
     {
-        $price = $this->_getAmountPrice($amount);
-
-        return $price;
+        return $this->_getAmountPrice($amount);
     }
 
     /**
@@ -2387,7 +2374,7 @@ class Article extends \oxI18n implements ArticleInterface, \oxIUrl
             if ($this->getId()) {
                 $articleId = $this->getId();
             }
-            if (!isset ($articleId)) {
+            if (!isset($articleId)) {
                 $articleId = $this->oxarticles__oxid->value;
             }
             if ($this->oxarticles__oxparentid->value) {
@@ -3070,8 +3057,12 @@ class Article extends \oxI18n implements ArticleInterface, \oxIUrl
             $sImgName = basename($this->{"oxarticles__oxpic" . $iIndex}->value);
             $sSize = $this->getConfig()->getConfigParam("sZoomImageSize");
 
-            return oxRegistry::get("oxPictureHandler")->getProductPicUrl("product/{$iIndex}/", $sImgName, $sSize,
-                'oxpic' . $iIndex);
+            return oxRegistry::get("oxPictureHandler")->getProductPicUrl(
+                "product/{$iIndex}/",
+                $sImgName,
+                $sSize,
+                'oxpic' . $iIndex
+            );
         }
     }
 
@@ -3342,7 +3333,6 @@ class Article extends \oxI18n implements ArticleInterface, \oxIUrl
     public function getArticleFiles($blAddFromParent = false)
     {
         if ($this->_aArticleFiles === null) {
-
             $this->_aArticleFiles = false;
 
             $sQ = "SELECT * FROM `oxfiles` WHERE `oxartid` = '" . $this->getId() . "'";
@@ -3378,7 +3368,6 @@ class Article extends \oxI18n implements ArticleInterface, \oxIUrl
     public function hasAmountPrice()
     {
         if (self::$_blHasAmountPrice === null) {
-
             self::$_blHasAmountPrice = false;
 
             $oDb = oxDb::getDb();
@@ -3434,7 +3423,6 @@ class Article extends \oxI18n implements ArticleInterface, \oxIUrl
             }
 
             if (($this->_blHasVariants = $this->_hasAnyVariant($forceCoreTableUsage))) {
-
                 //load simple variants for lists
                 if ($loadSimpleVariants) {
                     $variants = oxNew('oxSimpleVariantList');
@@ -3537,9 +3525,8 @@ class Article extends \oxI18n implements ArticleInterface, \oxIUrl
     protected function _getActiveCategorySelectSnippet()
     {
         $sCatView = $this->_getObjectViewName('oxcategories');
-        $sActiveCategorySql = "and oxcategories.oxhidden = 0 and (select count(cats.oxid) from $sCatView as cats where cats.oxrootid = oxcategories.oxrootid and cats.oxleft < oxcategories.oxleft and cats.oxright > oxcategories.oxright and ( cats.oxhidden = 1 or cats.oxactive = 0 ) ) = 0 ";
 
-        return $sActiveCategorySql;
+        return "and oxcategories.oxhidden = 0 and (select count(cats.oxid) from $sCatView as cats where cats.oxrootid = oxcategories.oxrootid and cats.oxleft < oxcategories.oxleft and cats.oxright > oxcategories.oxright and ( cats.oxhidden = 1 or cats.oxactive = 0 ) ) = 0 ";
     }
 
     /**
@@ -3607,17 +3594,16 @@ class Article extends \oxI18n implements ArticleInterface, \oxIUrl
      */
     protected function _hasAnyVariant($blForceCoreTable = null)
     {
-        $blHas = false;
         if (($sId = $this->getId())) {
             if ($this->oxarticles__oxshopid->value == $this->getConfig()->getShopId()) {
-                $blHas = (bool) $this->oxarticles__oxvarcount->value;
-            } else {
-                $sArticleTable = $this->getViewName($blForceCoreTable);
-                $blHas = (bool) oxDb::getDb()->getOne("select 1 from $sArticleTable where oxparentid='{$sId}'");
+                return (bool) $this->oxarticles__oxvarcount->value;
             }
+            $sArticleTable = $this->getViewName($blForceCoreTable);
+
+            return (bool) oxDb::getDb()->getOne("select 1 from $sArticleTable where oxparentid='{$sId}'");
         }
 
-        return $blHas;
+        return false;
     }
 
     /**
@@ -4036,16 +4022,13 @@ class Article extends \oxI18n implements ArticleInterface, \oxIUrl
 
         // we do not use lists here as we don't need this overhead right now
         if (!$blSearchPriceCat) {
-            $sSelect = "select {$sCatView}.* from {$sO2CView} as oxobject2category left join {$sCatView} on
+            return "select {$sCatView}.* from {$sO2CView} as oxobject2category left join {$sCatView} on
                          {$sCatView}.oxid = oxobject2category.oxcatnid
                          where oxobject2category.oxobjectid=" . oxDb::getDb()->quote($sOXID) . " and {$sCatView}.oxid is not null ";
-        } else {
-            $sSelect = "select {$sCatView}.* from {$sCatView} where
-                         '{$this->oxarticles__oxprice->value}' >= {$sCatView}.oxpricefrom and
-                         '{$this->oxarticles__oxprice->value}' <= {$sCatView}.oxpriceto ";
         }
-
-        return $sSelect;
+        return "select {$sCatView}.* from {$sCatView} where
+                      '{$this->oxarticles__oxprice->value}' >= {$sCatView}.oxpricefrom and
+                      '{$this->oxarticles__oxprice->value}' <= {$sCatView}.oxpriceto ";
     }
 
     /**
@@ -4061,7 +4044,6 @@ class Article extends \oxI18n implements ArticleInterface, \oxIUrl
         // fetching filter params
         $sIn = " '{$this->oxarticles__oxid->value}' ";
         if ($this->oxarticles__oxparentid->value) {
-
             // adding article parent
             $sIn .= ", '{$this->oxarticles__oxparentid->value}' ";
             $sParentIdForVariants = $this->oxarticles__oxparentid->value;
@@ -4083,7 +4065,7 @@ class Article extends \oxI18n implements ArticleInterface, \oxIUrl
         $iLimit = $iLimit ? ($iLimit * 10) : 50;
 
         // building sql (optimized)
-        $sQ = "select distinct {$sArtTable}.* from (
+        return "select distinct {$sArtTable}.* from (
                    select d.oxorderid as suborderid from {$sOrderArtTable} as d use index ( oxartid ) where d.oxartid in ( {$sIn} ) limit {$iLimit}
                ) as suborder
                left join {$sOrderArtTable} force index ( oxorderid ) on suborder.suborderid = {$sOrderArtTable}.oxorderid
@@ -4099,8 +4081,6 @@ class Article extends \oxI18n implements ArticleInterface, \oxIUrl
                and ( {$sArtTable}.oxissearch = 1 or {$sArtTable}.oxparentid <> '' )
                and ".$this->getSqlActiveSnippet();
         */
-
-        return $sQ;
     }
 
     /**
@@ -4215,14 +4195,19 @@ class Article extends \oxI18n implements ArticleInterface, \oxIUrl
 
         $sFieldName = strtolower($sFieldName);
 
-        if ($sFieldName == 'oxarticles__oxicon' && (strpos($mValue, "nopic_ico.jpg") !== false || strpos($mValue,
-                    "nopic.jpg") !== false)
+        if ($sFieldName == 'oxarticles__oxicon' && (strpos($mValue, "nopic_ico.jpg") !== false || strpos(
+            $mValue,
+            "nopic.jpg"
+        ) !== false)
         ) {
             return true;
         }
 
-        if (strpos($mValue, "nopic.jpg") !== false && ($sFieldName == 'oxarticles__oxthumb' || substr($sFieldName, 0,
-                    17) == 'oxarticles__oxpic' || substr($sFieldName, 0, 18) == 'oxarticles__oxzoom')
+        if (strpos($mValue, "nopic.jpg") !== false && ($sFieldName == 'oxarticles__oxthumb' || substr(
+            $sFieldName,
+            0,
+            17
+        ) == 'oxarticles__oxpic' || substr($sFieldName, 0, 18) == 'oxarticles__oxzoom')
         ) {
             return true;
         }
@@ -4247,7 +4232,6 @@ class Article extends \oxI18n implements ArticleInterface, \oxIUrl
 
         // assigning only these which parent article has
         if ($oParentArticle->$sCopyFieldName != null) {
-
             // only overwrite database values
             if (substr($sCopyFieldName, 0, 12) != 'oxarticles__') {
                 return;
@@ -4279,10 +4263,10 @@ class Article extends \oxI18n implements ArticleInterface, \oxIUrl
      */
     protected function _isImageField($sFieldName)
     {
-        $blIsImageField = (stristr($sFieldName, '_oxthumb') || stristr($sFieldName, '_oxicon') || stristr($sFieldName,
-                '_oxzoom') || stristr($sFieldName, '_oxpic'));
-
-        return $blIsImageField;
+        return (stristr($sFieldName, '_oxthumb') || stristr($sFieldName, '_oxicon') || stristr(
+            $sFieldName,
+            '_oxzoom'
+        ) || stristr($sFieldName, '_oxpic'));
     }
 
     /**
@@ -4458,9 +4442,7 @@ class Article extends \oxI18n implements ArticleInterface, \oxIUrl
 
         $this->_skipSaveFields();
 
-        $blRes = parent::_update();
-
-        return $blRes;
+        return parent::_update();
     }
 
     /**
@@ -4517,9 +4499,8 @@ class Article extends \oxI18n implements ArticleInterface, \oxIUrl
         $rs = $oDb->execute($sDelete);
 
         $sDelete = 'delete from oxobject2list where oxobjectid = ' . $articleId . ' ';
-        $rs = $oDb->execute($sDelete);
 
-        return $rs;
+        return $oDb->execute($sDelete);
     }
 
     /**
@@ -4645,9 +4626,11 @@ class Article extends \oxI18n implements ArticleInterface, \oxIUrl
         if ($myConfig->getConfigParam('blUseStock') && $this->oxarticles__oxstockflag->value == 2 &&
             ($this->oxarticles__oxstock->value + $this->oxarticles__oxvarstock->value) <= 0
         ) {
-
-            $this->_onChangeResetCounts($sOxid, $this->oxarticles__oxvendorid->value,
-                $this->oxarticles__oxmanufacturerid->value);
+            $this->_onChangeResetCounts(
+                $sOxid,
+                $this->oxarticles__oxvendorid->value,
+                $this->oxarticles__oxmanufacturerid->value
+            );
         }
     }
 
@@ -4979,9 +4962,7 @@ class Article extends \oxI18n implements ArticleInterface, \oxIUrl
     {
         $sSelect = $this->buildSelectString(array($this->getViewName() . ".oxid" => $articleId));
 
-        $aData = oxDb::getDb(oxDb::FETCH_MODE_ASSOC)->getRow($sSelect);
-
-        return $aData;
+        return oxDb::getDb(oxDb::FETCH_MODE_ASSOC)->getRow($sSelect);
     }
 
     /**

--- a/source/Core/AdminLogSqlDecorator.php
+++ b/source/Core/AdminLogSqlDecorator.php
@@ -41,9 +41,7 @@ class AdminLogSqlDecorator
     {
         $userId = $this->getUserId();
 
-        $preparedSql = "insert into {$this->table} (oxuserid, oxsql) values ('{$userId}', " . $this->quote($originalSql) . ")";
-
-        return $preparedSql;
+        return "insert into {$this->table} (oxuserid, oxsql) values ('{$userId}', " . $this->quote($originalSql) . ")";
     }
 
     /**
@@ -54,11 +52,9 @@ class AdminLogSqlDecorator
     protected function getUserId()
     {
         $user = oxNew('oxUser');
-        $result = '';
         if ($user->loadAdminUser()) {
-            $result = $user->getId();
+            return $user->getId();
         }
-        return $result;
     }
 
     /**
@@ -69,8 +65,6 @@ class AdminLogSqlDecorator
      */
     protected function quote($str)
     {
-        $db = oxDb::getDb();
-        $result = $db->quote($str);
-        return $result;
+        return oxDb::getDb()->quote($str);
     }
 }

--- a/source/Core/Autoload/ShopAutoload.php
+++ b/source/Core/Autoload/ShopAutoload.php
@@ -102,7 +102,7 @@ class ShopAutoload
     protected function generateDirectories()
     {
         $shopBasePath = __DIR__ . "/../../";
-        $aClassDirs = array(
+        return [
             $shopBasePath . 'Core/',
             $shopBasePath . 'Application/Component/Widget/',
             $shopBasePath . 'Application/Component/',
@@ -111,8 +111,6 @@ class ShopAutoload
             $shopBasePath . 'Application/Controller/Admin/',
             $shopBasePath . 'Core/exception/',
             $shopBasePath . 'Core/interface/'
-        );
-
-        return $aClassDirs;
+        ];
     }
 }

--- a/source/Core/Base.php
+++ b/source/Core/Base.php
@@ -357,8 +357,7 @@ class Base extends \oxSuperCfg
      */
     protected function getGetterViewName()
     {
-        $viewName = $this->getViewName();
-        return $viewName;
+        return $this->getViewName();
     }
 
     /**
@@ -728,16 +727,14 @@ class Base extends \oxSuperCfg
      */
     public function assignRecord($select)
     {
-        $result = false;
-
         $record = $this->getRecordByQuery($select);
 
         if ($record != false && $record->recordCount() > 0) {
-            $result = true;
             $this->assign($record->fields);
+            return true;
         }
 
-        return $result;
+        return false;
     }
 
     /**
@@ -788,9 +785,7 @@ class Base extends \oxSuperCfg
 
         }
 
-        $joinedSelectFields = implode(', ', $selectFields);
-
-        return $joinedSelectFields;
+        return implode(', ', $selectFields);
     }
 
     /**
@@ -1405,9 +1400,7 @@ class Base extends \oxSuperCfg
 
         $this->beforeUpdate();
 
-        $result = (bool) $database->execute($updateQuery);
-
-        return $result;
+        return (bool) $database->execute($updateQuery);
     }
 
     /**
@@ -1440,9 +1433,7 @@ class Base extends \oxSuperCfg
 
         $insertSql .= $this->_getUpdateFields($this->getUseSkipSaveFields());
 
-        $result = (bool) $database->execute($insertSql);
-
-        return $result;
+        return (bool) $database->execute($insertSql);
     }
 
     /**
@@ -1555,9 +1546,8 @@ class Base extends \oxSuperCfg
         $secondsToRoundForQueryCache = $this->getSecondsToRoundForQueryCache();
         $databaseFormattedDate = $dateObj->getRoundedRequestDateDBFormatted($secondsToRoundForQueryCache);
         $query = $query ? " $query or " : '';
-        $query = " ( $query ( $tableName.oxactivefrom < '$databaseFormattedDate' and $tableName.oxactiveto > '$databaseFormattedDate' ) ) ";
 
-        return $query;
+        return " ( $query ( $tableName.oxactivefrom < '$databaseFormattedDate' and $tableName.oxactiveto > '$databaseFormattedDate' ) ) ";
     }
 
     /**

--- a/source/Core/Config.php
+++ b/source/Core/Config.php
@@ -1059,7 +1059,6 @@ class Config extends SuperConfig
      */
     public function getShopCurrency()
     {
-        $curr = null;
         if ((null === ($curr = $this->getRequestParameter('cur')))) {
             if (null === ($curr = $this->getRequestParameter('currency'))) {
                 $curr = $this->getSession()->getVariable('currency');
@@ -1345,13 +1344,11 @@ class Config extends SuperConfig
      */
     public function getUrl($file, $dir, $admin = null, $ssl = null, $nativeImg = false, $lang = null, $shop = null, $theme = null)
     {
-        $url = str_replace(
+        return str_replace(
             $this->getOutDir(),
             $this->getOutUrl($ssl, $admin, $nativeImg),
             $this->getDir($file, $dir, $admin, $lang, $shop, $theme)
         );
-
-        return $url;
     }
 
     /**
@@ -1721,15 +1718,13 @@ class Config extends SuperConfig
      */
     public function getVersion()
     {
-        $version = $this->getActiveShop()->oxshops__oxversion->value;
-
-        return $version;
+        return $this->getActiveShop()->oxshops__oxversion->value;
     }
 
     /**
      * Returns build revision number or false on read error.
      *
-     * @return int
+     * @return bool|string
      */
     public function getRevision()
     {
@@ -1880,12 +1875,9 @@ class Config extends SuperConfig
         $query = "select oxvartype, " . $this->getDecodeValueQuery() . " as oxvarvalue from oxconfig where oxshopid = '{$shopId}' and oxmodule = '{$module}' and oxvarname = " . $db->quote($varName);
         $rs = $db->select($query);
 
-        $value = null;
         if ($rs != false && $rs->recordCount() > 0) {
-            $value = $this->decodeValue($rs->fields['oxvartype'], $rs->fields['oxvarvalue']);
+            return $this->decodeValue($rs->fields['oxvartype'], $rs->fields['oxvarvalue']);
         }
-
-        return $value;
     }
 
     /**
@@ -2168,16 +2160,13 @@ class Config extends SuperConfig
      */
     public function getShopUrlByLanguage($lang, $ssl = false)
     {
-        $languageUrl = null;
         $configParameter = $ssl ? 'aLanguageSSLURLs' : 'aLanguageURLs';
         $lang = isset($lang) ? $lang : Registry::getLang()->getBaseLanguage();
         $languageURLs = $this->getConfigParam($configParameter);
         if (isset($lang) && isset($languageURLs[$lang]) && !empty($languageURLs[$lang])) {
             $languageURLs[$lang] = Registry::getUtils()->checkUrlEndingSlash($languageURLs[$lang]);
-            $languageUrl = $languageURLs[$lang];
+            return $languageURLs[$lang];
         }
-
-        return $languageUrl;
     }
 
     /**
@@ -2189,15 +2178,11 @@ class Config extends SuperConfig
      */
     public function getMallShopUrl($ssl = false)
     {
-        $url = null;
         $configParameter = $ssl ? 'sMallSSLShopURL' : 'sMallShopURL';
         $mallShopUrl = $this->getConfigParam($configParameter);
         if ($mallShopUrl) {
-            $mallShopUrl = Registry::getUtils()->checkUrlEndingSlash($mallShopUrl);
-            $url = $mallShopUrl;
+            return Registry::getUtils()->checkUrlEndingSlash($mallShopUrl);
         }
-
-        return $url;
     }
 
     /**

--- a/source/Core/ConfigFile.php
+++ b/source/Core/ConfigFile.php
@@ -45,11 +45,7 @@ class ConfigFile
      */
     public function getVar($varName)
     {
-        if (isset($this->$varName)) {
-            return $this->$varName;
-        }
-
-        return null;
+        return isset($this->$varName) ? $this->$varName : null;
     }
 
     /**
@@ -82,9 +78,7 @@ class ConfigFile
      */
     public function getVars()
     {
-        $allVars = get_object_vars($this);
-
-        return $allVars;
+        return get_object_vars($this);
     }
 
     /**

--- a/source/Core/Curl.php
+++ b/source/Core/Curl.php
@@ -454,10 +454,7 @@ class Curl
      */
     protected function _prepareQueryParameters($params)
     {
-        $params = array_filter($params);
-        $params = array_map(array($this, '_htmlDecode'), $params);
-
-        return $params;
+        return array_map([$this, '_htmlDecode'], array_filter($params));
     }
 
     /**

--- a/source/Core/Database.php
+++ b/source/Core/Database.php
@@ -320,8 +320,7 @@ class Database
      */
     public function escapeString($string)
     {
-        $result = trim(self::getDb()->quote($string), "'");
-        return $result;
+        return trim(self::getDb()->quote($string), "'");
     }
 
     /**
@@ -346,8 +345,6 @@ class Database
         if (isset(self::$$configName)) {
             return self::$$configName;
         }
-
-        return null;
     }
 
     /**

--- a/source/Core/DbMetaDataHandler.php
+++ b/source/Core/DbMetaDataHandler.php
@@ -239,13 +239,12 @@ class DbMetaDataHandler extends oxSuperCfg
         $tableSet = getLangTableName($table, $lang);
 
         $res = oxDb::getDb()->getAll("show create table {$table}");
+
         $collation = $this->getConfig()->isUtf() ? '' : 'COLLATE latin1_general_ci';
-        $sql = "CREATE TABLE `{$tableSet}` (" .
+        return "CREATE TABLE `{$tableSet}` (" .
                 "`OXID` char(32) $collation NOT NULL, " .
                 "PRIMARY KEY (`OXID`)" .
                 ") " . strstr($res[0][1], 'ENGINE=');
-
-        return $sql;
     }
 
     /**
@@ -358,9 +357,7 @@ class DbMetaDataHandler extends oxSuperCfg
             $fieldSet = $field . '_' . $lang;
         }
 
-        $this->_iCurrentMaxLangId = --$lang;
-
-        return $this->_iCurrentMaxLangId;
+        return $this->_iCurrentMaxLangId = --$lang;
     }
 
     /**

--- a/source/Core/DynamicImageGenerator.php
+++ b/source/Core/DynamicImageGenerator.php
@@ -253,7 +253,7 @@ namespace OxidEsales\Eshop\Core {
          */
         protected function _getImageInfo()
         {
-            $info = array();
+            $info = [];
             if (($uri = $this->_getImageUri())) {
                 $info = explode($this->_sImageInfoSep, basename(dirname($uri)));
             }

--- a/source/Core/Email.php
+++ b/source/Core/Email.php
@@ -573,9 +573,7 @@ class Email extends \PHPMailer
         $this->setRecipient($user->oxuser__oxusername->value, $fullName);
         $this->setReplyTo($shop->oxshops__oxorderemail->value, $shop->oxshops__oxname->getRawValue());
 
-        $success = $this->send();
-
-        return $success;
+        return $this->send();
     }
 
     /**
@@ -1909,9 +1907,7 @@ class Email extends \PHPMailer
         // shop info
         $shop = $this->_getShop();
 
-        $ret = @mail($shop->oxshops__oxorderemail->value, "eMail problem in shop!", $ownerMessage);
-
-        return $ret;
+        return @mail($shop->oxshops__oxorderemail->value, "eMail problem in shop!", $ownerMessage);
     }
 
     /**

--- a/source/Core/FileCache.php
+++ b/source/Core/FileCache.php
@@ -100,9 +100,7 @@ class FileCache
      */
     protected function getCacheFilePath($key)
     {
-        $fileName = $this->getCacheDir() . "/" . $this->getCacheFileName($key);
-
-        return $fileName;
+        return $this->getCacheDir() . "/" . $this->getCacheFileName($key);
     }
 
     /**
@@ -112,9 +110,7 @@ class FileCache
      */
     protected function getCacheDir()
     {
-        $dir = oxRegistry::get("oxConfigFile")->getVar("sCompileDir");
-
-        return $dir;
+        return oxRegistry::get("oxConfigFile")->getVar("sCompileDir");
     }
 
     /**

--- a/source/Core/FileSystem/FileSystem.php
+++ b/source/Core/FileSystem/FileSystem.php
@@ -55,10 +55,6 @@ class FileSystem
      */
     public function isReadable($filePath)
     {
-        if (is_file($filePath) && is_readable($filePath)) {
-            return true;
-        } else {
-            return false;
-        }
+        return (is_file($filePath) && is_readable($filePath));
     }
 }

--- a/source/Core/GenericImport/GenericImport.php
+++ b/source/Core/GenericImport/GenericImport.php
@@ -433,9 +433,9 @@ class GenericImport
 
         if ($fieldEncloser = $config->getConfigParam('sGiCsvFieldEncloser')) {
             return $fieldEncloser;
-        } else {
-            return $this->defaultStringEncloser;
         }
+
+        return $this->defaultStringEncloser;
     }
 
     /**
@@ -463,6 +463,7 @@ class GenericImport
     protected function createImportObject($type)
     {
         $className = __NAMESPACE__ . "\\ImportObject\\".$type;
+
         return oxNew($className);
     }
 }

--- a/source/Core/GenericImport/ImportObject/Article.php
+++ b/source/Core/GenericImport/ImportObject/Article.php
@@ -71,9 +71,7 @@ class Article extends ImportObject
             }
         }
 
-        $data = parent::preAssignObject($shopObject, $data, $allowCustomShopId);
-
-        return $data;
+        return parent::preAssignObject($shopObject, $data, $allowCustomShopId);
     }
 
     /**

--- a/source/Core/GenericImport/ImportObject/ImportObject.php
+++ b/source/Core/GenericImport/ImportObject/ImportObject.php
@@ -181,6 +181,7 @@ abstract class ImportObject
     protected function getTableName()
     {
         $shopId = oxRegistry::getConfig()->getShopId();
+
         return getViewName($this->tableName, -1, $shopId);
     }
 

--- a/source/Core/InputValidator.php
+++ b/source/Core/InputValidator.php
@@ -152,18 +152,15 @@ class InputValidator extends \oxSuperCfg
         // check only for users with password during registration
         // if user wants to change user name - we must check if passwords are ok before changing
         if ($oUser->oxuser__oxpassword->value && $sLogin != $oUser->oxuser__oxusername->value) {
-
             // on this case password must be taken directly from request
             $sNewPass = (isset($aInvAddress['oxuser__oxpassword']) && $aInvAddress['oxuser__oxpassword']) ? $aInvAddress['oxuser__oxpassword'] : oxRegistry::getConfig()->getRequestParameter('user_password');
             if (!$sNewPass) {
-
                 // 1. user forgot to enter password
                 $oEx = oxNew('oxInputException');
                 $oEx->setMessage(oxRegistry::getLang()->translateString('ERROR_MESSAGE_INPUT_NOTALLFIELDS'));
 
                 return $this->_addValidationError("oxuser__oxpassword", $oEx);
             } else {
-
                 // 2. entered wrong password
                 if (!$oUser->isSamePassword($sNewPass)) {
                     $oEx = oxNew('oxUserException');
@@ -257,15 +254,7 @@ class InputValidator extends \oxSuperCfg
      */
     public function getPasswordLength()
     {
-        $passwordLength = 6;
-
-        $config = $this->getConfig();
-
-        if ($config->getConfigParam("iPasswordLength")) {
-            $passwordLength = $config->getConfigParam("iPasswordLength");
-        }
-
-        return $passwordLength;
+        return $this->getConfig()->getConfigParam("iPasswordLength") ?: 6;
     }
 
     /**
@@ -390,11 +379,9 @@ class InputValidator extends \oxSuperCfg
     public function checkVatId($oUser, $aInvAddress)
     {
         if ($this->_hasRequiredParametersForVatInCheck($aInvAddress)) {
-
             $oCountry = $this->_getCountry($aInvAddress['oxuser__oxcountryid']);
 
             if ($oCountry && $oCountry->isInEU()) {
-
                 $oVatInValidator = $this->getCompanyVatInValidator($oCountry);
 
                 /** @var oxCompanyVatIn $oVatIn */
@@ -450,13 +437,10 @@ class InputValidator extends \oxSuperCfg
      */
     public function getFirstValidationError()
     {
-        $oErr = null;
         $aErr = reset($this->_aInputValidationErrors);
         if (is_array($aErr)) {
-            $oErr = reset($aErr);
+            return reset($aErr);
         }
-
-        return $oErr;
     }
 
     /**
@@ -585,9 +569,9 @@ class InputValidator extends \oxSuperCfg
 
         if ($oStr->strlen($aDebitInfo['lsktonr']) < 10) {
             $sNewNum = str_repeat(
-                           '0',
-                           10 - $oStr->strlen($aDebitInfo['lsktonr'])
-                       ) . $aDebitInfo['lsktonr'];
+                '0',
+                10 - $oStr->strlen($aDebitInfo['lsktonr'])
+            ) . $aDebitInfo['lsktonr'];
             $aDebitInfo['lsktonr'] = $sNewNum;
         }
 
@@ -652,9 +636,7 @@ class InputValidator extends \oxSuperCfg
      */
     protected function _getVatIdValidator()
     {
-        $oVatCheck = oxNew('oxOnlineVatIdCheck');
-
-        return $oVatCheck;
+        return oxNew('oxOnlineVatIdCheck');
     }
 
     /**
@@ -677,7 +659,6 @@ class InputValidator extends \oxSuperCfg
     public function getCompanyVatInValidator($oCountry)
     {
         if (is_null($this->_oCompanyVatInValidator)) {
-
             /** @var oxCompanyVatInValidator $oVatInValidator */
             $oVatInValidator = oxNew('oxCompanyVatInValidator', $oCountry);
 

--- a/source/Core/Language.php
+++ b/source/Core/Language.php
@@ -161,7 +161,6 @@ class Language extends \oxSuperCfg
     public function getBaseLanguage()
     {
         if ($this->_iBaseLanguageId === null) {
-
             $myConfig = $this->getConfig();
             $blAdmin = $this->isAdmin();
 
@@ -196,7 +195,6 @@ class Language extends \oxSuperCfg
             // if language still not set and not search engine browsing,
             // getting language from browser
             if (is_null($this->_iBaseLanguageId) && !$blAdmin && !oxRegistry::getUtils()->isSearchEngine()) {
-
                 // getting from cookie
                 $this->_iBaseLanguageId = oxRegistry::get("oxUtilsServer")->getOxCookie('language');
 
@@ -266,11 +264,9 @@ class Language extends \oxSuperCfg
     public function getEditLanguage()
     {
         if ($this->_iEditLanguageId === null) {
-
             if (!$this->isAdmin()) {
                 $this->_iEditLanguageId = $this->getBaseLanguage();
             } else {
-
                 $iLang = null;
                 // choosing language ident
                 // check if we really need to set the new language
@@ -317,7 +313,6 @@ class Language extends \oxSuperCfg
             $i = 0;
             reset($aConfLanguages);
             while (list($key, $val) = each($aConfLanguages)) {
-
                 if ($blOnlyActive && is_array($aLangParams)) {
                     //skipping non active languages
                     if (!$aLangParams[$key]['active']) {
@@ -571,7 +566,7 @@ class Language extends \oxSuperCfg
 
         $iLanguage = (int) $iLanguage;
 
-        return (($iLanguage) ? "_$iLanguage" : "");
+        return ($iLanguage) ? "_$iLanguage" : "";
     }
 
     /**
@@ -583,8 +578,6 @@ class Language extends \oxSuperCfg
      */
     public function validateLanguage($iLang = null)
     {
-        $iLang = (int) $iLang;
-
         // checking if this language is valid
         $aLanguages = $this->getLanguageArray(null, !$this->isAdmin());
         if (!isset($aLanguages[$iLang]) && is_array($aLanguages)) {
@@ -594,7 +587,7 @@ class Language extends \oxSuperCfg
             }
         }
 
-        return $iLang;
+        return (int) $iLang;
     }
 
     /**
@@ -1103,12 +1096,9 @@ class Language extends \oxSuperCfg
      */
     public function getFormLang()
     {
-        $sLang = null;
         if (!$this->isAdmin()) {
-            $sLang = "<input type=\"hidden\" name=\"" . $this->getName() . "\" value=\"" . $this->getBaseLanguage() . "\" />";
+            return "<input type=\"hidden\" name=\"" . $this->getName() . "\" value=\"" . $this->getBaseLanguage() . "\" />";
         }
-
-        return $sLang;
     }
 
     /**
@@ -1120,13 +1110,10 @@ class Language extends \oxSuperCfg
      */
     public function getUrlLang($iLang = null)
     {
-        $sLang = null;
         if (!$this->isAdmin()) {
             $iLang = isset($iLang) ? $iLang : $this->getBaseLanguage();
-            $sLang = $this->getName() . "=" . $iLang;
+            return $this->getName() . "=" . $iLang;
         }
-
-        return $sLang;
     }
 
     /**
@@ -1181,7 +1168,6 @@ class Language extends \oxSuperCfg
         $sBrowserLanguage = $this->_getBrowserLanguage();
 
         if (!is_null($sBrowserLanguage)) {
-
             $aLanguages = $this->getLanguageArray(null, true);
             foreach ($aLanguages as $oLang) {
                 if ($oLang->abbr == $sBrowserLanguage) {
@@ -1204,7 +1190,7 @@ class Language extends \oxSuperCfg
                          "oxlinks",
                          // @deprecated since v.5.3.0 (2016-06-17); The Admin Menu: Customer Info -> News feature will be moved to a module in v6.0.0
                          "oxnews",
-                         // END deprecated 
+                         // END deprecated
                          "oxobject2attribute",
                          "oxpayments", "oxselectlist", "oxshops",
                          "oxactions", "oxwrapping", "oxdeliveryset",
@@ -1275,12 +1261,9 @@ class Language extends \oxSuperCfg
      */
     protected function _getBrowserLanguage()
     {
-        $sBrowserLang = null;
         if (isset($_SERVER['HTTP_ACCEPT_LANGUAGE']) && $_SERVER['HTTP_ACCEPT_LANGUAGE']) {
-            $sBrowserLang = strtolower(substr($_SERVER['HTTP_ACCEPT_LANGUAGE'], 0, 2));
+            return strtolower(substr($_SERVER['HTTP_ACCEPT_LANGUAGE'], 0, 2));
         }
-
-        return $sBrowserLang;
     }
 
     /**
@@ -1290,9 +1273,7 @@ class Language extends \oxSuperCfg
      */
     public function getAllShopLanguageIds()
     {
-        $aLanguages = $this->_getLanguageIdsFromDatabase();
-
-        return $aLanguages;
+        return $this->_getLanguageIdsFromDatabase();
     }
 
     /**

--- a/source/Core/LegacyDatabase.php
+++ b/source/Core/LegacyDatabase.php
@@ -270,14 +270,10 @@ class LegacyDatabase extends \oxSuperCfg
      */
     public function setTransactionIsolationLevel($level = null)
     {
-        $result = false;
-
         $availableLevels = array('READ UNCOMMITTED', 'READ COMMITTED', 'REPEATABLE READ', 'SERIALIZABLE');
         if (in_array(strtoupper($level), $availableLevels)) {
-            $result = $this->getDb(false)->Execute('SET SESSION TRANSACTION ISOLATION LEVEL ' . $level);
+            return $this->getDb(false)->Execute('SET SESSION TRANSACTION ISOLATION LEVEL ' . $level);
         }
-
-        return $result;
     }
 
     /**

--- a/source/Core/Module.php
+++ b/source/Core/Module.php
@@ -210,7 +210,6 @@ class Module extends \oxSuperCfg
     public function getInfo($sName, $iLang = null)
     {
         if (isset($this->_aModule[$sName])) {
-
             if ($iLang !== null && is_array($this->_aModule[$sName])) {
                 $sValue = null;
 
@@ -378,9 +377,7 @@ class Module extends \oxSuperCfg
 
         $sShopId = $this->getConfig()->getShopId();
 
-        $aTemplates = oxDb::getDb()->getCol("SELECT oxtemplate FROM oxtplblocks WHERE oxmodule = '$sModuleId' AND oxshopid = '$sShopId'");
-
-        return $aTemplates;
+        return oxDb::getDb()->getCol("SELECT oxtemplate FROM oxtplblocks WHERE oxmodule = '$sModuleId' AND oxshopid = '$sShopId'");
     }
 
     /**
@@ -442,9 +439,8 @@ class Module extends \oxSuperCfg
         $aInstalledExtensions = $this->getConfig()->getModulesWithExtendedClass();
         $iModuleExtensionsCount = $this->_countExtensions($aModuleExtensions);
         $iActivatedModuleExtensionsCount = $this->_countActivatedExtensions($aModuleExtensions, $aInstalledExtensions);
-        $blActive = $iModuleExtensionsCount > 0 && $iActivatedModuleExtensionsCount == $iModuleExtensionsCount;
 
-        return $blActive;
+        return $iModuleExtensionsCount > 0 && $iActivatedModuleExtensionsCount == $iModuleExtensionsCount;
     }
 
     /**
@@ -456,13 +452,6 @@ class Module extends \oxSuperCfg
      */
     protected function _isInDisabledList($sId)
     {
-        $blInDisabledList = false;
-
-        $aDisabledModules = (array) $this->getConfig()->getConfigParam('aDisabledModules');
-        if (in_array($sId, $aDisabledModules)) {
-            $blInDisabledList = true;
-        }
-
-        return $blInDisabledList;
+        return in_array($sId, (array) $this->getConfig()->getConfigParam('aDisabledModules'));
     }
 }

--- a/source/Core/Module/ModuleTemplateBlockPathFormatter.php
+++ b/source/Core/Module/ModuleTemplateBlockPathFormatter.php
@@ -109,8 +109,7 @@ class ModuleTemplateBlockPathFormatter
         $modulePath = $activeModuleInfo[$this->moduleId];
 
         $fileSystem = oxNew(FileSystem::class);
-        $connectedPath = $fileSystem->combinePaths($this->modulesPath, $modulePath, $fileName);
 
-        return $connectedPath;
+        return $fileSystem->combinePaths($this->modulesPath, $modulePath, $fileName);
     }
 }

--- a/source/Core/Module/ModuleTemplateBlockRepository.php
+++ b/source/Core/Module/ModuleTemplateBlockRepository.php
@@ -49,9 +49,8 @@ class ModuleTemplateBlockRepository
                             where oxactive=1
                                 and oxshopid = ?
                                 and oxmodule in ( " . $modulesIdQuery . " )";
-        $rs = $db->getOne($sql, array($shopId));
 
-        return $rs;
+        return $db->getOne($sql, array($shopId));
     }
 
     /**
@@ -78,9 +77,8 @@ class ModuleTemplateBlockRepository
                         and oxtheme in (" . $activeThemesIdQuery . ")
                         order by oxpos asc, oxtheme asc, oxid asc";
         $db = oxDb::getDb(oxDb::FETCH_MODE_ASSOC);
-        $activeBlockTemplates = $db->getAll($sql, [$shopId, $shopTemplateName]);
 
-        return $activeBlockTemplates;
+        return $db->getAll($sql, [$shopId, $shopTemplateName]);
     }
 
     /**
@@ -93,11 +91,8 @@ class ModuleTemplateBlockRepository
     private function formActiveThemesIdQuery($activeThemeIds = [])
     {
         $defaultThemeIndicator = '';
-
         array_unshift($activeThemeIds, $defaultThemeIndicator);
 
-        $activeThemesIdQuery = implode(', ', oxDb::getInstance()->quoteArray($activeThemeIds));
-
-        return $activeThemesIdQuery;
+        return implode(', ', oxDb::getInstance()->quoteArray($activeThemeIds));
     }
 }

--- a/source/Core/ModuleFilesValidator.php
+++ b/source/Core/ModuleFilesValidator.php
@@ -117,10 +117,7 @@ class ModuleFilesValidator implements \oxIModuleValidator
      */
     protected function _allModuleExtensionsExists($oModule)
     {
-        $aModuleExtendedFiles = $oModule->getExtensions();
-        $blAllModuleExtensionsExists = $this->_allFilesExists($aModuleExtendedFiles, true, 'extensions');
-
-        return $blAllModuleExtensionsExists;
+        return $this->_allFilesExists($oModule->getExtensions(), true, 'extensions');
     }
 
     /**
@@ -132,11 +129,7 @@ class ModuleFilesValidator implements \oxIModuleValidator
      */
     protected function _allModuleFilesExists($oModule)
     {
-        $aModuleExtendedFiles = $oModule->getFiles();
-        $blAllModuleFilesExists = $this->_allFilesExists($aModuleExtendedFiles);
-
-        return $blAllModuleFilesExists;
-
+        return $this->_allFilesExists($oModule->getFiles());
     }
 
     /**

--- a/source/Core/ModuleInstaller.php
+++ b/source/Core/ModuleInstaller.php
@@ -88,10 +88,7 @@ class ModuleInstaller extends \oxSuperCfg
     public function activate(oxModule $oModule)
     {
         $blResult = false;
-
-        $sModuleId = $oModule->getId();
-
-        if ($sModuleId) {
+        if ($sModuleId = $oModule->getId()) {
             $this->_addExtensions($oModule);
             $this->_removeFromDisabledList($sModuleId);
 
@@ -122,10 +119,7 @@ class ModuleInstaller extends \oxSuperCfg
     public function deactivate(oxModule $oModule)
     {
         $blResult = false;
-
-        $sModuleId = $oModule->getId();
-
-        if ($sModuleId) {
+        if ($sModuleId = $oModule->getId()) {
             $this->_callEvent('onDeactivate', $sModuleId);
 
             $this->_addToDisabledList($sModuleId);
@@ -201,7 +195,7 @@ class ModuleInstaller extends \oxSuperCfg
                         }
                     }
                     if (!count($aAllModuleArray[$sClass])) {
-                        unset ($aAllModuleArray[$sClass]);
+                        unset($aAllModuleArray[$sClass]);
                     }
                 } else {
                     $aAllModuleArray[$sClass] = $aModuleChain;

--- a/source/Core/ModuleMetadataValidator.php
+++ b/source/Core/ModuleMetadataValidator.php
@@ -45,8 +45,6 @@ class ModuleMetadataValidator implements \oxIModuleValidator
      */
     public function validate(oxModule $oModule)
     {
-        $sMetadataPath = $oModule->getMetadataPath();
-
-        return file_exists($sMetadataPath);
+        return file_exists($oModule->getMetadataPath());
     }
 }

--- a/source/Core/ModuleValidatorFactory.php
+++ b/source/Core/ModuleValidatorFactory.php
@@ -39,9 +39,7 @@ class ModuleValidatorFactory
      */
     public function getModuleMetadataValidator()
     {
-        $oModuleValidator = oxNew('oxModuleMetadataValidator');
-
-        return $oModuleValidator;
+        return oxNew('oxModuleMetadataValidator');
     }
 
     /**
@@ -52,8 +50,6 @@ class ModuleValidatorFactory
      */
     public function getModuleFilesValidator()
     {
-        $oModuleValidator = oxNew('oxModuleFilesValidator');
-
-        return $oModuleValidator;
+        return oxNew('oxModuleFilesValidator');
     }
 }

--- a/source/Core/ModuleVariablesLocator.php
+++ b/source/Core/ModuleVariablesLocator.php
@@ -139,9 +139,8 @@ class ModuleVariablesLocator
         $query = "SELECT DECODE( oxvarvalue , ? ) FROM oxconfig WHERE oxvarname = ? AND oxshopid = ?";
 
         $value = $database->getOne($query, array($configKey, $name, $shopId), false);
-        $value = unserialize($value);
 
-        return $value;
+        return unserialize($value);
     }
 
     /**

--- a/source/Core/NoJsValidator.php
+++ b/source/Core/NoJsValidator.php
@@ -36,11 +36,6 @@ class NoJsValidator
      */
     public function isValid($configValue)
     {
-        $isValid = true;
-        if (preg_match('/<script.*>/', $configValue) !== 0) {
-            $isValid = false;
-        }
-
-        return $isValid;
+        return preg_match('/<script.*>/', $configValue) === 0;
     }
 }

--- a/source/Core/OnlineCaller.php
+++ b/source/Core/OnlineCaller.php
@@ -130,7 +130,7 @@ abstract class OnlineCaller
      */
     protected function _castExceptionAndWriteToLog(Exception $oEx)
     {
-        if(!($oEx instanceof oxException)){
+        if (!($oEx instanceof oxException)) {
             $oOxException = oxNew("oxException");
             $oOxException->setMessage($oEx->getMessage());
             $oOxException->debugOut();
@@ -211,9 +211,8 @@ abstract class OnlineCaller
             oxCurl::EXECUTION_TIMEOUT_OPTION,
             static::CURL_EXECUTION_TIMEOUT
         );
-        $sOutput = $oCurl->execute();
 
-        return $sOutput;
+        return $oCurl->execute();
     }
 
     /**

--- a/source/Core/OnlineLicenseCheckCaller.php
+++ b/source/Core/OnlineLicenseCheckCaller.php
@@ -62,9 +62,7 @@ class OnlineLicenseCheckCaller extends \oxOnlineCaller
      */
     public function doRequest(oxOnlineLicenseCheckRequest $oRequest)
     {
-        $sResponse = $this->call($oRequest);
-
-        return $this->_formResponse($sResponse);
+        return $this->_formResponse($this->call($oRequest));
     }
 
     /**

--- a/source/Core/OnlineModuleVersionNotifier.php
+++ b/source/Core/OnlineModuleVersionNotifier.php
@@ -110,7 +110,6 @@ class OnlineModuleVersionNotifier
         $oRequestParams->modules = new stdClass();
         $oRequestParams->modules->module = $this->_prepareModulesInformation();
 
-
         return $oRequestParams;
     }
 

--- a/source/Core/PictureHandler.php
+++ b/source/Core/PictureHandler.php
@@ -293,7 +293,6 @@ class PictureHandler extends \oxSuperCfg
 
         if ($sAltUrl) {
             if ((is_null($blSSL) && $oConfig->isSsl()) || $blSSL) {
-
                 $sSslAltUrl = $oConfig->getConfigParam('sSSLAltImageUrl');
                 if (!$sSslAltUrl) {
                     $sSslAltUrl = $oConfig->getConfigParam('sSSLAltImageDir');
@@ -328,7 +327,6 @@ class PictureHandler extends \oxSuperCfg
     {
         $sUrl = null;
         if ($sPath && $sFile && ($aSize = $this->getImageSize($sSize, $sIndex))) {
-
             $aPicInfo = $this->_getPictureInfo("master/" . ($sAltPath ? $sAltPath : $sPath), $sFile, $this->isAdmin(), $bSsl);
             if ($aPicInfo['url'] && $aSize[0] && $aSize[1]) {
                 $sDirName = "{$aSize[0]}_{$aSize[1]}_" . $this->getConfig()->getConfigParam('sDefaultImageQuality');

--- a/source/Core/PriceList.php
+++ b/source/Core/PriceList.php
@@ -157,9 +157,7 @@ class PriceList
             return;
         }
 
-        $aVats = array_keys($aPrices, max($aPrices));
-
-        return max($aVats);
+        return max(array_keys($aPrices, max($aPrices)));
     }
 
     /**

--- a/source/Core/Registry.php
+++ b/source/Core/Registry.php
@@ -149,7 +149,6 @@ class Registry
      */
     public static function instanceExists($className)
     {
-        $className = strtolower($className);
-        return isset(self::$instances[$className]);
+        return isset(self::$instances[strtolower($className)]);
     }
 }

--- a/source/Core/SeoDecoder.php
+++ b/source/Core/SeoDecoder.php
@@ -206,7 +206,6 @@ class SeoDecoder extends \oxSuperCfg
 
         $sPath = $sPath ? $sPath : str_replace('oxseo.php', '', $_SERVER['SCRIPT_NAME']);
         if (($sParams = $this->_getParams($sRequest, $sPath))) {
-
             // in case SEO url is actual
             if (is_array($aGet = $this->decodeUrl($sParams))) {
                 $_GET = array_merge($aGet, $_GET);
@@ -244,14 +243,12 @@ class SeoDecoder extends \oxSuperCfg
         $sUrl = null;
 
         if ($sLastParam) {
-
             $iLanguage = oxRegistry::getLang()->getBaseLanguage();
 
             // article ?
             if (strpos($sLastParam, '.htm') !== false) {
                 $sUrl = $this->_getObjectUrl($sLastParam, 'oxarticles', $iLanguage, 'oxarticle');
             } else {
-
                 // category ?
                 if (!($sUrl = $this->_getObjectUrl($sLastParam, 'oxcategories', $iLanguage, 'oxcategory'))) {
                     // maybe manufacturer ?
@@ -280,17 +277,14 @@ class SeoDecoder extends \oxSuperCfg
     {
         $oDb = oxDb::getDb();
         $sTable = getViewName($sTable, $iLanguage);
-        $sSeoUrl = null;
 
         // first checking of field exists at all
         if ($oDb->getOne("show columns from {$sTable} where field = 'oxseoid'")) {
             // if field exists - searching for object id
             if ($sObjectId = $oDb->getOne("select oxid from {$sTable} where oxseoid = " . $oDb->quote($sSeoId))) {
-                $sSeoUrl = $oDb->getOne("select oxseourl from oxseo where oxtype = " . $oDb->quote($sType) . " and oxobjectid = " . $oDb->quote($sObjectId) . " and oxlang = " . $oDb->quote($iLanguage) . " ");
+                return $oDb->getOne("select oxseourl from oxseo where oxtype = " . $oDb->quote($sType) . " and oxobjectid = " . $oDb->quote($sObjectId) . " and oxlang = " . $oDb->quote($iLanguage) . " ");
             }
         }
-
-        return $sSeoUrl;
     }
 
     /**

--- a/source/Core/SeoEncoder.php
+++ b/source/Core/SeoEncoder.php
@@ -219,7 +219,6 @@ class SeoEncoder extends \oxSuperCfg
         if ($sOldSeoUrl === $sSeoUrl) {
             $sSeoUrl = $sOldSeoUrl;
         } else {
-
             if ($sOldSeoUrl) {
                 // old must be transferred to history
                 $this->_copyToHistory($sObjectId, $iShopId, $iLang, 'dynamic');
@@ -859,11 +858,7 @@ class SeoEncoder extends \oxSuperCfg
             }
         }
 
-
-        // special chars
-        $aReplaceWhat = array('&amp;', '&quot;', '&#039;', '&lt;', '&gt;');
-
-        return str_replace($aReplaceWhat, '', $sString);
+        return str_replace(['&amp;', '&quot;', '&#039;', '&lt;', '&gt;'], '', $sString);
     }
 
     /**
@@ -1017,7 +1012,6 @@ class SeoEncoder extends \oxSuperCfg
         }
 
         foreach ($aStaticUrl['oxseo__oxseourl'] as $iLang => $sSeoUrl) {
-
             $iLang = (int) $iLang;
 
             // generating seo url
@@ -1054,7 +1048,6 @@ class SeoEncoder extends \oxSuperCfg
 
         // (re)inserting
         if ($sValues) {
-
             $sQ = "insert into oxseo ( oxobjectid, oxident, oxshopid, oxlang, oxstdurl, oxseourl, oxtype ) values {$sValues} ";
             $oDb->execute($sQ);
         }
@@ -1134,7 +1127,6 @@ class SeoEncoder extends \oxSuperCfg
     {
         $sSeoUrl = $this->_processSeoUrl($this->_trimUrl($sSeoUrl ? $sSeoUrl : $this->_getAltUri($sAltObjectId ? $sAltObjectId : $sObjectId, $iLang)), $sObjectId, $iLang, $blExclude);
         if ($this->_saveToDb($sType, $sObjectId, $sStdUrl, $sSeoUrl, $iLang, $iShopId, $blFixed, $sParams)) {
-
             $oDb = oxDb::getDb();
 
             //
@@ -1246,5 +1238,4 @@ class SeoEncoder extends \oxSuperCfg
 
         return $database->getOne($query, array($standardUrl, $languageId, $shopId));
     }
-
 }

--- a/source/Core/SepaIBANValidator.php
+++ b/source/Core/SepaIBANValidator.php
@@ -65,7 +65,6 @@ class SepaIBANValidator
     public function isValidCodeLengths($aCodeLengths)
     {
         $blValid = false;
-
         if ($this->_isNotEmptyArray($aCodeLengths)) {
             $blValid = $this->_isEachCodeLengthValid($aCodeLengths);
         }
@@ -89,7 +88,6 @@ class SepaIBANValidator
         } else {
             return false;
         }
-
     }
 
     /**
@@ -133,7 +131,7 @@ class SepaIBANValidator
 
         $sCountryCode = getStr()->substr($sIBAN, 0, 2);
 
-        $iCorrectLength = (isset ($aIBANRegistry[$sCountryCode])) ? $aIBANRegistry[$sCountryCode] : null;
+        $iCorrectLength = (isset($aIBANRegistry[$sCountryCode])) ? $aIBANRegistry[$sCountryCode] : null;
 
         return $iCorrectLength;
     }
@@ -167,9 +165,8 @@ class SepaIBANValidator
 
         $sInitialChars = $oStr->substr($sIBAN, 0, 4);
         $sIBAN = $oStr->substr($sIBAN, 4);
-        $sIBAN = $sIBAN . $sInitialChars;
 
-        return $sIBAN;
+        return $sIBAN . $sInitialChars;
     }
 
     /**
@@ -210,13 +207,11 @@ class SepaIBANValidator
             'Z' => 35
         );
 
-        $sIBAN = str_replace(
+        return str_replace(
             array_keys($aReplaceArray),
             $aReplaceArray,
             $sIBAN
         );
-
-        return $sIBAN;
     }
 
     /**
@@ -228,14 +223,7 @@ class SepaIBANValidator
      */
     protected function _isIBANChecksumValid($sIBAN)
     {
-        $blValid = true;
-
-        $sModulus = bcmod($sIBAN, self::IBAN_ALGORITHM_MOD_VALUE);
-        if ((int) $sModulus != 1) {
-            $blValid = false;
-        }
-
-        return $blValid;
+        return (int) bcmod($sIBAN, self::IBAN_ALGORITHM_MOD_VALUE) === 1;
     }
 
     /**
@@ -262,11 +250,9 @@ class SepaIBANValidator
         $blValid = true;
 
         foreach ($aCodeLengths as $sCountryAbbr => $iLength) {
-
             if (!$this->_isCodeLengthKeyValid($sCountryAbbr) ||
                 !$this->_isCodeLengthValueValid($iLength)
             ) {
-
                 $blValid = false;
                 break;
             }

--- a/source/Core/SepaValidator.php
+++ b/source/Core/SepaValidator.php
@@ -164,9 +164,9 @@ class SepaValidator
             $this->_aIBANCodeLengths = $aIBANRegistry;
 
             return true;
-        } else {
-            return false;
         }
+
+        return false;
     }
 
     /**

--- a/source/Core/ServerChecker.php
+++ b/source/Core/ServerChecker.php
@@ -65,13 +65,7 @@ class ServerChecker
      */
     public function check(oxApplicationServer $oServer)
     {
-        $blResult = false;
-
-        if ($this->_isValid($oServer) && $this->_isServerTimeValid($oServer->getTimestamp())) {
-            $blResult = true;
-        }
-
-        return $blResult;
+        return $this->_isValid($oServer) && $this->_isServerTimeValid($oServer->getTimestamp());
     }
 
     /**

--- a/source/Core/ServersManager.php
+++ b/source/Core/ServersManager.php
@@ -67,9 +67,7 @@ class ServersManager
      */
     public function getServer($sServerId)
     {
-        $aServerData = $this->_getServerData($sServerId);
-
-        return $this->_createServer($sServerId, $aServerData);
+        return $this->_createServer($sServerId, $this->_getServerData($sServerId));
     }
 
     /**

--- a/source/Core/Session.php
+++ b/source/Core/Session.php
@@ -231,7 +231,6 @@ class Session extends \oxSuperCfg
 
         //starting session if only we can
         if ($this->_allowSessionStart()) {
-
             //creating new sid
             if (!$sid) {
                 self::$_blIsNewSession = true;
@@ -326,7 +325,6 @@ class Session extends \oxSuperCfg
             if (isset($_SERVER['HTTP_USER_AGENT']) &&
                 strpos($_SERVER['HTTP_USER_AGENT'], 'AOL') !== false
             ) {
-
                 session_cache_limiter(false);
                 header("Cache-Control: no-store, private, must-revalidate, proxy-revalidate, post-check=0, pre-check=0, max-age=0, s-maxage=0");
             }
@@ -477,19 +475,13 @@ class Session extends \oxSuperCfg
      */
     public function getVariable($name)
     {
-        if (isset($_SESSION[$name])) {
-            return $_SESSION[$name];
-        } else {
-            return null;
-        }
+        return isset($_SESSION[$name]) ? $_SESSION[$name] : null;
     }
 
     /**
      * Destroys a single element (passed to method) of an session array.
      *
      * @param string $name Name of parameter to destroy
-     *
-     * @return null
      */
     public function deleteVariable($name)
     {
@@ -679,7 +671,6 @@ class Session extends \oxSuperCfg
                     if ($blSidNeeded = $this->getVariable('blSidNeeded')) {
                         $this->_blSidNeeded = true;
                     } elseif ($this->_isSessionRequiredAction()) {
-
                         if (!count($_COOKIE)) {
                             $this->_blSidNeeded = true;
 
@@ -703,9 +694,7 @@ class Session extends \oxSuperCfg
      */
     public function isActualSidInCookie()
     {
-        $blReturn = (isset($_COOKIE[$this->getName()]) && ($_COOKIE[$this->getName()] == $this->getId()));
-
-        return $blReturn;
+        return isset($_COOKIE[$this->getName()]) && ($_COOKIE[$this->getName()] == $this->getId());
     }
 
     /**
@@ -790,7 +779,6 @@ class Session extends \oxSuperCfg
             } elseif (oxRegistry::get("oxUtilsServer")->getOxCookie('oxid_' . $myConfig->getShopId() . '_autologin') === '1') {
                 $blAllowSessionStart = true;
             } elseif (!$this->_forceSessionStart() && !oxRegistry::get("oxUtilsServer")->getOxCookie('sid_key')) {
-
                 // session is not needed to start when it is not necessary:
                 // - no sid in request and also user executes no session connected action
                 // - no cookie set and user executes no session connected action
@@ -820,7 +808,6 @@ class Session extends \oxSuperCfg
 
         // check only for non search engines
         if (!oxRegistry::getUtils()->isSearchEngine() && !$myUtilsServer->isTrustedClientIp() && !$this->_isValidRemoteAccessToken()) {
-
             $myConfig = $this->getConfig();
 
             // checking if session user agent matches actual
@@ -854,7 +841,6 @@ class Session extends \oxSuperCfg
     protected function _checkUserAgent($sAgent, $sExistingAgent)
     {
         $blCheck = false;
-
         // processing
         $oUtils = oxRegistry::get("oxUtilsServer");
         $sAgent = $oUtils->processUserAgentInfo($sAgent);
@@ -1066,9 +1052,8 @@ class Session extends \oxSuperCfg
     {
         $inputToken = $this->getConfig()->getRequestParameter('rtoken');
         $token = $this->getRemoteAccessToken(false);
-        $isValid = !empty($inputToken) ? ($token === $inputToken) : false;
 
-        return $isValid;
+        return !empty($inputToken) ? ($token === $inputToken) : false;
     }
 
     /**

--- a/source/Core/ShopControl.php
+++ b/source/Core/ShopControl.php
@@ -138,8 +138,7 @@ class ShopControl extends \oxSuperCfg
             $this->_handleSystemException($ex);
         } catch (oxCookieException $ex) {
             $this->_handleCookieException($ex);
-        }
-        catch (oxConnectionException $ex) {
+        } catch (oxConnectionException $ex) {
             $this->_handleDbConnectionException($ex);
         } catch (oxException $ex) {
             $this->_handleBaseException($ex);
@@ -367,7 +366,6 @@ class ShopControl extends \oxSuperCfg
     protected function _canExecuteFunction($view, $function)
     {
         $canExecute = true;
-
         if (method_exists($view, $function)) {
             $reflectionMethod = new ReflectionMethod($view, $function);
             if (!$reflectionMethod->isPublic()) {
@@ -563,11 +561,7 @@ class ShopControl extends \oxSuperCfg
      */
     protected function _isDebugMode()
     {
-        if (oxRegistry::get("OxConfigFile")->getVar('iDebug')) {
-            return true;
-        }
-
-        return false;
+        return (bool) oxRegistry::get("OxConfigFile")->getVar('iDebug');
     }
 
     /**

--- a/source/Core/Smarty/Plugin/Emos.php
+++ b/source/Core/Smarty/Plugin/Emos.php
@@ -220,10 +220,8 @@ class Emos
      *
      * @param string $sPathToFile     The path to the js-bib (/opt/myjs)
      * @param string $sScriptFileName If we want to have annother Filename than emos2.js you can set it here
-     *
-     * @return null
      */
-    public function __construct( $sPathToFile = "", $sScriptFileName = "emos2.js" )
+    public function __construct($sPathToFile = "", $sScriptFileName = "emos2.js")
     {
         $this->_sPathToFile = $sPathToFile;
         $this->_sScriptFileName = $sScriptFileName;
@@ -232,8 +230,6 @@ class Emos
     /**
      * switch on pretty printing of generated code. If not called, the output
      * will be in one line of html.
-     *
-     * @return null
      */
     public function prettyPrint()
     {
@@ -259,10 +255,8 @@ class Emos
      * sets content tracking
      *
      * @param string $sContent content to add
-     *
-     * @return null
      */
-    public function addContent( $sContent )
+    public function addContent($sContent)
     {
         $this->_content = $sContent;
     }
@@ -271,10 +265,8 @@ class Emos
      * sets orderprocess tracking
      *
      * @param string $sProcessStep process step to add
-     *
-     * @return null
      */
-    public function addOrderProcess( $sProcessStep )
+    public function addOrderProcess($sProcessStep)
     {
         $this->_orderProcess = $sProcessStep;
     }
@@ -283,10 +275,8 @@ class Emos
      * sets siteid tracking
      *
      * @param string $sIiteId site id to add
-     *
-     * @return null
      */
-    public function addSiteId( $sIiteId )
+    public function addSiteId($sIiteId)
     {
         $this->_siteid = $sIiteId;
     }
@@ -295,10 +285,8 @@ class Emos
      * sets language tracking
      *
      * @param string $sLangId language id to add
-     *
-     * @return null
      */
-    public function addLangId( $sLangId )
+    public function addLangId($sLangId)
     {
         $this->_langid = $sLangId;
     }
@@ -307,10 +295,8 @@ class Emos
      * sets country tracking
      *
      * @param string $sCountryId country id to add
-     *
-     * @return null
      */
-    public function addCountryId( $sCountryId )
+    public function addCountryId($sCountryId)
     {
         $this->_countryid = $sCountryId;
     }
@@ -319,10 +305,8 @@ class Emos
      * adds tracker Page ID
      *
      * @param string $sPageId page id to add
-     *
-     * @return null
      */
-    public function addPageId( $sPageId )
+    public function addPageId($sPageId)
     {
         $this->_pageid = $sPageId;
     }
@@ -332,10 +316,8 @@ class Emos
      *
      * @param string $sQueryString  query string
      * @param int    $iNumberOfHits number of hits
-     *
-     * @return null
      */
-    public function addSearch( $sQueryString, $iNumberOfHits )
+    public function addSearch($sQueryString, $iNumberOfHits)
     {
         // #4018: The emospro.search string is URL-encoded forwarded to econda instead of URL-escaped
         $this->_searchQuery = $this->_emos_DataFormat($sQueryString);
@@ -348,10 +330,8 @@ class Emos
      *
      * @param string $sUserId user id
      * @param string $sResult registration result
-     *
-     * @return null
      */
-    public function addRegister( $sUserId, $sResult )
+    public function addRegister($sUserId, $sResult)
     {
         $this->_registerUser = md5($sUserId);
         $this->_registerResult = $sResult;
@@ -363,10 +343,8 @@ class Emos
      *
      * @param string $sUserId user id
      * @param string $sResult login result
-     *
-     * @return null
      */
-    public function addLogin( $sUserId, $sResult )
+    public function addLogin($sUserId, $sResult)
     {
         $this->_loginUser = md5($sUserId);
         $this->_loginResult = $sResult;
@@ -376,10 +354,8 @@ class Emos
      * sets contact tracking
      *
      * @param string $sContactType contant type
-     *
-     * @return null
      */
-    public function addContact( $sContactType )
+    public function addContact($sContactType)
     {
         $this->_scontact = $sContactType;
     }
@@ -388,10 +364,8 @@ class Emos
      * sets download tracking
      *
      * @param string $sDownloadLabel download label
-     *
-     * @return null
      */
-    public function addDownload( $sDownloadLabel )
+    public function addDownload($sDownloadLabel)
     {
         $this->_download = $sDownloadLabel;
     }
@@ -403,15 +377,15 @@ class Emos
      *
      * @return null
      */
-    public function addEmosBasketPageArray( $aBasket )
+    public function addEmosBasketPageArray($aBasket)
     {
         if (!is_array($aBasket)) {
-            return ;
+            return;
         }
 
         $aBasketItems = array();
-        foreach ( $aBasket as $oItem ) {
-            $oItem = $this->_emos_ItemFormat( $oItem );
+        foreach ($aBasket as $oItem) {
+            $oItem = $this->_emos_ItemFormat($oItem);
             $aBasketItems[] = array("buy", $oItem->productId, $oItem->productName,
                                   $oItem->price, $oItem->productGroup, $oItem->quantity,
                                   $oItem->variant1, $oItem->variant2, $oItem->variant3 );
@@ -424,36 +398,30 @@ class Emos
      * adds a detailView to the preScript
      *
      * @param EMOS_Item $oItem item to add to view
-     *
-     * @return null
      */
-    public function addDetailView( $oItem )
+    public function addDetailView($oItem)
     {
-        $this->_setEmosECPageArray( $oItem, "view" );
+        $this->_setEmosECPageArray($oItem, "view");
     }
 
     /**
      * adds a removeFromBasket to the preScript
      *
      * @param EMOS_Item $oItem item to remove from basket
-     *
-     * @return null
      */
-    public function removeFromBasket( $oItem )
+    public function removeFromBasket($oItem)
     {
-        $this->_setEmosECPageArray( $oItem, "c_rmv" );
+        $this->_setEmosECPageArray($oItem, "c_rmv");
     }
 
     /**
      * adds a addToBasket to the preScript
      *
      * @param EMOS_Item $oItem item to add to basket
-     *
-     * @return null
      */
-    public function addToBasket( $oItem )
+    public function addToBasket($oItem)
     {
-        $this->_setEmosECPageArray( $oItem, "c_add" );
+        $this->_setEmosECPageArray($oItem, "c_add");
     }
 
     /**
@@ -465,12 +433,10 @@ class Emos
      * @param string $sCountry        customer country title
      * @param string $sCip            customer ip
      * @param string $sCity           customer city title
-     *
-     * @return null
      */
-    public function addEmosBillingPageArray( $sBillingId = "", $sCustomerNumber = "", $iTotal = 0, $sCountry = "", $sCip = "", $sCity = "" )
+    public function addEmosBillingPageArray($sBillingId = "", $sCustomerNumber = "", $iTotal = 0, $sCountry = "", $sCip = "", $sCity = "")
     {
-        $this->_setEmosBillingArray( $sBillingId, $sCustomerNumber, $iTotal, $sCountry, $sCip, $sCity);
+        $this->_setEmosBillingArray($sBillingId, $sCustomerNumber, $iTotal, $sCountry, $sCip, $sCity);
     }
 
     /**
@@ -482,34 +448,32 @@ class Emos
      * @param string $sCountry        customer country title
      * @param string $sCip            customer ip
      * @param string $sCity           customer city title
-     *
-     * @return string
      */
-    protected function _setEmosBillingArray( $sBillingId = "", $sCustomerNumber = "", $iTotal = 0, $sCountry = "", $sCip = "", $sCity = "")
+    protected function _setEmosBillingArray($sBillingId = "", $sCustomerNumber = "", $iTotal = 0, $sCountry = "", $sCip = "", $sCity = "")
     {
         /******************* prepare data *************************************/
         /* md5 the customer id to fullfill requirements of german datenschutzgeesetz */
-        $sCustomerNumber = md5( $sCustomerNumber );
+        $sCustomerNumber = md5($sCustomerNumber);
 
-        $sCountry = $this->_emos_DataFormat( $sCountry );
-        $sCip = $this->_emos_DataFormat( $sCip) ;
-        $sCity = $this->_emos_DataFormat( $sCity );
+        $sCountry = $this->_emos_DataFormat($sCountry);
+        $sCip = $this->_emos_DataFormat($sCip) ;
+        $sCity = $this->_emos_DataFormat($sCity);
 
         /* get a / separated location stzring for later drilldown */
         $ort = "";
-        if ( $sCountry ) {
+        if ($sCountry) {
             $ort .= "$sCountry/";
         }
 
-        if ( $sCip ) {
-            $ort .= getStr()->substr( $sCip, 0, 1 )."/".getStr()->substr( $sCip, 0, 2 )."/";
+        if ($sCip) {
+            $ort .= getStr()->substr($sCip, 0, 1)."/".getStr()->substr($sCip, 0, 2)."/";
         }
 
-        if ( $sCity ) {
+        if ($sCity) {
             $ort .= "$sCity/";
         }
 
-        if ( $sCip ) {
+        if ($sCip) {
             $ort.=$sCip;
         }
 
@@ -521,12 +485,10 @@ class Emos
      *
      * @param EMOS_Item $oItem      an instance of class EMOS_Item
      * @param string    $sEvent     Type of this event ("view","c_rmv","c_add")
-     *
-     * @return string
      */
-    protected function _setEmosECPageArray( $oItem, $sEvent)
+    protected function _setEmosECPageArray($oItem, $sEvent)
     {
-        $oItem = $this->_emos_ItemFormat( $oItem );
+        $oItem = $this->_emos_ItemFormat($oItem);
 
         $this->_ecEvent = array(array($sEvent, $oItem->productId, $oItem->productName,
                  $oItem->price, $oItem->productGroup,
@@ -541,14 +503,14 @@ class Emos
      *
      * @return null
      */
-    protected function _emos_ItemFormat( $oItem )
+    protected function _emos_ItemFormat($oItem)
     {
-        $oItem->productId = $this->_emos_DataFormat( $oItem->productId );
-        $oItem->productName = $this->_emos_DataFormat( $oItem->productName );
-        $oItem->productGroup = $this->_emos_DataFormat( $oItem->productGroup );
-        $oItem->variant1 = $this->_emos_DataFormat( $oItem->variant1 );
-        $oItem->variant2 = $this->_emos_DataFormat( $oItem->variant2 );
-        $oItem->variant3 = $this->_emos_DataFormat( $oItem->variant3 );
+        $oItem->productId = $this->_emos_DataFormat($oItem->productId);
+        $oItem->productName = $this->_emos_DataFormat($oItem->productName);
+        $oItem->productGroup = $this->_emos_DataFormat($oItem->productGroup);
+        $oItem->variant1 = $this->_emos_DataFormat($oItem->variant1);
+        $oItem->variant2 = $this->_emos_DataFormat($oItem->variant2);
+        $oItem->variant3 = $this->_emos_DataFormat($oItem->variant3);
 
         return $oItem;
     }
@@ -560,7 +522,7 @@ class Emos
      *
      * @return null
      */
-    protected function _emos_DataFormat( $sStr )
+    protected function _emos_DataFormat($sStr)
     {
         //null check
         if (is_null($sStr)) {
@@ -568,41 +530,39 @@ class Emos
         }
 
         //$sStr = urldecode($sStr);
-        $sStr = htmlspecialchars_decode( $sStr, ENT_QUOTES );
-        $sStr = getStr()->html_entity_decode( $sStr );
-        $sStr = strip_tags( $sStr );
-        $sStr = trim( $sStr );
+        $sStr = htmlspecialchars_decode($sStr, ENT_QUOTES);
+        $sStr = getStr()->html_entity_decode($sStr);
+        $sStr = strip_tags($sStr);
+        $sStr = trim($sStr);
 
         //2007-05-10 replace translated &nbsp; with spaces
         $nbsp = chr(0xa0);
-        $sStr = str_replace( $nbsp, " ", $sStr );
-        $sStr = str_replace( "\"", "", $sStr );
-        $sStr = str_replace( "'", "", $sStr );
-        $sStr = str_replace( "%", "", $sStr );
-        $sStr = str_replace( ",", "", $sStr );
-        $sStr = str_replace( ";", "", $sStr );
+        $sStr = str_replace($nbsp, " ", $sStr);
+        $sStr = str_replace("\"", "", $sStr);
+        $sStr = str_replace("'", "", $sStr);
+        $sStr = str_replace("%", "", $sStr);
+        $sStr = str_replace(",", "", $sStr);
+        $sStr = str_replace(";", "", $sStr);
         /* remove unnecessary white spaces*/
-        while ( true ) {
+        while (true) {
             $sStr_temp = $sStr;
-            $sStr = str_replace( "  ", " ", $sStr );
+            $sStr = str_replace("  ", " ", $sStr);
 
-            if ( $sStr == $sStr_temp ) {
+            if ($sStr == $sStr_temp) {
                 break;
             }
         }
-        $sStr = str_replace( " / ", "/", $sStr );
-        $sStr = str_replace( " /", "/", $sStr );
-        $sStr = str_replace( "/ ", "/", $sStr );
+        $sStr = str_replace(" / ", "/", $sStr);
+        $sStr = str_replace(" /", "/", $sStr);
+        $sStr = str_replace("/ ", "/", $sStr);
 
-        $sStr = getStr()->substr( $sStr, 0, 254 );
+        $sStr = getStr()->substr($sStr, 0, 254);
         //$sStr = rawurlencode( $sStr );
         return $sStr;
     }
 
-    /*
+    /**
      * formats up the connector script in a Econda ver 2 JS format
-     *
-     * @return null
      */
     public function _prepareScript()
     {
@@ -615,25 +575,24 @@ class Emos
         $this->_sPostscript  = '<script type="text/javascript"><!--' . $this->_br;
         $this->_sPostscript .= $this->_tab . 'var emospro = {};' . $this->_br;
 
-        $this->_sPostscript .= $this->_addJsFormat( "content", $this->_content);
-        $this->_sPostscript .= $this->_addJsFormat( "orderProcess", $this->_orderProcess);
-        $this->_sPostscript .= $this->_addJsFormat( "siteid", $this->_siteid);
-        $this->_sPostscript .= $this->_addJsFormat( "langid", $this->_langid);
-        $this->_sPostscript .= $this->_addJsFormat( "countryid", $this->_countryid);
-        $this->_sPostscript .= $this->_addJsFormat( "pageId", $this->_pageid);
-        $this->_sPostscript .= $this->_addJsFormat( "scontact", $this->_scontact);
-        $this->_sPostscript .= $this->_addJsFormat( "download", $this->_download);
-        $this->_sPostscript .= $this->_addJsFormat( "billing", array($this->_billing));
+        $this->_sPostscript .= $this->_addJsFormat("content", $this->_content);
+        $this->_sPostscript .= $this->_addJsFormat("orderProcess", $this->_orderProcess);
+        $this->_sPostscript .= $this->_addJsFormat("siteid", $this->_siteid);
+        $this->_sPostscript .= $this->_addJsFormat("langid", $this->_langid);
+        $this->_sPostscript .= $this->_addJsFormat("countryid", $this->_countryid);
+        $this->_sPostscript .= $this->_addJsFormat("pageId", $this->_pageid);
+        $this->_sPostscript .= $this->_addJsFormat("scontact", $this->_scontact);
+        $this->_sPostscript .= $this->_addJsFormat("download", $this->_download);
+        $this->_sPostscript .= $this->_addJsFormat("billing", array($this->_billing));
 
-        $this->_sPostscript .= $this->_addJsFormat( "search", array(array($this->_searchQuery, $this->_searchNumberOfHits)) );
-        $this->_sPostscript .= $this->_addJsFormat( "register", array(array($this->_registerUser, $this->_registerResult)) );
-        $this->_sPostscript .= $this->_addJsFormat( "login", array(array($this->_loginUser, $this->_loginResult)));
+        $this->_sPostscript .= $this->_addJsFormat("search", array(array($this->_searchQuery, $this->_searchNumberOfHits)));
+        $this->_sPostscript .= $this->_addJsFormat("register", array(array($this->_registerUser, $this->_registerResult)));
+        $this->_sPostscript .= $this->_addJsFormat("login", array(array($this->_loginUser, $this->_loginResult)));
 
-        $this->_sPostscript .= $this->_addJsFormat( "ec_Event", $this->_ecEvent);
+        $this->_sPostscript .= $this->_addJsFormat("ec_Event", $this->_ecEvent);
 
         $this->_sPostscript .= $this->_tab . 'window.emosPropertiesEvent(emospro);' . $this->_br;
         $this->_sPostscript .= '//-->' . $this->_br . '</script>' . $this->_br;
-
     }
 
     /**
@@ -646,7 +605,6 @@ class Emos
      */
     protected function _addJsFormat($sVarName, $mContents)
     {
-
         //get the first non array $mContents element
         $mVal = $mContents;
         while (is_array($mVal)) {
@@ -654,14 +612,12 @@ class Emos
         }
 
         if (is_null($mVal)) {
-            return ;
+            return;
         }
 
         $sEncoded = $this->_jsEncode(($mContents));
 
-        $sJsLine = $this->_tab . 'emospro.' . $sVarName . ' = ' . $sEncoded . ';' . $this->_br;
-
-        return $sJsLine;
+        return $this->_tab . 'emospro.' . $sVarName . ' = ' . $sEncoded . ';' . $this->_br;
     }
 
     /**

--- a/source/Core/Smarty/Plugin/EmosAdapter.php
+++ b/source/Core/Smarty/Plugin/EmosAdapter.php
@@ -183,6 +183,7 @@ class EmosAdapter extends oxSuperCfg
     protected function _getScriptPath()
     {
         $sShopUrl = $this->getConfig()->getCurrentShopUrl();
+
         return "{$sShopUrl}modules/econda/out/";
     }
 
@@ -209,6 +210,7 @@ class EmosAdapter extends oxSuperCfg
         if (!$myConfig->isUtf()) {
             $sContent = iconv(oxRegistry::getLang()->translateString('charset'), 'UTF-8', $sContent);
         }
+
         return $sContent;
     }
 
@@ -226,8 +228,8 @@ class EmosAdapter extends oxSuperCfg
         if ($oProduct->oxarticles__oxvarselect->value) {
             $sTitle .= " " . $oProduct->oxarticles__oxvarselect->value;
         }
-        $sTitle = $this->_convertToUtf($sTitle);
-        return $sTitle;
+
+        return $this->_convertToUtf($sTitle);
     }
 
     /**
@@ -286,6 +288,7 @@ class EmosAdapter extends oxSuperCfg
         } else {
             $sCl = $oActView->getClassName();
         }
+
         return $sCl ? strtolower($sCl) : 'start';
     }
 
@@ -307,6 +310,7 @@ class EmosAdapter extends oxSuperCfg
             $this->_sEmosCatPath = (count($aCatTitle) ? strip_tags(implode('/', $aCatTitle)) : 'NULL');
             $this->_sEmosCatPath = $this->_convertToUtf($this->_sEmosCatPath);
         }
+
         return $this->_sEmosCatPath;
     }
 
@@ -340,9 +344,8 @@ class EmosAdapter extends oxSuperCfg
                 }
             }
         }
-        $sCatPath = $this->_convertToUtf($sCatPath);
 
-        return $sCatPath;
+        return $this->_convertToUtf($sCatPath);
     }
 
     /**
@@ -375,6 +378,7 @@ class EmosAdapter extends oxSuperCfg
             // in case template was not defined in request
             $sCurrTpl = $this->getConfig()->getActiveView()->getTemplateName();
         }
+
         return $sCurrTpl;
     }
 
@@ -554,7 +558,8 @@ class EmosAdapter extends oxSuperCfg
         $oConfig = $this->getConfig();
         $oCur = $oConfig->getActShopCurrencyObject();
 
-        $oEmos->addEmosBillingPageArray($this->_convertToUtf($oOrder->oxorder__oxordernr->value),
+        $oEmos->addEmosBillingPageArray(
+            $this->_convertToUtf($oOrder->oxorder__oxordernr->value),
             $this->_convertToUtf($oUser->oxuser__oxusername->value),
             $oBasket->getPrice()->getBruttoPrice() * (1 / $oCur->rate),
             $this->_convertToUtf($oOrder->oxorder__oxbillcountry->value),

--- a/source/Core/StandardList.php
+++ b/source/Core/StandardList.php
@@ -80,11 +80,7 @@ class StandardList extends \oxSuperCfg implements \ArrayAccess, \Iterator, \Coun
      */
     public function offsetExists($offset)
     {
-        if (isset($this->_aArray[$offset])) {
-            return true;
-        } else {
-            return false;
-        }
+        return isset($this->_aArray[$offset]);
     }
 
     /**
@@ -98,9 +94,9 @@ class StandardList extends \oxSuperCfg implements \ArrayAccess, \Iterator, \Coun
     {
         if ($this->offsetExists($offset)) {
             return $this->_aArray[$offset];
-        } else {
-            return false;
         }
+
+        return false;
     }
 
     /**
@@ -391,11 +387,9 @@ class StandardList extends \oxSuperCfg implements \ArrayAccess, \Iterator, \Coun
         }
 
         if ($rs != false && $rs->recordCount() > 0) {
-
             $oSaved = clone $this->getBaseObject();
 
             while (!$rs->EOF) {
-
                 $oListObject = clone $oSaved;
 
                 $this->_assignElement($oListObject, $rs->fields);
@@ -430,7 +424,6 @@ class StandardList extends \oxSuperCfg implements \ArrayAccess, \Iterator, \Coun
     {
         $this->clear();
         if (count($aData)) {
-
             $oSaved = clone $this->getBaseObject();
 
             foreach ($aData as $aItem) {

--- a/source/Core/StrRegular.php
+++ b/source/Core/StrRegular.php
@@ -83,9 +83,8 @@ class StrRegular
     {
         if (is_null($iLength)) {
             return substr($sStr, $iStart);
-        } else {
-            return substr($sStr, $iStart, $iLength);
         }
+        return substr($sStr, $iStart, $iLength);
     }
 
     /**
@@ -297,8 +296,8 @@ class StrRegular
 
     /**
      * Recodes and returns passed input:
-     * if $blToHtmlEntities == true  ä -> &auml;
-     * if $blToHtmlEntities == false &auml; -> ä
+     * if $blToHtmlEntities == true  Ã¤ -> &auml;
+     * if $blToHtmlEntities == false &auml; -> Ã¤
      *
      * @param string $sInput           text to recode
      * @param bool   $blToHtmlEntities recode direction

--- a/source/Core/SystemEventHandler.php
+++ b/source/Core/SystemEventHandler.php
@@ -183,9 +183,7 @@ class SystemEventHandler
      */
     protected function _isSendingShopDataEnabled()
     {
-        $isSendingShopDataEnabled = (bool) $this->_getConfig()->getConfigParam('blLoadDynContents');
-
-        return $isSendingShopDataEnabled;
+        return (bool) $this->_getConfig()->getConfigParam('blLoadDynContents');
     }
 
     /**
@@ -208,13 +206,7 @@ class SystemEventHandler
      */
     private function _needToSendShopInformation()
     {
-        $blNeedToSend = false;
-
-        if ($this->_getNextCheckTime() < $this->_getCurrentTime()) {
-            $blNeedToSend = true;
-        }
-
-        return $blNeedToSend;
+        return $this->_getNextCheckTime() < $this->_getCurrentTime();
     }
 
     /**
@@ -272,9 +264,8 @@ class SystemEventHandler
     {
         /** @var oxUtilsDate $oUtilsDate */
         $oUtilsDate = oxRegistry::get('oxUtilsDate');
-        $iCurrentTime = $oUtilsDate->getTime();
 
-        return $iCurrentTime;
+        return $oUtilsDate->getTime();
     }
 
     /**

--- a/source/Core/SystemRequirements.php
+++ b/source/Core/SystemRequirements.php
@@ -284,14 +284,13 @@ class SystemRequirements
             return 2;
         }
 
-        $iState = 1;
         if (version_compare($this->getPhpVersion(), "5.3", ">=")) {
             if (version_compare($this->getPhpVersion(), "5.3.5", ">=") && version_compare($this->getPhpVersion(), "5.3.7", "!=")) {
-                $iState = 2;
+                return 2;
             }
         }
 
-        return $iState;
+        return 1;
     }
 
     /**
@@ -408,9 +407,9 @@ class SystemRequirements
                 'dir'  => $sScript,
                 'ssl'  => $blSsl,
             );
-        } else {
-            return false;
         }
+
+        return false;
     }
 
     /**
@@ -476,9 +475,9 @@ class SystemRequirements
     {
         if ($this->isAdmin()) {
             return $this->_getShopHostInfoFromConfig();
-        } else {
-            return $this->_getShopHostInfoFromServerVars();
         }
+
+        return $this->_getShopHostInfoFromServerVars();
     }
 
     /**
@@ -582,9 +581,8 @@ class SystemRequirements
                 fclose($oRes);
             }
         }
-        $iModStat = (!$iModStat) ? 1 : $iModStat;
 
-        return $iModStat;
+        return $iModStat ?: 1;
     }
 
     /**
@@ -804,8 +802,7 @@ class SystemRequirements
         /**
          * The following version of MySQL server are reported to not be compatible with OXID eShop
          */
-        if (
-            // https://bugs.oxid-esales.com/view.php?id=1877
+        if (// https://bugs.oxid-esales.com/view.php?id=1877
             version_compare($sVersion, '5.0.41', '=') ||
             // https://bugs.oxid-esales.com/view.php?id=1003
             version_compare($sVersion, '5.0.37', '=') ||
@@ -863,9 +860,9 @@ class SystemRequirements
     {
         if (function_exists('get_magic_quotes_gpc')) {
             return get_magic_quotes_gpc() ? 0 : 2;
-        } else {
-            return 2;
         }
+
+        return 2;
     }
 
     /**
@@ -887,11 +884,10 @@ class SystemRequirements
 
             $iMemLimit = $this->_getBytes($sMemLimit);
 
-            if($iMemLimit === '-1') {
+            if ($iMemLimit === '-1') {
                 // -1 is equivalent to no memory limit
                 $iModStat = 2;
-            }
-            else {
+            } else {
                 $iModStat = ($iMemLimit >= $this->_getBytes($sDefLimit)) ? 1 : 0;
                 $iModStat = $iModStat ? (($iMemLimit >= $this->_getBytes($sRecLimit)) ? 2 : $iModStat) : $iModStat;
             }
@@ -1203,9 +1199,7 @@ class SystemRequirements
      */
     protected function _getMinimumMemoryLimit()
     {
-        $requiredMinimalMemory = '14M';
-
-        return $requiredMinimalMemory;
+        return '14M';
     }
 
     /**
@@ -1215,8 +1209,6 @@ class SystemRequirements
      */
     protected function _getRecommendMemoryLimit()
     {
-        $recommendedMemory = '30M';
-
-        return $recommendedMemory;
+        return '30M';
     }
 }

--- a/source/Core/UniversallyUniqueIdGenerator.php
+++ b/source/Core/UniversallyUniqueIdGenerator.php
@@ -68,12 +68,10 @@ class UniversallyUniqueIdGenerator
     public function generateV4()
     {
         if ($this->_getOpenSSLChecker()->isOpenSslRandomBytesGeneratorAvailable()) {
-            $sUUID = $this->_generateBasedOnOpenSSL();
-        } else {
-            $sUUID = $this->_generateBasedOnMtRand();
+            return $this->_generateBasedOnOpenSSL();
         }
 
-        return $sUUID;
+        return $this->_generateBasedOnMtRand();
     }
 
     /**
@@ -94,7 +92,8 @@ class UniversallyUniqueIdGenerator
         $sHash = sha1($sBinarySeed . $sSalt);
         $sUUID = sprintf(
             '%08s-%04s-%04x-%04x-%12s',
-            substr($sHash, 0, 8), substr($sHash, 8, 4),
+            substr($sHash, 0, 8),
+            substr($sHash, 8, 4),
             (hexdec(substr($sHash, 12, 4)) & 0x0fff) | 0x3000,
             (hexdec(substr($sHash, 16, 4)) & 0x3fff) | 0x8000,
             substr($sHash, 20, 12)
@@ -136,11 +135,14 @@ class UniversallyUniqueIdGenerator
     {
         return sprintf(
             '%04x%04x-%04x-%04x-%04x-%04x%04x%04x',
-            mt_rand(0, 0xffff), mt_rand(0, 0xffff),
+            mt_rand(0, 0xffff),
+            mt_rand(0, 0xffff),
             mt_rand(0, 0xffff),
             mt_rand(0, 0x0fff) | 0x4000,
             mt_rand(0, 0x3fff) | 0x8000,
-            mt_rand(0, 0xffff), mt_rand(0, 0xffff), mt_rand(0, 0xffff)
+            mt_rand(0, 0xffff),
+            mt_rand(0, 0xffff),
+            mt_rand(0, 0xffff)
         );
     }
 }

--- a/source/Core/Utils.php
+++ b/source/Core/Utils.php
@@ -210,9 +210,7 @@ class Utils extends \oxSuperCfg
         // remove thousands
         $fRet = str_replace(array(" ", "."), "", $fRet);
 
-        $fRet = str_replace(",", ".", $fRet);
-
-        return (float) $fRet;
+        return (float) str_replace(",", ".", $fRet);
     }
 
     /**
@@ -239,10 +237,9 @@ class Utils extends \oxSuperCfg
                 $fRet = str_replace(",", ".", $fRet);
             }
         }
-        // remove thousands
-        $fRet = str_replace(array(" ", ","), "", $fRet);
 
-        return (float) $fRet;
+        // remove thousands
+        return (float) str_replace(array(" ", ","), "", $fRet);
     }
 
     /**
@@ -417,13 +414,14 @@ class Utils extends \oxSuperCfg
 
         //got a different result when using strict and not strict?
         //do a detail check
-        if( $result != $second) {
+        if ($result != $second) {
             $stringstack = array();
             foreach ($haystack as $value) {
                 $stringstack[] = (string) $value;
             }
             $result = array_search((string) $needle, $stringstack, true);
         }
+
         return $result;
     }
 
@@ -456,8 +454,6 @@ class Utils extends \oxSuperCfg
         if (isset($this->_aStaticCache[$sName])) {
             return $this->_aStaticCache[$sName];
         }
-
-        return null;
     }
 
     /**
@@ -485,7 +481,6 @@ class Utils extends \oxSuperCfg
     {
         //only simple arrays are supported
         if (is_array($mContents) && ($sCachePath = $this->getCacheFilePath($sKey, false, 'php'))) {
-
             // setting meta
             $this->setCacheMeta($sKey, array("serialize" => false, "cachepath" => $sCachePath));
 
@@ -664,7 +659,6 @@ class Utils extends \oxSuperCfg
             startProfile("!__SAVING CACHE__! (warning)");
             foreach ($this->_aLockedFileHandles[LOCK_EX] as $sKey => $rHandle) {
                 if ($rHandle !== false && isset($this->_aFileCacheContents[$sKey])) {
-
                     // #0002931A truncate file once more before writing
                     ftruncate($rHandle, 0);
 
@@ -696,12 +690,10 @@ class Utils extends \oxSuperCfg
     {
         $rHandle = isset($this->_aLockedFileHandles[$iLockMode][$sIdent]) ? $this->_aLockedFileHandles[$iLockMode][$sIdent] : null;
         if ($rHandle === null) {
-
             $blLocked = false;
             $rHandle = @fopen($sFilePath, "a+");
 
             if ($rHandle !== false) {
-
                 if (flock($rHandle, $iLockMode | LOCK_NB)) {
                     if ($iLockMode === LOCK_EX) {
                         // truncate file
@@ -721,7 +713,6 @@ class Utils extends \oxSuperCfg
 
             // in case system does not support file locking
             if (!$blLocked && $iLockMode === LOCK_EX) {
-
                 // clearing on first call
                 if (count($this->_aLockedFileHandles) == 0) {
                     clearstatcache();
@@ -753,7 +744,6 @@ class Utils extends \oxSuperCfg
         if (isset($this->_aLockedFileHandles[$iLockMode][$sIdent]) &&
             $this->_aLockedFileHandles[$iLockMode][$sIdent] !== false
         ) {
-
             // release the lock and close file
             $blSuccess = flock($this->_aLockedFileHandles[$iLockMode][$sIdent], LOCK_UN) &&
                          fclose($this->_aLockedFileHandles[$iLockMode][$sIdent]);
@@ -906,7 +896,6 @@ class Utils extends \oxSuperCfg
         if (($sPrevId = oxRegistry::getConfig()->getRequestParameter('preview')) &&
             ($sAdminSid = oxRegistry::get("oxUtilsServer")->getOxCookie('admin_sid'))
         ) {
-
             $sTable = getViewName('oxuser');
             $oDb = oxDb::getDb();
             $sQ = "select 1 from $sTable where MD5( CONCAT( " . $oDb->quote($sAdminSid) . ", {$sTable}.oxid, {$sTable}.oxpassword, {$sTable}.oxrights ) ) = " . oxDb::getDb()->quote($sPrevId);
@@ -1208,7 +1197,6 @@ class Utils extends \oxSuperCfg
         $aPrice = explode('!P!', $aName[0]);
 
         if (($myConfig->getConfigParam('bl_perfLoadSelectLists') && $myConfig->getConfigParam('bl_perfUseSelectlistPrice') && isset($aPrice[0]) && isset($aPrice[1])) || $this->isAdmin()) {
-
             // yes, price is there
             $oObject->price = isset($aPrice[1]) ? $aPrice[1] : 0;
             $aName[0] = isset($aPrice[0]) ? $aPrice[0] : '';
@@ -1444,9 +1432,8 @@ class Utils extends \oxSuperCfg
     public function setLangCache($sCacheName, $aLangCache)
     {
         $sCache = "<?php\n\$aLangCache = " . var_export($aLangCache, true) . ";\n?>";
-        $blRes = file_put_contents($this->getCacheFilePath($sCacheName), $sCache, LOCK_EX);
 
-        return $blRes;
+        return file_put_contents($this->getCacheFilePath($sCacheName), $sCache, LOCK_EX);
     }
 
     /**

--- a/source/Core/UtilsCount.php
+++ b/source/Core/UtilsCount.php
@@ -329,7 +329,6 @@ class UtilsCount extends \oxSuperCfg
     {
         // loading from cache
         if ($aCatData = $this->_getCatCache()) {
-
             $sTable = getViewName('oxcategories');
             $sSelect = "select $sTable.oxid from $sTable where " . (double) $iPrice . " >= $sTable.oxpricefrom and " . (double) $iPrice . " <= $sTable.oxpriceto ";
 

--- a/source/Core/UtilsDate.php
+++ b/source/Core/UtilsDate.php
@@ -376,13 +376,10 @@ class UtilsDate extends \oxSuperCfg
      */
     protected function _defaultDatePattern()
     {
-        // default date patterns
-        $aDefDatePatterns = array("/^0000-00-00/"   => "ISO",
-                                  "/^00\.00\.0000/" => "EUR",
-                                  "/^00\/00\/0000/" => "USA"
+        return array("/^0000-00-00/"   => "ISO",
+                     "/^00\.00\.0000/" => "EUR",
+                     "/^00\/00\/0000/" => "USA"
         );
-
-        return $aDefDatePatterns;
     }
 
     /**
@@ -392,13 +389,10 @@ class UtilsDate extends \oxSuperCfg
      */
     protected function _defaultTimePattern()
     {
-        // default time patterns
-        $aDefTimePatterns = array("/00:00:00$/"    => "ISO",
-                                  "/00\.00\.00$/"  => "EUR",
-                                  "/00:00:00 AM$/" => "USA"
+        return array("/00:00:00$/"    => "ISO",
+                     "/00\.00\.00$/"  => "EUR",
+                     "/00:00:00 AM$/" => "USA"
         );
-
-        return $aDefTimePatterns;
     }
 
     /**
@@ -408,13 +402,10 @@ class UtilsDate extends \oxSuperCfg
      */
     protected function _regexp2ValidateDateInput()
     {
-        // regexps to validate input
-        $aDatePatterns = array("/^([0-9]{4})-([0-9]{2})-([0-9]{2})/"   => "ISO",
-                               "/^([0-9]{2})\.([0-9]{2})\.([0-9]{4})/" => "EUR",
-                               "/^([0-9]{2})\/([0-9]{2})\/([0-9]{4})/" => "USA"
+        return array("/^([0-9]{4})-([0-9]{2})-([0-9]{2})/"   => "ISO",
+                     "/^([0-9]{2})\.([0-9]{2})\.([0-9]{4})/" => "EUR",
+                     "/^([0-9]{2})\/([0-9]{2})\/([0-9]{4})/" => "USA"
         );
-
-        return $aDatePatterns;
     }
 
     /**
@@ -424,13 +415,10 @@ class UtilsDate extends \oxSuperCfg
      */
     protected function _regexp2ValidateTimeInput()
     {
-        // regexps to validate input
-        $aTimePatterns = array("/([0-9]{2}):([0-9]{2}):([0-9]{2})$/"                 => "ISO",
-                               "/([0-9]{2})\.([0-9]{2})\.([0-9]{2})$/"               => "EUR",
-                               "/([0-9]{2}):([0-9]{2}):([0-9]{2}) ([AP]{1}[M]{1})$/" => "USA"
+        return array("/([0-9]{2}):([0-9]{2}):([0-9]{2})$/"                 => "ISO",
+                     "/([0-9]{2})\.([0-9]{2})\.([0-9]{2})$/"               => "EUR",
+                     "/([0-9]{2}):([0-9]{2}):([0-9]{2}) ([AP]{1}[M]{1})$/" => "USA"
         );
-
-        return $aTimePatterns;
     }
 
     /**
@@ -440,13 +428,10 @@ class UtilsDate extends \oxSuperCfg
      */
     protected function _defineDateFormattingRules()
     {
-        // date formatting rules
-        $aDFormats = array("ISO" => array("Y-m-d", array(2, 3, 1), "0000-00-00"),
-                           "EUR" => array("d.m.Y", array(2, 1, 3), "00.00.0000"),
-                           "USA" => array("m/d/Y", array(1, 2, 3), "00/00/0000")
+        return array("ISO" => array("Y-m-d", array(2, 3, 1), "0000-00-00"),
+                     "EUR" => array("d.m.Y", array(2, 1, 3), "00.00.0000"),
+                     "USA" => array("m/d/Y", array(1, 2, 3), "00/00/0000")
         );
-
-        return $aDFormats;
     }
 
     /**
@@ -456,13 +441,10 @@ class UtilsDate extends \oxSuperCfg
      */
     protected function _defineTimeFormattingRules()
     {
-        // time formatting rules
-        $aTFormats = array("ISO" => array("H:i:s", array(1, 2, 3), "00:00:00"),
-                           "EUR" => array("H.i.s", array(1, 2, 3), "00.00.00"),
-                           "USA" => array("h:i:s A", array(1, 2, 3), "00:00:00 AM")
+        return array("ISO" => array("H:i:s", array(1, 2, 3), "00:00:00"),
+                     "EUR" => array("H.i.s", array(1, 2, 3), "00.00.00"),
+                     "USA" => array("h:i:s A", array(1, 2, 3), "00:00:00 AM")
         );
-
-        return $aTFormats;
     }
 
     /**
@@ -504,7 +486,10 @@ class UtilsDate extends \oxSuperCfg
     {
         // formatting correct time value
         $iTimestamp = mktime(
-            0, 0, 0, $aDateMatches[$aDFields[0]],
+            0,
+            0,
+            0,
+            $aDateMatches[$aDFields[0]],
             $aDateMatches[$aDFields[1]],
             $aDateMatches[$aDFields[2]]
         );
@@ -595,13 +580,10 @@ class UtilsDate extends \oxSuperCfg
         $timestamp = $this->getRequestTime();
         //round up x minutes so query cache can work
         $timestamp = ceil($timestamp / $roundTo) * $roundTo;
+
         //format date for sql query
-        $date = $this->formatDBTimestamp($timestamp);
-        return $date;
+        return $this->formatDBTimestamp($timestamp);
     }
-
-
-
 
     /**
      * Returns the the request time formatted as date string for the database
@@ -612,7 +594,6 @@ class UtilsDate extends \oxSuperCfg
     {
         return $this->formatDBTimestamp($this->getRequestTime());
     }
-
 
     /**
      * Form time
@@ -711,18 +692,14 @@ class UtilsDate extends \oxSuperCfg
      */
     public function isEmptyDate($sDate)
     {
-        $blIsEmpty = true;
-
         if (!empty($sDate)) {
             $sDate = preg_replace("/[^0-9a-z]/i", "", $sDate);
-            if (is_numeric($sDate) && $sDate == 0) {
-                $blIsEmpty = true;
-            } else {
-                $blIsEmpty = false;
+            if (!is_numeric($sDate) || $sDate != 0) {
+                return false;
             }
         }
 
-        return $blIsEmpty;
+        return true;
     }
 
     /**
@@ -739,8 +716,8 @@ class UtilsDate extends \oxSuperCfg
     {
         if ($blGerman) {
             return date($sFormat, mktime($aTime[0], $aTime[1], $aTime[2], $aDate[1], $aDate[0], $aDate[2]));
-        } else {
-            return date($sFormat, mktime($aTime[0], $aTime[1], $aTime[2], $aDate[1], $aDate[2], $aDate[0]));
         }
+
+        return date($sFormat, mktime($aTime[0], $aTime[1], $aTime[2], $aDate[1], $aDate[2], $aDate[0]));
     }
 }

--- a/source/Core/UtilsFile.php
+++ b/source/Core/UtilsFile.php
@@ -192,7 +192,6 @@ class UtilsFile extends \oxSuperCfg
         while (false !== ($file = readdir($handle))) {
             if ($file != '.' && $file != '..') {
                 if (is_dir($sSourceDir . '/' . $file)) {
-
                     // recursive
                     $sNewSourceDir = $sSourceDir . '/' . $file;
                     $sNewTargetDir = $sTargetDir . '/' . $file;
@@ -225,7 +224,6 @@ class UtilsFile extends \oxSuperCfg
     {
         if (is_dir($sSourceDir)) {
             if ($oDir = dir($sSourceDir)) {
-
                 while (false !== $sFile = $oDir->read()) {
                     if ($sFile == '.' || $sFile == '..') {
                         continue;
@@ -290,7 +288,6 @@ class UtilsFile extends \oxSuperCfg
             $sFileType = trim($aFilename[count($aFilename) - 1]);
 
             if (isset($sFileType)) {
-
                 $oStr = getStr();
 
                 // unallowed files ?
@@ -325,9 +322,8 @@ class UtilsFile extends \oxSuperCfg
     protected function _getImagePath($sType)
     {
         $sFolder = array_key_exists($sType, $this->_aTypeToPath) ? $this->_aTypeToPath[$sType] : '0';
-        $sPath = $this->normalizeDir($this->getConfig()->getPictureDir(false)) . "{$sFolder}/";
 
-        return $sPath;
+        return $this->normalizeDir($this->getConfig()->getPictureDir(false)) . "{$sFolder}/";
     }
 
     /**
@@ -429,7 +425,6 @@ class UtilsFile extends \oxSuperCfg
     {
         $aFiles = $aFiles ? $aFiles : $_FILES;
         if (isset($aFiles['myfile']['name'])) {
-
             $oConfig = $this->getConfig();
             $oStr = getStr();
 
@@ -447,7 +442,6 @@ class UtilsFile extends \oxSuperCfg
             $oEx = oxNew("oxExceptionToDisplay");
             // process all files
             while (list($sKey, $sValue) = each($aFiles['myfile']['name'])) {
-
                 $sSource = $aSource[$sKey];
                 $iError = $aError[$sKey];
                 $aFiletype = explode("@", $sKey);
@@ -471,7 +465,6 @@ class UtilsFile extends \oxSuperCfg
                     $sProcessPath = $sTmpFolder . basename($sSource);
 
                     if ($sProcessPath) {
-
                         if ($blUseMasterImage) {
                             //using master image as source, so only copying it to
                             $blMoved = $this->_copyFile($sSource, $sImagePath . $sValue);
@@ -540,7 +533,6 @@ class UtilsFile extends \oxSuperCfg
         $aUrlParts = @parse_url($sLink);
         $sHost = (isset($aUrlParts["host"]) && $aUrlParts["host"]) ? $aUrlParts["host"] : null;
 
-        $blValid = false;
         if ($sHost) {
             $sDocumentPath = (isset($aUrlParts["path"]) && $aUrlParts["path"]) ? $aUrlParts["path"] : '/';
             $sDocumentPath .= (isset($aUrlParts["query"]) && $aUrlParts["query"]) ? '?' . $aUrlParts["query"] : '';
@@ -554,12 +546,12 @@ class UtilsFile extends \oxSuperCfg
                 fclose($oConn);
 
                 if (preg_match("/200 OK/", $sResponse)) {
-                    $blValid = true;
+                    return true;
                 }
             }
         }
 
-        return $blValid;
+        return false;
     }
 
     /**
@@ -609,9 +601,9 @@ class UtilsFile extends \oxSuperCfg
 
         if ($this->_moveImage($aFileInfo['tmp_name'], $sBasePath . $sUploadPath . "/" . $sFileName)) {
             return $sFileName;
-        } else {
-            return false;
         }
+
+        return false;
     }
 
     /**

--- a/source/Core/UtilsObject.php
+++ b/source/Core/UtilsObject.php
@@ -349,9 +349,7 @@ class UtilsObject
 
         $class = $classNameProvider->getClassName($classAlias);
 
-        $class = $this->getModuleChainsGenerator()->createClassChain($class, $classAlias);
-
-        return $class;
+        return $this->getModuleChainsGenerator()->createClassChain($class, $classAlias);
     }
 
     /**

--- a/source/Core/UtilsPic.php
+++ b/source/Core/UtilsPic.php
@@ -55,19 +55,17 @@ class UtilsPic extends \oxSuperCfg
      */
     public function resizeImage($sSrc, $sTarget, $iDesiredWidth, $iDesiredHeight)
     {
-        $blResize = false;
-
         // use this GD Version
         if (($iUseGDVersion = getGdVersion()) && function_exists('imagecreate') &&
             file_exists($sSrc) && ($aImageInfo = @getimagesize($sSrc))
         ) {
-
             $myConfig = $this->getConfig();
             list($iWidth, $iHeight) = calcImageSize($iDesiredWidth, $iDesiredHeight, $aImageInfo[0], $aImageInfo[1]);
-            $blResize = $this->_resize($aImageInfo, $sSrc, null, $sTarget, $iWidth, $iHeight, $iUseGDVersion, $myConfig->getConfigParam('blDisableTouch'), $myConfig->getConfigParam('sDefaultImageQuality'));
+
+            return $this->_resize($aImageInfo, $sSrc, null, $sTarget, $iWidth, $iHeight, $iUseGDVersion, $myConfig->getConfigParam('blDisableTouch'), $myConfig->getConfigParam('sDefaultImageQuality'));
         }
 
-        return $blResize;
+        return false;
     }
 
 
@@ -107,7 +105,6 @@ class UtilsPic extends \oxSuperCfg
         if (!$myConfig->isDemoShop() && (strpos($sPicName, 'nopic.jpg') === false ||
                                          strpos($sPicName, 'nopic_ico.jpg') === false)
         ) {
-
             $sFile = "$sAbsDynImageDir/$sPicName";
 
             if (file_exists($sFile) && is_file($sFile)) {
@@ -167,17 +164,15 @@ class UtilsPic extends \oxSuperCfg
      */
     public function overwritePic($oObject, $sPicTable, $sPicField, $sPicType, $sPicDir, $aParams, $sAbsDynImageDir)
     {
-        $blDelete = false;
         $sPic = $sPicTable . '__' . $sPicField;
         if (isset($oObject->{$sPic}) &&
             ($_FILES['myfile']['size'][$sPicType . '@' . $sPic] > 0 || $aParams[$sPic] != $oObject->{$sPic}->value)
         ) {
-
             $sImgDir = $sAbsDynImageDir . oxRegistry::get("oxUtilsFile")->getImageDirByType($sPicType);
-            $blDelete = $this->safePictureDelete($oObject->{$sPic}->value, $sImgDir, $sPicTable, $sPicField);
+            return $this->safePictureDelete($oObject->{$sPic}->value, $sImgDir, $sPicTable, $sPicField);
         }
 
-        return $blDelete;
+        return false;
     }
 
     /**

--- a/source/Core/UtilsServer.php
+++ b/source/Core/UtilsServer.php
@@ -77,7 +77,7 @@ class UtilsServer extends \oxSuperCfg
             return;
         }
         $config = $this->getConfig();
-        //if shop runs in https only mode we can set secure flag to all cookies 
+        //if shop runs in https only mode we can set secure flag to all cookies
         $blSecure = $blSecure || ($config->isSsl() && $config->getSslShopUrl() == $config->getShopUrl());
         return setcookie(
             $sName,

--- a/source/Core/UtilsString.php
+++ b/source/Core/UtilsString.php
@@ -76,9 +76,7 @@ class UtilsString
             $sString = $oStr->substr($sString, 0, $iLength);
         }
 
-        $sString = $oStr->preg_replace("/,+$/", "", $sString);
-
-        return $sString;
+        return $oStr->preg_replace("/,+$/", "", $sString);
     }
 
     /**

--- a/source/Core/UtilsUrl.php
+++ b/source/Core/UtilsUrl.php
@@ -291,6 +291,7 @@ class UtilsUrl extends \oxSuperCfg
     public function getActiveShopHost()
     {
         $shopUrl = $this->getConfig()->getShopUrl();
+
         return $this->extractHost($shopUrl);
     }
 
@@ -303,14 +304,7 @@ class UtilsUrl extends \oxSuperCfg
      */
     public function extractHost($url)
     {
-        $host = $url;
-        $sUrlHost = $this->parseUrlAndAppendSchema($host, PHP_URL_HOST);
-
-        if (!is_null($sUrlHost)) {
-            $host = $sUrlHost;
-        }
-
-        return $host;
+        return $this->parseUrlAndAppendSchema($url, PHP_URL_HOST) ?: $url;
     }
 
     /**
@@ -334,9 +328,7 @@ class UtilsUrl extends \oxSuperCfg
      */
     public function extractUrlPath($shopUrl)
     {
-        $urlPath = $this->parseUrlAndAppendSchema($shopUrl, PHP_URL_PATH);
-
-        return $urlPath;
+        return $this->parseUrlAndAppendSchema($shopUrl, PHP_URL_PATH);
     }
 
     /**
@@ -479,9 +471,7 @@ class UtilsUrl extends \oxSuperCfg
             $sProtocol = 'https://';
         }
 
-        $sUrl = $sProtocol . $aServerParams['HTTP_HOST'] . $aServerParams['REQUEST_URI'];
-
-        return $sUrl;
+        return $sProtocol . $aServerParams['HTTP_HOST'] . $aServerParams['REQUEST_URI'];
     }
 
     /**
@@ -518,10 +508,7 @@ class UtilsUrl extends \oxSuperCfg
      */
     public function getUrlLanguageParameter($languageId)
     {
-        $language = oxRegistry::getLang();
-        $languageParameter = array($language->getName() => $languageId);
-
-        return $languageParameter;
+        return [oxRegistry::getLang()->getName() => $languageId];
     }
 
     /**
@@ -650,6 +637,7 @@ class UtilsUrl extends \oxSuperCfg
             $newFilteredParameters = array_diff_key($aAddParams, $currentUrlParameters);
             $newParameters = array_merge($currentUrlParameters, $newFilteredParameters);
         }
+
         return $newParameters;
     }
 
@@ -660,8 +648,6 @@ class UtilsUrl extends \oxSuperCfg
      */
     private function rightTrimAmp($url)
     {
-        /** @var oxStrRegular $oStr */
-        $oStr = getStr();
-        return $oStr->preg_replace('/(\?|&(amp;)?)$/i', '', $url);
+        return getStr()->preg_replace('/(\?|&(amp;)?)$/i', '', $url);
     }
 }

--- a/source/Core/UtilsView.php
+++ b/source/Core/UtilsView.php
@@ -314,9 +314,8 @@ class UtilsView extends \oxSuperCfg
     {
         $shopId = $this->getConfig()->getShopId();
         $templateDirectories = $this->getTemplateDirs();
-        $templateDirectory = reset($templateDirectories);
 
-        return md5($templateDirectory . '__' . $shopId);
+        return md5(reset($templateDirectories) . '__' . $shopId);
     }
 
     /**
@@ -540,9 +539,7 @@ class UtilsView extends \oxSuperCfg
             $themeId = 'admin';
         }
 
-        $fullThemePath = $themePath . $themeId . "/tpl/";
-
-        return $fullThemePath;
+        return $themePath . $themeId . "/tpl/";
     }
 
     /**
@@ -673,6 +670,7 @@ class UtilsView extends \oxSuperCfg
                 $templateBlocks[] = $activeBlockTemplate;
             }
         }
+
         return $templateBlocks;
     }
 
@@ -696,6 +694,7 @@ class UtilsView extends \oxSuperCfg
                 $templateBlocks[] = $activeBlockTemplate;
             }
         }
+
         return $templateBlocks;
     }
 

--- a/source/Core/View.php
+++ b/source/Core/View.php
@@ -209,9 +209,7 @@ class View extends \oxSuperCfg
      */
     public function getViewParameter($sKey)
     {
-        $sValue = (isset($this->_aViewParams[$sKey])) ? $this->_aViewParams[$sKey] : $this->getConfig()->getRequestParameter($sKey);
-
-        return $sValue;
+        return (isset($this->_aViewParams[$sKey])) ? $this->_aViewParams[$sKey] : $this->getConfig()->getRequestParameter($sKey);
     }
 
     /**
@@ -513,7 +511,7 @@ class View extends \oxSuperCfg
                 $sNewAction = $this->$sFunction();
                 self::$_blExecuted = true;
 
-                if (isset ($sNewAction)) {
+                if (isset($sNewAction)) {
                     $this->_executeNewAction($sNewAction);
                 }
             } else {
@@ -703,13 +701,7 @@ class View extends \oxSuperCfg
      */
     public function isBetaVersion()
     {
-        $blBetaVersion = false;
-
-        if (stripos($this->getConfig()->getVersion(), 'beta') !== false) {
-            $blBetaVersion = true;
-        }
-
-        return $blBetaVersion;
+        return (stripos($this->getConfig()->getVersion(), 'beta') !== false);
     }
 
     /**
@@ -719,13 +711,7 @@ class View extends \oxSuperCfg
      */
     public function isRCVersion()
     {
-        $blRCVersion = false;
-
-        if (stripos($this->getConfig()->getVersion(), 'rc') !== false) {
-            $blRCVersion = true;
-        }
-
-        return $blRCVersion;
+        return (stripos($this->getConfig()->getVersion(), 'rc') !== false);
     }
 
     /**
@@ -735,13 +721,7 @@ class View extends \oxSuperCfg
      */
     public function showBetaNote()
     {
-        $blBetaNote = false;
-
-        if ($this->isBetaVersion() || $this->isRCVersion()) {
-            $blBetaNote = true;
-        }
-
-        return $blBetaNote;
+        return ($this->isBetaVersion() || $this->isRCVersion());
     }
 
     /**
@@ -765,11 +745,7 @@ class View extends \oxSuperCfg
      */
     public function showNewsletter()
     {
-        if ($this->_iNewsStatus === null) {
-            return 1;
-        }
-
-        return $this->_iNewsStatus;
+        return $this->_iNewsStatus === null ? 1 : $this->_iNewsStatus;
     }
 
     /**
@@ -823,7 +799,6 @@ class View extends \oxSuperCfg
         // this may be usefull when category component was unable to load active category
         // and we still need some object to mount navigation info
         if ($this->_oClickCat === null) {
-
             $this->_oClickCat = false;
             $oCategory = oxNew('oxCategory');
             if ($oCategory->load($this->getCategoryId())) {
@@ -915,14 +890,11 @@ class View extends \oxSuperCfg
      */
     public function getSidForWidget()
     {
-        $sRet = null;
         $oSession = $this->getSession();
 
         if (!$oSession->isActualSidInCookie()) {
-            $sRet = $oSession->getId();
+            return $oSession->getId();
         }
-
-        return $sRet;
     }
 
     /**

--- a/source/Core/ViewConfig.php
+++ b/source/Core/ViewConfig.php
@@ -25,7 +25,6 @@ namespace OxidEsales\Eshop\Core;
 use OxidEsales\Eshop\Core\Edition\EditionSelector;
 use oxRegistry;
 
-
 /**
  * View config data access class. Keeps most
  * of getters needed for formatting various urls,
@@ -125,9 +124,7 @@ class ViewConfig extends \oxSuperCfg
         $shopConfig = $this->getConfig();
         $isSeoActive = oxRegistry::getUtils()->seoIsActive();
 
-        $isStartRequired = $isSeoActive && ($baseLanguage != $shopConfig->getConfigParam('sDefaultLang'));
-
-        return $isStartRequired;
+        return $isSeoActive && ($baseLanguage != $shopConfig->getConfigParam('sDefaultLang'));
     }
 
     /**
@@ -456,7 +453,6 @@ class ViewConfig extends \oxSuperCfg
     public function getBaseDir()
     {
         if (($sValue = $this->getViewConfigParam('basedir')) === null) {
-
             if ($this->getConfig()->isSsl()) {
                 $sValue = $this->getConfig()->getSSLShopURL();
             } else {
@@ -1086,9 +1082,7 @@ class ViewConfig extends \oxSuperCfg
      */
     public function getRemoteAccessToken()
     {
-        $sRaToken = oxRegistry::getSession()->getRemoteAccessToken();
-
-        return $sRaToken;
+        return oxRegistry::getSession()->getRemoteAccessToken();
     }
 
     /**
@@ -1155,9 +1149,7 @@ class ViewConfig extends \oxSuperCfg
      */
     public function getPasswordLength()
     {
-        $inputValidator = oxRegistry::get('oxInputValidator');
-
-        return $inputValidator->getPasswordLength();
+        return oxRegistry::get('oxInputValidator')->getPasswordLength();
     }
 
     /**
@@ -1267,7 +1259,6 @@ class ViewConfig extends \oxSuperCfg
     public function getViewThemeParam($sName)
     {
         $sValue = false;
-
         if ($this->getConfig()->isThemeOption($sName)) {
             $sValue = $this->getConfig()->getConfigParam($sName);
         }
@@ -1392,13 +1383,7 @@ class ViewConfig extends \oxSuperCfg
      */
     private function _moduleExists($sModuleId, $aModuleVersions)
     {
-        $blModuleExists = false;
-
-        if (in_array($sModuleId, array_keys($aModuleVersions) )) {
-            $blModuleExists = true;
-        }
-
-        return $blModuleExists;
+        return (in_array($sModuleId, array_keys($aModuleVersions)));
     }
 
     /**
@@ -1410,13 +1395,9 @@ class ViewConfig extends \oxSuperCfg
      */
     private function _isModuleEnabled($sModuleId)
     {
-        $blModuleIsActive = false;
-
         $aDisabledModules = $this->getConfig()->getConfigParam('aDisabledModules');
-        if (!(is_array($aDisabledModules) && in_array($sModuleId, $aDisabledModules))) {
-            $blModuleIsActive = true;
-        }
-        return $blModuleIsActive;
+
+        return !in_array($sModuleId, (array) $aDisabledModules);
     }
 
     /**

--- a/source/Core/ViewHelper/JavaScriptRenderer.php
+++ b/source/Core/ViewHelper/JavaScriptRenderer.php
@@ -200,14 +200,12 @@ JS;
      */
     protected function enclose($scriptsOutput, $widget, $isAjaxRequest)
     {
-        $output = '';
         if ($scriptsOutput) {
             if ($widget && !$isAjaxRequest) {
                 $scriptsOutput = "window.addEventListener('load', function() { $scriptsOutput }, false )";
             }
-            $output = "<script type='text/javascript'>$scriptsOutput</script>";
-        }
 
-        return $output;
+            return "<script type='text/javascript'>$scriptsOutput</script>";
+        }
     }
 }

--- a/source/Core/oxmailvalidator.php
+++ b/source/Core/oxmailvalidator.php
@@ -79,8 +79,7 @@ class oxMailValidator
     public function isValidEmail($sEmail)
     {
         $sEmailRule = $this->getMailValidationRule();
-        $blValid = (getStr()->preg_match($sEmailRule, $sEmail) != 0);
 
-        return $blValid;
+        return (getStr()->preg_match($sEmailRule, $sEmail) != 0);
     }
 }


### PR DESCRIPTION
Hi there, this PR is huge, I'm aware of that, but I thing many parts of the code can simplified without loosing functionality.
By looking into the code, I noticed some weird patterns:
```php
$blReturn = false;
if ($isSomethingTruely) {
	$blReturn = true;
}

return $blReturn;
```
Which can be simplified to:
```php
return (bool) $isSomethingTruely
```
---
```php
if ($arr = $this->giveMeAnArray()) {
	if (isset($arr['hasThatKey'])) {
		return true;
	}
}

return false;
```
Which can be simplified to:
```php
return isset($this->giveMeAnArray['hasThatKey']);
```
---
```php
$whyDoINeedToStoreThisInAVariable = oxNew('oxClass');

return $whyDoINeedToStoreThisInAVariable;
```
Which can be simplified to:
```php
return oxNew('oxClass');
```
---
```php
$sId = null;
if ($this->someFunction()) {
	$sId = $this->giveMeAValue();
}

return $sId;
```
Which can be simplified to:
```php
if ($this->someFunction()) {
	return $this->giveMeAValue();
}
```
---
```php
if ($this->_blNotBuyableParent) {
	return false;
}

return !$this->_blNotBuyable;
```
Which can be simplified to:
```php
return !($this->_blNotBuyableParent || $this->_blNotBuyable);
```
---
```php
$value = false; //defaultValue
if ($otherValue) {
	$value = $otherValue;
}

return $value;
```
Which can be simplified to:
```php
return $otherValue ?: false;
```
---
There are a few more, which I haven't mentioned here, but take a look at the diff. ([SepaIBANValidator@_isIBANChecksumValid](https://github.com/OXID-eSales/oxideshop_ce/pull/414/files#diff-54e74d4e198a40248145fbe700d4c786L229) for example)