### PR TITLE
erros / exception interface

### DIFF
--- a/source/Core/Exception/ExceptionHandler.php
+++ b/source/Core/Exception/ExceptionHandler.php
@@ -107,7 +107,7 @@ class ExceptionHandler
     /**
      * Handler for uncaught exceptions. As this is the las resort no fancy business logic should be applied here.
      *
-     * @param $exception throwable
+     * @param Throwable $exception
      *
      * @return void
      **/
@@ -151,7 +151,7 @@ class ExceptionHandler
     /**
      * Write a formatted log entry to the log file.
      *
-     * @param throwable $exception
+     * @param Throwable $exception
      *
      * @return int|false The function returns the number of bytes that were written to the file, or false on failure.
      */
@@ -189,7 +189,7 @@ class ExceptionHandler
     /**
      * Print a debug message to the screen.
      *
-     * @param throwable $exception
+     * @param Throwable $exception
      * @param bool       $logWritten True, if an entry was written to the log file
      *
      * @return null
@@ -217,7 +217,7 @@ class ExceptionHandler
     /**
      * Return a formatted exception to be written to the log file.
      *
-     * @param throwable $exception
+     * @param Throwable $exception
      *
      * @return string
      */

--- a/source/Core/Exception/ExceptionHandler.php
+++ b/source/Core/Exception/ExceptionHandler.php
@@ -107,11 +107,11 @@ class ExceptionHandler
     /**
      * Handler for uncaught exceptions. As this is the las resort no fancy business logic should be applied here.
      *
-     * @param \Exception $exception exception object
+     * @param $exception throwable object
      *
      * @return void
      **/
