### PR TITLE
restore field values after validation error

### DIFF
--- a/source/Application/Component/UserComponent.php
+++ b/source/Application/Component/UserComponent.php
@@ -570,8 +570,14 @@ class UserComponent extends \oxView
             } else {
                 return 'register?success=1&newslettererror=4';
             }
-        } else {
-            // problems with registration ...
+        } else { // problems with registration ...
+            //restore form values for password fields
+            $this->getParent()->addTplParam('lgn_pwd',$this->getConfig()->getRequestParameter('lgn_pwd'));
+            $this->getParent()->addTplParam('lgn_pwd2',$this->getConfig()->getRequestParameter('lgn_pwd2'));
+            //address meight be fetched from request by the register controller via smarty code from the template
+            //anyway the following line makes it at least possible to extract some logic from there.
+            $this->getParent()->addTplParam('invadr',$this->getConfig()->getRequestParameter('invadr'));
+            
             $this->logout();
         }
     }


### PR DESCRIPTION
if register request was not accepted by the shop for any reason, the shop forgets some of the values, so the user must enter them again even if the error was related to some other field