### PR TITLE
Cleanup url extension in SeoUrlEncoderArticle

### DIFF
--- a/source/Application/Model/SeoEncoderArticle.php
+++ b/source/Application/Model/SeoEncoderArticle.php
@@ -371,7 +371,7 @@ class SeoEncoderArticle extends \OxidEsales\Eshop\Core\SeoEncoder
             $sTitle .= ($sTitle ? ' ' : '') . $oArticle->oxarticles__oxartnum->value;
         }
 
-        return $this->_prepareTitle($sTitle, false, $oArticle->getLanguage()) . '.html';
+        return $this->_prepareTitle($sTitle, false, $oArticle->getLanguage()) . $this->_getUrlExtension();
     }
 
     /**


### PR DESCRIPTION
Replace every occurrence of `.html` with call to `$this->_getUrlExtension()`