### PR TITLE
Made some changes like fixed typos, moved similar parameters together…

### DIFF
--- a/source/config.inc.php.dist
+++ b/source/config.inc.php.dist
@@ -20,191 +20,224 @@
  * @version   OXID eShop CE
  */
 
-    /** database connection information */
-    $this->dbType = 'pdo_mysql';
-    $this->dbHost = '<dbHost>'; // database host name
-    $this->dbPort  = 3306; // tcp port to which the database is bound
-    $this->dbName = '<dbName>'; // database name
-    $this->dbUser = '<dbUser>'; // database user name
-    $this->dbPwd  = '<dbPwd>'; // database user password
-    $this->sShopURL     = '<sShopURL>'; // eShop base url, required
-    $this->sSSLShopURL  = null;            // eShop SSL url, optional
-    $this->sAdminSSLURL = null;            // eShop Admin SSL url, optional
-    $this->sShopDir     = '<sShopDir>';
-    $this->sCompileDir  = '<sCompileDir>';
+// database connection information
+$this->dbType = 'pdo_mysql';
+$this->dbHost = '<dbHost>'; // database host name
+$this->dbPort  = 3306; // tcp port to which the database is bound
+$this->dbName = '<dbName>'; // database name
+$this->dbUser = '<dbUser>'; // database user name
+$this->dbPwd  = '<dbPwd>'; // database user password
 
-    // UTF-8 mode in shop 0 - off, 1 - on
-    $this->iUtfMode = '<iUtfMode>';
+/*
+ * Default database connection character set.
+ * This option is only used when config option iUtfMode is set to 0.
+ */
+$this->sDefaultDatabaseConnection = 'latin1';
 
-    // Force shop edition. Even if enterprise or professional packages exists, shop edition can still be forced here.
-    // Possible options: CE|PE|EE or left empty (will be determined automatically).
-    $this->edition = '';
+// Shop URL information
+$this->sShopURL     = '<sShopURL>'; // eShop base url, required
+$this->sSSLShopURL  = null; // eShop SSL url, optional
+$this->sAdminSSLURL = null; // eShop Admin SSL url, optional
 
-    // Location of composer's vendor directory.
-    $this->vendorDirectory = __DIR__ . '/../vendor';
+// Shop directory information
+$this->sShopDir     = '<sShopDir>';
+$this->sCompileDir  = '<sCompileDir>';
 
-    // File type whitelist for file upload
-    $this->aAllowedUploadTypes = array('jpg', 'gif', 'png', 'pdf', 'mp3', 'avi', 'mpg', 'mpeg', 'doc', 'xls', 'ppt');
+// Location of composer's vendor directory.
+$this->vendorDirectory = __DIR__ . '/../vendor';
 
-    // timezone information
-    date_default_timezone_set('Europe/Berlin');
+/*
+ * Force shop edition. Even if enterprise or professional packages exists, shop edition can still be forced here.
+ * Possible options: CE|PE|EE or left empty (will be determined automatically).
+ */
+$this->edition = '';
 
-    // Search engine friendly URL processor
-    // After changing this value, you should rename oxid.php file as well
-    // Always leave .php extension here unless you know what you are doing
-    $this->sOXIDPHP = "oxid.php";
+// File type whitelist for file upload
+$this->aAllowedUploadTypes = array(
+    'jpg',
+    'gif',
+    'png',
+    'pdf',
+    'mp3',
+    'avi',
+    'mpg',
+    'mpeg',
+    'doc',
+    'xls',
+    'ppt',
+);
 
-    //  enable debug mode for template development or bugfixing
-    // -1 = Log more messages and throw exceptions on errors (not recommended for production)
-    //  0 = off
-    //  1 = smarty
-    //  3 = smarty
-    //  4 = smarty + shoptemplate data
-    //  5 = Delivery Cost calculation info
-    //  6 = SMTP Debug Messages
-    //  8 = display smarty template names (requires /tmp cleanup)
-    $this->iDebug = 0;
+// Timezone information
+date_default_timezone_set('Europe/Berlin');
 
