### PR TITLE
removed undefined $oCur

### DIFF
--- a/source/core/oxemail.php
+++ b/source/core/oxemail.php
@@ -1360,7 +1360,7 @@ class oxEmail extends PHPMailer
         $oSmarty = $this->_getSmarty();
         $this->setViewData("product", $oArticle);
         $this->setViewData("email", $aParams['email']);
-        $this->setViewData("bidprice", $oLang->formatCurrency($oAlarm->oxpricealarm__oxprice->value, $oCur));
+        $this->setViewData("bidprice", $oLang->formatCurrency($oAlarm->oxpricealarm__oxprice->value));
 
         // Process view data array through oxOutput processor
         $this->_processViewArray();


### PR DESCRIPTION
$oLang->formatCurrency() can get active currency if there is no currency passed.

also, there are some translation idents missing
![image](https://user-images.githubusercontent.com/1874024/30221574-0f9854d0-94c4-11e7-89e2-58147b6b654b.png)
(tested in demoshop)