### PR TITLE
remove duplicate directory separator

### DIFF
--- a/source/Core/Edition/EditionRootPathProvider.php
+++ b/source/Core/Edition/EditionRootPathProvider.php
@@ -63,7 +63,7 @@ class EditionRootPathProvider
             $configFile = new ConfigFile(getShopBasePath() . '/config.inc.php');
             Registry::set('oxConfigFile', $configFile);
         }
-        $editionsPath = VENDOR_PATH  .'/'. static::EDITIONS_DIRECTORY;
+        $editionsPath = VENDOR_PATH . static::EDITIONS_DIRECTORY;
         $path = getShopBasePath();
         if ($this->getEditionSelector()->isEnterprise()) {
             $path = $editionsPath  .'/'. static::ENTERPRISE_DIRECTORY;

--- a/source/Setup/Utilities.php
+++ b/source/Setup/Utilities.php
@@ -528,7 +528,7 @@ class Utilities extends Core
      */
     private function getVendorBinaryDirectory()
     {
-        return implode(DIRECTORY_SEPARATOR, [$this->getVendorDirectory(), self::COMPOSER_VENDOR_BIN_DIRECTORY]);
+        return $this->getVendorDirectory() . self::COMPOSER_VENDOR_BIN_DIRECTORY;
     }
 
     /**
@@ -629,14 +629,10 @@ class Utilities extends Core
     {
         $editionSelector = new EditionSelector();
 
-        return implode(
-            DIRECTORY_SEPARATOR,
-            [
-                $this->getUtilitiesInstance()->getVendorDirectory(),
-                EditionRootPathProvider::EDITIONS_DIRECTORY,
-                sprintf(self::DEMODATA_PACKAGE_NAME, strtolower($editionSelector->getEdition())),
-            ]
-        );
+        return $this->getUtilitiesInstance()->getVendorDirectory()
+            . EditionRootPathProvider::EDITIONS_DIRECTORY
+            . DIRECTORY_SEPARATOR
+            . sprintf(self::DEMODATA_PACKAGE_NAME, strtolower($editionSelector->getEdition()));
     }
 
     /**

--- a/source/Setup/functions.php
+++ b/source/Setup/functions.php
@@ -66,8 +66,8 @@ if (!function_exists('getCountryList')) {
     {
         $aCountries = array();
         $relativePath = 'Application/Controller/Admin/ShopCountries.php';
-        if (file_exists(getVendorDirectory() . "/oxid-esales/oxideshop-ce/source/$relativePath")) {
-            include getVendorDirectory() . "/oxid-esales/oxideshop-ce/source/$relativePath";
+        if (file_exists(getVendorDirectory() . "oxid-esales/oxideshop-ce/source/$relativePath")) {
+            include getVendorDirectory() . "oxid-esales/oxideshop-ce/source/$relativePath";
         } else {
             include __DIR__ . "/../$relativePath";
         }
@@ -86,8 +86,8 @@ if (!function_exists('getLocation')) {
     {
         $aLocationCountries = array();
         $relativePath = 'Application/Controller/Admin/ShopCountries.php';
-        if (file_exists(getVendorDirectory() . "/oxid-esales/oxideshop-ce/source/$relativePath")) {
-            include getVendorDirectory() . "/oxid-esales/oxideshop-ce/source/$relativePath";
+        if (file_exists(getVendorDirectory() . "oxid-esales/oxideshop-ce/source/$relativePath")) {
+            include getVendorDirectory() . "oxid-esales/oxideshop-ce/source/$relativePath";
         } else {
             include __DIR__ . "/../$relativePath";
         }
@@ -105,8 +105,8 @@ if (!function_exists('getLanguages')) {
     {
         $aLanguages = array();
         $relativePath = 'Application/Controller/Admin/ShopCountries.php';
-        if (file_exists(getVendorDirectory() . "/oxid-esales/oxideshop-ce/source/$relativePath")) {
-            include getVendorDirectory() . "/oxid-esales/oxideshop-ce/source/$relativePath";
+        if (file_exists(getVendorDirectory() . "oxid-esales/oxideshop-ce/source/$relativePath")) {
+            include getVendorDirectory() . "oxid-esales/oxideshop-ce/source/$relativePath";
         } else {
             include __DIR__ . "/../$relativePath";
         }


### PR DESCRIPTION
`VENDOR_PATH` [has already](https://github.com/OXID-eSales/oxideshop_ce/blob/68d569564cede01b839da8e56ae9390e349214be/source/bootstrap.php#L32) a `DIRECTORY_SEPARATOR` at the end:
```
define('VENDOR_PATH', INSTALLATION_ROOT_PATH . DIRECTORY_SEPARATOR . 'vendor' . DIRECTORY_SEPARATOR);
```