### PR TITLE
log missing translations

### DIFF
--- a/source/Core/Language.php
+++ b/source/Core/Language.php
@@ -7,6 +7,7 @@
 namespace OxidEsales\EshopCommunity\Core;
 
 use stdClass;
+use OxidEsales\Eshop\Core\Registry;
 
 /**
  * Language related utility class
@@ -439,6 +440,13 @@ class Language extends \OxidEsales\Eshop\Core\Base
         }
 
         $this->setIsTranslated(false);
+
+        if (!$this->isTranslated()) {
+            Registry::getLogger()->warning(
+                "translation for $sStringToTranslate not found",
+                compact('iLang', 'blAdminMode')
+            );
+        }
 
         return $sStringToTranslate;
     }


### PR DESCRIPTION
This PR will enable logging for missing translations.

Questions:
* Do we need an additional flag to enable/disable this kind of logging?
* Do we need more data like shop-id, activated theme or modules?
* Is there a better way to log stuff like this?

I found comments like this
```
//deprecated since v5.3 (2016-06-17); Logging mechanism will be changed in 6.0.
```
over and over again, but I don't know if you have already implemented another logging mechanism.

---

sample output:
```
OxidEsales\EshopCommunity\Core\Exception\StandardException (time: 2016-12-09 13:09:20): [0]: ERROR: Translation for MORE_INFO not found! 
 Stack Trace: #0 /var/www/oxideshop/source/Core/UtilsObject.php(273): OxidEsales\EshopCommunity\Core\UtilsObject->_getObject('oxexception', 0, Array)
#1 [internal function]: OxidEsales\EshopCommunity\Core\UtilsObject->oxNew('oxException')
#2 /var/www/oxideshop/source/oxfunctions.php(317): call_user_func_array(Array, Array)
#3 /var/www/oxideshop/source/Core/Smarty/Plugin/function.oxmultilang.php(90): oxNew('oxException')
#4 /var/www/oxideshop/source/tmp/smarty/6ce77b7a9d9444335a4b8f5ea13cf8cb^%%CB^CB6^CB6C1C15%%listitem_infogrid.tpl.php(224): smarty_function_oxmultilang(Array, Object(Smarty))
#5 /var/www/oxideshop/vendor/smarty/smarty/libs/Smarty.class.php(1270): include('/var/www/oxides...')
#6 /var/www/oxideshop/source/Core/ShopControl.php(469): Smarty->fetch('widget/product/...', 'ox|0|0|0|0')
#7 /var/www/oxideshop/source/Core/ShopControl.php(328): OxidEsales\EshopCommunity\Core\ShopControl->_render(Object(OxidEsales\EshopCommunity\Application\Component\Widget\ArticleBox))
#8 /var/www/oxideshop/source/Core/ShopControl.php(260): OxidEsales\EshopCommunity\Core\ShopControl->formOutput(Object(OxidEsales\EshopCommunity\Application\Component\Widget\ArticleBox))
#9 /var/www/oxideshop/source/Core/ShopControl.php(153): OxidEsales\EshopCommunity\Core\ShopControl->_process('oxwarticlebox', NULL, Array, Array)
#10 /var/www/oxideshop/source/Core/WidgetControl.php(74): OxidEsales\EshopCommunity\Core\ShopControl->start('oxwarticlebox', NULL, Array, Array)
#11 /var/www/oxideshop/source/Core/Smarty/Plugin/function.oxid_include_widget.php(47): OxidEsales\EshopCommunity\Core\WidgetControl->start('oxwarticlebox', NULL, Array, Array)
#12 /var/www/oxideshop/source/tmp/smarty/6ce77b7a9d9444335a4b8f5ea13cf8cb^%%FC^FCA^FCA347E9%%list.tpl.php(79): smarty_function_oxid_include_widget(Array, Object(Smarty))
#13 /var/www/oxideshop/vendor/smarty/smarty/libs/Smarty.class.php(1876): include('/var/www/oxides...')
#14 /var/www/oxideshop/source/tmp/smarty/6ce77b7a9d9444335a4b8f5ea13cf8cb^%%40^405^405277AF%%start.tpl.php(52): Smarty->_smarty_include(Array)
#15 /var/www/oxideshop/vendor/smarty/smarty/libs/Smarty.class.php(1270): include('/var/www/oxides...')
#16 /var/www/oxideshop/source/Core/ShopControl.php(469): Smarty->fetch('page/shop/start...', 'ox|0|0|0|0')
#17 /var/www/oxideshop/source/Core/ShopControl.php(328): OxidEsales\EshopCommunity\Core\ShopControl->_render(Object(OxidEsales\EshopCommunity\Application\Controller\StartController))
#18 /var/www/oxideshop/source/Core/ShopControl.php(260): OxidEsales\EshopCommunity\Core\ShopControl->formOutput(Object(OxidEsales\EshopCommunity\Application\Controller\StartController))
#19 /var/www/oxideshop/source/Core/ShopControl.php(153): OxidEsales\EshopCommunity\Core\ShopControl->_process('start', NULL, NULL, NULL)
#20 /var/www/oxideshop/source/Core/Oxid.php(46): OxidEsales\EshopCommunity\Core\ShopControl->start()
#21 /var/www/oxideshop/source/index.php(26): OxidEsales\EshopCommunity\Core\Oxid::run()
#22 {main}


---------------------------------------------
```