### PR TITLE
Updates tpl & ajax controller to allow custom fields in table oxobjec…

### DIFF
--- a/source/Application/Controller/Admin/ArticleAttributeAjax.php
+++ b/source/Application/Controller/Admin/ArticleAttributeAjax.php
@@ -156,10 +156,13 @@ class ArticleAttributeAjax extends \ajaxListComponent
                 $objectToAttribute->init("oxobject2attribute");
                 if ($objectToAttribute->assignRecord($select)) {
                     $objectToAttribute->oxobject2attribute__oxvalue->setValue($attributeValue);
-                    foreach ($attributeCustomData as $key=>$value)
+                    if (isset($attributeCustomData) && is_array($attributeCustomData))
                     {
-                        $fieldName = 'oxobject2attribute__'.$key;
-                        $objectToAttribute->$fieldName->setValue($value);
+                        foreach ($attributeCustomData as $key=>$value)
+                        {
+                            $fieldName = 'oxobject2attribute__'.$key;
+                            $objectToAttribute->$fieldName->setValue($value);
+                        }
                     }
                     $objectToAttribute->save();
                 }

--- a/source/Application/Controller/Admin/ArticleAttributeAjax.php
+++ b/source/Application/Controller/Admin/ArticleAttributeAjax.php
@@ -136,6 +136,7 @@ class ArticleAttributeAjax extends \ajaxListComponent
         $articleId = oxRegistry::getConfig()->getRequestParameter("oxid");
         $attributeId = oxRegistry::getConfig()->getRequestParameter("attr_oxid");
         $attributeValue = oxRegistry::getConfig()->getRequestParameter("attr_value");
+        $attributeCustomData = oxRegistry::getConfig()->getRequestParameter("customData");
 
         $article = oxNew("oxArticle");
         if ($article->load($articleId)) {
@@ -155,6 +156,11 @@ class ArticleAttributeAjax extends \ajaxListComponent
                 $objectToAttribute->init("oxobject2attribute");
                 if ($objectToAttribute->assignRecord($select)) {
                     $objectToAttribute->oxobject2attribute__oxvalue->setValue($attributeValue);
+                    foreach ($attributeCustomData as $key=>$value)
+                    {
+                        $fieldName = 'oxobject2attribute__'.$key;
+                        $objectToAttribute->$fieldName->setValue($value);
+                    }
                     $objectToAttribute->save();
                 }
             }

--- a/source/Application/views/admin/tpl/popups/article_attribute.tpl
+++ b/source/Application/views/admin/tpl/popups/article_attribute.tpl
@@ -1,117 +1,140 @@
 [{include file="popups/headitem.tpl" title="GENERAL_ADMIN_TITLE"|oxmultilangassign}]
 
 <script type="text/javascript">
