### PR TITLE
Reduce php notices

### DIFF
--- a/source/application/models/oxbasket.php
+++ b/source/application/models/oxbasket.php
@@ -1320,7 +1320,6 @@ class oxBasket extends oxSuperCfg
         }
 
         if ($oWrappingPrices->getCount()) {
-            $oWrappingCost = oxNew('oxPrice');
             $oWrappingCost = $oWrappingPrices->calculateToPrice();
         }
 

--- a/source/application/models/oxbasket.php
+++ b/source/application/models/oxbasket.php
@@ -1305,6 +1305,7 @@ class oxBasket extends oxSuperCfg
      */
     protected function _calcBasketWrapping()
     {
+        $oWrappingCost = null;
         $oWrappingPrices = oxNew('oxPriceList');
 
         foreach ($this->_aBasketContents as $oBasketItem) {

--- a/source/application/models/oxtagcloud.php
+++ b/source/application/models/oxtagcloud.php
@@ -169,6 +169,9 @@ class oxTagCloud extends oxSuperCfg
      */
     public function formCloudArray(oxITagList $oTagList)
     {
+        $aCloudArray = null;
+        $sCacheIdent = null;
+
         // checking if current data is already loaded
         if ($oTagList->getCacheId()) {
             $sCacheIdent = $this->_formCacheKey($oTagList->getCacheId());

--- a/source/core/oxfunctions.php
+++ b/source/core/oxfunctions.php
@@ -299,13 +299,17 @@ function debug($mVar)
  * Sorting for crossselling
  *
  * @param object $a first compare item
- * @param object $b second compre item
+ * @param object $b second compare item
  *
  * @return integer
  */
 function cmpart($a, $b)
 {
-    // sorting for crossselling
+    if (!is_object($a) || !is_object($b)) {
+        return 0;
+    }
+
+    // sorting for cross-selling
     if ($a->cnt == $b->cnt) {
         return 0;
     }

--- a/source/core/oxlang.php
+++ b/source/core/oxlang.php
@@ -434,7 +434,7 @@ class oxLang extends oxSuperCfg
 
         // checking if in map exist
         $aMap = $this->_getLanguageMap($iLang, $blAdminMode);
-        if (isset($aLang[$aMap[$sStringToTranslate]])) {
+        if (isset($aMap[$sStringToTranslate], $aLang[$aMap[$sStringToTranslate]])) {
             return $aLang[$aMap[$sStringToTranslate]];
         }
 

--- a/source/core/oxseoencoder.php
+++ b/source/core/oxseoencoder.php
@@ -369,7 +369,7 @@ class oxSeoEncoder extends oxSuperCfg
         }
         $iLang = (int) $iLang;
 
-        if (!isset(self::$_aFixedCache[$sType][$sShopId][$sId][$iLang])) {
+        if (!isset(self::$_aFixedCache[$sType][$iShopId][$sId][$iLang])) {
             $oDb = oxDb::getDb();
 
             $sQ = "SELECT `oxfixed`
@@ -387,10 +387,10 @@ class oxSeoEncoder extends oxSuperCfg
             }
             $sQ .= " LIMIT 1";
 
-            self::$_aFixedCache[$sType][$sShopId][$sId][$iLang] = (bool) $oDb->getOne($sQ);
+            self::$_aFixedCache[$sType][$iShopId][$sId][$iLang] = (bool) $oDb->getOne($sQ);
         }
 
-        return self::$_aFixedCache[$sType][$sShopId][$sId][$iLang];
+        return self::$_aFixedCache[$sType][$iShopId][$sId][$iLang];
     }
 
     /**

--- a/source/core/smarty/plugins/function.oxid_include_dynamic.php
+++ b/source/core/smarty/plugins/function.oxid_include_dynamic.php
@@ -57,7 +57,6 @@ function smarty_function_oxid_include_dynamic($params, &$smarty)
 
         foreach ($params as $key => $val) {
             if ($key != 'type' && $key != 'file') {
-                $sContent .= " $key='$val'";
                 $smarty->assign($sPrefix.$key, $val);
             }
         }

--- a/source/core/smarty/plugins/function.oxid_include_widget.php
+++ b/source/core/smarty/plugins/function.oxid_include_widget.php
@@ -27,19 +27,15 @@
  * Use [{ oxid_include_dynamic file="..." }] instead of include
  * -------------------------------------------------------------
  *
- * @param array  $params   params
- * @param Smarty &$oSmarty clever simulation of a method
+ * @param array $params params
  *
  * @return string
  */
-function smarty_function_oxid_include_widget($params, &$oSmarty)
+function smarty_function_oxid_include_widget($params)
 {
-    $myConfig = oxRegistry::getConfig();
-    $blNoScript = ($params['noscript']?$params['noscript']:false);
     $sClass     = strtolower($params['cl']);
     $params['cl'] = $sClass;
     $aParentViews = null;
-
 
     unset($params['cl']);
 

--- a/source/core/smarty/plugins/function.oxinputhelp.php
+++ b/source/core/smarty/plugins/function.oxinputhelp.php
@@ -40,7 +40,7 @@ function smarty_function_oxinputhelp($params, &$smarty)
     $iLang  = $oLang->getTplLanguage();
 
     try {
-        $sTranslation = $oLang->translateString( $sIdent, $iLang, $blAdmin );
+        $sTranslation = $oLang->translateString( $sIdent, $iLang, $myConfig->isAdmin() );
     } catch ( oxLanguageException $oEx ) {
         // is thrown in debug mode and has to be caught here, as smarty hangs otherwise!
     }

--- a/source/core/smarty/plugins/function.oxscript.php
+++ b/source/core/smarty/plugins/function.oxscript.php
@@ -45,7 +45,7 @@
 function smarty_function_oxscript($params, &$smarty)
 {
     $myConfig             = oxRegistry::getConfig();
-    $sSuffix               = ($smarty->_tpl_vars["__oxid_include_dynamic"])?'_dynamic':'';
+    $sSuffix              = isset($smarty->_tpl_vars["__oxid_include_dynamic"]) ? '_dynamic' : '';
     $sIncludes            = 'includes'.$sSuffix;
     $sScripts             = 'scripts'.$sSuffix;
     $iPriority            = !empty($params['priority']) ? $params['priority'] : 3;

--- a/source/core/smarty/plugins/insert.oxid_newbasketitem.php
+++ b/source/core/smarty/plugins/insert.oxid_newbasketitem.php
@@ -47,10 +47,10 @@ function smarty_insert_oxid_newbasketitem($params, &$smarty)
     }
 
     //name of template file where is stored message text
-    $sTemplate = $params['tpl']?$params['tpl']:'inc_newbasketitem.snippet.tpl';
+    $sTemplate = isset($params['tpl']) ? $params['tpl'] : 'inc_newbasketitem.snippet.tpl';
 
-    //allways render for ajaxstyle popup
-    $blRender = $params['ajax'] && ($iType == 2);
+    //always render for ajaxstyle popup
+    $blRender = isset($params['ajax']) && ($iType == 2);
 
     //fetching article data
     $oNewItem = oxRegistry::getSession()->getVariable( '_newitem' );


### PR DESCRIPTION
This will fix some PHP notices:
```
Undefined variable: sContent in /xxx/core/smarty/plugins/function.oxid_include_dynamic.php on line 60
Undefined variable: sCacheIdent in /xxx/application/models/oxtagcloud.php on line 191
Undefined variable: aCloudArray in /xxx/application/models/oxtagcloud.php on line 181
Undefined index: __oxid_include_dynamic in /xxx/core/smarty/plugins/function.oxscript.php on line 48
Undefined index: noscript in /xxx/core/smarty/plugins/function.oxid_include_widget.php on line 38
Undefined index: ajax in /xxx/core/smarty/plugins/insert.oxid_newbasketitem.php on line 53
Trying to get property of non-object in /xxx/core/oxfunctions.php on line 309
Undefined variable: oWrappingCost in /xxx/application/models/oxbasket.php on line 1326
Undefined index: PAGE_TITLE_START in /xxx/core/oxlang.php on line 437
Undefined variable: sShopId in /xxx/core/oxseoencoder.php on line 372
Undefined variable: sShopId in /xxx/core/oxseoencoder.php on line 390
Undefined variable: sShopId in /xxx/core/oxseoencoder.php on line 393
Undefined variable: blAdmin in /xxx/core/smarty/plugins/function.oxinputhelp.php on line 43
```