### PR TITLE
pass correct oxseo type for manufacturerUrl

### DIFF
--- a/source/Application/Model/SeoEncoderManufacturer.php
+++ b/source/Application/Model/SeoEncoderManufacturer.php
@@ -94,10 +94,10 @@ class SeoEncoderManufacturer extends \OxidEsales\Eshop\Core\SeoEncoder
         $seoUrl = $this->getManufacturerUri($manufacturer, $languageId);
 
         if ($isFixed === null) {
-            $isFixed = $this->_isFixed('oxmanufacturers', $manufacturer->getId(), $languageId);
+            $isFixed = $this->_isFixed('oxmanufacturer', $manufacturer->getId(), $languageId);
         }
 
-        return $this->assembleFullPageUrl($manufacturer, 'oxmanufacturers', $stdUrl, $seoUrl, $pageNumber, $parameters, $languageId, $isFixed);
+        return $this->assembleFullPageUrl($manufacturer, 'oxmanufacturer', $stdUrl, $seoUrl, $pageNumber, $parameters, $languageId, $isFixed);
     }
 
     /**


### PR DESCRIPTION
On line 69 _saveToDb is called with the `oxmanufacturer` type:

https://github.com/OXID-eSales/oxideshop_ce/blob/f79cadfd4269830b5eebbe82b6d1ddd1808a37af/source/Application/Model/SeoEncoderManufacturer.php#L69

However in the `getManufacturerPageUrl()` method the type is passed as `oxmanufacturers` which results in never being able to read the result from DB & always writing on every request instead even when a result already exists. 