### PR TITLE
show offlinepage directly instead of redirects

### DIFF
--- a/source/Core/Utils.php
+++ b/source/Core/Utils.php
@@ -1069,16 +1069,29 @@ class Utils extends \oxSuperCfg
     }
 
     /**
-     * Redirects to shop offline page
-     *
+     * Shows offline page
+     * @deprecated since v.5.3.0 (2016-06-28); Use Utils::showOfflinePage().
      * @param int $iHeaderCode header code, default 302
      */
     public function redirectOffline($iHeaderCode = 302)
     {
-        $sUrl = $this->getConfig()->getShopUrl() . 'offline.html';
-        $this->redirect($sUrl, false, $iHeaderCode);
+        $this->showOfflinePage();
     }
 
+    /**
+     * shows offline page
+     * directly displays the offline page to the client (browser)
+     * with a 500 status code header
+     * @return null or exit;
+     */
+    public function showOfflinePage()
+    {
+        $this->setHeader("HTTP/1.1 500 Internal Server Error");
+        $offlineMessageFile = $this->getConfig()->getConfigParam('sShopDir') . 'offline.html';
+        $offline = file_get_contents($offlineMessageFile);
+        $this->showMessageAndExit($offline);
+    }
+    
     /**
      * redirect user to the specified URL
      *

--- a/tests/Unit/Application/Controller/CmpShopTest.php
+++ b/tests/Unit/Application/Controller/CmpShopTest.php
@@ -37,18 +37,17 @@ class CmpShopTest extends \OxidTestCase
      * @return null
      */
     public function testRenderNoActiveShop()
-    {
-        $sRedirUrl = $this->getConfig()->getShopMainUrl() . 'offline.html';
-        $this->setExpectedException('oxException', $sRedirUrl);
-
+    {        
         $oView = $this->getMock("oxView", array("getClassName"));
         $oView->expects($this->once())->method('getClassName')->will($this->returnValue("test"));
 
         $oShop = oxNew('oxShop');
         $oShop->oxshops__oxactive = new oxField(0);
 
-        oxTestModules::addFunction('oxUtils', 'redirect($url, $blAddRedirectParam = true, $iHeaderCode = 301)', '{throw new oxException($url);}');
-
+        $oUtils = $this->getMock('oxUtils', array('showOfflinePage'));
+        $oUtils->expects($this->once())->method('showOfflinePage');
+        oxTestModules::addModuleObject('oxUtils', $oUtils);
+        
         $oConfig = $this->getMock("oxConfig", array("getConfigParam", "getActiveView", "getActiveShop"));
         $oConfig->expects($this->once())->method('getActiveView')->will($this->returnValue($oView));
         $oConfig->expects($this->any())->method('getConfigParam')->will($this->returnValue(false));

--- a/tests/Unit/Core/UtilsTest.php
+++ b/tests/Unit/Core/UtilsTest.php
@@ -1009,29 +1009,18 @@ class UtilsTest extends \OxidTestCase
         $this->assertEquals($sCode, "zloynnSbbFgevat!");
     }
 
-    public function testRedirectOffline_WithDefaultHeader()
+    /**
+     * 
+     */
+    public function testShowOfflinePage()
     {
-        $oConfig = $this->getMock('oxConfig', array('getShopUrl'));
-        $oConfig->expects($this->once())->method('getShopUrl')->will($this->returnValue('http://shopUrl/'));
-
-        $oUtils = $this->getMock('oxutils', array('redirect'));
-        $oUtils->expects($this->once())->method('redirect')->with($this->equalTo('http://shopUrl/offline.html'), $this->equalTo(false), $this->equalTo(302));
-        $oUtils->setConfig($oConfig);
-
-        $oUtils->redirectOffline();
+        $utils = $this->getMock('oxutils', array('setHeader','showMessageAndExit'));
+        $utils->expects($this->once())->method('setHeader')->with($this->stringContains('HTTP/1.1 5'));
+        $utils->expects($this->once())->method('showMessageAndExit')->with($this->stringContains('<meta name="robots" content="noindex, nofollow">'));
+        
+        $utils->showOfflinePage();
     }
-
-    public function testRedirectOffline_WithDifferentHeader()
-    {
-        $oConfig = $this->getMock('oxConfig', array('getShopUrl'));
-        $oConfig->expects($this->once())->method('getShopUrl')->will($this->returnValue('http://shopUrl/'));
-
-        $oUtils = $this->getMock('oxutils', array('redirect'));
-        $oUtils->expects($this->once())->method('redirect')->with($this->equalTo('http://shopUrl/offline.html'), $this->equalTo(false), $this->equalTo(500));
-        $oUtils->setConfig($oConfig);
-
-        $oUtils->redirectOffline(500);
-    }
+    
 
     public function testRedirect()
     {


### PR DESCRIPTION
the benefit of not redirecting is:
- clear status code for the caller (500) so the client knows about the error
- http standard: using 500 status with body instead of 500 with location header 
- enable the client to resend the request by refreshing the page (helps to fix the problem, can help to restore data)
- enable the client to navigate back in history