### PR TITLE
fix "open shop frontend" button opens the correct subshop in EE edition

### DIFF
--- a/source/Application/Controller/Admin/NavigationController.php
+++ b/source/Application/Controller/Admin/NavigationController.php
@@ -155,6 +155,12 @@ class NavigationController extends \oxAdminView
         oxRegistry::getUtils()->redirect('index.php', true, 302);
     }
 
+    public function shopfront()
+    {
+        $redirect = $this->getConfig()->getShopConfVar('sMallShopURL',$this->getSession()->getVariable('shp'));
+        oxRegistry::getUtils()->redirect($redirect);
+    }
+    
     /**
      * Caches external url file locally, adds <base> tag with original url to load images and other links correcly
      */

--- a/source/Application/views/admin/tpl/header.tpl
+++ b/source/Application/views/admin/tpl/header.tpl
@@ -16,7 +16,7 @@
               <a href="[{$oViewConf->getSelfLink()}]&cl=navigation&amp;item=home.tpl" id="homelink" target="basefrm" class="rc"><b>[{oxmultilang ident="NAVIGATION_HOME"}]</b></a>
           </li>
           <li class="sep">
-              <a href="[{$oConfig->getShopURL()}]" id="shopfrontlink" target="_blank" class="rc"><b>[{oxmultilang ident="NAVIGATION_SHOPFRONT"}]</b></a>
+              <a href="[{$oViewConf->getSelfLink()|replace:'shp':''}]&cl=navigation&amp;fnc=shopfront" id="shopfrontlink" target="_blank" class="rc"><b>[{oxmultilang ident="NAVIGATION_SHOPFRONT"}]</b></a>
           </li>
           <li class="sep">
               <a href="[{$oViewConf->getSelfLink()}]&cl=navigation&amp;fnc=logout" id="logoutlink" target="_parent" class="rc"><b>[{oxmultilang ident="NAVIGATION_LOGOUT"}]</b></a>


### PR DESCRIPTION
This PR fix the button in the admin area that brings you to the front end.
The bug is that it always brings you to the main shop and not to the selected subshop.

Ported from an oxid ee 5.3 project, please test this in ee and ce edition to make sure it does not break any functionallity.
