### PR TITLE
normalized the comments, fixed some typos.

### DIFF
--- a/source/config.inc.php.dist
+++ b/source/config.inc.php.dist
@@ -20,7 +20,7 @@
  * @version   OXID eShop CE
  */
 
-    /** database connection information */
+    // Database connection information
     $this->dbType = 'pdo_mysql';
     $this->dbHost = '<dbHost>'; // database host name
     $this->dbPort  = 3306; // tcp port to which the database is bound
@@ -33,8 +33,10 @@
     $this->sShopDir     = '<sShopDir>';
     $this->sCompileDir  = '<sCompileDir>';
 
-    // Force shop edition. Even if enterprise or professional packages exists, shop edition can still be forced here.
-    // Possible options: CE|PE|EE or left empty (will be determined automatically).
+    /**
+     * Force shop edition. Even if enterprise or professional packages exists, shop edition can still be forced here.
+     * Possible options: CE|PE|EE or left empty (will be determined automatically).
+     */
     $this->edition = '';
 
     // Location of composer's vendor directory.
@@ -43,23 +45,27 @@
     // File type whitelist for file upload
     $this->aAllowedUploadTypes = array('jpg', 'gif', 'png', 'pdf', 'mp3', 'avi', 'mpg', 'mpeg', 'doc', 'xls', 'ppt');
 
-    // timezone information
+    // Timezone information
     date_default_timezone_set('Europe/Berlin');
 
-    // Search engine friendly URL processor
-    // After changing this value, you should rename oxid.php file as well
-    // Always leave .php extension here unless you know what you are doing
+    /**
+     * Search engine friendly URL processor.
+     * After changing this value, you should rename oxid.php file as well
+     * Always leave .php extension here unless you know what you are doing
+     */
     $this->sOXIDPHP = "oxid.php";
 
-    //  enable debug mode for template development or bugfixing
-    // -1 = Log more messages and throw exceptions on errors (not recommended for production)
-    //  0 = off
-    //  1 = smarty
-    //  3 = smarty
-    //  4 = smarty + shoptemplate data
-    //  5 = Delivery Cost calculation info
-    //  6 = SMTP Debug Messages
-    //  8 = display smarty template names (requires /tmp cleanup)
+    /**
+     * Enable debug mode for template development or bugfixing
+     * -1 = Log more messages and throw exceptions on errors (not recommended for production)
+     * 0 = off
+     * 1 = smarty
+     * 3 = smarty
+     * 4 = smarty + shoptemplate data
+     * 5 = Delivery Cost calculation info
+     * 6 = SMTP Debug Messages
+     * 8 = display smarty template names (requires /tmp cleanup)
+     */
     $this->iDebug = 0;
 
     // Log all modifications performed in Admin
@@ -67,22 +73,26 @@
 
     // Force admin email. Offline warnings are sent with high priority to this address.
     $this->sAdminEmail = '';
+
     // Defines the time interval in seconds warnings are sent during the shop is offline.
     $this->offlineWarningInterval = 60 * 5;
 
-    // in case session must be started on first user page visit (not only on
-    // session required action) set this option value 1
+    // In case session must be started on the very first user page visit (not only on session required action).
     $this->blForceSessionStart = false;
 
     // Use browser cookies to store session id (no sid parameter in URL)
     $this->blSessionUseCookies = true;
 
-    // The domain that the cookie is available: array( _SHOP_ID_ => _DOMAIN_ );
-    // check setcookie() documentation for more details @php.net
+    /**
+     * The domain that the cookie is available: array(_SHOP_ID_ => _DOMAIN_);
+     * Check setcookie() documentation for more details: http://php.net/manual/de/function.setcookie.php
+     */
     $this->aCookieDomains = null;
 