-    // Log all modifications performed in Admin
-    $this->blLogChangesInAdmin = false;
+/*
+ * Search engine friendly URL processor.
+ * After changing this value, you should rename oxid.php file as well
+ * Always leave .php extension here unless you know what you are doing
+ */
+$this->sOXIDPHP = "oxid.php";
 
-    // Force admin email. Offline warnings are sent with high priority to this address.
-    $this->sAdminEmail = '';
-    // Defines the time interval in seconds warnings are sent during the shop is offline.
-    $this->offlineWarningInterval = 60 * 5;
+/*
+ * Activates search engine friendly URLs.
+ * on:  https://example.com/Kiteboarding/Kiteboards/Kiteboard-CABRINHA-CALIBER-2011.html
+ * off: https://example.com/index.php?cl=details&anid=058de8224773a1d5fd54d523f0c823e0&lang=0
+ */
+$this->blSeoMode = true;
 
-    // in case session must be started on first user page visit (not only on
-    // session required action) set this option value 1
-    $this->blForceSessionStart = false;
+/*
+ * Should requests coming via stdurl and not redirected to seo url be logged to seologs db table?
+ * Note: only active if in productive mode, as the eShop in non productive more will always log such urls
+ */
+$this->blSeoLogging = false;
 
-    // Use browser cookies to store session id (no sid parameter in URL)
-    $this->blSessionUseCookies = true;
+// List of all Search-Engine Robots
+$this->aRobots = array(
+    'googlebot',
+    'ultraseek',
+    'crawl',
+    'spider',
+    'fireball',
+    'robot',
+    'slurp',
+    'fast',
+    'altavista',
+    'teoma',
+    'msnbot',
+    'bingbot',
+    'yandex',
+    'gigabot',
+    'scrubby',
+);
 
-    // The domain that the cookie is available: array( _SHOP_ID_ => _DOMAIN_ );
-    // check setcookie() documentation for more details @php.net
-    $this->aCookieDomains = null;
+// Deactivate Static URL's for these Robots
+$this->aRobotsExcept = array();
 
-    // The path on the server in which the cookie will be available on: array( _SHOP_ID_ => _PATH_ );
-    // check setcookie() documentation for more details @php.net
-    $this->aCookiePaths = null;
+/*
+ * Enable debug mode for template development or bugfixing
+ * -1 = Log more messages and throw exceptions on errors (not recommended for production)
+ * 0 = off
+ * 1 = smarty
+ * 3 = smarty
+ * 4 = smarty + shoptemplate data
+ * 5 = Delivery Cost calculation info
+ * 6 = SMTP Debug Messages
+ * 8 = display smarty template names (requires /tmp cleanup)
+ */
+$this->iDebug = 0;
 
-    // uncomment the following line if you want to leave euro sign unchanged in output
-    // by default is set to convert euro sign symbol to html entity
-    // $this->blSkipEuroReplace = true;
+/*
+ * Should template blocks be highlighted in frontend?
+ * This is mainly intended for module writers in non productive environment
+ */
+$this->blDebugTemplateBlocks = false;
 
-    // List of all Search-Engine Robots
-    $this->aRobots = array(
-                        'googlebot',
-                        'ultraseek',
-                        'crawl',
-                        'spider',
-                        'fireball',
-                        'robot',
-                        'slurp',
-                        'fast',
-                        'altavista',
-                        'teoma',
-                        'msnbot',
-                        'bingbot',
-                        'yandex',
-                        'gigabot',
-                        'scrubby'
-                        );
+// Log all modifications performed in Admin
+$this->blLogChangesInAdmin = false;
 
-    // Deactivate Static URL's for these Robots
-    $this->aRobotsExcept = array();
+// Force admin email. Offline warnings are sent with high priority to this address.
+$this->sAdminEmail = '';
 
