### PR TITLE
Adding not documented [symbol position] parameter in shop_config.tpl

### DIFF
--- a/source/application/views/admin/tpl/shop_config.tpl
+++ b/source/application/views/admin/tpl/shop_config.tpl
@@ -1089,7 +1089,7 @@ function showInvitations()
                 </dt>
                 <dd>
                   [{ oxmultilang ident="SHOP_CONFIG_SETORDELETECURRENCY" }]<br>
-                  [name]@[rate]@[decimal separator]@[thousand separator]@[symbol]@[decimal precision]
+                  [name]@[rate]@[decimal separator]@[thousand separator]@[symbol]@[decimal precision]@[symbol position]
                 </dd>
                 <div class="spacer"></div>
             </dl>


### PR DESCRIPTION
Argument "Front" for positioning of currency symbol ( in front of price or behind, if not specified )