-    // The path on the server in which the cookie will be available on: array( _SHOP_ID_ => _PATH_ );
-    // check setcookie() documentation for more details @php.net
+    /**
+     * The path on the server in which the cookie will be available on: array(_SHOP_ID_ => _PATH_);
+     * Check setcookie() documentation for more details: http://php.net/manual/de/function.setcookie.php
+     */
     $this->aCookiePaths = null;
 
     // List of all Search-Engine Robots
@@ -124,42 +134,34 @@
     $this->iBasketReservationCleanPerRequest = 200;
 
     /**
-     * should template blocks be highlighted in frontend ?
-     * this is mainly intended for module writers in non productive environment
+     * Should template blocks be highlighted in frontend?
+     * This is mainly intended for module writers in non productive environment
      */
     $this->blDebugTemplateBlocks = false;
 
     /**
-     * should requests, coming via stdurl and not redirected to seo url be logged to seologs db table?
-     * note: only active if in productive mode, as the eShop in non productive more will always log such urls
+     * Should requests, coming via stdurl and not redirected to seo url be logged to seologs db table?
+     * Note: only active if in productive mode, as the eShop in non productive more will always log such urls
      */
     $this->blSeoLogging = false;
 
     /**
-     * To override oxubase::_aUserComponentNames use this array option:
+     * To override FrontendController::$_aUserComponentNames use this array option:
      * array keys are component(class) names and array values defines if component is cacheable (true/false)
-     * e.g. array("user_class" => false);
+     * E.g. array('user_class' => false);
      */
     $this->aUserComponentNames = null;
 
-    /**
-     * Additional multi language tables
-     */
+    // Additional multi language tables
     $this->aMultiLangTables = null;
 
-    /**
-     * Instructs shop that price update is perfomed by cron (time based job sheduler)
-     */
+    // Instructs shop that price update is performed by cron (time based job sheduler)
     $this->blUseCron = false;
 
-    /**
-     * Do not disable module if class from extension path does not exist.
-     */
+    // Do not disable module if class from extension path does not exist.
     $this->blDoNotDisableModuleOnError = false;
 
-    /**
-     * Enable temporarily in case you can't access the backend due to broken views
-     */
+    // Enable temporarily in case you can't access the backend due to broken views
     $this->blSkipViewUsage = false;
 
     /**
@@ -170,19 +172,23 @@
     //Time limit in ms to be notified about slow queries
     $this->iDebugSlowQueryTime = 20;
 
-    // enables Rights and Roles engine
-    // 0 - off,
-    // 1 - only in admin,
-    // 2 - only in shop,
-    // 3 - both
+    /**
+     * Enables Rights and Roles engine
+     * 0 - off,
+     * 1 - only in admin,
+     * 2 - only in shop,
+     * 3 - both
+     */
     $this->blUseRightsRoles = 3;
 
-    //define oxarticles fields which could be edited individually in subshops
-    //do not forget to add these fields to oxfield2shop table
-    //note the field names are case sensitive here
+    /**
+     * Define oxarticles fields which could be edited individually in subshops.
+     * Do not forget to add these fields to oxfield2shop table.
+     * Note: The field names are case sensitive here.
+     */
     $this->aMultishopArticleFields = array("OXPRICE", "OXPRICEA", "OXPRICEB", "OXPRICEC", "OXUPDATEPRICE", "OXUPDATEPRICEA", "OXUPDATEPRICEB", "OXUPDATEPRICEC", "OXUPDATEPRICETIME");
 
-    //Show "Update Views" button in admin
+    // Show "Update Views" button in admin
     $this->blShowUpdateViews = true;
 
     // If default 30 seconds is not enougth


### PR DESCRIPTION
I did a few things here with the background that the file is basically a file which represents a part of class attributes from \OxidEsales\EshopCommunity\Core\Config.

1. Normalized the comments. 
 - A comment which needs only one line is beginning with two Slashes and a whitespace.
 - Multiple line comments have the comment pattern of a method comment.
2. Fixed typos.
3. Added or removed line breaks.

What is missing and will not be added are the public / protected / private keywords for the class attributes as this could have to much impact.