### PR TITLE
fix setup corrupts password

### DIFF
--- a/source/Setup/Utilities.php
+++ b/source/Setup/Utilities.php
@@ -218,7 +218,7 @@ class Utilities extends Core
             if ($sParamName[0] != 'i') {
                 $sParamValue = "'{$sParamValue}'";
             }
-            $sConfFile = preg_replace("/(this->{$sParamName}).*'<.*>'.*;/", "\\1 = " . preg_quote($sParamValue) . ";", $sConfFile);
+            $sConfFile = str_replace("<$sParamName>", $sParamValue, $sConfFile);
         }
 
         if (($fp = fopen($sConfPath, "w"))) {

--- a/source/Setup/Utilities.php
+++ b/source/Setup/Utilities.php
@@ -218,7 +218,7 @@ class Utilities extends Core
             if ($sParamName[0] != 'i') {
                 $sParamValue = "'{$sParamValue}'";
             }
-            $sConfFile = preg_replace("/(this->{$sParamName}).*'<.*>'.*;/", "\\1 = " . $sParamValue . ";", $sConfFile);
+            $sConfFile = preg_replace("/(this->{$sParamName}).*'<.*>'.*;/", "\\1 = " . preg_quote($sParamValue) . ";", $sConfFile);
         }
 
         if (($fp = fopen($sConfPath, "w"))) {

--- a/tests/Unit/Setup/UtilitiesTest.php
+++ b/tests/Unit/Setup/UtilitiesTest.php
@@ -235,7 +235,7 @@ class UtilitiesTest extends \OxidTestCase
         $this->assertTrue(function_exists('getDefaultConfigFileMode'), 'missing function getDefaultConfigFileMode');
 
         $utilities = new Utilities();
-        $password = 'l3$z4f#buzhdcv5745XC$lic';
+        $password = 'l3$z4f#buzhdc$1\1\\1\2v5745XC$lic';
         $url = 'http://test.myoxidshop.com';
 
         $originalFile = $this->configTestPath . '/config.inc.php.dist';


### PR DESCRIPTION
Setup could corrupt passowrds containing references e.g. \1 or $1
https://bugs.oxid-esales.com/view.php?id=6465
