### PR TITLE
use registry instead of oxNew for request object

### DIFF
--- a/source/Application/Component/Widget/CategoryTree.php
+++ b/source/Application/Component/Widget/CategoryTree.php
@@ -22,6 +22,8 @@
  */
 
 namespace  OxidEsales\Eshop\Application\Component\Widget;
+use OxidEsales\Eshop\Core\Request;
+use OxidEsales\Eshop\Core\Registry;
 
 /**
  * Category tree widget.
@@ -82,7 +84,8 @@ class CategoryTree extends \oxWidget
      */
     public function getContentCategory()
     {
-        $request = oxNew('OxidEsales\Eshop\Core\Request');
+        $request = Registry::get(Request::class);
         return $request->getRequestParameter('oxcid', false);
     }
+
 }


### PR DESCRIPTION
Using 'new/oxnew' should be avoided because it allocates new memory,
even if oxnew may clone the object (with copy on write support) it is sometimes better to reuse objects.
For the Request object this is the case because someday you might want to give it intarnal state, it may need to parse post data from inputstream once, or you may like to manipulate that data within the controlflow of the application.
