### PR TITLE
remove copypaste frameset in admin area

### DIFF
--- a/source/Application/views/admin/tpl/admin_links.tpl
+++ b/source/Application/views/admin/tpl/admin_links.tpl
@@ -1,15 +1,1 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN">
-
-<html>
-<head>
-    <title>[{oxmultilang ident="GENERAL_ADMIN_TITLE"}]</title>
-</head>
-
-<!-- frames -->
-<frameset  rows="40%,*" border="0" onload="top.loadEditFrame('[{$oViewConf->getSelfLink()}]&[{$editurl}][{if $oxid}]&oxid=[{$oxid}][{/if}]');">
-    <frame src="[{$oViewConf->getSelfLink()}]&[{$listurl}][{if $oxid}]&oxid=[{$oxid}][{/if}]" name="list" id="list" frameborder="0" scrolling="auto" noresize marginwidth="0" marginheight="0">
-    <frame src="" name="edit" id="edit" frameborder="0" scrolling="auto" noresize marginwidth="0" marginheight="0">
-</frameset>
-
-
-</html>
+[{include 'includes/frameset.tpl'}]

--- a/source/Application/views/admin/tpl/admin_news.tpl
+++ b/source/Application/views/admin/tpl/admin_news.tpl
@@ -1,15 +1,1 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN">
-
-<html>
-<head>
-    <title>[{oxmultilang ident="GENERAL_ADMIN_TITLE"}]</title>
-</head>
-
-<!-- frames -->
-<frameset  rows="40%,*" border="0" onload="top.loadEditFrame('[{$oViewConf->getSelfLink()}]&[{$editurl}][{if $oxid}]&oxid=[{$oxid}][{/if}]');">
-    <frame src="[{$oViewConf->getSelfLink()}]&[{$listurl}][{if $oxid}]&oxid=[{$oxid}][{/if}]" name="list" id="list" frameborder="0" scrolling="auto" noresize marginwidth="0" marginheight="0">
-    <frame src="" name="edit" id="edit" frameborder="0" scrolling="auto" noresize marginwidth="0" marginheight="0">
-</frameset>
-
-
-</html>
+[{include 'includes/frameset.tpl'}]

--- a/source/Application/views/admin/tpl/article.tpl
+++ b/source/Application/views/admin/tpl/article.tpl
@@ -1,15 +1,1 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN">
-
-<html>
-<head>
-    <title>[{oxmultilang ident="GENERAL_ADMIN_TITLE"}]</title>
-</head>
-
-<!-- frames -->
-<frameset  rows="40%,*" border="0" onload="top.loadEditFrame('[{$oViewConf->getSelfLink()}]&[{$editurl}][{if $oxid}]&oxid=[{$oxid}][{/if}]');">
-    <frame src="[{$oViewConf->getSelfLink()}]&[{$listurl}][{if $oxid}]&oxid=[{$oxid}][{/if}]" name="list" id="list" frameborder="0" scrolling="Auto" noresize marginwidth="0" marginheight="0">
-    <frame src="" name="edit" id="edit" frameborder="0" scrolling="Auto" noresize marginwidth="0" marginheight="0">
-</frameset>
-
-
-</html>
+[{include 'includes/frameset.tpl'}]

--- a/source/Application/views/admin/tpl/category.tpl
+++ b/source/Application/views/admin/tpl/category.tpl
@@ -1,15 +1,1 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN">
-
-<html>
-<head>
-    <title>[{oxmultilang ident="GENERAL_ADMIN_TITLE"}]</title>
-</head>
-
-<!-- frames -->
-<frameset  rows="40%,*" border="0" onload="top.loadEditFrame('[{$oViewConf->getSelfLink()}]&[{$editurl}][{if $oxid}]&oxid=[{$oxid}][{/if}]');">
-    <frame src="[{$oViewConf->getSelfLink()}]&[{$listurl}][{if $oxid}]&oxid=[{$oxid}][{/if}]" name="list" id="list" frameborder="0" scrolling="auto" noresize marginwidth="0" marginheight="0">
-    <frame src="" name="edit" id="edit" frameborder="0" scrolling="auto" noresize marginwidth="0" marginheight="0">
-</frameset>
-
-
-</html>
+[{include 'includes/frameset.tpl'}]

