### PR TITLE
fix wrong return type in docblock

### DIFF
--- a/source/Application/Model/Basket.php
+++ b/source/Application/Model/Basket.php
@@ -1964,7 +1964,7 @@ class Basket extends \oxSuperCfg
      *
      * @param string $sId cost id ( optional )
      *
-     * @return array
+     * @return array|oxPrice|null
      */
     public function getCosts($sId = null)
     {


### PR DESCRIPTION
if `$sId` is set, `getCosts()` will return an `oxPrice` object, otherwise it will be an array with all costs