### PR TITLE
Remove unneeded require_once statements in module tests

### DIFF
--- a/tests/Integration/Modules/BaseModuleInheritanceTestCase.php
+++ b/tests/Integration/Modules/BaseModuleInheritanceTestCase.php
@@ -21,9 +21,6 @@
  */
 namespace OxidEsales\EshopCommunity\Tests\Integration\Modules;
 
-require_once __DIR__ . '/Validator.php';
-require_once __DIR__ . '/Environment.php';
-
 use OxidEsales\EshopCommunity\Core\Registry;
 
 /**

--- a/tests/Integration/Modules/BaseModuleTestCase.php
+++ b/tests/Integration/Modules/BaseModuleTestCase.php
@@ -24,9 +24,6 @@ namespace OxidEsales\EshopCommunity\Tests\Integration\Modules;
 use oxModule;
 use oxRegistry;
 
-require_once __DIR__ . '/Validator.php';
-require_once __DIR__ . '/Environment.php';
-
 /**
  * Base class for module integration tests.
  *

--- a/tests/Integration/Modules/ModuleActivateWithSimilarNameTest.php
+++ b/tests/Integration/Modules/ModuleActivateWithSimilarNameTest.php
@@ -21,8 +21,6 @@
  */
 namespace OxidEsales\EshopCommunity\Tests\Integration\Modules;
 
-require_once __DIR__ . '/BaseModuleTestCase.php';
-
 class ModuleActivateWithSimilarNameTest extends BaseModuleTestCase
 {
     /**


### PR DESCRIPTION
Let autoloader do the trick.
Require_once for BaseModuleTestCase in ModuleActivateWithSimilarNameTest breaks vendor/bin/runtests in vm.