### PR TITLE
replaced subselect with simple field selection

### DIFF
--- a/source/Application/Model/Article.php
+++ b/source/Application/Model/Article.php
@@ -620,7 +620,7 @@ class Article extends \oxI18n implements ArticleInterface, \oxIUrl
                 if ($myConfig->getConfigParam('blUseTimeCheck')) {
                     $activeCheck = $this->addSqlActiveRangeSnippet($activeCheck, 'art');
                 }
-                $sQ = " $sQ and IF( $sTable.oxvarcount = 0, 1, oxvarstock) ";
+                $sQ = " $sQ and IF( $sTable.oxvarcount = 0, 1, $sTable.oxvarstock) ";
             }
         }
 

--- a/source/Application/Model/Article.php
+++ b/source/Application/Model/Article.php
@@ -620,7 +620,7 @@ class Article extends \oxI18n implements ArticleInterface, \oxIUrl
                 if ($myConfig->getConfigParam('blUseTimeCheck')) {
                     $activeCheck = $this->addSqlActiveRangeSnippet($activeCheck, 'art');
                 }
-                $sQ = " $sQ and IF( $sTable.oxvarcount = 0, 1, ( select 1 from $sTable as art where art.oxparentid=$sTable.oxid and $activeCheck and ( art.oxstockflag != 2 or art.oxstock > 0 ) limit 1 ) ) ";
+                $sQ = " $sQ and IF( $sTable.oxvarcount = 0, 1, oxvarstock) ";
             }
         }
 

--- a/tests/Unit/Application/Model/ArticleTest.php
+++ b/tests/Unit/Application/Model/ArticleTest.php
@@ -401,7 +401,7 @@ class ArticleTest extends \OxidTestCase
 
         $sTimeCheckQ = " or ( art.oxactivefrom < '$sDate' and art.oxactiveto > '$sDate' )";
         $sQ = " and ( $sTable.oxstockflag != 2 or ( $sTable.oxstock + $sTable.oxvarstock ) > 0  ) ";
-        $sQ = " $sQ and IF( $sTable.oxvarcount = 0, 1, ( select 1 from $sTable as art where art.oxparentid=$sTable.oxid and ( art.oxactive = 1 $sTimeCheckQ ) and ( art.oxstockflag != 2 or art.oxstock > 0 ) limit 1 ) ) ";
+        $sQ = " $sQ and IF( $sTable.oxvarcount = 0, 1, oxvarstock ) ";
 
         $this->assertEquals(str_replace(array(" ", "\n", "\t", "\r"), "", $sQ), str_replace(array(" ", "\n", "\t", "\r"), "", $oArticle->getStockCheckQuery()));
     }

--- a/tests/Unit/Application/Model/ArticleTest.php
+++ b/tests/Unit/Application/Model/ArticleTest.php
@@ -401,7 +401,7 @@ class ArticleTest extends \OxidTestCase
 
         $sTimeCheckQ = " or ( art.oxactivefrom < '$sDate' and art.oxactiveto > '$sDate' )";
         $sQ = " and ( $sTable.oxstockflag != 2 or ( $sTable.oxstock + $sTable.oxvarstock ) > 0  ) ";
-        $sQ = " $sQ and IF( $sTable.oxvarcount = 0, 1, oxvarstock ) ";
+        $sQ = " $sQ and IF( $sTable.oxvarcount = 0, 1, $sTable.oxvarstock ) ";
 
         $this->assertEquals(str_replace(array(" ", "\n", "\t", "\r"), "", $sQ), str_replace(array(" ", "\n", "\t", "\r"), "", $oArticle->getStockCheckQuery()));
     }

--- a/tests/Unit/Application/Model/ArticleTest.php
+++ b/tests/Unit/Application/Model/ArticleTest.php
@@ -2160,7 +2160,7 @@ class ArticleTest extends \OxidTestCase
         $oArticle->setAdminMode(true);
         $sInsert = "";
         if (!$this->getConfig()->getConfigParam('blVariantParentBuyable')) {
-            $sInsert = " and IF( $sTable.oxvarcount = 0, 1, oxvarstock) ";
+            $sInsert = " and IF( $sTable.oxvarcount = 0, 1, $sTable.oxvarstock) ";
         }
         $sExpSelect = "(  $sTable.oxactive = 1  and $sTable.oxhidden = 0  and ( $sTable.oxstockflag != 2 or ( $sTable.oxstock + $sTable.oxvarstock ) > 0  ) $sInsert ) ";
         $sSelect = $oArticle->getSqlActiveSnippet();

