### PR TITLE
Category tree, selected category search fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,22 +21,22 @@
 
 # Theme
 /source/Application/views/*
-!/source/Application/views/admin/
-!/source/Application/views/azure/
+!/source/Application/views/admin
+!/source/Application/views/azure
 
 # out Folder
 /source/out/*
-!/source/out/admin/
-!/source/out/azure/
-!/source/out/downloads/
-!/source/out/media/
-!/source/out/pictures/
+!/source/out/admin
+!/source/out/azure
+!/source/out/downloads
+!/source/out/media
+!/source/out/pictures
 /source/out/pictures/*
-!/source/out/pictures/master/
-!/source/out/pictures/media/
-!/source/out/pictures/promo/
-!/source/out/pictures/vendor/
-!/source/out/pictures/wysiwigpro/
+!/source/out/pictures/master
+!/source/out/pictures/media
+!/source/out/pictures/promo
+!/source/out/pictures/vendor
+!/source/out/pictures/wysiwigpro
 
 # Modules
 /source/modules/*
@@ -44,7 +44,7 @@
 !/source/modules/functions.php.dist
 
 # Except our own modules
-!/source/modules/oe/
+!/source/modules/oe
 /source/modules/oe/*
 !/source/modules/oe/vendormetadata.php
 !/source/modules/oe/invoicepdf


### PR DESCRIPTION
About error, in category list wrong category was selected. This was because parent category ID was '003' and other category ID was '03'. And then '==' comparison tries to compare these strings, it interprets them like a numbers. Fixed by strcmp() which checks strings in binary level.