### PR TITLE
set latin1_general_ci as default encoding due to convention

### DIFF
--- a/source/Core/SystemRequirements.php
+++ b/source/Core/SystemRequirements.php
@@ -824,6 +824,7 @@ class SystemRequirements
 
     /**
      * Checks tables and columns (oxsysrequirements::$_aColumns) collation
+     * Due to convention the IDs should be latin1_general_ci encoded
      *
      * @return array
      */
@@ -832,19 +833,15 @@ class SystemRequirements
         $myConfig = $this->getConfig();
 
         $aCollations = array();
-        $sCollation = '';
+        $sCollation = 'latin1_general_ci';
         $sSelect = 'select TABLE_NAME, COLUMN_NAME, COLLATION_NAME from INFORMATION_SCHEMA.columns
                     where TABLE_NAME not like "oxv\_%" and table_schema = "' . $myConfig->getConfigParam('dbName') . '"
                     and COLUMN_NAME in ("' . implode('", "', $this->_aColumns) . '") ' . $this->_getAdditionalCheck() .
                    'ORDER BY TABLE_NAME, COLUMN_NAME DESC;';
         $aRez = oxDb::getDb()->getAll($sSelect);
         foreach ($aRez as $aRetTable) {
-            if (!$sCollation) {
-                $sCollation = $aRetTable[2];
-            } else {
-                if ($aRetTable[2] && $sCollation != $aRetTable[2]) {
-                    $aCollations[$aRetTable[0]][$aRetTable[1]] = $aRetTable[2];
-                }
+            if ($aRetTable[2] && $sCollation != $aRetTable[2]) {
+                $aCollations[$aRetTable[0]][$aRetTable[1]] = $aRetTable[2];
             }
         }
 


### PR DESCRIPTION
Due to convention the ID columns should be latin1 encoded. Oxid does this also in the migration to utf8 scripts. I fixed in this pull request 2 problems. First make this convention as default and avoid the check for an empty sCollation var. Second when the first table/column was utf8_general_ci encoded then the sCollation var was automatically set to utf8_general_ci. This caused faulty error messages in the backend when all other tables in the loop were correct latin1_general_ci encoded because the sCollation var was set to utf8_general_ci from the first table hit and never changed.