### PR TITLE
added mkdir if folders not exist in _copyFile method

### DIFF
--- a/source/Core/UtilsFile.php
+++ b/source/Core/UtilsFile.php
@@ -370,6 +370,10 @@ class UtilsFile extends \OxidEsales\Eshop\Core\Base
     {
         $blDone = false;
 
+        if (!is_dir(dirname($sTarget))) {
+            mkdir(dirname($sTarget), 0744, true);
+        }
+
         if ($sSource === $sTarget) {
             $blDone = true;
         } else {


### PR DESCRIPTION
while UtilsFile::processFiles/processFile  with parameter $blUseMasterImage = true
the shop cannot create a subfolder on demand.

f.e. the master/product/* folders doesn't exist (after installation of oxid v6.0.0.0) you cant use the method with blMasterImage = true; 
you get a warning: 
Warning: copy(/.../oxideshop_ce/source/out/pictures/master/product/1/kitefix_self-adhesive_dacron_1.jpeg): failed to open stream: No such file or directory in /.../oxideshop_ce/source/Core/UtilsFile.php on line 376