--- a/source/Application/views/admin/tpl/content.tpl
+++ b/source/Application/views/admin/tpl/content.tpl
@@ -1,15 +1,1 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN">
-
-<html>
-<head>
-    <title>[{oxmultilang ident="GENERAL_ADMIN_TITLE"}]</title>
-</head>
-
-<!-- frames -->
-<frameset  rows="40%,*" border="0" onload="top.loadEditFrame('[{$oViewConf->getSelfLink()}]&[{$editurl}][{if $oxid}]&oxid=[{$oxid}][{/if}]');">
-    <frame src="[{$oViewConf->getSelfLink()}]&[{$listurl}][{if $oxid}]&oxid=[{$oxid}][{/if}]" name="list" id="list" frameborder="0" scrolling="auto" noresize marginwidth="0" marginheight="0">
-    <frame src="" name="edit" id="edit" frameborder="0" scrolling="auto" noresize marginwidth="0" marginheight="0">
-</frameset>
-
-
-</html>
+[{include 'includes/frameset.tpl'}]

--- a/source/Application/views/admin/tpl/include/frameset.tpl
+++ b/source/Application/views/admin/tpl/include/frameset.tpl
@@ -1,0 +1,15 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN">
+
+<html>
+<head>
+    <title>[{oxmultilang ident="GENERAL_ADMIN_TITLE"}]</title>
+</head>
+
+<!-- frames -->
+<frameset  rows="40%,*" border="0" onload="top.loadEditFrame('[{$oViewConf->getSelfLink()}]&[{$editurl}][{if $oxid}]&oxid=[{$oxid}][{/if}]');">
+    <frame src="[{$oViewConf->getSelfLink()}]&[{$listurl}][{if $oxid}]&oxid=[{$oxid}][{/if}]" name="list" id="list" frameborder="0" scrolling="auto" noresize marginwidth="0" marginheight="0">
+    <frame src="" name="edit" id="edit" frameborder="0" scrolling="auto" noresize marginwidth="0" marginheight="0">
+</frameset>
+
+
+</html>

--- a/source/Application/views/admin/tpl/order.tpl
+++ b/source/Application/views/admin/tpl/order.tpl
@@ -1,15 +1,1 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN">
-
-<html>
-<head>
-    <title>[{oxmultilang ident="GENERAL_ADMIN_TITLE"}]</title>
-</head>
-
-<!-- frames -->
-<frameset  rows="40%,*" border="0" onload="top.loadEditFrame('[{$oViewConf->getSelfLink()}]&[{$editurl}][{if $oxid}]&oxid=[{$oxid}][{/if}]');">
-    <frame src="[{$oViewConf->getSelfLink()}]&[{$listurl}][{if $oxid}]&oxid=[{$oxid}][{/if}]" name="list" id="list" frameborder="0" scrolling="auto" noresize marginwidth="0" marginheight="0">
-    <frame src="" name="edit" id="edit" frameborder="0" scrolling="Auto" noresize marginwidth="0" marginheight="0">
-</frameset>
-
-
-</html>
+[{include 'includes/frameset.tpl'}]

--- a/source/Application/views/admin/tpl/selectlist.tpl
+++ b/source/Application/views/admin/tpl/selectlist.tpl
@@ -1,15 +1,1 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN">
-
-<html>
-<head>
-    <title>[{oxmultilang ident="GENERAL_ADMIN_TITLE"}]</title>
-</head>
-
-<!-- frames -->
-<frameset  rows="40%,*" border="0" onload="top.loadEditFrame('[{$oViewConf->getSelfLink()}]&[{$editurl}][{if $oxid}]&oxid=[{$oxid}][{/if}]');">
-    <frame src="[{$oViewConf->getSelfLink()}]&[{$listurl}][{if $oxid}]&oxid=[{$oxid}][{/if}]" name="list" id="list" frameborder="0" scrolling="auto" noresize marginwidth="0" marginheight="0">
-    <frame src="" name="edit" id="edit" frameborder="0" scrolling="auto" noresize marginwidth="0" marginheight="0">
-</frameset>
-
-
-</html>
+[{include 'includes/frameset.tpl'}]


### PR DESCRIPTION
Removing duplicate code because it is the root of all evil.
- extracted duplicate code into an other template and included that.
- removes about 80% code from the affected files.
- it could be done better by using only one template at all, but i suggest refactoring on template level with 'include' statements first because you can use that pattern almost everywhere without any BC breaks and with low efforts.