--- a/tests/Unit/Application/Model/ArticleTest.php
+++ b/tests/Unit/Application/Model/ArticleTest.php
@@ -2160,7 +2160,7 @@ class ArticleTest extends \OxidTestCase
         $oArticle->setAdminMode(true);
         $sInsert = "";
         if (!$this->getConfig()->getConfigParam('blVariantParentBuyable')) {
-            $sInsert = " and IF( $sTable.oxvarcount = 0, 1, ( select 1 from $sTable as art where art.oxparentid=$sTable.oxid and  art.oxactive = 1  and ( art.oxstockflag != 2 or art.oxstock > 0 ) limit 1 ) ) ";
+            $sInsert = " and IF( $sTable.oxvarcount = 0, 1, oxvarstock) ";
         }
         $sExpSelect = "(  $sTable.oxactive = 1  and $sTable.oxhidden = 0  and ( $sTable.oxstockflag != 2 or ( $sTable.oxstock + $sTable.oxvarstock ) > 0  ) $sInsert ) ";
         $sSelect = $oArticle->getSqlActiveSnippet();

--- a/tests/Unit/Application/Model/SearchTest.php
+++ b/tests/Unit/Application/Model/SearchTest.php
@@ -818,7 +818,7 @@ class SearchTest extends UnitTestCase
                $sArticleTable.oxvarstock ) > 0  )  ";
         if (!$this->getConfig()->getConfigParam('blVariantParentBuyable')) {
             $sTimeCheckQ = " or ( art.oxactivefrom < '$sSearchDate' and art.oxactiveto > '$sSearchDate' )";
-            $sQ .= "and IF( $sTable.oxvarcount = 0, 1, ( select 1 from $sTable as art where art.oxparentid=$sTable.oxid and ( art.oxactive = 1 $sTimeCheckQ ) and ( art.oxstockflag != 2 or art.oxstock > 0 ) limit 1 ) ) ";
+            $sQ .= "and IF( $sTable.oxvarcount = 0, 1, $sTable.oxvarstock ) ";
         }
         $sQ .= ")  and $sArticleTable.oxparentid = '' and $sArticleTable.oxissearch = 1  and
                 ( (  $sAETable.oxlongdesc like '%xxx%' )  ) ";

--- a/tests/Unit/Application/Model/SearchTest.php
+++ b/tests/Unit/Application/Model/SearchTest.php
@@ -818,7 +818,7 @@ class SearchTest extends UnitTestCase
                $sArticleTable.oxvarstock ) > 0  )  ";
         if (!$this->getConfig()->getConfigParam('blVariantParentBuyable')) {
             $sTimeCheckQ = " or ( art.oxactivefrom < '$sSearchDate' and art.oxactiveto > '$sSearchDate' )";
-            $sQ .= "and IF( $sTable.oxvarcount = 0, 1, $sTable.oxvarstock ) ";
+            $sQ .= "and IF( $sTable.oxvarcount = 0, 1, $sTable.oxvarstock) ";
         }
         $sQ .= ")  and $sArticleTable.oxparentid = '' and $sArticleTable.oxissearch = 1  and
                 ( (  $sAETable.oxlongdesc like '%xxx%' )  ) ";


### PR DESCRIPTION
The subselect can cost many time with big data and if you use this in a LEFT JOIN context.
F.e.:
select all articles within a category:

> SELECT oxv_oxarticles_de.* FROM oxobject2category AS oc LEFT JOIN oxv_oxarticles_de 
 ON oxv_oxarticles_de.oxid = oc.oxobjectid
 WHERE (  oxv_oxarticles_de.oxactive = 1   and ( oxv_oxarticles_de.oxstockflag != 2 or ( oxv_oxarticles_de.oxstock + oxv_oxarticles_de.oxvarstock ) > 0  )  and IF( oxv_oxarticles_de.oxvarcount = 0, 1, ( select 1 from oxv_oxarticles_de as art where art.oxparentid=oxv_oxarticles_de.oxid and ( art.oxactive = 1  ) and ( art.oxstockflag != 2 or art.oxstock > 0 ) limit 1 ) )  ) 
 AND oxv_oxarticles_de.oxparentid = '' 
 AND oc.oxcatnid = '_xxxxxxxxxx_'  
 GROUP BY oc.oxcatnid, oc.oxobjectid ORDER BY  oxv_oxarticles_de.oxsort asc ,  oc.oxpos, oc.oxobjectid

and now faster:
> SELECT oxv_oxarticles_de.* FROM oxobject2category AS oc LEFT JOIN oxv_oxarticles_de 
 ON oxv_oxarticles_de.oxid = oc.oxobjectid
 WHERE (  oxv_oxarticles_de.oxactive = 1   and ( oxv_oxarticles_de.oxstockflag != 2 or ( oxv_oxarticles_de.oxstock + oxv_oxarticles_de.oxvarstock ) > 0  )  and IF( oxv_oxarticles_de.oxvarcount = 0, 1,oxvarstock) 
 AND oxv_oxarticles_de.oxparentid = '' 
 AND oc.oxcatnid = '_xxxxxxxxxx_'  
 GROUP BY oc.oxcatnid, oc.oxobjectid ORDER BY  oxv_oxarticles_de.oxsort asc ,  oc.oxpos, oc.oxobjectid