### PR TITLE
Use oxcounter for oxbillnr and oxinvoicenr to fix duplicate numbers

### DIFF
--- a/source/Application/Model/Order.php
+++ b/source/Application/Model/Order.php
@@ -1555,9 +1555,8 @@ class Order extends \OxidEsales\Eshop\Core\Model\BaseModel
      */
     public function getInvoiceNum()
     {
-        $sQ = 'select max(oxorder.oxinvoicenr) from oxorder where oxorder.oxshopid = "' . $this->getConfig()->getShopId() . '" ';
-
-        return (( int ) oxDb::getDb()->getOne($sQ, false) + 1);
+        $sCounterIdent = ($this->_blSeparateNumbering) ? 'oxOrder_oxinvoicenr_' . $this->getConfig()->getShopId() : 'oxOrder_oxinvoicenr';
+        return oxNew('oxCounter')->getNext($sCounterIdent);
     }
 
     /**
@@ -1567,9 +1566,8 @@ class Order extends \OxidEsales\Eshop\Core\Model\BaseModel
      */
     public function getNextBillNum()
     {
-        $sQ = 'select max(cast(oxorder.oxbillnr as unsigned)) from oxorder where oxorder.oxshopid = "' . $this->getConfig()->getShopId() . '" ';
-
-        return (( int ) oxDb::getDb()->getOne($sQ, false) + 1);
+        $sCounterIdent = ($this->_blSeparateNumbering) ? 'oxOrder_oxbillnr_' . $this->getConfig()->getShopId() : 'oxOrder_oxbillnr';
+        return oxNew('oxCounter')->getNext($sCounterIdent);
     }
 
     /**


### PR DESCRIPTION
…that occur if orders are saved quickly after each other. Fixes bug #6312

**Background:** First reported 2016 [here ](https://bugs.oxid-esales.com/view.php?id=6312) oxid creates duplicate `oxbillnr` and `oxinvoicenr` if orders are saved at short intervals. This is because `oxcounter` is only used for `oxordernr` and the other numbers are still using `MAX(…)` to get the next free number.

**Migration:** If this fix will be merged there should be a migration SQL that sets the counter values in oxcounter table.

**Steps to reproduce**

The following script will clone a order of your choice and saves it. If executed simultaneously (see below), you can easily reproduce duplicate invoice numbers if the suggested fix is not applied.

```
<?php

require_once __DIR__ .  '/bootstrap.php';

$oOrder = oxNew('oxOrder');
$oOrder->load('PUT_A_OXID_OF_YOUR_CHOICE');

$aFakeOrders = [];

for ($i=0; $i < 10; $i++) {
    $oFakeOrder = clone $oOrder;
    $oFakeOrder->setId();
    $oFakeOrder->oxorder__oxbillnr = null;
    $oFakeOrder->oxorder__oxordernr = null;
    $aFakeOrders[] = $oFakeOrder;
}

foreach($aFakeOrders as $oFakeOrder) {
     $oFakeOrder->save();
     print "BillNr: " . $oFakeOrder->oxorder__oxbillnr->value ." \n";
}
```

Call this script from CLI to reproduce the error. It will execute the script five times, so a total of 50 orders should be created.

```
#!/bin/bash
for value in {1..5}
do
    php spamorders.php &
done
```

