### PR TITLE
replace intval with typecast

### DIFF
--- a/source/Application/Model/Voucher.php
+++ b/source/Application/Model/Voucher.php
@@ -875,8 +875,7 @@ class Voucher extends \OxidEsales\Eshop\Core\Model\BaseModel
      */
     protected function _getVoucherTimeout()
     {
-        $iVoucherTimeout = intval(oxRegistry::getConfig()->getConfigParam('iVoucherTimeout')) ?
-            intval(oxRegistry::getConfig()->getConfigParam('iVoucherTimeout')) :
+        $iVoucherTimeout = (int) oxRegistry::getConfig()->getConfigParam('iVoucherTimeout') ?:
             3 * 3600;
 
         return $iVoucherTimeout;

--- a/source/Core/Language.php
+++ b/source/Core/Language.php
@@ -1122,8 +1122,8 @@ class Language extends \OxidEsales\Eshop\Core\Base
     public function processUrl($sUrl, $iLang = null)
     {
         $iLang = isset($iLang) ? $iLang : $this->getBaseLanguage();
-        $iDefaultLang = intval(oxRegistry::getConfig()->getConfigParam('sDefaultLang'));
-        $iBrowserLanguage = intval($this->detectLanguageByBrowser());
+        $iDefaultLang = (int) oxRegistry::getConfig()->getConfigParam('sDefaultLang');
+        $iBrowserLanguage = (int) $this->detectLanguageByBrowser();
         /** @var oxStrRegular $oStr */
         $oStr = getStr();
 

--- a/source/Core/Module/ModuleInstaller.php
+++ b/source/Core/Module/ModuleInstaller.php
@@ -421,7 +421,7 @@ class ModuleInstaller extends \OxidEsales\Eshop\Core\Base
 
                 $template = $moduleBlock["template"];
                 $position = isset($moduleBlock['position']) && is_numeric($moduleBlock['position']) ?
-                    intval($moduleBlock['position']) : 1;
+                    (int) $moduleBlock['position'] : 1;
 
                 $block = $moduleBlock["block"];
                 $filePath = $moduleBlock["file"];


### PR DESCRIPTION
* There is no particular difference between intval and typecast (int) 
* [typecast is faster](http://stackoverflow.com/questions/1912599/is-there-any-particular-difference-between-intval-and-casting-to-int-int-x#comment39379007_1912613)

---

Related to source/Application/Model/Voucher.php:
You can omit the first value after the ternary operator to use the second value as a fallback. ([see here](http://stackoverflow.com/a/5972529/2123108))
```
Psy Shell v0.7.2 (PHP 7.0.15-0ubuntu0.16.04.4 — cli) by Justin Hileman
>>> $a = '2';
=> "2"
>>> (int) $a ?: 3;
=> 2
>>>
```