### PR TITLE
Fix missing DIRECTORY_SEPARATOR in mysqli driver

### DIFF
--- a/source/core/adodblite/adodbSQL_drivers/mysqli/mysqli_driver.inc
+++ b/source/core/adodblite/adodbSQL_drivers/mysqli/mysqli_driver.inc
@@ -391,7 +391,7 @@ class mysqli_driver_ADOConnection extends ADOConnection
 	} 
 }
 
-require_once __DIR__ . '..' . DIRECTORY_SEPARATOR. '..' . DIRECTORY_SEPARATOR. '..' . DIRECTORY_SEPARATOR. 'interface' . DIRECTORY_SEPARATOR. 'ResultSetInterface.php';
+require_once __DIR__ . DIRECTORY_SEPARATOR . '..' . DIRECTORY_SEPARATOR. '..' . DIRECTORY_SEPARATOR. '..' . DIRECTORY_SEPARATOR. 'interface' . DIRECTORY_SEPARATOR. 'ResultSetInterface.php';
 
 class mysqli_driver_ResultSet implements IteratorAggregate, \OxidEsales\Eshop\Core\Database\Adapter\ResultSetInterface
 {


### PR DESCRIPTION
The mysqli driver in the current `b-5.3-ce`-branch is not working because there is a slash (DIRECTORY_SEPARATOR) missing in the `require_once`-path (file mysqli_driver.inc).