### PR TITLE
Update oxseoencoder.php

### DIFF
--- a/source/core/oxseoencoder.php
+++ b/source/core/oxseoencoder.php
@@ -545,7 +545,7 @@ class oxSeoEncoder extends oxSuperCfg
                 if ($oRs->fields['oxexpired'] && ($oRs->fields['oxtype'] == 'static' || $oRs->fields['oxtype'] == 'dynamic')) {
                     // if expired - copying to history, marking as not expired
                     $this->_copyToHistory($sId, $iShopId, $iLang);
-                    $oDb->execute("update oxseo set oxexpired = 0 where oxobjectid = " . $oDb->quote($sId) . " and oxlang = '{$iLang}'");
+                    $oDb->execute("update oxseo set oxexpired = 0 where oxobjectid = " . $oDb->quote($sId) . " and oxshopid = " . $oDb->quote($iShopId) . " and oxlang = '{$iLang}'");
                     $sSeoUrl = $oRs->fields['oxseourl'];
                 } elseif (!$oRs->fields['oxexpired'] || $oRs->fields['oxfixed']) {
                     // if seo url is available and is valid


### PR DESCRIPTION
i think, there was a minor bug in oxseoencoder, which should be fixed with this.. SEO-URLs are stored separately for every subshop. In oxseoencoder->_loadFromDb() SEO-Urls, which are marked as expired, were copied to seohistory-Table for given ObjectID and shopID, but the expired-Flag was unset for given ObjectID and every Subshop (given shopId wasnt used). This should work better now.