### PR TITLE
WIP: 6375 - cumulation percentual discounts leads to wrong calculation

### DIFF
--- a/source/Core/Price.php
+++ b/source/Core/Price.php
@@ -472,9 +472,11 @@ class Price
             foreach ($aDiscounts as $aDiscount) {
 
                 if ($aDiscount['type'] == 'abs') {
-                    $dPrice = $dPrice - $aDiscount['value'];
+                    //$dPrice = $dPrice - $aDiscount['value'];
+                    $sumOfCalculatedDiscounts += $aDiscount['value'];
                 } else {
-                    $sumOfCalculatedDiscounts += $dPrice - $dPrice * (100 - $aDiscount['value']) / 100;
+                    //$sumOfCalculatedDiscounts += $dPrice * (100 - $aDiscount['value']) / 100;
+                    $sumOfCalculatedDiscounts += $dPrice - ($dPrice * (100 - $aDiscount['value']) / 100);
                 }
             }
 

--- a/source/Core/Price.php
+++ b/source/Core/Price.php
@@ -454,14 +454,19 @@ class Price
         $aDiscounts = $this->getDiscounts();
 
         if ($aDiscounts) {
+            $sumOfCalculatedDiscounts = 0;
+
             foreach ($aDiscounts as $aDiscount) {
 
                 if ($aDiscount['type'] == 'abs') {
                     $dPrice = $dPrice - $aDiscount['value'];
                 } else {
-                    $dPrice = $dPrice * (100 - $aDiscount['value']) / 100;
+                    $sumOfCalculatedDiscounts += $dPrice - $dPrice * (100 - $aDiscount['value']) / 100;
                 }
             }
+
+            $dPrice -= $sumOfCalculatedDiscounts;
+
             if ($dPrice < 0) {
                 $this->setPrice(0);
             } else {

--- a/source/Core/Price.php
+++ b/source/Core/Price.php
@@ -421,8 +421,21 @@ class Price
      *
      * @param double $dValue discount value
      * @param string $sType  discount type: abs or %
+     *
+     * @deprecated Use Price::addDiscount instead
      */
     public function setDiscount($dValue, $sType)
+    {
+        $this->addDiscount($dValue, $sType);
+    }
+
+    /**
+     * Adds discount to price
+     *
+     * @param double $dValue discount value
+     * @param string $sType  discount type: abs or %
+     */
+    public function addDiscount($dValue, $sType)
     {
         $this->_aDiscounts[] = array('value' => $dValue, 'type' => $sType);
     }

--- a/tests/Integration/Price/testcases/basket/case97.php
+++ b/tests/Integration/Price/testcases/basket/case97.php
@@ -115,9 +115,9 @@ $aData = array(
         // Article expected prices: ARTICLE ID => ( Unit price, Total Price )
         'articles' => array (
              111 => array ( '0,50', '0,50' ),
-             1112 => array ( '4,97', '4,97' ),
+             1112 => array ( '5,02', '5,02' ),
              1113 => array ( '0,90', '0,90' ),
-             1114 => array ( '990,99', '990,99' ),
+             1114 => array ( '1.001,00', '1.001,00' ),
         ),
         // Expectations of other totals
         'totals' => array (

--- a/tests/Integration/Price/testcases/basket/case97.php
+++ b/tests/Integration/Price/testcases/basket/case97.php
@@ -122,9 +122,9 @@ $aData = array(
         // Expectations of other totals
         'totals' => array (
             // Total BRUTTO
-            'totalBrutto' => '1.186,86',
+            'totalBrutto' => '1.198,83',
             // Total NETTO
-            'totalNetto'  => '997,36',
+            'totalNetto'  => '1.007,42',
             // Total VAT amount: vat% => total cost
             'vats' => array (
                 19 => '191,41',
@@ -132,9 +132,9 @@ $aData = array(
 
             // Total delivery amounts
             'delivery' => array(
-                'brutto' => '652,77',
-                'netto' => '548,55',
-                'vat' => '104,22'
+                'brutto' => '659,36',
+                'netto' => '554,08',
+                'vat' => '105,28'
             ),
             // Total payment amounts
             'payment' => array(
@@ -143,7 +143,7 @@ $aData = array(
                 'vat' => '0,10'
             ),
             // GRAND TOTAL
-            'grandTotal'  => '1.840,28'
+            'grandTotal'  => '1.858,84'
         ),
     ),
     // Test case options

--- a/tests/Integration/Price/testcases/basket/case97.php
+++ b/tests/Integration/Price/testcases/basket/case97.php
@@ -127,7 +127,7 @@ $aData = array(
             'totalNetto'  => '997,36',
             // Total VAT amount: vat% => total cost
             'vats' => array (
-                19 => '189,50',
+                19 => '191,41',
             ),
 
             // Total delivery amounts

--- a/tests/Integration/Price/testcases/price/community/case122.php
+++ b/tests/Integration/Price/testcases/price/community/case122.php
@@ -76,7 +76,7 @@ $aData = array (
         'expected' => array (
                 1000 => array (
                         'base_price'        => '100,00',
-                        'price'             => '99,00',
+                        'price'             => '100,00',
                 ),
         ),
         'options' => array (

--- a/tests/Integration/Price/testcases/price/community/case123.php
+++ b/tests/Integration/Price/testcases/price/community/case123.php
@@ -76,7 +76,7 @@ $aData = array (
         'expected' => array (
                 1000 => array (
                         'base_price'        => '10,00',
-                        'price'             => '10,45',
+                        'price'             => '10,50',
                 ),
         ),
         'options' => array (

--- a/tests/Integration/Price/testcases/price/community/case124.php
+++ b/tests/Integration/Price/testcases/price/community/case124.php
@@ -76,7 +76,7 @@ $aData = array (
         'expected' => array (
                 1000 => array (
                         'base_price'        => '100,00',
-                        'price'             => '85,05',
+                        'price'             => '84,50',
                 ),
         ),
         'options' => array (

--- a/tests/Integration/Price/testcases/price/community/case126.php
+++ b/tests/Integration/Price/testcases/price/community/case126.php
@@ -76,7 +76,7 @@ $aData = array (
         'expected' => array (
                 1000 => array (
                         'base_price'        => '10,00',
-                        'price'             => '8,98',
+                        'price'             => '8,95',
                 ),
         ),
         'options' => array (

--- a/tests/Integration/Price/testcases/price/community/case128.php
+++ b/tests/Integration/Price/testcases/price/community/case128.php
@@ -76,7 +76,7 @@ $aData = array (
         'expected' => array (
                 1000 => array (
                         'base_price'        => '9,00',
-                        'price'             => '7,65',
+                        'price'             => '7,61',
                 ),
         ),
         'options' => array (

--- a/tests/Integration/Price/testcases/price/community/case129.php
+++ b/tests/Integration/Price/testcases/price/community/case129.php
@@ -76,7 +76,7 @@ $aData = array (
         'expected' => array (
                 1000 => array (
                         'base_price'        => '5,00',
-                        'price'             => '4,49',
+                        'price'             => '4,48',
                 ),
         ),
         'options' => array (

--- a/tests/Integration/Price/testcases/price/community/case131.php
+++ b/tests/Integration/Price/testcases/price/community/case131.php
@@ -76,7 +76,7 @@ $aData = array (
         'expected' => array (
                 1000 => array (
                         'base_price'        => '100,00',
-                        'price'             => '82,50',
+                        'price'             => '83,33',
                 ),
         ),
         'options' => array (

--- a/tests/Integration/Price/testcases/price/community/case132.php
+++ b/tests/Integration/Price/testcases/price/community/case132.php
@@ -76,7 +76,7 @@ $aData = array (
         'expected' => array (
                 1000 => array (
                         'base_price'        => '10,00',
-                        'price'             => '8,70',
+                        'price'             => '8,75',
                 ),
         ),
         'options' => array (

--- a/tests/Integration/Price/testcases/price/community/case134.php
+++ b/tests/Integration/Price/testcases/price/community/case134.php
@@ -76,8 +76,8 @@ $aData = array (
         'expected' => array (
                 1000 => array (
                         'base_price'        => '100,00',
-                        'price'             => '70,87',
-                ),
+                        'price'             => '70,41',
+                )
         ),
         'options' => array (
                 'config' => array(

--- a/tests/Integration/Price/testcases/price/community/case135.php
+++ b/tests/Integration/Price/testcases/price/community/case135.php
@@ -76,7 +76,7 @@ $aData = array (
         'expected' => array (
                 1000 => array (
                         'base_price'        => '10,00',
-                        'price'             => '7,48',
+                        'price'             => '7,46',
                 ),
         ),
         'options' => array (

--- a/tests/Integration/Price/testcases/price/community/case137.php
+++ b/tests/Integration/Price/testcases/price/community/case137.php
@@ -76,7 +76,7 @@ $aData = array (
         'expected' => array (
                 1000 => array (
                         'base_price'        => '9,00',
-                        'price'             => '6,38',
+                        'price'             => '6,34',
                 ),
         ),
         'options' => array (

--- a/tests/Integration/Price/testcases/price/community/case138.php
+++ b/tests/Integration/Price/testcases/price/community/case138.php
@@ -76,7 +76,7 @@ $aData = array (
         'expected' => array (
                 1000 => array (
                         'base_price'        => '5,00',
-                        'price'             => '3,74',
+                        'price'             => '3,73',
                 ),
         ),
         'options' => array (

--- a/tests/Integration/Price/testcases/price/community/case141.php
+++ b/tests/Integration/Price/testcases/price/community/case141.php
@@ -76,7 +76,7 @@ $aData = array (
         'expected' => array (
                 1000 => array (
                         'base_price'        => '9,00',
-                        'price'             => '9,19',
+                        'price'             => '9,13',
                 ),
         ),
         'options' => array (

--- a/tests/Integration/Price/testcases/price/community/case54.php
+++ b/tests/Integration/Price/testcases/price/community/case54.php
@@ -76,7 +76,7 @@ $aData = array (
         'expected' => array (
                 1000 => array (
                         'base_price'        => '100,00',
-                        'price'             => '118,80',
+                        'price'             => '120,00',
                 ),
         ),
         'options' => array (

--- a/tests/Integration/Price/testcases/price/community/case55.php
+++ b/tests/Integration/Price/testcases/price/community/case55.php
@@ -76,7 +76,7 @@ $aData = array (
         'expected' => array (
                 1000 => array (
                         'base_price'        => '10,00',
-                        'price'             => '12,54',
+                        'price'             => '12,60',
                 ),
         ),
         'options' => array (

--- a/tests/Integration/Price/testcases/price/community/case57.php
+++ b/tests/Integration/Price/testcases/price/community/case57.php
@@ -76,7 +76,7 @@ $aData = array (
         'expected' => array (
                 1000 => array (
                         'base_price'        => '100,00',
-                        'price'             => '102,06',
+                        'price'             => '101,40',
                 ),
         ),
         'options' => array (

--- a/tests/Integration/Price/testcases/price/community/case58.php
+++ b/tests/Integration/Price/testcases/price/community/case58.php
@@ -76,7 +76,7 @@ $aData = array (
         'expected' => array (
                 1000 => array (
                         'base_price'        => '10,00',
-                        'price'             => '10,77',
+                        'price'             => '10,74',
                 ),
         ),
         'options' => array (

--- a/tests/Integration/Price/testcases/price/community/case60.php
+++ b/tests/Integration/Price/testcases/price/community/case60.php
@@ -76,7 +76,7 @@ $aData = array (
         'expected' => array (
                 1000 => array (
                         'base_price'        => '5,00',
-                        'price'             => '5,39',
+                        'price'             => '5,37',
                 ),
         ),
         'options' => array (

--- a/tests/Integration/Price/testcases/price/community/case62.php
+++ b/tests/Integration/Price/testcases/price/community/case62.php
@@ -76,7 +76,7 @@ $aData = array (
         'expected' => array (
                 1000 => array (
                         'base_price'        => '100,00',
-                        'price'             => '99,00',
+                        'price'             => '100,00',
                 ),
         ),
         'options' => array (

--- a/tests/Integration/Price/testcases/price/community/case63.php
+++ b/tests/Integration/Price/testcases/price/community/case63.php
@@ -76,7 +76,7 @@ $aData = array (
         'expected' => array (
                 1000 => array (
                         'base_price'        => '10,00',
-                        'price'             => '10,45',
+                        'price'             => '10,50',
                 ),
         ),
         'options' => array (

--- a/tests/Integration/Price/testcases/price/community/case65.php
+++ b/tests/Integration/Price/testcases/price/community/case65.php
@@ -76,7 +76,7 @@ $aData = array (
         'expected' => array (
                 1000 => array (
                         'base_price'        => '100,00',
-                        'price'             => '85,05',
+                        'price'             => '84,50',
                 ),
         ),
         'options' => array (

--- a/tests/Integration/Price/testcases/price/community/case66.php
+++ b/tests/Integration/Price/testcases/price/community/case66.php
@@ -76,7 +76,7 @@ $aData = array (
         'expected' => array (
                 1000 => array (
                         'base_price'        => '10,00',
-                        'price'             => '8,98',
+                        'price'             => '8,95',
                 ),
         ),
         'options' => array (

--- a/tests/Integration/Price/testcases/price/community/case68.php
+++ b/tests/Integration/Price/testcases/price/community/case68.php
@@ -76,7 +76,7 @@ $aData = array (
         'expected' => array (
                 1000 => array (
                         'base_price'        => '9,00',
-                        'price'             => '7,65',
+                        'price'             => '7,61',
                 ),
         ),
         'options' => array (

--- a/tests/Integration/Price/testcases/price/community/case69.php
+++ b/tests/Integration/Price/testcases/price/community/case69.php
@@ -76,7 +76,7 @@ $aData = array (
         'expected' => array (
                 1000 => array (
                         'base_price'        => '5,00',
-                        'price'             => '4,49',
+                        'price'             => '4,48',
                 ),
         ),
         'options' => array (

--- a/tests/Unit/Application/Model/BasketTest.php
+++ b/tests/Unit/Application/Model/BasketTest.php
@@ -2248,9 +2248,44 @@ class BasketTest extends \OxidTestCase
         $this->getConfig()->setConfigParam('blEnterNetPrice', true);
         $aTestValues = array('aDiscounts');
 
-        // deleting discounts to ignore bundle problems
+        // Changing discount types to % from itm
         foreach ($this->aDiscounts as $oDiscount) {
             $oDiscount->oxdiscount__oxaddsumtype = new oxField('%', oxField::T_RAW);
+            $oDiscount->save();
+        }
+
+        $oBasket = oxNew('oxbasket');
+        $oBasket->setPayment('oxidcashondel');
+        $oBasket->setCardId($this->oCard->getId());
+        $oBasket->setCardMessage('message');
+
+        $oItem = $oBasket->addToBasket($this->oArticle->getId(), 10);
+        $oItem->setWrapping($this->oWrap->getId());
+
+
+        $oBasket->addToBasket($this->oVariant->getId(), 10);
+        $oBasket->calculateBasket(false);
+
+        foreach ($aTestValues as $sName) {
+            $this->assertFalse(isset($oBasket->{$sName}), " $sName is not set ");
+        }
+    }
+
+    /**
+     * Tests if formatting discounts
+     *
+     * @return null
+     */
+    public function testFormatDiscountWithDiscountValueIsMoreThanPrice()
+    {
+        $this->getConfig()->setConfigParam('blEnterNetPrice', true);
+        $aTestValues = array('aDiscounts');
+
+        // Changing discount types to % from itm
+        // Changing discount value to 10 (else we have more discount value than price and the assert would fail)
+        foreach ($this->aDiscounts as $oDiscount) {
+            $oDiscount->oxdiscount__oxaddsumtype = new oxField('%', oxField::T_RAW);
+            $oDiscount->oxdiscount__oxaddsum = new oxField(10, oxField::T_RAW);
             $oDiscount->save();
         }
 

--- a/tests/Unit/Core/PriceTest.php
+++ b/tests/Unit/Core/PriceTest.php
@@ -608,4 +608,24 @@ class PriceTest extends \OxidTestCase
         $this->assertFalse($oPrice->isNettoMode());
     }
 
+    /**
+     * Test case for Price::calculateDiscount
+     * It is wrong to subtract a percentual discount from a basic price and use it then for further subtraction of
+     * further percentual discounts
+     *
+     * #6375
+     * @see https://bugs.oxid-esales.com/view.php?id=6375
+     */
+    public function testMultipleDiscounts()
+    {
+        /** @var oxPrice $price */
+        $price = oxNew('oxPrice');
+        $price->setNettoMode(false);
+        $price->setPrice(879.0);
+        $price->setDiscount(10.0, '%');
+        $price->setDiscount(18.0, '%');
+        $price->calculateDiscount();
+
+        $this->assertEquals(632.88, $price->getPrice());
+    }
 }


### PR DESCRIPTION
https://bugs.oxid-esales.com/view.php?id=6375

The commit f3847eca998b95baae2eefc0a21246d3fdb7882f adds the method Price::addDiscount, because the method name setDiscount is misleading. As the commit messages says: "_introduced the method Price::addDiscount as the body of setDiscount adds a discount to an array. But set implies that only one discount can be set._". Therefore I added the tag "@deprecated" to the method header of Price::setDiscount.
If the commit is not conform, please feel free to skip this commit.