### PR TITLE
fixed ignore warning with mysql5.6 during setup process

### DIFF
--- a/source/Setup/Controller.php
+++ b/source/Setup/Controller.php
@@ -296,15 +296,18 @@ class Controller extends Core
             $database->openDatabase($databaseConfigValues);
         } catch (Exception $exception) {
             if ($exception->getCode() === Database::ERROR_MYSQL_VERSION_DOES_NOT_FIT_RECOMMENDATIONS) {
-                $setup->setNextStep(null);
-                $this->formMessageIfMySqyVersionIsNotRecommended($view, $language);
-                // check if DB is already UP and running
-                if (!$this->databaseCanBeOverwritten($database)) {
-                    $this->formMessageIfDBCanBeOverwritten($databaseConfigValues['dbName'], $view, $language);
+                $bIgnore = (bool)$this->getInstance('Utilities')->getRequestVar('ow');
+                
+                if ($bIgnore === false) {
+                    $setup->setNextStep(null);
+                    $this->formMessageIfMySqyVersionIsNotRecommended($view, $language);
+                    // check if DB is already UP and running
+                    if (!$this->databaseCanBeOverwritten($database)) {
+                        $this->formMessageIfDBCanBeOverwritten($databaseConfigValues['dbName'], $view, $language);
+                    }
+                    $this->formMessageInstallAnyway($view, $language, $session->getSid(), $setup->getStep('STEP_DB_CREATE'));
+                    throw new SetupControllerExitException();
                 }
-                $this->formMessageInstallAnyway($view, $language, $session->getSid(), $setup->getStep('STEP_DB_CREATE'));
-
-                throw new SetupControllerExitException();
             } else {
                 $setup->setNextStep($setup->getStep('STEP_DB_CREATE'));
                 $view->setMessage($exception->getMessage());


### PR DESCRIPTION
There was an error during the install process with mysql 5.6. When the warning pop ups and you click ignore the mysql 5.6 warning the process ends in and endless loop and you are always redirected to the same page with the same warning.

I added a check for the ow request parameter. When set then the setup process continues also on mysql 5.6 databases. 