### PR TITLE
wrong first Argument in email::_getUseInlineImages()

### DIFF
--- a/source/Core/Email.php
+++ b/source/Core/Email.php
@@ -396,7 +396,7 @@ class Email extends \PHPMailer
 
         if ($this->_getUseInlineImages()) {
             $this->_includeImages(
-                $myConfig->getImageDir(),
+                $myConfig->getImageUrl(),
                 $myConfig->getImageUrl(false, false),
                 $myConfig->getPictureUrl(null, false),
                 $myConfig->getImageDir(),


### PR DESCRIPTION
in Core/Email.php, L. 397

if ($this->_getUseInlineImages()) {
    $this->_includeImages(
        $myConfig->getImageDir(),
        $myConfig->getImageUrl(false, false),
        $myConfig->getPictureUrl(null, false),
        $myConfig->getImageDir(),
        $myConfig->getPictureDir(false)
    );
}

Argument $myConfig->getImageDir() comes 2 times
that's have no sense as _includeImages() awaiting first arg as URL, not abs path.

Problem was figured out, as i inserted a https image-URL in e-mail template - that was'n embedded.
P.S: It's first time as i making a pull request, sorry if something going wrong )