### PR TITLE
Added event binding to oxscript smarty plugin.

### DIFF
--- a/source/Core/Smarty/Plugin/function.oxscript.php
+++ b/source/Core/Smarty/Plugin/function.oxscript.php
@@ -29,6 +29,7 @@
  * Purpose: Collect given javascript includes/calls, but include/call them at the bottom of the page.
  *
  * Add [{oxscript add="oxid.popup.load();"}] to add script call.
+ * Add [{oxscript add="$('#anylist').equalizer();" event="onload"}] to add script call.
  * Add [{oxscript include="oxid.js"}] to include local javascript file.
  * Add [{oxscript include="oxid.js?20120413"}] to include local javascript file with query string part.
  * Add [{oxscript include="http://www.oxid-esales.com/oxid.js"}] to include external javascript file.
@@ -57,7 +58,7 @@ function smarty_function_oxscript($params, &$smarty)
         }
 
         $register = oxNew('OxidEsales\Eshop\Core\ViewHelper\JavaScriptRegistrator');
-        $register->addSnippet($params['add'], $isDynamic);
+        $register->addSnippet($params['add'], $isDynamic, $params['event']);
     } elseif (isset($params['include'])) {
         if (empty($params['include'])) {
             $smarty->trigger_error("{oxscript} parameter 'include' can not be empty!");

--- a/source/Core/ViewHelper/JavaScriptRegistrator.php
+++ b/source/Core/ViewHelper/JavaScriptRegistrator.php
@@ -37,12 +37,23 @@ class JavaScriptRegistrator
      *
      * @param string $script
      * @param bool   $isDynamic
+     * @param string $event
      */
-    public function addSnippet($script, $isDynamic = false)
+    public function addSnippet($script, $isDynamic = false, $event = '')
     {
         $config = oxRegistry::getConfig();
+        if(!empty($event)) {
+            $eventsParameterName = static::SNIPPETS_PARAMETER_NAME . '_events';
+            $events = (array) $config->getGlobalParameter($eventsParameterName);
+            $event = trim($event);
+            if (!in_array($event, $events)) {
+                $events[] = $event;
+            }
+            $config->setGlobalParameter( $eventsParameterName, $events );
+        }
         $suffix = $isDynamic ? '_dynamic' : '';
-        $scriptsParameterName = static::SNIPPETS_PARAMETER_NAME . $suffix;
+        $event = empty($event) ? '' : '_'.$event;
+        $scriptsParameterName = static::SNIPPETS_PARAMETER_NAME . $suffix . $event;
         $scripts = (array) $config->getGlobalParameter($scriptsParameterName);
         $script = trim($script);
         if (!in_array($script, $scripts)) {

--- a/source/Core/ViewHelper/JavaScriptRenderer.php
+++ b/source/Core/ViewHelper/JavaScriptRenderer.php
@@ -45,6 +45,7 @@ class JavaScriptRenderer
         $suffix = $isDynamic ? '_dynamic' : '';
         $filesParameterName = JavaScriptRegistrator::FILES_PARAMETER_NAME . $suffix;
         $scriptsParameterName = JavaScriptRegistrator::SNIPPETS_PARAMETER_NAME . $suffix;
+        $eventsParameterName = JavaScriptRegistrator::SNIPPETS_PARAMETER_NAME . '_events';
 
         $isAjaxRequest = $this->isAjaxRequest();
         $forceRender = $this->shouldForceRender($forceRender, $isAjaxRequest);
@@ -69,6 +70,16 @@ class JavaScriptRenderer
                 $dynamicScripts = (array) $config->getGlobalParameter(JavaScriptRegistrator::SNIPPETS_PARAMETER_NAME . '_dynamic');
                 $scriptOutput .= $this->formSnippetsOutput($dynamicScripts, $widget, $isAjaxRequest);
                 $config->setGlobalParameter(JavaScriptRegistrator::SNIPPETS_PARAMETER_NAME . '_dynamic', null);
+            }
+
+            $events = (array) $config->getGlobalParameter($eventsParameterName);
+            foreach($events as $event) {
+                $eventScriptsParameterName = JavaScriptRegistrator::SNIPPETS_PARAMETER_NAME . $suffix. '_'.$event;
+                // Form onload output for adds.
+                $eventScripts = (array)$config->getGlobalParameter($eventScriptsParameterName);
+                $eventScriptOutput = $this->formSnippetsOutput($eventScripts, $widget, $isAjaxRequest);
+                $eventScriptOutput = $this->bindEvent($eventScriptOutput, $event);
+                $scriptOutput .= $eventScriptOutput;
             }
             $output .= $this->enclose($scriptOutput, $widget, $isAjaxRequest);
         }
@@ -209,5 +220,20 @@ JS;
         }
 
         return $output;
+    }
+
+    /**
+     * Bind js code to a event.
+     *
+     * @param string $scriptsOutput
+     * @param string $event
+     *
+     * @return null | string
+     */
+    protected function bindEvent($scriptsOutput, $event) {
+        if(!empty($scriptsOutput) && !empty($event)) {
+            $output = "window.addEventListener('$event', function() { $scriptsOutput }, false );";
+            return $output;
+        }
     }
 }


### PR DESCRIPTION
As i said in dev-general-de i will add a posibility to bind js code direktly via smarty plugin oxscript.

Just do it like that:
[{oxscript add="Console.log('Bound to window.onload.');" event="load"}]
or
[{oxscript add="Console.log('Window was resized.');" event="resize"}]