### PR TITLE
only getAdminTplLanguageArray() when isAdmin()

### DIFF
--- a/source/Core/Language.php
+++ b/source/Core/Language.php
@@ -235,11 +235,14 @@ class Language extends \OxidEsales\Eshop\Core\Base
     {
         if ($this->_iObjectTplLanguageId === null) {
             $this->_iObjectTplLanguageId = $this->getTplLanguage();
-            $aLanguages = $this->getAdminTplLanguageArray();
-            if (!isset($aLanguages[$this->_iObjectTplLanguageId]) ||
-                $aLanguages[$this->_iObjectTplLanguageId]->active == 0
-            ) {
-                $this->_iObjectTplLanguageId = key($aLanguages);
+
+            if ($this->isAdmin()) {
+                $aLanguages = $this->getAdminTplLanguageArray();
+                if (!isset($aLanguages[$this->_iObjectTplLanguageId]) ||
+                    $aLanguages[$this->_iObjectTplLanguageId]->active == 0
+                ) {
+                    $this->_iObjectTplLanguageId = key($aLanguages);
+                }
             }
         }
 

--- a/tests/Unit/Core/LangTest.php
+++ b/tests/Unit/Core/LangTest.php
@@ -1484,9 +1484,9 @@ class LangTest extends \OxidTestCase
         $oStdLang = new stdClass();
         $oStdLang->active = 0;
 
-        $oLang = $this->getMock(\OxidEsales\Eshop\Core\Language::class, array('getTplLanguage', 'getAdminTplLanguageArray'));
-        $oLang->expects($this->once())->method('getTplLanguage')->will($this->returnValue(555));
-        $oLang->expects($this->once())->method('getAdminTplLanguageArray')->will($this->returnValue(array(444 => $oStdLang, 555 => $oStdLang)));
+        $oLang = $this->getMock(\OxidEsales\Eshop\Core\Language::class, array('isAdmin', 'getTplLanguage'));
+        $oLang->expects($this->once())->method('isAdmin')->will($this->returnValue(false));
+        $oLang->expects($this->once())->method('getTplLanguage')->will($this->returnValue(444));
 
         $this->assertEquals(444, $oLang->getObjectTplLanguage());
     }


### PR DESCRIPTION
getObjectTplLanguage() will return wrong language ID due to missing isAdmin() check. If the language doesn't exist on admin it can cause issues.