### PR TITLE
fixed entity error with &amp; value

### DIFF
--- a/source/Application/views/admin/tpl/include/category_main_form.tpl
+++ b/source/Application/views/admin/tpl/include/category_main_form.tpl
@@ -36,7 +36,7 @@
             <td class="edittext" colspan="2">
                 <select name="editval[oxcategories__oxparentid]" class="editinput" [{$readonly}]>
                     [{foreach from=$cattree->aList item=pcat}]
-                        <option value="[{if $pcat->oxcategories__oxid->value}][{$pcat->oxcategories__oxid->value}][{else}]oxrootid[{/if}]" [{if $pcat->selected}]SELECTED[{/if}]>[{$pcat->oxcategories__oxtitle->value|oxtruncate:33:"..":true}]</option>
+                        <option value="[{if $pcat->oxcategories__oxid->value}][{$pcat->oxcategories__oxid->value}][{else}]oxrootid[{/if}]" [{if $pcat->selected}]SELECTED[{/if}]>[{$pcat->oxcategories__oxtitle->rawValue|oxtruncate:33:"..":true}]</option>
                     [{/foreach}]
                 </select>
                 [{oxinputhelp ident="HELP_CATEGORY_MAIN_PARENTID"}]


### PR DESCRIPTION
In Backend category main when you select a sub category which has a & char in title the char is displayed as &amp;. This commit should fix it.