### PR TITLE
set server collations during migration

### DIFF
--- a/source/migration/data/Version20170718124421.php
+++ b/source/migration/data/Version20170718124421.php
@@ -20,6 +20,10 @@ class Version20170718124421 extends AbstractMigration
      */
     public function up(Schema $schema)
     {
+        /// set server collation variables
+        $this->addSql("SET @@session.collation_connection = 'utf8_general_ci';");
+        $this->addSql("SET @@session.collation_server = 'utf8_general_ci';");
+
         $this->addSql("ALTER TABLE `oxtplblocks` 
           CHANGE `OXMODULE` `OXMODULE` varchar(100) 
           character set latin1 collate latin1_general_ci NOT NULL 

--- a/source/migration/data/Version20171018144650.php
+++ b/source/migration/data/Version20171018144650.php
@@ -19,6 +19,10 @@ class Version20171018144650 extends AbstractMigration
      */
     public function up(Schema $schema)
     {
+        /// set server collation variables
+        $this->addSql("SET @@session.collation_connection = 'utf8_general_ci';");
+        $this->addSql("SET @@session.collation_server = 'utf8_general_ci';");
+
         // All tables should have the same default character set and collation
         $this->addSql("ALTER table `oxinvitations` COLLATE utf8_general_ci;");
 

--- a/source/migration/data/Version20180214152228.php
+++ b/source/migration/data/Version20180214152228.php
@@ -22,10 +22,15 @@ class Version20180214152228 extends AbstractMigration
      */
     public function up(Schema $schema)
     {
+
         $facts = new Facts();
         $configFile = new ConfigFile($facts->getSourcePath().'/config.inc.php');
         $configKey = !is_null($configFile->getVar('sConfigKey')) ? $configFile->getVar('sConfigKey') : Config::DEFAULT_CONFIG_KEY;
         $settingName = 'blAllowSuggestArticle';
+
+        /// set server collation variables
+        $this->addSql("SET @@session.collation_connection = 'utf8_general_ci';");
+        $this->addSql("SET @@session.collation_server = 'utf8_general_ci';");
 
         $this->addSql("INSERT INTO `oxconfig` (`OXID`, `OXSHOPID`, `OXMODULE`, `OXVARNAME`, `OXVARTYPE`, `OXVARVALUE`)
                             SELECT SUBSTRING(md5(uuid_short()), 1, 32),  `OXID`, '', '".$settingName."', 'bool', ENCODE('1', '".$configKey."') FROM oxshops


### PR DESCRIPTION
After update of a shop to actual v6.x.x there can be this message during "php vendor/bin/oe-eshop-db_migrate migrations:migrate":

```
Migration 20171018144650 failed during Execution. Error An exception occurred while executing 'INSERT INTO `oxconfig` (`OXID`, `OXSHOPID`, `OXMODULE`, `OXVARNAME`, `OXVARTYPE`, `OXVARVALUE`)
          SELECT
            CONCAT(SUBSTRING(`OXID`,1, 16),SUBSTRING(REPLACE( UUID( ) ,  '-',  '' ), 17,32)) AS `OXID`,
            `OXSHOPID`,
            `OXMODULE`,
            "blSendTechnicalInformationToOxid" AS `OXVARNAME`,
            `OXVARTYPE`,
            `OXVARVALUE`
          FROM `oxconfig`
          WHERE `OXVARNAME` = 'blLoadDynContents'
          AND NOT EXISTS (
            SELECT `OXVARNAME` FROM `oxconfig` WHERE `OXVARNAME` = 'blSendTechnicalInformationToOxid'
          );':

SQLSTATE[HY000]: General error: 1270 Illegal mix of collations (utf8_general_ci,COERCIBLE), (utf8_unicode_ci,COERCIBLE), (utf8_unicode_ci,COERCIBLE) for operation 'replace'
```
