### PR TITLE
feedback on firewall blocking license check

### DIFF
--- a/source/Application/Controller/Admin/ShopLicense.php
+++ b/source/Application/Controller/Admin/ShopLicense.php
@@ -8,6 +8,7 @@ namespace OxidEsales\EshopCommunity\Application\Controller\Admin;
 
 use oxRegistry;
 use oxSystemComponentException;
+use OxidEsales\Eshop\Core\Exception\ConnectionException;
 
 /**
  * Admin shop license setting manager.
@@ -101,8 +102,11 @@ class ShopLicense extends \OxidEsales\Eshop\Application\Controller\Admin\ShopCon
         $oCurl->setMethod("POST");
         $oCurl->setUrl($sUrl . "/" . $sLang);
         $oCurl->setParameters($aParams);
-        $sOutput = $oCurl->execute();
-
+        try {
+            $sOutput = $oCurl->execute();
+        } catch (ConnectionException $ex) {
+            $sOutput = "Connecting to $sUrl failed, please check network and firewalls";
+        }
         $sOutput = strip_tags($sOutput, "<br>, <b>");
         $aResult = explode("<br>", $sOutput);
         if (strstr($aResult[5], "update")) {

--- a/source/Application/Controller/Admin/ShopLicense.php
+++ b/source/Application/Controller/Admin/ShopLicense.php
@@ -105,7 +105,7 @@ class ShopLicense extends \OxidEsales\Eshop\Application\Controller\Admin\ShopCon
         try {
             $sOutput = $oCurl->execute();
         } catch (ConnectionException $ex) {
-            $sOutput = "Connecting to $sUrl failed, please check network and firewalls";
+            $sOutput = "<div class='errorbox'>Connecting to $sUrl failed, please check network and firewalls</div>";
         }
         $sOutput = strip_tags($sOutput, "<br>, <b>");
         $aResult = explode("<br>", $sOutput);

--- a/source/Core/Curl.php
+++ b/source/Core/Curl.php
@@ -5,6 +5,7 @@
  */
 
 namespace OxidEsales\EshopCommunity\Core;
+use OxidEsales\Eshop\Core\Exception\ConnectionException;
 
 /**
  * CURL request handler.
@@ -294,7 +295,9 @@ class Curl
             /**
              * @var \OxidEsales\Eshop\Core\Exception\StandardException $exception
              */
-            $exception = oxNew(\OxidEsales\Eshop\Core\Exception\StandardException::class);
+            $exception = oxNew(ConnectionException::class);
+            $exception->setConnectionError($curlErrorNumber);
+            $exception->setAdress($this->_sUrl);
             $lang = \OxidEsales\Eshop\Core\Registry::getLang();
             $exception->setMessage(sprintf($lang->translateString('EXCEPTION_CURL_ERROR', $lang->getTplLanguage()), $curlErrorNumber));
             throw $exception;


### PR DESCRIPTION
make it possible to use admin backend, and see the error message if firewall is blocking the license check.
without this fix it is not possible to review or change the current license if the shop runs behind a firewall.
![screenshot](https://user-images.githubusercontent.com/1001186/49872341-0c5f2680-fe19-11e8-9eb4-f16abdfa0251.png)
