### PR TITLE
PSR3 Logger Interface Support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,6 +11,7 @@
     "require": {
         "phpmailer/phpmailer": "^5.2.14",
         "smarty/smarty": "^2.6.30",
+        "keywan-ghadami/monolog-configuration": "^1.1.0",
         "oxid-esales/oxideshop-composer-plugin": "dev-master",
         "oxid-esales/flow-theme": "dev-master"
     },

--- a/monolog.dist.yaml
+++ b/monolog.dist.yaml
@@ -1,0 +1,28 @@
+# Monolog Configuration File
+# see https://github.com/keywan-ghadami-oxid/monolog-configuration/wiki
+# use monolog.yaml instead of monolog.dist.yaml
+# to protect it from beeing overridden by updates
+loggers:
+   default:
+      handlers: [stderr,LogFileOxid]
+      processors: [PsrLogMessageProcessor]
+      use_microseconds: true
+handlers:
+   stderr:
+       type: stream
+       file: 'php://stderr'
+       level: error
+   LogFileOxid:
+       type: stream
+       file: 'log/oxid.log'
+       level: info
+#### For legacy use if you need the EXCEPTION_LOG.txt 
+# you can uncomment the following 4 Lines and add EXCEPTION_LOG to the list of handlers in the default channel
+#   EXCEPTION_LOG:
+#       type: stream
+#       file: 'log/EXCEPTION_LOG.txt'
+#       level: error
+##
+processors:
+   PsrLogMessageProcessor:
+       class: PsrLogMessageProcessor

--- a/source/Core/CompanyVatInChecker.php
+++ b/source/Core/CompanyVatInChecker.php
@@ -22,14 +22,17 @@
 
 namespace OxidEsales\Eshop\Core;
 
+use Psr\Log\LoggerAwareInterface;
+use Psr\Log\LoggerAwareTrait;
 use oxCompanyVatIn;
 
 /**
  * Company VAT identification number (VATIN) checker
  *
  */
