### PR TITLE
rethrowing the exception in order

### DIFF
--- a/source/Application/Model/Order.php
+++ b/source/Application/Model/Order.php
@@ -1368,6 +1368,8 @@ class Order extends \oxBase
         } catch (Exception $oE) {
             // if exception, rollBack everything
             oxDb::getDb()->rollbackTransaction();
+            
+            throw $oE;
         }
     }
 


### PR DESCRIPTION
rethrowing the exception after rolling back the transaction is important to give the user and the shop owner feedback.
Message must come into logfile, and must get feedback that his order was not executed.
