### PR TITLE
Fix wrong oxid in basket attributes

### DIFF
--- a/source/Application/Model/Article.php
+++ b/source/Application/Model/Article.php
@@ -2568,14 +2568,23 @@ class Article extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
     }
 
     /**
+     * the uninitilized list of attributes
+     * use getAttributes
+     * @return \OxidEsales\Eshop\Application\Model\AttributeList
+     */
+    protected function newAttributeList(){
+        return oxNew(\OxidEsales\Eshop\Application\Model\AttributeList::class);
+    }
+
+    /**
      * Loads and returns attribute list associated with this article
      *
-     * @return object
+     * @return \OxidEsales\Eshop\Application\Model\AttributeList
      */
     public function getAttributes()
     {
         if ($this->_oAttributeList === null) {
-            $this->_oAttributeList = oxNew(\OxidEsales\Eshop\Application\Model\AttributeList::class);
+            $this->_oAttributeList = $this->newAttributelist();
             $this->_oAttributeList->loadAttributes($this->getId(), $this->getParentId());
         }
 
@@ -2585,12 +2594,12 @@ class Article extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
     /**
      * Loads and returns displayable in basket/order attributes list associated with this article
      *
-     * @return object
+     * @return oxattributelist
      */
     public function getAttributesDisplayableInBasket()
     {
         if ($this->_oAttributeList === null) {
-            $this->_oAttributeList = oxNew(\OxidEsales\Eshop\Application\Model\AttributeList::class);
+            $this->_oAttributeList = $this->newAttributelist();
             $this->_oAttributeList->loadAttributesDisplayableInBasket($this->getId(), $this->getParentId());
         }
 

--- a/source/Application/Model/AttributeList.php
+++ b/source/Application/Model/AttributeList.php
@@ -140,7 +140,7 @@ class AttributeList extends \OxidEsales\Eshop\Core\Model\ListModel
             $sAttrViewName = getViewName('oxattribute');
             $sViewName = getViewName('oxobject2attribute');
 
-            $sSelect = "select {$sAttrViewName}.oxid, {$sAttrViewName}.oxtitle, o2a.oxvalue, o2a.oxobjectid from $sViewName as o2a ";
+            $sSelect = "select o2a.*, {$sAttrViewName}.* from $sViewName as o2a ";
             $sSelect .= "left join {$sAttrViewName} on {$sAttrViewName}.oxid = o2a.oxattrid ";
             $sSelect .= "where o2a.oxobjectid = '%s' and {$sAttrViewName}.oxdisplayinbasket  = 1 and o2a.oxvalue != '' ";
             $sSelect .= "order by o2a.oxpos, {$sAttrViewName}.oxpos";

--- a/source/Application/Model/AttributeList.php
+++ b/source/Application/Model/AttributeList.php
@@ -140,7 +140,7 @@ class AttributeList extends \OxidEsales\Eshop\Core\Model\ListModel
             $sAttrViewName = getViewName('oxattribute');
             $sViewName = getViewName('oxobject2attribute');
 
-            $sSelect = "select {$sAttrViewName}.*, o2a.* from {$sViewName} as o2a ";
+            $sSelect = "select {$sAttrViewName}.oxid, {$sAttrViewName}.oxtitle, o2a.oxvalue, o2a.oxobjectid from $sViewName as o2a ";
             $sSelect .= "left join {$sAttrViewName} on {$sAttrViewName}.oxid = o2a.oxattrid ";
             $sSelect .= "where o2a.oxobjectid = '%s' and {$sAttrViewName}.oxdisplayinbasket  = 1 and o2a.oxvalue != '' ";
             $sSelect .= "order by o2a.oxpos, {$sAttrViewName}.oxpos";

--- a/tests/Unit/Application/Model/ArticleTest.php
+++ b/tests/Unit/Application/Model/ArticleTest.php
@@ -4501,27 +4501,24 @@ class ArticleTest extends \OxidTestCase
     }
 
     /**
-     * Test get displayable in basket/order attributes, when all are not dispayable.
+     * Test get displayable in basket/order attributes
      *
      * @return null
      */
     public function testGetAttributesDisplayableInBasket()
     {
-        $sSelect = "update oxattribute set oxdisplayinbasket = 1 where oxid = '8a142c3f0b9527634.96987022' ";
-        oxDb::getDB()->execute($sSelect);
-        $sSelect = "update oxattribute set oxdisplayinbasket = 1 where oxid = 'd8842e3b7c5e108c1.63072778' "; // texture
-        oxDb::getDB()->execute($sSelect);
 
-        $oArticle = oxNew('oxArticle');
-        $oArticle->load('1672');
+        $attrList = $this->getMock('oxAttributeList',array('loadAttributesDisplayableInBasket'));
+        $attrList
+            ->expects($this->once())
+            ->method('loadAttributesDisplayableInBasket')
+            ->with($this->equalTo('1672'),$this->equalTo('1351'));
+        $oArticle = $this->getMock('oxArticle',array('newAttributeList'));
+        $oArticle->expects($this->once())->method('newAttributeList')->willReturn($attrList);
+        $oArticle->setId('1672');
         $oArticle->oxarticles__oxparentid = new oxField('1351');
-        $oArticle->save();
 
-        $aAttrList = $oArticle->getAttributesDisplayableInBasket();
-        $sAttribValue = $aAttrList['8a142c3f0c0baa3f4.54955953']->oxattribute__oxvalue->rawValue;
-        $sAttribParentValue = $aAttrList['d8842e3b7d4e7acb1.34583879']->oxattribute__oxvalue->rawValue;
-        $this->assertEquals('25 cm', $sAttribValue);
-        $this->assertEquals('Granit', $sAttribParentValue);
+        $oArticle->getAttributesDisplayableInBasket();
     }
 
     /**

--- a/tests/Unit/Application/Model/AttributelistTest.php
+++ b/tests/Unit/Application/Model/AttributelistTest.php
@@ -142,8 +142,8 @@ class AttributelistTest extends \OxidTestCase
 
         $oAttrList = oxNew('oxAttributelist');
         $oAttrList->loadAttributesDisplayableInBasket('1672', '1351');
-        $sAttribValue = $oAttrList['8a142c3f0c0baa3f4.54955953']->oxattribute__oxvalue->rawValue;
-        $sAttribParentValue = $oAttrList['d8842e3b7d4e7acb1.34583879']->oxattribute__oxvalue->rawValue;
+        $sAttribValue = $oAttrList['8a142c3f0b9527634.96987022']->oxattribute__oxvalue->rawValue;
+        $sAttribParentValue = $oAttrList['d8842e3b7c5e108c1.63072778']->oxattribute__oxvalue->rawValue;
         $this->assertEquals('25 cm', $sAttribValue);
         $this->assertEquals('Granit', $sAttribParentValue);
     }


### PR DESCRIPTION
loadAttributesDisplayableInBasket did select the wrong "oxid" for attributes. This is a problem for extensions/developers that need to work with that attribute "oxid".
This was discussed in german dev-general https://join.skype.com/f2D5egqWQbDA

As far i know nobody found time yet to create a bug ticket