-    initAoc = function()
-    {
+    initAoc = function () {
 
-        YAHOO.oxid.container1 = new YAHOO.oxid.aoc( 'container1',
-                                                    [ [{foreach from=$oxajax.container1 item=aItem key=iKey}]
-                                                       [{$sSep}][{strip}]{ key:'_[{$iKey}]', ident: [{if $aItem.4}]true[{else}]false[{/if}]
-                                                       [{if !$aItem.4}],
-                                                       label: '[{oxmultilang ident="GENERAL_AJAX_SORT_"|cat:$aItem.0|oxupper}]',
-                                                       visible: [{if $aItem.2}]true[{else}]false[{/if}]
-                                                       [{/if}]}
-                                                      [{/strip}]
-                                                      [{assign var="sSep" value=","}]
-                                                      [{/foreach}] ],
-                                                    '[{$oViewConf->getAjaxLink()}]cmpid=container1&container=article_attribute&synchoxid=[{$oxid}]'
-                                                    );
+        YAHOO.oxid.container1 = new YAHOO.oxid.aoc('container1',
+            [ [{foreach from=$oxajax.container1 item=aItem key=iKey}]
+                    [{$sSep}][{strip}]{
+                    key: '_[{$iKey}]', ident: [{if $aItem.4}]true[{else}]false[{/if}]
+                    [{if !$aItem.4}],
+                    label: '[{oxmultilang ident="GENERAL_AJAX_SORT_"|cat:$aItem.0|oxupper}]',
+                    visible: [{if $aItem.2}]true[{else}]false[{/if}]
+                    [{/if}]}
+                [{/strip}]
+                [{assign var="sSep" value=","}]
+                [{/foreach}] ],
+            '[{$oViewConf->getAjaxLink()}]cmpid=container1&container=article_attribute&synchoxid=[{$oxid}]'
+        );
 
         [{assign var="sSep" value=""}]
 
-        YAHOO.oxid.container2 = new YAHOO.oxid.aoc( 'container2',
-                                                    [ [{foreach from=$oxajax.container2 item=aItem key=iKey}]
-                                                       [{$sSep}][{strip}]{ key:'_[{$iKey}]', ident: [{if $aItem.4}]true[{else}]false[{/if}]
-                                                       [{if !$aItem.4}],
-                                                       label: '[{oxmultilang ident="GENERAL_AJAX_SORT_"|cat:$aItem.0|oxupper}]',
-                                                       visible: [{if $aItem.2}]true[{else}]false[{/if}],
-                                                       formatter: YAHOO.oxid.aoc.custFormatter
-                                                       [{/if}]}
-                                                      [{/strip}]
-                                                      [{assign var="sSep" value=","}]
-                                                      [{/foreach}] ],
-                                                    '[{$oViewConf->getAjaxLink()}]cmpid=container2&container=article_attribute&oxid=[{$oxid}]'
-                                                    )
-        YAHOO.oxid.container1.getDropAction = function()
-        {
+        YAHOO.oxid.container2 = new YAHOO.oxid.aoc('container2',
+            [ [{foreach from=$oxajax.container2 item=aItem key=iKey}]
+                    [{$sSep}][{strip}]{
+                    key: '_[{$iKey}]', ident: [{if $aItem.4}]true[{else}]false[{/if}]
+                    [{if !$aItem.4}],
+                    label: '[{oxmultilang ident="GENERAL_AJAX_SORT_"|cat:$aItem.0|oxupper}]',
+                    visible: [{if $aItem.2}]true[{else}]false[{/if}],
+                    formatter: YAHOO.oxid.aoc.custFormatter
+                    [{/if}]}
+                [{/strip}]
+                [{assign var="sSep" value=","}]
+                [{/foreach}] ],
+            '[{$oViewConf->getAjaxLink()}]cmpid=container2&container=article_attribute&oxid=[{$oxid}]'
+        )
+        YAHOO.oxid.container1.getDropAction = function () {
             return 'fnc=addattr';
         }
 
-        YAHOO.oxid.container2.getDropAction = function()
-        {
+        YAHOO.oxid.container2.getDropAction = function () {
             return 'fnc=removeattr';
         }
-        YAHOO.oxid.container2.subscribe( "rowClickEvent", function( oParam )
-        {
-            var aSelRows= YAHOO.oxid.container2.getSelectedRows();
-            if ( aSelRows.length ) {
+        YAHOO.oxid.container2.subscribe("rowClickEvent", function (oParam) {
+            var aSelRows = YAHOO.oxid.container2.getSelectedRows();
+            if (aSelRows.length) {
                 oParam = YAHOO.oxid.container2.getRecord(aSelRows[0]);
-                $('_attrname').innerHTML = oParam._oData._0;
-                $('attr_value').value    = oParam._oData._2;
-                $('attr_oxid').value     = oParam._oData._3;
-                $D.setStyle( $('arrt_conf'), 'visibility', '' );
-            } else {
-                $D.setStyle( $('arrt_conf'), 'visibility', 'hidden' );
+                for (var i = 0; i < Object.keys(oParam._oData).length; i++) {
+                    var domElement = document.querySelector('[data-param-id="_' + i + '"]');
+                    if (domElement) {
+                        var tagName = domElement.tagName.toLowerCase();
+                        switch (tagName) {
+                            case 'input':
+                                $(domElement.id).value = oParam._oData['_' + i];
+                                break;
+
+                            default:
+                                $(domElement.id).innerHTML = oParam._oData['_' + i];
+                        }
+                    }
+                }
+                $D.setStyle($('arrt_conf'), 'visibility', '');
+            }
+            else {
+                $D.setStyle($('arrt_conf'), 'visibility', 'hidden');
             }
         })
-        YAHOO.oxid.container2.subscribe( "dataReturnEvent", function()
-        {
-            $D.setStyle( $('arrt_conf'), 'visibility', 'hidden' );
+        YAHOO.oxid.container2.subscribe("dataReturnEvent", function () {
+            $D.setStyle($('arrt_conf'), 'visibility', 'hidden');
         })
-        YAHOO.oxid.container2.onSave = function()
-        {
+        YAHOO.oxid.container2.onSave = function () {
             YAHOO.oxid.container1.getDataSource().flushCache();
-            YAHOO.oxid.container1.getPage( 0 );
+            YAHOO.oxid.container1.getPage(0);
             YAHOO.oxid.container2.getDataSource().flushCache();
-            YAHOO.oxid.container2.getPage( 0 );
+            YAHOO.oxid.container2.getPage(0);
         }
-        YAHOO.oxid.container2.onFailure = function() { /* currently does nothing */ }
-        YAHOO.oxid.container2.saveAttribute = function()
-        {
+        YAHOO.oxid.container2.onFailure = function () { /* currently does nothing */
+        }
+        YAHOO.oxid.container2.saveAttribute = function () {
             var callback = {
                 success: YAHOO.oxid.container2.onSave,
                 failure: YAHOO.oxid.container2.onFailure,
-                scope:   YAHOO.oxid.container2
+                scope: YAHOO.oxid.container2
             };
-            YAHOO.util.Connect.asyncRequest( 'GET', '[{$oViewConf->getAjaxLink()}]&cmpid=container2&container=article_attribute&fnc=saveAttributeValue&oxid=[{$oxid}]&attr_value=' + encodeURIComponent( $('attr_value').value ) + '&attr_oxid=' + encodeURIComponent( $('attr_oxid').value ), callback );
+
+            var customAttributes = document.getElementsByClassName('custom-attributes');
+            var customAttributesForUrl = '';
+            for (var i = 0; i < customAttributes.length; i++) {
+                var current = customAttributes[i];
+                customAttributesForUrl += '&customData[' + current.dataset.tableColumn + ']=' + encodeURIComponent(current.value);
+            }
+
+            YAHOO.util.Connect.asyncRequest('GET', '[{$oViewConf->getAjaxLink()}]&cmpid=container2&container=article_attribute&fnc=saveAttributeValue&oxid=[{$oxid}]&attr_value=' + encodeURIComponent($('attr_value').value) + '&attr_oxid=' + encodeURIComponent($('attr_oxid').value) + customAttributesForUrl, callback);
 
         }
         // subscribint event listeners on buttons
-        $E.addListener( $('saveBtn'), "click", YAHOO.oxid.container2.saveAttribute, $('saveBtn') );
+        $E.addListener($('saveBtn'), "click", YAHOO.oxid.container2.saveAttribute, $('saveBtn'));
     }
-    $E.onDOMReady( initAoc );
+    $E.onDOMReady(initAoc);
 </script>
 
-    <table width="100%">
-        <colgroup>
-            <col span="2" width="40%" />
-            <col width="20%" />
-        </colgroup>
-        <tr class="edittext">
-            <td colspan="3">[{oxmultilang ident="GENERAL_AJAX_DESCRIPTION"}]<br>[{oxmultilang ident="GENERAL_FILTERING"}]<br /><br /></td>
-        </tr>
-        <tr class="edittext">
-            <td align="center" valign="top"><b>[{oxmultilang ident="ARTICLE_ATTRIBUTE_NOATTRIBUTE"}]</b></td>
-            <td align="center" valign="top"><b>[{oxmultilang ident="ARTICLE_ATTRIBUTE_ITEMSATTRIBUTE"}]</b></td>
-            <td align="center" valign="top">[{oxmultilang ident="ARTICLE_ATTRIBUTE_SELECTONEATTR"}]</td>
-        </tr>
-        <tr>
-            <td valign="top" id="container1"></td>
-            <td valign="top" id="container2"></td>
-            <td valign="top" align="center" class="edittext" id="arrt_conf" style="visibility:hidden">
-              <br><br>
-              <b id="_attrname">[{$attr_name}]</b>:<br><br>
-              <input id="attr_oxid" type="hidden">
-              <input id="attr_value" class="editinput" type="text"><br><br>
-              <input id="saveBtn" type="button" class="edittext" value="[{oxmultilang ident="ARTICLE_ATTRIBUTE_SAVE"}]">
-            </td>
-        </tr>
-        <tr>
-            <td class="oxid-aoc-actions"><input type="button" value="[{oxmultilang ident="GENERAL_AJAX_ASSIGNALL"}]" id="container1_btn"></td>
-            <td class="oxid-aoc-actions"><input type="button" value="[{oxmultilang ident="GENERAL_AJAX_UNASSIGNALL"}]" id="container2_btn"></td>
-            <td></td>
-        </tr>
-    </table>
+<table width="100%">
+    <colgroup>
+        <col span="2" width="40%"/>
+        <col width="20%"/>
+    </colgroup>
+    <tr class="edittext">
+        <td colspan="3">[{oxmultilang ident="GENERAL_AJAX_DESCRIPTION"}]<br>[{oxmultilang ident="GENERAL_FILTERING"}]
+            <br/><br/></td>
+    </tr>
+    <tr class="edittext">
+        <td align="center" valign="top"><b>[{oxmultilang ident="ARTICLE_ATTRIBUTE_NOATTRIBUTE"}]</b></td>
+        <td align="center" valign="top"><b>[{oxmultilang ident="ARTICLE_ATTRIBUTE_ITEMSATTRIBUTE"}]</b></td>
+        <td align="center" valign="top">[{oxmultilang ident="ARTICLE_ATTRIBUTE_SELECTONEATTR"}]</td>
+    </tr>
+    <tr>
+        <td valign="top" id="container1"></td>
+        <td valign="top" id="container2"></td>
+        <td valign="top" align="center" class="edittext" id="arrt_conf" style="visibility:hidden">
+            <br><br>
+            <b id="_attrname" data-param-id="_0">[{$attr_name}]</b>:<br><br>
+            <input id="attr_oxid" data-param-id="_3" type="hidden">
+            [{block name="admin_article_attribute_data"}]
+                <input id="attr_value" data-param-id="_2" class="editinput" type="text">
+            [{/block}]
+            <br>
+            <br>
+            <input id="saveBtn" type="button" class="edittext" value="[{oxmultilang ident="ARTICLE_ATTRIBUTE_SAVE"}]">
+        </td>
+    </tr>
+    <tr>
+        <td class="oxid-aoc-actions">
+            <input type="button" value="[{oxmultilang ident="GENERAL_AJAX_ASSIGNALL"}]" id="container1_btn"></td>
+        <td class="oxid-aoc-actions">
+            <input type="button" value="[{oxmultilang ident="GENERAL_AJAX_UNASSIGNALL"}]" id="container2_btn"></td>
+        <td></td>
+    </tr>
+</table>
 
 </body>
 </html>

--- a/tests/Unit/Application/Controller/Admin/ArticleAttributeAjaxTest.php
+++ b/tests/Unit/Application/Controller/Admin/ArticleAttributeAjaxTest.php
@@ -190,10 +190,12 @@ class ArticleAttributeAjaxTest extends \OxidTestCase
         $sOxid = '_testAttributeArticle';
         $sAttrOxid = '_testAttributeSaveAttr';
         $sAttrValue = '_testAttrValue';
+        $aCustomData = '';
 
         $this->setRequestParameter("oxid", $sOxid);
         $this->setRequestParameter("attr_oxid", $sAttrOxid);
         $this->setRequestParameter("attr_value", $sAttrValue);
+        $this->setRequestParameter("customData", $aCustomData);
 
         $this->assertEquals(0, oxDb::getDb()->getOne("select count(oxid) from oxobject2attribute where oxvalue='$sAttrValue'"));
 


### PR DESCRIPTION
Updates tpl & ajax controller to allow custom fields in table oxobject2attribute. In order to use this each editable field must have following attributes: "id" and "data-param-id". The latter is equal to the key of the object stored in the js variable `oParam._oData`.

![oxideshop_ce-feature-customize-oxobject2attribute](https://cloud.githubusercontent.com/assets/5464339/21391618/bd19b00a-c78c-11e6-9c24-46f1de41b78a.png)
