### PR TITLE
allowing minibasket on privatesales login page

### DIFF
--- a/source/Application/Component/UserComponent.php
+++ b/source/Application/Component/UserComponent.php
@@ -94,7 +94,9 @@ class UserComponent extends \oxView
         'content',
         'account',
         'clearcookies',
-        'oxwServiceMenu',
+        //allowing some widgets so login page can use same layout as the normal shop
+        'oxwservicemenu',
+        'oxwminibasket',
     );
 
     /**


### PR DESCRIPTION
allowing minibasket and menu on privatesales login page so the login page so it can have the same layout then other pages.
The mini basket will of cause be empty, but it enables to reuse template structure by including the default page layout within the private sales login page:

```
[{include file="layout/page.tpl"}]
```

without this PR, developers will end up in infinitive loops because the privatesales check will cause a redirect to the login page, because the widgets included on that login page will redirect again to the loginpage.
This only a quick workaround for this bug, but i guess it will cover more then 90% of the use cases where no other widgets (with access to the user component) are used within the normal layout.
