### PR TITLE
ignore StrMb-wrapper functions (phpcs)

### DIFF
--- a/source/Core/StrMb.php
+++ b/source/Core/StrMb.php
@@ -172,6 +172,7 @@ class StrMb
         return htmlentities($sString, $iQuotStyle, $this->_sEncoding);
     }
 
+    // @codingStandardsIgnoreStart
     /**
      * PHP html_entity_decode() function wrapper
      *
@@ -279,6 +280,7 @@ class StrMb
     {
         return preg_match_all($sPattern . 'u', $sSubject, $aMatches, $iFlags, $iOffset);
     }
+    // @codingStandardsIgnoreEnd
 
     /**
      * PHP ucfirst() function wrapper
@@ -397,6 +399,7 @@ class StrMb
         return json_encode($data);
     }
 
+    // @codingStandardsIgnoreStart
     /**
      * PHP strip_tags() function wrapper.
      *
@@ -414,6 +417,7 @@ class StrMb
 
         return strip_tags($sString, $sAllowableTags);
     }
+    // @codingStandardsIgnoreEnd
 
     /**
      * Compares two strings. Case sensitive.


### PR DESCRIPTION
The `StrMb` Class wraps some php functions like `preg_match`. Some of these functions are not in camelCase. phpcs reports this as an error, so I wrapped that in an ignore block (via `@codingStandardsIgnoreStart` and `@codingStandardsIgnoreEnd`)