### PR TITLE
Use ISO-8859-15 encoding for the setup

### DIFF
--- a/source/setup/index.php
+++ b/source/setup/index.php
@@ -20,7 +20,7 @@
  * @version   OXID eShop CE
  */
 
-
+header('Content-Type: text/html; charset=ISO-8859-15');
 error_reporting((E_ALL ^ E_NOTICE) | E_STRICT);
 
 //setting basic configuration parameters


### PR DESCRIPTION
PHP 5.6 uses a UTF-8 default header, which causes certain (German) characters to appear broken. For 4.10/5.3.