### PR TITLE
Remove substr from oxid generation

### DIFF
--- a/source/Core/UtilsObject.php
+++ b/source/Core/UtilsObject.php
@@ -333,7 +333,7 @@ class UtilsObject
      */
     public function generateUId()
     {
-        return substr(md5(uniqid('', true) . '|' . microtime()), 0, 32);
+        return md5(uniqid('', true) . '|' . microtime());
     }
 
     /**


### PR DESCRIPTION
To generate an oxid (ox-id) we are using the PHP function md5. This function returns always a string with a length of 32 chars. Because of the good ol' days the md5 function is wrapped with substr, which cuts the returned string of the md5 function to 32 chars. This isn't necessary anymore.