### PR TITLE
display full field names in filter dropdowns in admin

### DIFF
--- a/source/Application/views/admin/tpl/article_list.tpl
+++ b/source/Application/views/admin/tpl/article_list.tpl
@@ -68,7 +68,7 @@ window.onload = function ()
                     [{foreach from=$pwrsearchfields key=field item=desc}]
                     [{assign var="ident" value=GENERAL_ARTICLE_$desc}]
                     [{assign var="ident" value=$ident|oxupper}]
-                    <option value="[{$desc}]" [{if $pwrsearchfld == $desc|oxupper}]SELECTED[{/if}]>[{oxmultilang|oxtruncate:20:"..":true noerror=true alternative=$desc ident=$ident}]</option>
+                    <option value="[{$desc}]" [{if $pwrsearchfld == $desc|oxupper}]SELECTED[{/if}]>[{oxmultilang noerror=true alternative=$desc ident=$ident}]</option>
                     [{/foreach}]
                 </select>
                 <input class="listedit" type="text" size="20" maxlength="128" name="where[oxarticles][[{$pwrsearchfld|oxlower}]]" value="[{$pwrsearchinput}]" [{include file="help.tpl" helpid=searchfieldoxdynamic}]>


### PR DESCRIPTION
since its almost 2018 and screen resolution and size increased over last 20 years, we could display full field names in filter dropdowns 
![image](https://user-images.githubusercontent.com/1874024/33668726-d88c3038-daa0-11e7-8f6e-c6d7dbe8a353.png)


