### PR TITLE
load language files even without 'charset' key

### DIFF
--- a/source/Core/Language.php
+++ b/source/Core/Language.php
@@ -920,26 +920,23 @@ class Language extends \oxSuperCfg
             $aLang = array();
             $aLangSeoReplaceChars = array();
             foreach ($aLangFiles as $sLangFile) {
-
                 if (file_exists($sLangFile) && is_readable($sLangFile)) {
                     $aSeoReplaceChars = array();
                     include $sLangFile;
 
-                    // including only (!) those, which has charset defined
-                    if (isset($aLang['charset'])) {
+                    $aLang = array_merge(['charset' => 'UTF-8'], $aLang);
 
-                        $aLang = $this->_recodeLangArray($aLang, $aLang['charset']);
+                    $aLang = $this->_recodeLangArray($aLang, $aLang['charset']);
 
-                        if (isset($aSeoReplaceChars) && is_array($aSeoReplaceChars)) {
-                            $aSeoReplaceChars = $this->_recodeLangArray($aSeoReplaceChars, $aLang['charset'], true);
-                        }
-
-                        if (isset($aSeoReplaceChars) && is_array($aSeoReplaceChars)) {
-                            $aLangSeoReplaceChars = array_merge($aLangSeoReplaceChars, $aSeoReplaceChars);
-                        }
-
-                        $aLangCache = array_merge($aLangCache, $aLang);
+                    if (isset($aSeoReplaceChars) && is_array($aSeoReplaceChars)) {
+                        $aSeoReplaceChars = $this->_recodeLangArray($aSeoReplaceChars, $aLang['charset'], true);
                     }
+
+                    if (isset($aSeoReplaceChars) && is_array($aSeoReplaceChars)) {
+                        $aLangSeoReplaceChars = array_merge($aLangSeoReplaceChars, $aSeoReplaceChars);
+                    }
+
+                    $aLangCache = array_merge($aLangCache, $aLang);
                 }
             }
 

--- a/tests/Unit/Core/LangTest.php
+++ b/tests/Unit/Core/LangTest.php
@@ -303,6 +303,54 @@ class LangTest extends \OxidTestCase
         $this->assertEquals($aResult, $oLangFilesData);
     }
 
+    public function testSetCharsetToUtf8IfMissing()
+    {
+        $this->setConfigParam('iUtfMode', 1);
+        $sFilePrefix = md5(uniqid(rand(), true));
+
+        //writing a test lang file
+        $sFilePath = $this->getConfig()->getConfigParam('sCompileDir');
+        file_put_contents($sFilePath . "/baselang$sFilePrefix.txt", '<?php $aLang = array( "TESTKEY" => "value");');
+
+        $aLangFilesPath = array($sFilePath . "/baselang$sFilePrefix.txt");
+
+        $aResult = array(
+            "charset" => "UTF-8",
+            "TESTKEY" => "value",
+            "_aSeoReplaceChars" => [],
+        );
+
+        $oLang = $this->getMock("oxlang", array("_getLangFilesPathArray"));
+        $oLang->expects($this->any())->method('_getLangFilesPathArray')->will($this->returnValue($aLangFilesPath));
+        $oLangFilesData = $oLang->UNITgetLanguageFileData(false, 0);
+
+        $this->assertEquals($aResult, $oLangFilesData);
+    }
+
+    public function testSetCharsetToIsoIfMissing()
+    {
+        $this->setConfigParam('iUtfMode', 0);
+        $sFilePrefix = md5(uniqid(rand(), true));
+
+        //writing a test lang file
+        $sFilePath = $this->getConfig()->getConfigParam('sCompileDir');
+        file_put_contents($sFilePath . "/baselang$sFilePrefix.txt", '<?php $aLang = array( "TESTKEY" => "value");');
+
+        $aLangFilesPath = array($sFilePath . "/baselang$sFilePrefix.txt");
+
+        $aResult = array(
+            "charset" => "ISO-8859-15",
+            "TESTKEY" => "value",
+            "_aSeoReplaceChars" => [],
+        );
+
+        $oLang = $this->getMock("oxlang", array("_getLangFilesPathArray"));
+        $oLang->expects($this->any())->method('_getLangFilesPathArray')->will($this->returnValue($aLangFilesPath));
+        $oLangFilesData = $oLang->UNITgetLanguageFileData(false, 0);
+
+        $this->assertEquals($aResult, $oLangFilesData);
+    }
+
     public function testGetLanguageFileDataInUtfMode()
     {
         $this->setConfigParam('iUtfMode', 1);


### PR DESCRIPTION
Language files without the `charset` key are not included, e.g.
```php
<?php
$sLangName = "English";
$aLang = [
    'KEY' => 'value',
];
```