### PR TITLE
change sorting category articles

### DIFF
--- a/source/Application/Model/RssFeed.php
+++ b/source/Application/Model/RssFeed.php
@@ -540,7 +540,7 @@ class RssFeed extends \OxidEsales\Eshop\Core\Base
         }
 
         $oArtList = oxNew(\OxidEsales\Eshop\Application\Model\ArticleList::class);
-        $oArtList->setCustomSorting('oc.oxtime desc');
+        $oArtList->setCustomSorting('oxinsert desc');
         $oArtList->loadCategoryArticles($oCat->getId(), null, $this->getConfig()->getConfigParam('iRssItemsCount'));
 
         $oLang = Registry::getLang();

--- a/source/Application/Model/RssFeed.php
+++ b/source/Application/Model/RssFeed.php
@@ -540,7 +540,7 @@ class RssFeed extends \OxidEsales\Eshop\Core\Base
         }
 
         $oArtList = oxNew(\OxidEsales\Eshop\Application\Model\ArticleList::class);
-        $oArtList->setCustomSorting('oxinsert desc');
+        $oArtList->setCustomSorting('oc.oxtimestamp desc');
         $oArtList->loadCategoryArticles($oCat->getId(), null, $this->getConfig()->getConfigParam('iRssItemsCount'));
 
         $oLang = Registry::getLang();


### PR DESCRIPTION
see bug report https://bugs.oxid-esales.com/view.php?id=6739

if a product is assigned to one category, oxobject2category.oxtime is always 0 --> no sorting