### PR TITLE
use 301 code for permanent redirects

### DIFF
--- a/source/Application/Controller/BaseController.php
+++ b/source/Application/Controller/BaseController.php
@@ -471,7 +471,7 @@ class BaseController extends \oxView
         if (!isSearchEngineUrl() && $utils->seoIsActive() && ($requestUrl = getRequestUrl('', true))) {
             // fetching standard url and looking for it in seo table
             if ($this->_canRedirect() && ($redirectUrl = oxRegistry::get("oxSeoEncoder")->fetchSeoUrl($requestUrl))) {
-                $utils->redirect($this->getConfig()->getCurrentShopUrl() . $redirectUrl, false);
+                $utils->redirect($this->getConfig()->getCurrentShopUrl() . $redirectUrl, false, 301);
             } elseif (VIEW_INDEXSTATE_INDEX == $this->noIndex()) {
                 // forcing to set no index/follow meta
                 $this->_forceNoIndex();


### PR DESCRIPTION
if you somehow call the internal url (not the seo url) on (for example) a category,
the redirect to the seo optimized url will not use 301.
This similar to:
https://bugs.oxid-esales.com/view.php?id=5471
but may occur only in special situation because normally the non seo urls are not used in links.
