### PR TITLE
New block in admin, before the list of installed modules

### DIFF
--- a/source/application/views/admin/tpl/module_sortlist.tpl
+++ b/source/application/views/admin/tpl/module_sortlist.tpl
@@ -9,6 +9,8 @@
         <input type="hidden" name="editlanguage" value="[{ $editlanguage }]">
     </form>
 
+    [{block name="admin_modules_sortlist_content" }][{/block}]
+
      <div id="infoContent">
 
          [{ if $aDeletedExt }]


### PR DESCRIPTION
I need a new block in the modules list page.

This will allow us to filter extended classes.

Thanks in advance