### PR TITLE
removed unused parameters in method call

### DIFF
--- a/source/Application/Controller/BaseController.php
+++ b/source/Application/Controller/BaseController.php
@@ -468,7 +468,7 @@ class BaseController extends \oxView
         $utils = oxRegistry::getUtils();
 
         // non admin, request is not empty and was not processed by seo engine
-        if (!isSearchEngineUrl() && $utils->seoIsActive() && ($requestUrl = getRequestUrl('', true))) {
+        if (!isSearchEngineUrl() && $utils->seoIsActive() && ($requestUrl = getRequestUrl())) {
             // fetching standard url and looking for it in seo table
             if ($this->_canRedirect() && ($redirectUrl = oxRegistry::get("oxSeoEncoder")->fetchSeoUrl($requestUrl))) {
                 $utils->redirect($this->getConfig()->getCurrentShopUrl() . $redirectUrl, false);


### PR DESCRIPTION
btw. getRequestUrl is deprecated, and it has some magic (it checks if it is a post request), which should be better done by the caller