### PR TITLE
shipping cost rule must include free shipping articles (please discuss)

### DIFF
--- a/source/Application/Model/Delivery.php
+++ b/source/Application/Model/Delivery.php
@@ -234,36 +234,35 @@ class Delivery extends \oxI18n
         } else {
 
             $this->_blFreeShipping = false;
-
-            switch ($this->getConditionType()) {
-                case self::CONDITION_TYPE_PRICE: // price
-                    if ($this->getCalculationRule() == self::CALCULATION_RULE_FOR_EACH_PRODUCT) {
-                        $dAmount += $oProduct->getPrice()->getPrice();
-                    } else {
-                        $dAmount += $oBasketItem->getPrice()->getPrice(); // price// currency conversion must allready be done in price class / $oCur->rate; // $oBasketItem->oPrice->getPrice() / $oCur->rate;
-                    }
-                    break;
-                case self::CONDITION_TYPE_WEIGHT: // weight
-                    if ($this->getCalculationRule() == self::CALCULATION_RULE_FOR_EACH_PRODUCT) {
-                        $dAmount += $oProduct->getWeight();
-                    } else {
-                        $dAmount += $oBasketItem->getWeight();
-                    }
-                    break;
-                case self::CONDITION_TYPE_SIZE: // size
-                    $dAmount += $oProduct->getSize();
-                    if ($this->getCalculationRule() != self::CALCULATION_RULE_FOR_EACH_PRODUCT) {
-                        $dAmount *= $oBasketItem->getAmount();
-                    }
-                    break;
-                case self::CONDITION_TYPE_AMOUNT: // amount
-                    $dAmount += $oBasketItem->getAmount();
-                    break;
-            }
-
             if ($oBasketItem->getPrice()) {
                 $this->_dPrice += $oBasketItem->getPrice()->getPrice();
-            }
+            }  
+        }
+
+        switch ($this->getConditionType()) {
+            case self::CONDITION_TYPE_PRICE: // price
+                if ($this->getCalculationRule() == self::CALCULATION_RULE_FOR_EACH_PRODUCT) {
+                    $dAmount += $oProduct->getPrice()->getPrice();
+                } else {
+                    $dAmount += $oBasketItem->getPrice()->getPrice(); // price// currency conversion must allready be done in price class / $oCur->rate; // $oBasketItem->oPrice->getPrice() / $oCur->rate;
+                }
+                break;
+            case self::CONDITION_TYPE_WEIGHT: // weight
+                if ($this->getCalculationRule() == self::CALCULATION_RULE_FOR_EACH_PRODUCT) {
+                    $dAmount += $oProduct->getWeight();
+                } else {
+                    $dAmount += $oBasketItem->getWeight();
+                }
+                break;
+            case self::CONDITION_TYPE_SIZE: // size
+                $dAmount += $oProduct->getSize();
+                if ($this->getCalculationRule() != self::CALCULATION_RULE_FOR_EACH_PRODUCT) {
+                    $dAmount *= $oBasketItem->getAmount();
+                }
+                break;
+            case self::CONDITION_TYPE_AMOUNT: // amount
+                $dAmount += $oBasketItem->getAmount();
+                break;                        
         }
 
         return $dAmount;

--- a/tests/Unit/Application/Model/DeliveryTest.php
+++ b/tests/Unit/Application/Model/DeliveryTest.php
@@ -610,7 +610,7 @@ class DeliveryTest extends \OxidTestCase
         $oDelivery = oxNew('oxDelivery');
         $oDelivery->oxdelivery__oxdeltype = new oxField('p', oxField::T_RAW);
 
-        $this->assertEquals(0, $oDelivery->getDeliveryAmount($this->_oBasketItem));
+        $this->assertEquals(512, $oDelivery->getDeliveryAmount($this->_oBasketItem));
         $this->assertTrue($oDelivery->getblFreeShipping());
 
         // non free shipping

--- a/tests/Unit/Application/Model/DeliveryTest.php
+++ b/tests/Unit/Application/Model/DeliveryTest.php
@@ -635,7 +635,7 @@ class DeliveryTest extends \OxidTestCase
         $oDelivery = oxNew('oxDelivery');
         $oDelivery->oxdelivery__oxdeltype = new oxField('p');
 
-        $this->assertEquals(0, $oDelivery->getDeliveryAmount($this->_oBasketItem));
+        $this->assertEquals(512, $oDelivery->getDeliveryAmount($this->_oBasketItem));
         $this->assertTrue($oDelivery->getblFreeShipping());
 
         // non free shiping


### PR DESCRIPTION
The shipping cost rule must calculate the amount over all articles including free shipping articles to check if it can be applied.

A customer having a free shipping article and a normal article in basket but the total amount of both articles should make the free shipping cost rule to be applied.

Without this pull request only normal articles are included in the amount and so the free shipping does not apply even if the total amount would be higher than the minimum for the free shipping.

There was a discussen on skye chat with no final result if this is a bug or feature.
So i kindly ask all readers to participate and ask questions and give feedback.
If the old behavior is really an feature we could make it configurable.
