### PR TITLE
make addValidationError public

### DIFF
--- a/source/Core/InputValidator.php
+++ b/source/Core/InputValidator.php
@@ -507,14 +507,28 @@ class InputValidator extends \oxSuperCfg
      *
      * @param string    $sFieldName field name
      * @param exception $oErr       exception
-     *
+     * @deprecated since 5.3 use addValidationError
      * @return exception
      */
     protected function _addValidationError($sFieldName, $oErr)
     {
-        return $this->_aInputValidationErrors[$sFieldName][] = $oErr;
+        return $this->addValidationError($sFieldName, $oErr);
     }
 
+    /**
+     * Used to collect user validation errors. This method is called from all of
+     * the input checking functionality to report found error.
+     *
+     * @param string    $sFieldName field name
+     * @param exception $oErr       exception
+     *
+     * @return exception
+     */
+    public function addValidationError($sFieldName, $oErr)
+    {
+        return $this->_aInputValidationErrors[$sFieldName][] = $oErr;
+    }
+    
     /**
      * Validates debit note.
      *


### PR DESCRIPTION
This class holds the "global" array of error messages, it should be possible to add error messages to the view from other classes, so we can extract & add functionality to & from other places.
