### PR TITLE
delivery dates from past shouldn't be displayed on product page

### DIFF
--- a/source/Application/Model/Article.php
+++ b/source/Application/Model/Article.php
@@ -2865,13 +2865,13 @@ class Article extends \oxI18n implements ArticleInterface, \oxIUrl
     }
 
     /**
-     * Returns formatted delivery date. If the date is not set ('0000-00-00') returns false.
+     * Returns formatted delivery date. If the date is past or not set ('0000-00-00') returns false.
      *
      * @return string | bool
      */
     public function getDeliveryDate()
     {
-        if ($this->oxarticles__oxdelivery->value != '0000-00-00') {
+        if ($this->oxarticles__oxdelivery->value != '0000-00-00' && $this->oxarticles__oxdelivery->value > date('Y-m-d')) {
             return oxRegistry::get("oxUtilsDate")->formatDBDate($this->oxarticles__oxdelivery->value);
         }
 


### PR DESCRIPTION
example situation:

**1st April 2017** - shop owner receives 25 x iPhones 8 and creates new oxArticle with stock 25
**5th April 2017** - all iPhones are sold out, but shop owner will get another delivery on 15th April. So he sets "2017-04-15" as delivery date and keeps product online for possible preorders. "Available on 15th April 2017" is displayed on product page.
**15th April 2017** - shop owner receives 10 products and updates stock. "Available on ..." disappears.
**17th April  2017** - Products are sold out again and "Available on 15th April 2017" appears again.

On 17th april shop customer see product, which is currently out of stock but should be available on 15th april 2017 (which is past date), so he thinks this product should be available, but actually it is not available. 

German customers might be very confused, because the german translation for "available on" is more like "avaialble after", which implies even more, that this product is supposed to be available right now and you can preorder it.

Marco told me to extend unit tests, too. I'm new to unit test, but i will do my best and add changes to this PR.

cheers