### PR TITLE
rename $SMTP_PORT to $smtpPort

### DIFF
--- a/source/Core/Email.php
+++ b/source/Core/Email.php
@@ -40,9 +40,18 @@ class Email extends \PHPMailer
     /**
      * Default Smtp server port
      *
+     * @deprecated use $smtpPort instead
+     *
      * @var int
      */
     public $SMTP_PORT = 25;
+
+    /**
+     * Default Smtp server port
+     *
+     * @var int
+     */
+    public $smtpPort = 25;
 
     /**
      * Password reminder mail template
@@ -502,13 +511,14 @@ class Email extends \PHPMailer
     {
         $isSmtp = false;
         if ($smtpHost) {
-            $smtpPort = $this->SMTP_PORT;
             $match = array();
+            $smtpPort = isset($this->SMTP_PORT)
+                ? $this->SMTP_PORT
+                : $this->smtpPort;
             if (getStr()->preg_match('@^(.*?)(:([0-9]+))?$@i', $smtpHost, $match)) {
                 $smtpHost = $match[1];
-                $smtpPort = (int) $match[3];
-                if (!$smtpPort) {
-                    $smtpPort = $this->SMTP_PORT;
+                if ((int) $match[3] !== 0) {
+                    $smtpPort = (int) $match[3];
                 }
             }
             if ($isSmtp = (bool) ($rHandle = @fsockopen($smtpHost, $smtpPort, $errNo, $errStr, 30))) {


### PR DESCRIPTION
This is a property in the `Email` class, which extends the `PHPMailer` class (class.phpmailer.php).
The property `SMTP_PORT` is used only in the `SMTP` class (class.smtp.php)
```
$ grep -rI 'SMTP_PORT' .
./vendor/phpmailer/phpmailer/class.smtp.php:    const DEFAULT_SMTP_PORT = 25;
./vendor/phpmailer/phpmailer/class.smtp.php:     * @deprecated This is only ever used as a default value, so use the `DEFAULT_SMTP_PORT` constant instead
./vendor/phpmailer/phpmailer/class.smtp.php:     * @see SMTP::DEFAULT_SMTP_PORT
./vendor/phpmailer/phpmailer/class.smtp.php:    public $SMTP_PORT = 25;
./vendor/phpmailer/phpmailer/class.smtp.php:            $port = self::DEFAULT_SMTP_PORT;
```