-    public function handleUncaughtException(\Exception $exception)
+    public function handleUncaughtException($exception)
     {
         /**
          * Report the exception
@@ -151,11 +151,11 @@ class ExceptionHandler
     /**
      * Write a formatted log entry to the log file.
      *
-     * @param \Exception $exception
+     * @param throwable $exception
      *
      * @return int|false The function returns the number of bytes that were written to the file, or false on failure.
      */
-    public function writeExceptionToLog(\Exception $exception)
+    public function writeExceptionToLog($exception)
     {
         /** self::_sFileName is @deprecated since v6.0 (2017-03-30); Logging mechanism will change in the future. */
         $logFile = dirname(OX_LOG_FILE) . DIRECTORY_SEPARATOR . $this->_sFileName;
@@ -189,12 +189,12 @@ class ExceptionHandler
     /**
      * Print a debug message to the screen.
      *
-     * @param \Exception $exception  The exception to be treated
+     * @param throwable $exception  The exception to be treated
      * @param bool       $logWritten True, if an entry was written to the log file
      *
      * @return null
      */
-    protected function displayDebugMessage(\Exception $exception, $logWritten)
+    protected function displayDebugMessage($exception, $logWritten)
     {
         $loggingErrorMessage = $logWritten ? '' : 'Could not write log file' . PHP_EOL;
 
@@ -217,11 +217,11 @@ class ExceptionHandler
     /**
      * Return a formatted exception to be written to the log file.
      *
-     * @param \Exception $exception
+     * @param throwable $exception
      *
      * @return string
      */
-    protected function getFormattedException(\Exception $exception)
+    protected function getFormattedException($exception)
     {
         $time = microtime(true);
         $micro = sprintf("%06d", ($time - floor($time)) * 1000000);


### PR DESCRIPTION
since php7/oxid6 exception output has changed.

at the moment an exception from instance exception is expected. but with this condition it´s not possible to get other errors like parse error, or an full stack trace.

---
[11 Nov 09:28:27.571274 2017] [uncaught error] [type E_ERROR] [file /var/www/html/vendor/oxid-esales/oxideshop-ce/source/Core/Exception/ExceptionHandler.php] [line 114] [code ] [message Uncaught TypeError: Argument 1 passed to OxidEsales\EshopCommunity\Core\Exception\ExceptionHandler::handleUncaughtException() must be an instance of Exception, instance of ParseError given in /var/www/html/vendor/oxid-esales/oxideshop-ce/source/Core/Exception/ExceptionHandler.php:114
Stack trace:
#0 [internal function]: OxidEsales\EshopCommunity\Core\Exception\ExceptionHandler->handleUncaughtException(Object(ParseError))
#1 {main}
  thrown]
---

after removing exception and only using throwable interface we gat a meaningful message.

---
[11 Nov 09:26:03.952171 2017] [exception] [type ParseError] [code 0] [file /var/www/html/vendor/oxid-esales/oxideshop-ce/source/Application/Controller/StartController.php] [line 30] [message syntax error, unexpected 'protected' (T_PROTECTED), expecting ',' or ';']
[11 Nov 09:26:03.952171 2017] [exception] [stacktrace] #0 /var/www/html/vendor/composer/ClassLoader.php(322): Composer\Autoload\includeFile('/var/www/html/v...')
[11 Nov 09:26:03.952171 2017] [exception] [stacktrace] #1 [internal function]: Composer\Autoload\ClassLoader->loadClass('OxidEsales\\Esho...')
[11 Nov 09:26:03.952171 2017] [exception] [stacktrace] #2 /var/www/html/vendor/oxid-esales/oxideshop-unified-namespace-generator/generated/OxidEsales/Eshop/Application/Controller/StartController.php(34): spl_autoload_call('OxidEsales\\Esho...')
[11 Nov 09:26:03.952171 2017] [exception] [stacktrace] #3 /var/www/html/vendor/composer/ClassLoader.php(444): include('/var/www/html/v...')
[11 Nov 09:26:03.952171 2017] [exception] [stacktrace] #4 /var/www/html/vendor/composer/ClassLoader.php(322): Composer\Autoload\includeFile('/var/www/html/v...')
[11 Nov 09:26:03.952171 2017] [exception] [stacktrace] #5 [internal function]: Composer\Autoload\ClassLoader->loadClass('OxidEsales\\Esho...')
[11 Nov 09:26:03.952171 2017] [exception] [stacktrace] #6 [internal function]: spl_autoload_call('OxidEsales\\Esho...')
[11 Nov 09:26:03.952171 2017] [exception] [stacktrace] #7 /var/www/html/vendor/oxid-esales/oxideshop-ce/source/Core/UtilsObject.php(221): class_exists('OxidEsales\\Esho...')
[11 Nov 09:26:03.952171 2017] [exception] [stacktrace] #8 /var/www/html/source/oxfunctions.php(103): OxidEsales\EshopCommunity\Core\UtilsObject->oxNew('OxidEsales\\Esho...')
[11 Nov 09:26:03.952171 2017] [exception] [stacktrace] #9 /var/www/html/vendor/oxid-esales/oxideshop-ce/source/Core/ShopControl.php(372): oxNew('OxidEsales\\Esho...')
[11 Nov 09:26:03.952171 2017] [exception] [stacktrace] #10 /var/www/html/vendor/oxid-esales/oxideshop-ce/source/Core/ShopControl.php(272): OxidEsales\EshopCommunity\Core\ShopControl->_initializeViewObject('OxidEsales\\Esho...', NULL, NULL, NULL)
[11 Nov 09:26:03.952171 2017] [exception] [stacktrace] #11 /var/www/html/vendor/oxid-esales/oxideshop-ce/source/Core/ShopControl.php(137): OxidEsales\EshopCommunity\Core\ShopControl->_process('OxidEsales\\Esho...', NULL, NULL, NULL)
[11 Nov 09:26:03.952171 2017] [exception] [stacktrace] #12 /var/www/html/vendor/oxid-esales/oxideshop-ce/source/Core/Oxid.php(26): OxidEsales\EshopCommunity\Core\ShopControl->start()
[11 Nov 09:26:03.952171 2017] [exception] [stacktrace] #13 /var/www/html/source/index.php(15): OxidEsales\EshopCommunity\Core\Oxid::run()
[11 Nov 09:26:03.952171 2017] [exception] [stacktrace] #14 {main}
---

this is a know "problem", eg. see phpunit: https://github.com/sebastianbergmann/phpunit/commit/ac2e32c1d87cd8d2689a25e344a87de93858608c#diff-6e322f26d88c0e616cb69e9788b9a0b6R9
