### PR TITLE
new apache 2.4 auth syntax

### DIFF
--- a/source/.htaccess
+++ b/source/.htaccess
@@ -1,16 +1,3 @@
-# In case you want to add a .htpasswd authentification
-# you'll have to add the host of the shop as an allowed entity,
-# so that calls from the host skip the authentification
-# Example:
-# Order Deny,Allow
-# Deny from All
-# AuthType Basic
-# AuthName "Access not allowed"
-# AuthUserFile path_to_htpasswd_file/.htpasswd
-# Require valid-user
-# Allow from localhost
-# Satisfy Any
-
 <IfModule mod_rewrite.c>
     Options +FollowSymLinks
     RewriteEngine On
@@ -50,14 +37,24 @@
 
 # disabling log file access from outside
 <FilesMatch "(EXCEPTION_LOG\.txt|\.log|\.tpl|pkg\.rev|\.ini|pkg\.info|\.pem|composer\.json|composer\.lock|test_config\.yml)$">
-    order allow,deny
-    deny from all
+   <IfModule mod_authz_core.c>   
+       Require all denied
+   </IfModule>
+   <IfModule !mod_authz_core.c>
+       Order allow,deny
+       Deny from all   
+   </IfModule>
 </FilesMatch>
 
-# Prevent .ht* files from being sended to outside requests
+# Prevent .ht* files from being sent to outside requests
 <Files ~ "^\.ht">
-    Order allow,deny
-    Deny from all
+    <IfModule mod_authz_core.c>
+        Require all denied
+    </IfModule>
+    <IfModule !mod_authz_core.c>
+        Order allow,deny
+        Deny from all
+    </IfModule>
 </Files>
 
 Options -Indexes

--- a/source/Application/views/admin/tpl/.htaccess
+++ b/source/Application/views/admin/tpl/.htaccess
@@ -1,5 +1,14 @@
 <Files ~ ".*">
-  deny from all
+    <IfModule mod_authz_core.c>
+        Require all denied
+    </IfModule>
+    <IfModule !mod_authz_core.c>
+        Order allow,deny
+        Deny from all
+    </IfModule>
 </Files>
 Options Indexes
-order deny,allow
+<IfModule !mod_authz_core.c>
+    Order deny,allow
+</IfModule>
+

--- a/source/bin/.htaccess
+++ b/source/bin/.htaccess
@@ -1,5 +1,10 @@
 # disabling file access
 <FilesMatch ".*">
- order allow,deny
- deny from all
+    <IfModule mod_authz_core.c>
+        Require all denied
+    </IfModule>
+    <IfModule !mod_authz_core.c>
+        Order allow,deny
+        Deny from all
+    </IfModule>
 </FilesMatch>

--- a/source/cache/.htaccess
+++ b/source/cache/.htaccess
@@ -1,7 +1,12 @@
 # disabling file access
 <FilesMatch .*>
-order allow,deny
-deny from all
+    <IfModule mod_authz_core.c>
+        Require all denied
+    </IfModule>
+    <IfModule !mod_authz_core.c>
+        Order allow,deny
+        Deny from all
+    </IfModule>
 </FilesMatch>
 
 Options -Indexes

--- a/source/log/.htaccess
+++ b/source/log/.htaccess
@@ -1,7 +1,12 @@
 # disabling log file access from outside
 <FilesMatch .*>
-order allow,deny
-deny from all
+    <IfModule mod_authz_core.c>
+        Require all denied
+    </IfModule>
+    <IfModule !mod_authz_core.c>
+        Order allow,deny
+        Deny from all
+    </IfModule>
 </FilesMatch>
 
 Options -Indexes

--- a/source/out/downloads/.htaccess
+++ b/source/out/downloads/.htaccess
@@ -1,1 +1,7 @@
-deny from all
+<IfModule mod_authz_core.c>
+    Require all denied
+</IfModule>
+<IfModule !mod_authz_core.c>
+    Order allow,deny
+    Deny from all
+</IfModule>

--- a/source/tmp/.htaccess
+++ b/source/tmp/.htaccess
@@ -1,7 +1,12 @@
 # disabling file access
 <FilesMatch .*>
-order allow,deny
-deny from all
+    <IfModule mod_authz_core.c>
+        Require all denied
+    </IfModule>
+    <IfModule !mod_authz_core.c>
+        Order allow,deny
+        Deny from all
+    </IfModule>
 </FilesMatch>
 
 Options -Indexes


### PR DESCRIPTION
This pull request makes oxid esales compatible with apache 2.4 and above and will keep it compatible older versions.
- fix .htaccess typo
- new apache 2.4 syntax for auth.
