### PR TITLE
Add ^ to version constraint on doctrine/dbal

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "oxid-esales/flow-theme": "dev-master || ^2.2.0",
         "oxid-esales/oxideshop-doctrine-migration-wrapper": "^v2.1.0",
         "oxid-esales/oxideshop-db-views-generator": "^v1.1.1",
-        "doctrine/dbal": "v2.5.12",
+        "doctrine/dbal": "^v2.5.12",
         "oxid-esales/oxideshop-demodata-installer": "^v1.1.0",
         "oxid-esales/oxideshop-composer-plugin": "^v2.0.0",
         "oxid-esales/oxideshop-unified-namespace-generator": "dev-master || ^1.0.0"


### PR DESCRIPTION
Adding ^ to doctrine/dbal version constraint makes it compatible with Symfony >=3.4 and >=4.0