### PR TITLE
cast value to float

### DIFF
--- a/source/Core/Utils.php
+++ b/source/Core/Utils.php
@@ -338,6 +338,8 @@ class Utils extends \oxSuperCfg
         }
         stopProfile('fround');
 
+        $sVal = (float) $sVal;
+
         return round($sVal + $dprez * ($sVal >= 0 ? 1 : -1), $iCurPrecision);
     }
 


### PR DESCRIPTION
fix failing php7.1 build

see also #518 and eb6af3562e60095c48f3267a1a9fb4b72cb36490

btw: We use `(float)` and `(double)` in the code. Maybe we should use just one of these?