-    // IP addresses for which session/cookie id match and user agent change checks are off
-    $this->aTrustedIPs = array();
+// Defines the time interval in seconds warnings are sent during the shop is offline.
+$this->offlineWarningInterval = 60 * 5;
 
-    /**
-     * Works only if basket reservations feature is enabled in admin.
-     *
-     * The number specifies how many expired basket reservations are
-     * cleaned per one request (to the eShop).
-     * Cleaning a reservation basically means returning the reserved
-     * stock to the articles.
-     *
-     * Keeping this number too low may cause article stock being returned too
-     * slowly, while too high value may have spiking impact on the performance.
-     */
-    $this->iBasketReservationCleanPerRequest = 200;
+// In case session must be started on the very first user page visit (not only on session required action).
+$this->blForceSessionStart = false;
 
-    /**
-     * should template blocks be highlighted in frontend ?
-     * this is mainly intended for module writers in non productive environment
-     */
-    $this->blDebugTemplateBlocks = false;
+// Use browser cookies to store session id (no sid parameter in URL).
+$this->blSessionUseCookies = true;
 
-    /**
-     * should requests, coming via stdurl and not redirected to seo url be logged to seologs db table?
-     * note: only active if in productive mode, as the eShop in non productive more will always log such urls
-     */
-    $this->blSeoLogging = false;
+/*
+ * The domain that the cookie is available: array(_SHOP_ID_ => _DOMAIN_);
+ * Check setcookie() documentation for more details: http://php.net/manual/de/function.setcookie.php
+ */
+$this->aCookieDomains = null;
 
-    /**
-     * To override oxubase::_aUserComponentNames use this array option:
-     * array keys are component(class) names and array values defines if component is cacheable (true/false)
-     * e.g. array("user_class" => false);
-     */
-    $this->aUserComponentNames = null;
+/*
+ * The path on the server in which the cookie will be available on: array(_SHOP_ID_ => _PATH_);
+ * Check setcookie() documentation for more details: http://php.net/manual/de/function.setcookie.php
+ */
+$this->aCookiePaths = null;
 
-    /**
-     * Default database connection character set. This option is only used when config option iUtfMode is set to 0.
-     */
-    $this->sDefaultDatabaseConnection = 'latin1';
+// IP addresses for which session/cookie id match and user agent change checks are off
+$this->aTrustedIPs = array();
 
-    /**
-     * Additional multi language tables
-     */
-    $this->aMultiLangTables = null;
+/*
+ * Uncomment the following line if you want to leave euro sign unchanged in output by default is set
+ * to convert euro sign symbol to html entity
+ */
+//$this->blSkipEuroReplace = true;
 
-    /**
-     * Instructs shop that price update is perfomed by cron (time based job sheduler)
-     */
-    $this->blUseCron = false;
+/*
+ * Works only if basket reservations feature is enabled in admin.
+ *
+ * The number specifies how many expired basket reservations are
+ * cleaned per one request (to the eShop).
+ * Cleaning a reservation basically means returning the reserved
+ * stock to the articles.
+ *
+ * Keeping this number too low may cause article stock being returned too
+ * slowly, while too high value may have spiking impact on the performance.
+ */
+$this->iBasketReservationCleanPerRequest = 200;
 
-    /**
-     * Do not disable module if class from extension path does not exist.
-     */
-    $this->blDoNotDisableModuleOnError = false;
+/*
+ * To override FrontendController::$_aUserComponentNames use this array option:
+ * Array keys are component(class) names and array values defines if component is cacheable (true/false)
+ * E.g. array('user_class' => false);
+ */
+$this->aUserComponentNames = null;
 
-    /**
-     * Enable temporarily in case you can't access the backend due to broken views
-     */
-    $this->blSkipViewUsage = false;
+// Additional multi language tables
+$this->aMultiLangTables = null;
 
-    /**
-     * Enterprise Edition related config options.
-     * This options have no effect on Community/Professional Editions.
-     */
+// Instructs shop that price update is perfomed by cron (time based job sheduler)
+$this->blUseCron = false;
 
