### PR TITLE
Remove questenmark from external link

### DIFF
--- a/source/Application/Model/Category.php
+++ b/source/Application/Model/Category.php
@@ -644,7 +644,7 @@ class Category extends \oxI18n implements \oxIUrl
     public function getStdLink($iLang = null, $aParams = array())
     {
         if (isset($this->oxcategories__oxextlink) && $this->oxcategories__oxextlink->value) {
-            return oxRegistry::get("oxUtilsUrl")->processUrl($this->oxcategories__oxextlink->value, false);
+            return oxRegistry::get("oxUtilsUrl")->processUrl($this->oxcategories__oxextlink->value, true);
         }
 
         if ($iLang === null) {

--- a/tests/Unit/Application/Model/CategoryTest.php
+++ b/tests/Unit/Application/Model/CategoryTest.php
@@ -490,7 +490,7 @@ class CategoryTest extends \OxidTestCase
         $oCategory = oxNew('oxCategory');
         $oCategory->oxcategories__oxextlink = new oxField('xxx', oxField::T_RAW);
 
-        $this->assertEquals('xxx?', $oCategory->getStdLink());
+        $this->assertEquals('xxx', $oCategory->getStdLink());
     }
 
     public function testGetStdLinkshoudlReturnDefaultLink()
@@ -521,7 +521,7 @@ class CategoryTest extends \OxidTestCase
         $oCategory = oxNew('oxCategory');
         $oCategory->oxcategories__oxextlink = new oxField('www.test.com', oxField::T_RAW);
 
-        $this->assertEquals('www.test.com?', $oCategory->getLink());
+        $this->assertEquals('www.test.com', $oCategory->getLink());
     }
 
     public function testGetLinkSeoDe()
@@ -565,7 +565,7 @@ class CategoryTest extends \OxidTestCase
         $oCategory = oxNew('oxCategory');
         $oCategory->oxcategories__oxextlink = new oxField('xxx', oxField::T_RAW);
 
-        $this->assertEquals('xxx?', $oCategory->getStdLink(2));
+        $this->assertEquals('xxx', $oCategory->getStdLink(2));
     }
 
     public function testGetStdLinkshoudlReturnDefaultLinkWithLangParam()


### PR DESCRIPTION
Remove questenmark from externel links
Discussed in oxid developer skype chat and found the same issue described in german oxid forum
http://forum.oxid-esales.com/showthread.php?t=12884
 bug https://bugs.oxid-esales.com/view.php?id=6498
