### PR TITLE
Added cache for getAttributesDisplayableInBasket()

### DIFF
--- a/source/Application/Model/Article.php
+++ b/source/Application/Model/Article.php
@@ -206,6 +206,11 @@ class Article extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
     protected $_oAttributeList = null;
 
     /**
+     * Object holding the list of attributes and attribute values associated with this article and displayable in basket
+     */
+    protected $_oAttributeListDisplayableInBasket = null;
+    
+    /**
      * Indicates whether the price is "From" price
      *
      * @var bool
@@ -2561,12 +2566,12 @@ class Article extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
      */
     public function getAttributesDisplayableInBasket()
     {
-        if ($this->_oAttributeList === null) {
-            $this->_oAttributeList = oxNew(\OxidEsales\Eshop\Application\Model\AttributeList::class);
-            $this->_oAttributeList->loadAttributesDisplayableInBasket($this->getId(), $this->getParentId());
+        if ($this->_oAttributeListDisplayableInBasket === null) {
+            $this->_oAttributeListDisplayableInBasket = oxNew(\OxidEsales\Eshop\Application\Model\AttributeList::class);
+            $this->_oAttributeListDisplayableInBasket->loadAttributesDisplayableInBasket($this->getId(), $this->getParentId());
         }
 
-        return $this->_oAttributeList;
+        return $this->_oAttributeListDisplayableInBasket;
     }
 
 

--- a/source/Application/Model/Article.php
+++ b/source/Application/Model/Article.php
@@ -202,13 +202,15 @@ class Article extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
 
     /**
      * Object holding the list of attributes and attribute values associated with this article
+     * @var \OxidEsales\Eshop\Application\Model\AttributeList
      */
     protected $_oAttributeList = null;
 
     /**
      * Object holding the list of attributes and attribute values associated with this article and displayable in basket
+     * @var \OxidEsales\Eshop\Application\Model\AttributeList
      */
-    protected $_oAttributeListDisplayableInBasket = null;
+    protected $basketAttributeList = null;
     
     /**
      * Indicates whether the price is "From" price
@@ -2547,7 +2549,7 @@ class Article extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
     /**
      * Loads and returns attribute list associated with this article
      *
-     * @return object
+     * @return \OxidEsales\Eshop\Application\Model\AttributeList
      */
     public function getAttributes()
     {
@@ -2560,18 +2562,18 @@ class Article extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
     }
 
     /**
-     * Loads and returns displayable in basket/order attributes list associated with this article
+     * Loads and returns attribute list for display in basket
      *
-     * @return object
+     * @return \OxidEsales\Eshop\Application\Model\AttributeList
      */
-    public function getAttributesDisplayableInBasket()
+    public function getBasketAttributeList()
     {
-        if ($this->_oAttributeListDisplayableInBasket === null) {
-            $this->_oAttributeListDisplayableInBasket = oxNew(\OxidEsales\Eshop\Application\Model\AttributeList::class);
-            $this->_oAttributeListDisplayableInBasket->loadAttributesDisplayableInBasket($this->getId(), $this->getParentId());
+        if ($this->basketAttributeList === null) {
+            $this->basketAttributeList = oxNew(\OxidEsales\Eshop\Application\Model\AttributeList::class);
+            $this->basketAttributeList->loadAttributesDisplayableInBasket($this->getId(), $this->getParentId());
         }
 
-        return $this->_oAttributeListDisplayableInBasket;
+        return $this->basketAttributeList;
     }
 
 


### PR DESCRIPTION
`getAttributes()` and `getAttributesDisplayableInBasket()` both use `$this->_oAttributeList` as a result cache.  
This leads to wrong results if both methods are called during the same request.

This change adds `$this->_oAttributeListDisplayableInBasket` to separate the caches.