### PR TITLE
Fix User::delete

### DIFF
--- a/source/Application/Model/User.php
+++ b/source/Application/Model/User.php
@@ -613,9 +613,7 @@ class User extends \oxBase
             $this->deleteAdditionally($sOXIDQuoted);
 
             // and leaving all order related information
-            $rs = $oDb->execute("delete from oxremark where oxparentid = {$sOXIDQuoted} and oxtype !='o'");
-
-            $blDeleted = $rs->EOF;
+            $oDb->execute("delete from oxremark where oxparentid = {$sOXIDQuoted} and oxtype !='o'");
         }
 
         return $blDeleted;

--- a/tests/Unit/Application/Model/UserTest.php
+++ b/tests/Unit/Application/Model/UserTest.php
@@ -1250,7 +1250,9 @@ class UserTest extends \OxidTestCase
 
         $oUser = oxNew('oxUser');
         $oUser->load($sUserId);
-        $oUser->delete();
+        $bSuccess = $oUser->delete();
+
+        $this->assertEquals(true, $bSuccess);
 
         $aWhat = array('oxuser'            => 'oxid',
                        'oxaddress'         => 'oxuserid',


### PR DESCRIPTION
There is a case when User::delete method returns null. Unnecessary code is written.
Deleted this code. 