### PR TITLE
feature: Store the price without discounts

### DIFF
--- a/source/Core/Price.php
+++ b/source/Core/Price.php
@@ -60,7 +60,14 @@ class Price
      */
     protected $_aDiscounts = null;
 
-
+    
+    /**
+     * The price without discounts
+     * @var \oxPrice
+     */
+    protected $priceWithoutDiscounts = null;
+    
+    
     /**
      * Price entering mode
      * Reference to myConfig->blEnterNetPrice
@@ -445,6 +452,7 @@ class Price
         $this->_aDiscounts = null;
     }
 
+    
     /**
      * Calculates price: affects discounts
      */
@@ -454,6 +462,7 @@ class Price
         $aDiscounts = $this->getDiscounts();
 
         if ($aDiscounts) {
+            $this->priceWithoutDiscounts = clone $this;
             foreach ($aDiscounts as $aDiscount) {
                 if ($aDiscount['type'] == 'abs') {
                     $dPrice = $dPrice - $aDiscount['value'];
@@ -469,5 +478,11 @@ class Price
 
             $this->_flushDiscounts();
         }
+    }
+    
+    public function getPriceWithoutDiscounts()
+    {
+        return isset($this->priceWithoutDiscounts) ?
+            $this->priceWithoutDiscounts : $this;
     }
 }


### PR DESCRIPTION
What:
This pull requests adds the ability to retrieve the price without discounts.  

Why:
This is helpful in projects if you need to display the original price next to the effective price.
As the price logic with vats and discounts can become complicate, without this methods developer tending to create even more logic on top that in there module, making thing unmaintainable.

BC Break: 
no

Side effects:
if discounts are in effect it uses some bits additionally memory to store the original price, but that is nothing that should be measurable in practical use.
