### PR TITLE
CategoryTree: Add oxcmp_basket to the array _aComponentNames as it is used.

### DIFF
--- a/source/Application/Component/Widget/CategoryTree.php
+++ b/source/Application/Component/Widget/CategoryTree.php
@@ -35,11 +35,11 @@ class CategoryTree extends \OxidEsales\Eshop\Application\Component\Widget\Widget
     /**
      * Names of components (classes) that are initiated and executed
      * before any other regular operation.
-     * Cartegory component used in template.
+     * Category and MiniBasket components are used in this template.
      *
      * @var array
      */
-    protected $_aComponentNames = array('oxcmp_categories' => 1);
+    protected $_aComponentNames = array('oxcmp_categories' => 1, 'oxcmp_basket' => 1);
 
     /**
      * Current class template name.


### PR DESCRIPTION
On a few systems with activated Varnish cache the "body" container of the shop wasn't loaded. You could only see the header and the footer of the shop. After some investigation it became apparent that the object oxcmp_basket had the value "null". As a consequence, a broken HTML oppresed the main body of the shop. That was because a smarty condition couldn't be executed as the object was "null": 

<svg class="shopping-bag-mini[{if $oxcmp_basket->getItemsCount()}] filled[{/if}]" viewBox="0 0 64 64">
ee534/application/views/flow/tpl/widget/header/categorylist.tpl

After adding the component to the "load this components at first" array, it could be loaded on all systems just fine.

