### PR TITLE
Bugfix for sequential JPEG's

### DIFF
--- a/source/Core/utils/oxpicgenerator.php
+++ b/source/Core/utils/oxpicgenerator.php
@@ -241,7 +241,7 @@ if (!function_exists("resizeJpeg")) {
             if ($hDestinationImage === null) {
                 $hDestinationImage = $iGdVer == 1 ? imagecreate($iNewWidth, $iNewHeight) : imagecreatetruecolor($iNewWidth, $iNewHeight);
             }
-            $hSourceImage = imagecreatefromjpeg($sSrc);
+            $hSourceImage = imagecreatefromstring(file_get_contents($sSrc));
             if (copyAlteredImage($hDestinationImage, $hSourceImage, $iNewWidth, $iNewHeight, $aImageInfo, $sTarget, $iGdVer)) {
                 imagejpeg($hDestinationImage, $sTarget, $iDefQuality);
                 imagedestroy($hDestinationImage);


### PR DESCRIPTION
imagecreatefromjpeg can't handle sequential jpeg's correctly, so you will see the following errors in your log files:

> Warning: imagecreatefromjpeg(): gd-jpeg, libjpeg: recoverable error: Invalid SOS parameters for sequential JPEG
> Warning: imagecreatefromjpeg(): 'filename.jpg' is not a valid JPEG file in /var/www/html/core/utils/oxpicgenerator.php