### PR TITLE
Cleanup config params init

### DIFF
--- a/source/Core/Config.php
+++ b/source/Core/Config.php
@@ -364,7 +364,6 @@ class Config extends \OxidEsales\Eshop\Core\Base
      *
      * @throws \OxidEsales\Eshop\Core\Exception\DatabaseException
      * @param int $shopID
-     * @return void
      */
     public function initVars($shopID)
     {


### PR DESCRIPTION
This merge request splits config parameter initialization from application initialization, which gives you the option to init a config object with parameters from another subshop and it implements the dependency inversion principle 