### PR TITLE
User::delete method must return boolean, but there is a case when nul…

### DIFF
--- a/source/Application/Model/User.php
+++ b/source/Application/Model/User.php
@@ -613,9 +613,7 @@ class User extends \oxBase
             $this->deleteAdditionally($sOXIDQuoted);
 
             // and leaving all order related information
-            $rs = $oDb->execute("delete from oxremark where oxparentid = {$sOXIDQuoted} and oxtype !='o'");
-
-            $blDeleted = $rs->EOF;
+            $oDb->execute("delete from oxremark where oxparentid = {$sOXIDQuoted} and oxtype !='o'");
         }
 
         return $blDeleted;

--- a/tests/Unit/Application/Model/UserTest.php
+++ b/tests/Unit/Application/Model/UserTest.php
@@ -1250,7 +1250,9 @@ class UserTest extends \OxidTestCase
 
         $oUser = oxNew('oxUser');
         $oUser->load($sUserId);
-        $oUser->delete();
+        $sSuccess = $oUser->delete();
+
+        $this->assertEquals(true, $sSuccess);
 
         $aWhat = array('oxuser'            => 'oxid',
                        'oxaddress'         => 'oxuserid',


### PR DESCRIPTION
Model\User::delete must always return boolean, but here is a case when null is returned.
execute method returns number of affected rows and then trying to reach EOF of this number, null is returned. This causes issues.