### PR TITLE
removed changes from PR390 therefore unbuyable parents can be assigned again.

### DIFF
--- a/source/Application/Controller/Admin/DiscountArticlesAjax.php
+++ b/source/Application/Controller/Admin/DiscountArticlesAjax.php
@@ -87,19 +87,12 @@ class DiscountArticlesAjax extends \ajaxListComponent
         if (!$sOxid && $sSynchOxid) {
             $sQAdd = " from $sArticleTable where 1 ";
             $sQAdd .= $oConfig->getConfigParam('blVariantsSelection') ? '' : "and $sArticleTable.oxparentid = '' ";
-
-            //#6027
-            //if we have variants then depending on config option the parent may be non buyable
-            //when the checkbox is checked, blVariantParentBuyable is true.
-            $sQAdd .= $oConfig->getConfigParam('blVariantParentBuyable') ?  '' : "and $sArticleTable.oxvarcount = 0";
         } else {
             // selected category ?
             if ($sSynchOxid && $sOxid != $sSynchOxid) {
                 $sQAdd = " from $sO2CView left join $sArticleTable on ";
                 $sQAdd .= $oConfig->getConfigParam('blVariantsSelection') ? "($sArticleTable.oxid=$sO2CView.oxobjectid or $sArticleTable.oxparentid=$sO2CView.oxobjectid)" : " $sArticleTable.oxid=$sO2CView.oxobjectid ";
                 $sQAdd .= " where $sO2CView.oxcatnid = " . $oDb->quote($sOxid) . " and $sArticleTable.oxid is not null ";
-                //#6027
-                $sQAdd .= $oConfig->getConfigParam('blVariantParentBuyable') ?  '' : " and $sArticleTable.oxvarcount = 0";
 
                 // resetting
                 $sId = null;

--- a/tests/Unit/Application/Controller/Admin/DiscountArticlesAjaxTest.php
+++ b/tests/Unit/Application/Controller/Admin/DiscountArticlesAjaxTest.php
@@ -81,31 +81,6 @@ class DiscountArticlesAjaxTest extends \OxidTestCase
         $sSynchoxid = '_testSynchoxid';
         $this->setRequestParameter("oxid", $sOxid);
         $this->setRequestParameter("synchoxid", $sSynchoxid);
-        $this->setConfigParam('blVariantParentBuyable', false);
-        $sArticleTable = getViewName("oxarticles");
-        $sO2CView = getViewName("oxobject2category");
-
-        $oView = oxNew('discount_articles_ajax');
-        $sQuery = "from $sO2CView left join $sArticleTable on  $sArticleTable.oxid=$sO2CView.oxobjectid ";
-        $sQuery .= " where $sO2CView.oxcatnid = '_testOxid' and $sArticleTable.oxid is not null  and ";
-        $sQuery .= "$sArticleTable.oxvarcount = 0 and ";
-        $sQuery .= " $sArticleTable.oxid not in (  select $sArticleTable.oxid from oxobject2discount, $sArticleTable where $sArticleTable.oxid=oxobject2discount.oxobjectid ";
-        $sQuery .= " and oxobject2discount.oxdiscountid = '_testSynchoxid' and oxobject2discount.oxtype = 'oxarticles'  )";
-        $this->assertEquals($sQuery, trim($oView->UNITgetQuery()));
-    }
-
-    /**
-     * DiscountArticlesAjax::_getQuery() test case
-     *
-     * @return null
-     */
-    public function testGetQueryOxidParentIsBuyable()
-    {
-        $sOxid = '_testOxid';
-        $sSynchoxid = '_testSynchoxid';
-        $this->setRequestParameter("oxid", $sOxid);
-        $this->setRequestParameter("synchoxid", $sSynchoxid);
-        $this->setConfigParam('blVariantParentBuyable', true);
         $sArticleTable = getViewName("oxarticles");
         $sO2CView = getViewName("oxobject2category");
 
@@ -126,26 +101,6 @@ class DiscountArticlesAjaxTest extends \OxidTestCase
     {
         $sSynchoxid = '_testSynchoxid';
         $this->setRequestParameter("synchoxid", $sSynchoxid);
-        $this->setConfigParam('blVariantParentBuyable', false);
-        $sArticleTable = getViewName("oxarticles");
-
-        $oView = oxNew('discount_articles_ajax');
-        $sQuery = "from $sArticleTable where 1 and $sArticleTable.oxparentid = '' and $sArticleTable.oxvarcount = 0 and ";
-        $sQuery .= " $sArticleTable.oxid not in (  select $sArticleTable.oxid from oxobject2discount, $sArticleTable where $sArticleTable.oxid=oxobject2discount.oxobjectid ";
-        $sQuery .= " and oxobject2discount.oxdiscountid = '_testSynchoxid' and oxobject2discount.oxtype = 'oxarticles'  )";
-        $this->assertEquals($sQuery, trim($oView->UNITgetQuery()));
-    }
-
-    /**
-     * DiscountArticlesAjax::_getQuery() test case
-     *
-     * @return null
-     */
-    public function testGetQuerySynchoxidParentIsBuyable()
-    {
-        $sSynchoxid = '_testSynchoxid';
-        $this->setRequestParameter("synchoxid", $sSynchoxid);
-        $this->setConfigParam('blVariantParentBuyable', true);
         $sArticleTable = getViewName("oxarticles");
 
         $oView = oxNew('discount_articles_ajax');
@@ -215,29 +170,6 @@ class DiscountArticlesAjaxTest extends \OxidTestCase
         $sSynchoxid = '_testDiscountNew';
         $this->setRequestParameter("synchoxid", $sSynchoxid);
         $this->setRequestParameter("all", true);
-        $this->setConfigParam('blVariantParentBuyable', false);
-
-        $iCount = oxDb::getDb()->getOne("select count(oxid) from oxarticles where oxparentid = '' and oxvarcount = 0");
-
-        $oView = oxNew('discount_articles_ajax');
-        $this->assertGreaterThan(0, $iCount);
-        $this->assertEquals(0, oxDb::getDb()->getOne("select count(oxid) from oxobject2discount where oxdiscountid='$sSynchoxid'"));
-
-        $oView->addDiscArt();
-        $this->assertEquals($iCount, oxDb::getDb()->getOne("select count(oxid) from oxobject2discount where oxdiscountid='$sSynchoxid'"));
-    }
-
-    /**
-     * DiscountArticlesAjax::addDiscArt() test case
-     *
-     * @return null
-     */
-    public function testAddDiscArtAllParentIsBuyable()
-    {
-        $sSynchoxid = '_testDiscountNewParentIsBuyable';
-        $this->setRequestParameter("synchoxid", $sSynchoxid);
-        $this->setRequestParameter("all", true);
-        $this->setConfigParam('blVariantParentBuyable', true);
 
         $iCount = oxDb::getDb()->getOne("select count(oxid) from oxarticles where oxparentid = ''");
 


### PR DESCRIPTION
Please see https://bugs.oxid-esales.com/view.php?id=6501#c11770 for more information, especially 

> Reporter in 0006027 says it is wrong that you can assign an unbuyable item as a discount. He does not say it is wrong to assign an unbuyable parent to a discount. It is a good thing if unbuyable parents can be assigned, just as you can assign categories, which are also not buyable.