### PR TITLE
better documentation for "-1" value for debuglevel

### DIFF
--- a/source/config.inc.php.dist
+++ b/source/config.inc.php.dist
@@ -54,7 +54,7 @@
     $this->sOXIDPHP = "oxid.php";
 
     //  enable debug mode for template development or bugfixing
-    // -1 = Logger Messages internal use only
+    // -1 = Log more messages and throw exceptions on errors (not recommend for production)
     //  0 = off
     //  1 = smarty
     //  2 = SQL


### PR DESCRIPTION
iDebug can be set -1, then the shop is more strict about missing templates and other errors.