-abstract class CompanyVatInChecker
+abstract class CompanyVatInChecker implements LoggerAwareInterface
 {
+     use LoggerAwareTrait;
 
     /**
      * Error message

--- a/source/Core/Exception/StandardException.php
+++ b/source/Core/Exception/StandardException.php
@@ -23,27 +23,24 @@
 namespace OxidEsales\Eshop\Core\Exception;
 
 use oxRegistry;
+use Psr\Log\LoggerAwareTrait;
+use Psr\Log\LoggerInterface;
+use Psr\Log\LoggerAwareInterface;
 
 /**
  * Basic exception class
  *
  */
-class StandardException extends \Exception
+class StandardException extends \Exception implements LoggerAwareInterface
 {
+    use LoggerAwareTrait;
+
     /**
      * Exception type, currently old class name is used.
      *
      * @var string
      */
     protected $type = 'oxException';
-
-    /**
-     * Log file path/name
-     * @deprecated since v5.3 (2016-06-17); Logging mechanism will be changed in 6.0.
-     *
-     * @var string
-     */
-    protected $_sFileName = 'EXCEPTION_LOG.txt';
 
     /**
      * Not caught means the exception was not caught and occured in the rendering process,
@@ -69,31 +66,9 @@ class StandardException extends \Exception
     public function __construct($sMessage = "not set", $iCode = 0)
     {
         parent::__construct($sMessage, $iCode);
+        $this->setLogger(oxRegistry::get('Logger'));
     }
 
-    /**
-     * Set log file path/name
-     *
-     * @deprecated since v5.3 (2016-06-17); Logging mechanism will be changed in 6.0.
-     *
-     * @param string $sFile File name
-     */
-    public function setLogFileName($sFile)
-    {
-        $this->_sFileName = $sFile;
-    }
-
-    /**
-     * Get log file path/name
-     *
-     * @deprecated since v5.3 (2016-06-17); Logging mechanism will be changed in 6.0.
-     *
-     * @return string
-     */
-    public function getLogFileName()
-    {
-        return $this->_sFileName;
-    }
 
     /**
      * Sets the exception message
@@ -149,10 +124,10 @@ class StandardException extends \Exception
         //We are most likely are already dealing with an exception so making sure no other exceptions interfere
         try {
             $sLogMsg = $this->getString() . "\n---------------------------------------------\n";
-            //deprecated since v5.3 (2016-06-17); Logging mechanism will be changed in 6.0.
-            oxRegistry::getUtils()->writeToLog($sLogMsg, $this->getLogFileName());
-            //end deprecated
+            $this->logger->error($sLogMsg);
         } catch (\Exception $e) {
+            //TODO log some basic information e.g.
+            //original error name/class and error during logging that error to some very basic place e.g. STDERR
         }
     }
 

--- a/source/Core/OnlineVatIdCheck.php
+++ b/source/Core/OnlineVatIdCheck.php
@@ -177,13 +177,7 @@ class OnlineVatIdCheck extends \oxCompanyVatInChecker
     {
         // message to write to exception log
         $sLogMessage = "Warning: $sErrStr in $sErrFile on line $iErrLine";
-
-        // fetching exception log file name
-        $oEx = oxNew("oxException");
-        $sLogFileName = $oEx->getLogFileName();
-
-        // logs error message
-        return oxRegistry::getUtils()->writeToLog($sLogMessage, $sLogFileName);
+        $this->logger->error($sLogMessage);      
     }
 
     /**

--- a/source/Core/SuperConfig.php
+++ b/source/Core/SuperConfig.php
@@ -27,13 +27,21 @@ use oxRegistry;
 use oxSession;
 use oxSystemComponentException;
 use oxUser;
+use Psr\Log\LoggerAwareTrait;
+use Psr\Log\LoggerInterface;
+use Psr\Log\LoggerAwareInterface;
 
 /**
- * Super config class
+ * Super config class is the base class of most classes in Oxid
+ * it provided some basic access to things like 
+ * config,session,current user and rights,admin(in backend) mode
+ * usually all objects based on this class should be created with oxNew
+ * so dependencies can get injected and classes can be overloaded by modules.
  */
-class SuperConfig
+class SuperConfig implements LoggerAwareInterface
 {
-
+    use LoggerAwareTrait;
+    
     /**
      * oxconfig instance
      *
@@ -101,6 +109,13 @@ class SuperConfig
      */
     public function __construct()
     {
+       /* because not all objects that extending this are initialised by oxNew
+       the logger can not always be set by dependency injection */
+       if (Registry::instanceExists('Logger')){
+          $this->logger = Registry::get('Logger');
+       }
+       // do not use the Logger within this constructor
+       // because it can't guaranteed that it was already created
     }
 
     /**

--- a/source/Core/Utils.php
+++ b/source/Core/Utils.php
@@ -1137,6 +1137,14 @@ class Utils extends \oxSuperCfg
     public function showMessageAndExit($sMsg)
     {
         $this->prepareToExit();
+        if (defined('OXID_PHP_UNIT')) {
+            //do not allow calling exit in a unit tests because this will stop all tests
+            //without error report. test code should always mock this method and must not depend on this exception
+            //it is only a protection against incompatible tests
+            // - with one exception the test that tests this method is allowed to check for this exception.
+            throw new \Exception("attempt to call exit from within a phpunit test");
+        }
+
         exit($sMsg);
     }
 

--- a/source/Core/UtilsObject.php
+++ b/source/Core/UtilsObject.php
@@ -28,6 +28,8 @@ use oxSystemComponentException;
 use oxUtilsObject;
 use ReflectionClass;
 use ReflectionException;
+use Psr\Log\LoggerAwareInterface;
+use Psr\Log\LoggerInterface;
 
 /**
  * Object Factory implementation (oxNew() method is implemented in this class).
@@ -80,6 +82,9 @@ class UtilsObject
 
     /** @var ShopIdCalculator */
     private $shopIdCalculator;
+   
+    /** @var LoggerInterface */
+    private $logger;
 
     /**
      * @param ClassNameProvider       $classNameProvider
@@ -88,6 +93,8 @@ class UtilsObject
      */
     public function __construct($classNameProvider = null, $moduleChainsGenerator = null, $shopIdCalculator = null)
     {
+        $this->logger = Registry::get('Logger');       
+        
         if (!$classNameProvider) {
             $classMapProvider = new ClassMapProvider(new EditionSelector());
             $classNameProvider = new ClassNameProvider($classMapProvider->getOverridableClassMap());
@@ -270,6 +277,13 @@ class UtilsObject
         }
 
         $object = $this->_getObject($realClassName, $argumentsCount, $arguments);
+
+        //setting the Logger by dependency injection because it's the PSR3 standard way and makes other objects independent
+        //of the architecture
+        if ($object instanceof LoggerAwareInterface) {
+            $object->setLogger($this->logger);
+        }
+
         if ($shouldUseCache && $object instanceof oxBase) {
             self::$_aInstanceCache[$cacheKey] = clone $object;
         }

--- a/source/bootstrap.php
+++ b/source/bootstrap.php
@@ -47,7 +47,10 @@ registerComposerAutoload();
 
 //init config.inc.php file reader
 $oConfigFile = new ConfigFile(OX_BASE_PATH . "config.inc.php");
-Registry::set("oxConfigFile", $oConfigFile);
+Registry::set('oxConfigFile', $oConfigFile);
+$lf = createLoggerFactory();
+Registry::set('LoggerFactory', $lf);
+Registry::set('Logger', $lf->getLogger());
 
 registerModuleDependenciesAutoload();
 registerShopAutoLoad();

--- a/source/oxfunctions.php
+++ b/source/oxfunctions.php
@@ -23,6 +23,28 @@
 use OxidEsales\Eshop\Core\Registry;
 use OxidEsales\Eshop\Core\Request;
 
+if (!function_exists('createLoggerFactory')) {
+    /**
+     * Creates the loggerFactory
+     * this method is used to make it possible to customize behavior by providing a custom
+     * createRootLogger function in modules/functions.php
+     * @return LoggerFactoryInterface 
+     */
+    function createLoggerFactory() {
+        $config = Registry::get("oxConfigFile");
+        $path = $config->getVar('sShopDir');
+        $rootDir = dirname($path);
+        if(defined('OXID_PHP_UNIT')){
+             $rootDir .= '/tests';
+        }
+        $vars['monolog_config_dir'] = $rootDir;
+        $vars['kernel.root_dir'] = $path;
+        $vars['kernel.logs_dir'] = $path . '/log';
+        
+        return new \Monolog\Configuration\MonologFactory($vars);
+    }
+}
+
 if (!function_exists('registerComposerAutoload')) {
     /**
      * Registers auto-loader for shop namespaced classes.

--- a/tests/Unit/Core/ExceptionTest.php
+++ b/tests/Unit/Core/ExceptionTest.php
@@ -20,6 +20,8 @@
  * @version   OXID eShop CE
  */
 namespace Unit\Core;
+use Psr\Log\NullLogger;
+use Psr\Log\LoggerInterface;
 
 class ExceptionTest extends \OxidTestCase
 {
@@ -40,64 +42,21 @@ class ExceptionTest extends \OxidTestCase
         $this->assertTrue($oTestObject->getMessage() === $sMsg);
     }
 
-    public function testSetGetLogFileName()
-    {
-        $oTestObject = oxNew('oxException');
-        $oTestObject->setLogFileName('TEST.log');
-        $this->assertEquals('TEST.log', $oTestObject->getLogFileName());
-    }
 
     // Test log file output
     public function testDebugOut()
     {
         $sMsg = 'Erik was here..';
-        $sFileName = 'oxexceptionsTest_test_debugOut.txt';
         $oTestObject = oxNew('oxException', $sMsg);
-        $oTestObject->setLogFileName($sFileName);
+        $logger = $this->getMock(NullLogger::class, ['error']);
+        $this->assertInstanceOf(NullLogger::class, $logger);
+        $this->assertInstanceOf('Psr\Log\LoggerInterface', $logger);
+
+        $logger->expects($this->once())->method('error')->with($this->matchesRegularExpression("/oxException.*$sMsg/"));
+        $oTestObject->setLogger($logger);
+        
         $this->assertEquals('OxidEsales\Eshop\Core\Exception\StandardException', get_class($oTestObject));
-
-        try {
-            $oTestObject->debugOut(1); // actuall test
-        } catch (Exception $e) {
-            // Lets try to delete an eventual left over file
-            unlink($this->getConfig()->getConfigParam('sShopDir') . 'log/' . $sFileName);
-            $this->fail();
-
-            return;
-        }
-        $sFile = file_get_contents($this->getConfig()->getConfigParam('sShopDir') . 'log/' . $sFileName);
-        unlink($this->getConfig()->getConfigParam('sShopDir') . 'log/' . $sFileName);
-        // we check on class name and message - rest is not checked yet
-        $this->assertContains($sMsg, $sFile);
-        $this->assertContains('oxException', $sFile);
-    }
-
-    /**
-     * A test for bug #1465
-     *
-     */
-    public function testDebugOutNoDebug()
-    {
-        $sMsg = 'Erik was here..';
-        $sFileName = 'oxexceptionsTest_test_debugOut.txt';
-        $oTestObject = oxNew('oxException', $sMsg);
-        $oTestObject->setLogFileName($sFileName);
-        $this->assertEquals('OxidEsales\Eshop\Core\Exception\StandardException', get_class($oTestObject));
-
-        try {
-            $oTestObject->debugOut(0); // actuall test
-        } catch (Exception $e) {
-            // Lets try to delete an eventual left over file
-            unlink($this->getConfig()->getConfigParam('sShopDir') . 'log/' . $sFileName);
-            $this->fail();
-
-            return;
-        }
-        $sFile = file_get_contents($this->getConfig()->getConfigParam('sShopDir') . 'log/' . $sFileName);
-        unlink($this->getConfig()->getConfigParam('sShopDir') . 'log/' . $sFileName);
-        // we check on class name and message - rest is not checked yet
-        $this->assertContains($sMsg, $sFile);
-        $this->assertContains('oxException', $sFile);
+        $oTestObject->debugOut();               
     }
 
     // Test set & get message

--- a/tests/Unit/Core/ExceptionhandlerTest.php
+++ b/tests/Unit/Core/ExceptionhandlerTest.php
@@ -21,10 +21,11 @@
  */
 namespace Unit\Core;
 
-use \Exception;
+use Exception;
+use OxidEsales\Eshop\Core\Registry;
 use oxSystemComponentException;
-use \oxTestModules;
-
+use oxTestModules;
+use Psr\Log\NullLogger;
 class ExceptionhandlerTest extends \OxidTestCase
 {
 
@@ -37,80 +38,63 @@ class ExceptionhandlerTest extends \OxidTestCase
         $oExcpHandler->__test__();
     }
 
-    public function testSetGetFileName()
-    {
-        $oTestObject = oxNew('oxexceptionhandler');
-        $oTestObject->setLogFileName('TEST.log');
-        $this->assertEquals('TEST.log', $oTestObject->getLogFileName());
-    }
-
+    
     // still incomplete
     // We can only test if a log file is written - screen output must be checked manually or with selenium
     public function testExceptionHandlerNotRendererDebug()
     {
-        $sFileName = 'oxexceptionhandlerTest_NotRenderer.txt';
+        
         $oExc = oxNew('oxexception', $this->_sMsg);
         $oTestObject = oxNew('oxexceptionhandler', '1'); // iDebug = 1
-        $oTestObject->setLogFileName($sFileName);
-
-        try {
-            $sMsg = $oTestObject->handleUncaughtException($oExc); // actuall test
-            $this->assertNotEquals($this->_sMsg, $sMsg);
-        } catch (Exception $e) {
-            // Lets try to delete an possible left over file
-            if (file_exists($this->getConfig()->getConfigParam('sShopDir') . 'log/' . $sFileName)) {
-                unlink($this->getConfig()->getConfigParam('sShopDir') . 'log/' . $sFileName);
-            }
-            $this->fail('handleUncaughtException() throws an exception.');
-        }
-        if (!file_exists($this->getConfig()->getConfigParam('sShopDir') . 'log/' . $sFileName)) {
-            $this->fail('No debug log file written');
-        }
-        $sFile = file_get_contents($this->getConfig()->getConfigParam('sShopDir') . 'log/' . $sFileName);
-        unlink($this->getConfig()->getConfigParam('sShopDir') . 'log/' . $sFileName); // delete file first as assert may return out this function
-        // we check on class name and message - rest is not checked yet
-        $this->assertContains($this->_sMsg, $sFile);
-        $this->assertContains('Exception', $sFile);
+        $logger = $this->getMock(NullLogger::class, ['error']);
+        
+        $logger->expects($this->once())->method('error');
+        $oExc->setLogger($logger);
+        
+        $this->expectShowMessageAndExit();
+       
+        $sMsg = $oTestObject->handleUncaughtException($oExc); // actual test
+        $this->assertNotEquals($this->_sMsg, $sMsg);
+        
+       
     }
 
     // We can only test if a log file is not written - screen output must be checked manually or with selenium
     public function testExceptionHandlerNotRendererNoDebug()
     {
-        $sFileName = 'oxexceptionhandlerTest_NotRenderer.txt';
+        $this->expectOffline();
         $oExc = oxNew('oxexception', $this->_sMsg);
-        $oTestObject = oxNew('oxexceptionhandler');
-        $oTestObject->setLogFileName($sFileName);
+        $oTestObject = oxNew('oxexceptionhandler');            
+        $oTestObject->handleUncaughtException($oExc); // actual test
+    }
 
-        try {
-            $oTestObject->handleUncaughtException($oExc); // actuall test
-        } catch (Exception $e) {
-            // Lets try to delete an possible left over file
-            if (file_exists($sFileName)) {
-                unlink($sFileName);
-            }
-            $this->fail('handleUncaughtException() throws an exception.');
-        }
-        if (file_exists($sFileName)) {
-            $this->fail('Illegally written in log file.');
-            @unlink($sFileName); // delete file first as assert may return out this function
-        }
+    private function expectShowMessageAndExit()
+    {
+        $this->expectUtilsMethod('showMessageAndExit');
     }
 
     public function testExceptionHandlerNotRendererDebugNotOxidException()
     {
-        $sFileName = 'oxexceptionhandlerTest_NotRenderer.txt';
+       
         $oTestObject = oxNew('oxexceptionhandler', '1'); // iDebug = 1
-        $oTestObject->setLogFileName($sFileName);
+        $this->expectShowMessageAndExit();
 
-        $oTestObject->handleUncaughtException(new Exception("test exception"));
-        if (!file_exists($this->getConfig()->getConfigParam('sShopDir') . 'log/' . $sFileName)) {
-            $this->fail('No debug log file written');
-        }
-        $sFile = file_get_contents($this->getConfig()->getConfigParam('sShopDir') . 'log/' . $sFileName);
-        unlink($this->getConfig()->getConfigParam('sShopDir') . 'log/' . $sFileName); // delete file first as assert may return out this function
-        $this->assertContains("test exception", $sFile);
-        $this->assertContains('Exception', $sFile);
+        $oTestObject->handleUncaughtException(new Exception("test exception"));      
     }
+
+    private function expectOffline()
+    {
+        $this->expectUtilsMethod('redirectOffline');
+    }
+
+    private function expectUtilsMethod($methodName)
+    {
+        /** @var oxUtils|PHPUnit_Framework_MockObject_MockObject $utilsMock */
+        $utilsMock = $this->getMock('oxUtils', array($methodName));
+        $utilsMock->expects($this->once())->method($methodName);
+        Registry::set('oxUtils', $utilsMock);
+    }
+
 
     public function testSetIDebug()
     {
@@ -122,20 +106,10 @@ class ExceptionhandlerTest extends \OxidTestCase
 
     public function testDealWithNoOxException()
     {
-        $oTestObject = $this->getProxyClass("oxexceptionhandler");
-        $oTestObject->setIDebug(-1);
-
-        $oTestUtils = $this->getMock("oxUtils", array("writeToLog", "showMessageAndExit", "getTime"));
-        $oTestUtils->expects($this->once())->method("writeToLog");
-        $oTestException = new Exception("testMsg");
-
-        oxTestModules::addModuleObject('oxUtils', $oTestUtils);
-
-        try {
-            $oTestObject->UNITdealWithNoOxException($oTestException);
-        } catch (Exception $e) {
-
-        }
+        $oTestObject = oxNew("oxexceptionhandler",'-1');
+        $this->expectShowMessageAndExit();       
+        $oTestException = new Exception("testMsg");       
+        $oTestObject->UNITdealWithNoOxException($oTestException);
     }
 
 }

--- a/tests/Unit/Core/OnlineModuleVersionNotifierTest.php
+++ b/tests/Unit/Core/OnlineModuleVersionNotifierTest.php
@@ -21,7 +21,7 @@
  */
 namespace Unit\Core;
 
-use \oxOnlineModuleVersionNotifier;
+use oxOnlineModuleVersionNotifier;
 
 class OnlineModuleVersionNotifierTest extends \OxidTestCase
 {
@@ -36,6 +36,7 @@ class OnlineModuleVersionNotifierTest extends \OxidTestCase
         $oModuleList->expects($this->any())->method('getList')->will($this->returnValue(array($oModule)));
 
         $oNotifier = new oxOnlineModuleVersionNotifier($oCaller, $oModuleList);
+        // does not yet use logger $oNotifier->setLogger(new \Psr\Log\NullLogger());
         $oNotifier->versionNotify();
     }
 }

--- a/tests/Unit/Core/OnlineVatIdCheckTest.php
+++ b/tests/Unit/Core/OnlineVatIdCheckTest.php
@@ -21,10 +21,10 @@
  */
 namespace Unit\Core;
 
-use \stdClass;
-use \oxCompanyVatIn;
-use \oxTestModules;
-
+use stdClass;
+use oxCompanyVatIn;
+use oxTestModules;
+use Psr\Log\NullLogger;
 class OnlineVatIdCheckTest extends \OxidTestCase
 {
 
@@ -43,12 +43,11 @@ class OnlineVatIdCheckTest extends \OxidTestCase
      */
     public function testCatchWarning()
     {
-        oxTestModules::addFunction('oxUtils', 'writeToLog', '{ return $aA; }');
-
         $oOnlineVatIdCheck = oxNew('oxOnlineVatIdCheck');
-        $aResult = $oOnlineVatIdCheck->catchWarning(1, 1, 1, 1);
-
-        $this->assertEquals(array("Warning: 1 in 1 on line 1", "EXCEPTION_LOG.txt"), $aResult);
+        $logger = $this->getMock(NullLogger::class);
+        $logger->expects($this->once())->method('error')->with("Warning: best shop system found in allShops.list on line 1");
+        $oOnlineVatIdCheck->setLogger($logger);
+        $aResult = $oOnlineVatIdCheck->catchWarning(1, "best shop system found", "allShops.list", 1);
     }
 
     /**
@@ -59,7 +58,7 @@ class OnlineVatIdCheckTest extends \OxidTestCase
         $oOnlineVatIdCheck = $this->getMock("oxOnlineVatIdCheck", array("_checkOnline", "_getError"));
         $oOnlineVatIdCheck->expects($this->once())->method('_checkOnline')->will($this->returnValue(false));
         $oOnlineVatIdCheck->expects($this->once())->method('_getError')->will($this->returnValue(false));
-
+        $oOnlineVatIdCheck->setLogger(new NullLogger());
         $this->setExpectedException('Exception', 'VAT_MESSAGE_ID_NOT_VALID');
         $oOnlineVatIdCheck->checkUid("testVatId");
     }
@@ -89,6 +88,7 @@ class OnlineVatIdCheckTest extends \OxidTestCase
         $oCheckVat->vatNumber = '123456789';
 
         $oOnlineVatCheck = $this->getMock('oxOnlineVatIdCheck', array('_checkOnline'));
+        $oOnlineVatCheck->setLogger(new NullLogger());
         $oOnlineVatCheck->expects($this->never())->method('_checkOnline');
 
         $this->setExpectedException('oxConnectionException', 'VAT_MESSAGE_SERVER_BUSY');
@@ -126,7 +126,7 @@ class OnlineVatIdCheckTest extends \OxidTestCase
         $oOnlineVatCheck = $this->getMock('oxOnlineVatIdCheck', array('_checkOnline', '_getError'));
         $oOnlineVatCheck->expects($this->once())->method('_checkOnline')->will($this->returnValue(false));
         $oOnlineVatCheck->expects($this->once())->method('_getError')->will($this->returnValue('INVALID_INPUT'));
-
+        $oOnlineVatCheck->setLogger(new NullLogger());
         $this->setExpectedException('oxInputException', 'VAT_MESSAGE_INVALID_INPUT');
         $this->assertTrue($oOnlineVatCheck->checkUid('DE123456789'));
     }
@@ -143,7 +143,7 @@ class OnlineVatIdCheckTest extends \OxidTestCase
         $oOnlineVatCheck = $this->getMock('oxOnlineVatIdCheck', array('_checkOnline', '_getError'));
         $oOnlineVatCheck->expects($this->once())->method('_checkOnline')->will($this->returnValue(false));
         $oOnlineVatCheck->expects($this->once())->method('_getError')->will($this->returnValue('MY_ERROR_MSG'));
-
+        $oOnlineVatCheck->setLogger(new NullLogger());
         $this->setExpectedException('oxConnectionException', 'VAT_MESSAGE_MY_ERROR_MSG');
         $this->assertTrue($oOnlineVatCheck->checkUid('DE123456789'));
     }
@@ -195,6 +195,7 @@ class OnlineVatIdCheckTest extends \OxidTestCase
         $oCheckVat->vatNumber = '111111';
 
         $oOnlineVatCheck = $this->getProxyClass('oxOnlineVatIdCheck');
+        $oOnlineVatCheck->setLogger(new NullLogger());
         if (!$oOnlineVatCheck->UNITisServiceAvailable()) {
             $this->markTestSkipped('VAT check service is not available');
         }
@@ -217,6 +218,7 @@ class OnlineVatIdCheckTest extends \OxidTestCase
         $oCheckVat->vatNumber = '111111';
 
         $oOnlineVatCheck = $this->getProxyClass('oxOnlineVatIdCheck');
+        $oOnlineVatCheck->setLogger(new NullLogger());
         if (!$oOnlineVatCheck->UNITisServiceAvailable()) {
             $this->markTestSkipped('VAT check service is not available');
         }
@@ -238,6 +240,7 @@ class OnlineVatIdCheckTest extends \OxidTestCase
     public function testCheckOnlineWithServiceNotReachable()
     {
         $oOnlineVatIdCheck = $this->getMock($this->getProxyClassName("oxOnlineVatIdCheck"), array("_isServiceAvailable"));
+        $oOnlineVatIdCheck->setLogger(new NullLogger());
         $oOnlineVatIdCheck->expects($this->once())->method('_isServiceAvailable')->will($this->returnValue(false));
 
         $this->assertEquals(false, $oOnlineVatIdCheck->UNITcheckOnline(new stdClass()));
@@ -251,7 +254,7 @@ class OnlineVatIdCheckTest extends \OxidTestCase
     {
         $oOnlineVatCheck = $this->getProxyClass('oxOnlineVatIdCheck');
         $oOnlineVatCheck->setNonPublicVar('_sError', null);
-
+        $oOnlineVatCheck->setLogger(new NullLogger());
         $this->assertSame('', $oOnlineVatCheck->UNITgetError());
     }
 
@@ -261,6 +264,7 @@ class OnlineVatIdCheckTest extends \OxidTestCase
     public function testGetErrorWithError()
     {
         $oOnlineVatCheck = $this->getProxyClass('oxOnlineVatIdCheck');
+        $oOnlineVatCheck->setLogger(new NullLogger());
         $sErrMsg = "soapenv:Server.userException: javax.xml.rpc.soap.SOAPFaultException: { 'INVALID_INPUT' }";
         $oOnlineVatCheck->setNonPublicVar('_sError', $sErrMsg);
 
@@ -273,6 +277,7 @@ class OnlineVatIdCheckTest extends \OxidTestCase
     public function testGetErrorWithUnknownErrorMsg()
     {
         $oOnlineVatCheck = $this->getProxyClass('oxOnlineVatIdCheck');
+        $oOnlineVatCheck->setLogger(new NullLogger());
         $sErrMsg = "soapenv:Server.userException: bla bla bla bla ";
         $oOnlineVatCheck->setNonPublicVar('_sError', $sErrMsg);
 
@@ -320,6 +325,7 @@ class OnlineVatIdCheckTest extends \OxidTestCase
         $oExpect->vatNumber = '1212';
 
         $oOnlineVatCheck = $this->getMock('oxOnlineVatIdCheck', array('_checkOnline'));
+        $oOnlineVatCheck->setLogger(new NullLogger());
         $oOnlineVatCheck->expects($this->once())->method('_checkOnline')->with($this->equalTo($oExpect));
 
         $oOnlineVatCheck->validate($oVatIn);
@@ -334,6 +340,7 @@ class OnlineVatIdCheckTest extends \OxidTestCase
         $oExpect->vatNumber = '1212';
 
         $oOnlineVatCheck = $this->getMock('oxOnlineVatIdCheck', array('_checkOnline'));
+        $oOnlineVatCheck->setLogger(new NullLogger());
         $oOnlineVatCheck->expects($this->once())->method('_checkOnline')->with($this->equalTo($oExpect))->will($this->returnValue(false));
 
         $this->assertFalse($oOnlineVatCheck->validate($oVatIn));

--- a/tests/monolog.dist.yaml
+++ b/tests/monolog.dist.yaml
@@ -1,0 +1,8 @@
+loggers:
+    default: 
+        handlers:
+            - SilentTesting
+handlers:
+    SilentTesting:
+        type: 'Null'
+


### PR DESCRIPTION
This pull requests adds the PSR3 (Logger) support

The logger will be available by
1. a logger property on all objects extding the base class SuperConfig.
2. Aditionally all classes that are instanced via oxNew can get the logger object injected
   they only need to implement the setLogger method by using Psr\Log\LoggerAwareInterface.
3. Also the Logger will be stored internally in the Registry but i suggest not to use
   Registry.get('Logger') within modules in favor of first and second method.
4. By using the LoggerFactory
   Registry.get('LoggerFactory')->getLogger('SpecialLoggerName');
   Use this method when you need to log something special, that should be logged into other places/files then other log messages.

The monolog configuration file monolog.yaml and the monolog.dist.yaml can be used to configure the logger
this configuration functionallity is be provided by the monolog configuration library
see https://github.com/keywan-ghadami-oxid/monolog-configuration for documentation.
