### PR TITLE
fix loosing sessions with captchas in subshops

### DIFF
--- a/source/Core/UtilsServer.php
+++ b/source/Core/UtilsServer.php
@@ -446,7 +446,7 @@ class UtilsServer extends \oxSuperCfg
 
         //fetch the path from SCRIPT_NAME and ad it to the $sServerHost
         $sScriptName = $this->getServerVar('SCRIPT_NAME');
-        $sCurrentHost = preg_replace('/\/(modules\/[\w\/]*)?\w*\.php.*/', '', $sServerHost . $sScriptName);
+        $sCurrentHost = preg_replace('/\/((?:modules|core)\/[\w\/]*)?\w*\.php.*/', '', $sServerHost . $sScriptName);
 
         //remove double slashes all the way
         $sCurrentHost = str_replace('/', '', $sCurrentHost);

--- a/tests/Unit/Core/UtilsServerTest.php
+++ b/tests/Unit/Core/UtilsServerTest.php
@@ -408,6 +408,7 @@ class UtilsServerTest extends \OxidTestCase
             ['/modules/oe/test_module/module_index.php', 'http://oxideshop.dev/module_index.php', true],
             ['/modules/test_module/module_index.php', 'http://oxideshop.dev/module_index.php', true],
             ['/shop1/modules/test_module/module_index.php', 'http://oxideshop.dev/shop1/module_index.php', true],
+            ['/core/utils/verificationimg.php', 'http://oxideshop.dev/core/utils/verificationimg.php', true],
             ['/shop1/index.php', 'http://oxideshop.dev/shop2/index.php', false],
             ['/shop1/modules/test_module/module_index.php', 'http://oxideshop.dev/shop2/module_index.php', false],
         ];


### PR DESCRIPTION
isCurrentUrl has again a problem that it does not correctly find the matching sub shop url
because it fails for /core/utils/verificationimg.php.

this will destroy the session of the current user because the shopid from the url will not match with that shopid from the session
and then the sessionid will be regenerated.