### PR TITLE
pass along shopid to call to _loadFromDb()

### DIFF
--- a/source/Core/SeoEncoder.php
+++ b/source/Core/SeoEncoder.php
@@ -288,7 +288,7 @@ class SeoEncoder extends \OxidEsales\Eshop\Core\Base
     {
         $sStdUrl = $this->_trimUrl($sStdUrl, $iLang);
 
-        return $this->_loadFromDb('static', $this->_getStaticObjectId($iShopId, $sStdUrl), $iLang);
+        return $this->_loadFromDb('static', $this->_getStaticObjectId($iShopId, $sStdUrl), $iLang, $iShopId);
     }
 
     /**


### PR DESCRIPTION
The Parameter $iShopId didn't get passed along to the call to _loadFromDb() which results in null being returned if you try to retrieve a static url from another subshop like so:
oxRegistry::get("oxSeoEncoder")->getStaticUrl("index.php?cl=account_order", $iLang, $iShopId);
If $iShopId is not the same as the active shop, you get null returned.