-    //Time limit in ms to be notified about slow queries
-    $this->iDebugSlowQueryTime = 20;
+// Do not disable module if class from extension path does not exist.
+$this->blDoNotDisableModuleOnError = false;
 
-    // enables Rights and Roles engine
-    // 0 - off,
-    // 1 - only in admin,
-    // 2 - only in shop,
-    // 3 - both
-    $this->blUseRightsRoles = 3;
+// Enable temporarily in case you can't access the backend due to broken views
+$this->blSkipViewUsage = false;
 
-    //define oxarticles fields which could be edited individually in subshops
-    //do not forget to add these fields to oxfield2shop table
-    //note the field names are case sensitive here
-    $this->aMultishopArticleFields = array("OXPRICE", "OXPRICEA", "OXPRICEB", "OXPRICEC", "OXUPDATEPRICE", "OXUPDATEPRICEA", "OXUPDATEPRICEB", "OXUPDATEPRICEC", "OXUPDATEPRICETIME");
+// Show "Update Views" button in admin
+$this->blShowUpdateViews = true;
 
-    //Show "Update Views" button in admin
-    $this->blShowUpdateViews = true;
+// Control the removal of Setup directory
+$this->blDelSetupDir = true;
 
-    // If default 30 seconds is not enougth
-    // @set_time_limit(3000);
+/*
+ * Enterprise Edition related config options.
+ * This options have no effect on Community/Professional Editions.
+ */
 
-    /**
-     * Database master-slave configuration:
-     * aSlaveHosts - array of slave hosts: array('localhost', '10.2.3.12')
-     */
-    $this->aSlaveHosts = null;
+/*
+ * Enables Rights and Roles engine
+ * 0 - off,
+ * 1 - only in admin,
+ * 2 - only in shop,
+ * 3 - both
+ */
+$this->blUseRightsRoles = 3;
 
-    // Control the removal of Setup directory
-    $this->blDelSetupDir = true;
+/*
+ * Define oxarticles fields which could be edited individually in subshops.
+ * Do not forget to add these fields to oxfield2shop table.
+ * Note: The field names are case sensitive here.
+ */
+$this->aMultishopArticleFields = array(
+    'OXPRICE',
+    'OXPRICEA',
+    'OXPRICEB',
+    'OXPRICEC',
+    'OXUPDATEPRICE',
+    'OXUPDATEPRICEA',
+    'OXUPDATEPRICEB',
+    'OXUPDATEPRICEC',
+    'OXUPDATEPRICETIME',
+);
+
+/*
+ * Database master-slave configuration:
+ * aSlaveHosts - array of slave hosts: array('localhost', '10.2.3.12')
+ */
+$this->aSlaveHosts = null;


### PR DESCRIPTION
I did a few things here, as the time is perfect:

1. Moved all lines to the left. The file will be included into a PHP file, but it isn't necessary for a human nor the machine to have those whitespaces on each line.

2. Changed multiline comments to inline comments:
Example:
```
//aaa
//aaa
$this->a = null;
```
to
```
/*
 * aaa
 * aaa
 */
$this->a = null;
```
3. Moved parameters because they were in the "Enterprise Edition only" section.
- blShowUpdateViews
- blDelSetupDir

4. Removed as it isn't used anymore. #5337
`$this->iDebugSlowQueryTime`

5. Removed @set_time_limit(3000) as this should be configured in the php.ini file and not in the shop code.
```
// If default 30 seconds is not enougth
// @set_time_limit(3000);
```
6. Added the configuration parameter `$this->blSeoMode = true;`

7. Normalized the arrays.

8. Fixed typos, changed some beginnings to uppercase.




There are two questions left: 
- Should all lines have an inline comment to have some consistency? It wouldn't be PSR like, but it would be a more clear form.
- Variables with no value like arrays are sometimes initiated with array() and sometimes will null. Should it be changed to array()? Same for strings. Sometimes it's '' and sometimes null. For the arrays I checked the unit tests and it seems like it wouldn't be a problem to change the value to array().