### PR TITLE
add semicolon to html entity

### DIFF
--- a/source/Application/views/admin/tpl/discount_list.tpl
+++ b/source/Application/views/admin/tpl/discount_list.tpl
@@ -72,7 +72,7 @@ window.onload = function ()
             [{if $listitem->getId() == $oxid}]
                 [{assign var="listclass" value=listitem4}]
             [{/if}]
-            <td valign="top" class="[{$listclass}][{if $listitem->oxdiscount__oxactive->value == 1}] active[{/if}]" height="15"><div class="listitemfloating">&nbsp</a></div></td>
+            <td valign="top" class="[{$listclass}][{if $listitem->oxdiscount__oxactive->value == 1}] active[{/if}]" height="15"><div class="listitemfloating">&nbsp;</a></div></td>
             <td valign="top" class="[{$listclass}]" height="15"><div class="listitemfloating">&nbsp;<a href="Javascript:top.oxid.admin.editThis('[{$listitem->oxdiscount__oxid->value}]');" class="[{$listclass}]">[{$listitem->oxdiscount__oxtitle->value}]</a></div></td>
             <td class="[{$listclass}]">
             [{if !$readonly}]


### PR DESCRIPTION
Html entity should/must be followed by an ;
http://stackoverflow.com/questions/18689230/why-do-html-entity-names-with-dec-255-not-require-semicolon