### PR TITLE
New static function Registry::getRequest()

### DIFF
--- a/source/Core/Registry.php
+++ b/source/Core/Registry.php
@@ -156,6 +156,18 @@ class Registry
     }
 
     /**
+     * Return an instance of \OxidEsales\Eshop\Core\Request
+     *
+     * @static
+     *
+     * @return \OxidEsales\Eshop\Core\Request
+     */
+    public static function getRequest()
+    {
+        return self::getObject(\OxidEsales\Eshop\Core\Request::class);
+    }
+
+    /**
      * Return an instance of \OxidEsales\Eshop\Core\SeoEncoder
      *
      * @static

--- a/tests/Unit/Core/RegistryTest.php
+++ b/tests/Unit/Core/RegistryTest.php
@@ -293,6 +293,15 @@ class RegistryTest extends \OxidEsales\TestingLibrary\UnitTestCase
     }
 
     /**
+     * Test Registry::getRequest().
+     */
+    public function testRegistryGetRequest()
+    {
+        $object = Registry::getRequest();
+        $this->assertTrue(is_a($object, \OxidEsales\Eshop\Core\Request::class));
+    }
+
+    /**
      * Test Registry::getSeoDecoder().
      */
     public function testRegistryGetSeoDecoder()
@@ -438,6 +447,7 @@ class RegistryTest extends \OxidEsales\TestingLibrary\UnitTestCase
         return [
             ['getInputValidator', \OxidEsales\Eshop\Core\InputValidator::class],
             ['getPictureHandler', \OxidEsales\Eshop\Core\PictureHandler::class],
+            ['getRequest', \OxidEsales\Eshop\Core\Request::class],
             ['getSeoDecoder', \OxidEsales\Eshop\Core\SeoDecoder::class],
             ['getSeoEncoder', \OxidEsales\Eshop\Core\SeoEncoder::class],
             ['getUtilsCount', \OxidEsales\Eshop\Core\UtilsCount::class],
@@ -478,6 +488,7 @@ class RegistryTest extends \OxidEsales\TestingLibrary\UnitTestCase
         return [
             ['getInputValidator'],
             ['getPictureHandler'],
+            ['getRequest'],
             ['getSeoDecoder'],
             ['getSeoEncoder'],
             ['getUtilsCount'],


### PR DESCRIPTION
A faster way to get OXID Request Class.
befor: 
`\OxidEsales\Eshop\Core\Registry::get(\OxidEsales\Eshop\Core\Request::class)->getRequestParameter('cl');`

after:

`\OxidEsales\Eshop\Core\Registry::getRequest()->getRequestParameter('cl');`