### PR TITLE
Set canUserAccountBeDeleted() visibility to public

### DIFF
--- a/source/Application/Controller/AccountController.php
+++ b/source/Application/Controller/AccountController.php
@@ -387,7 +387,7 @@ class AccountController extends \OxidEsales\Eshop\Application\Controller\Fronten
      *
      * @return bool
      */
-    private function canUserAccountBeDeleted()
+    public function canUserAccountBeDeleted()
     {
         return $this->getSession()->checkSessionChallenge() && $this->isUserAllowedToDeleteOwnAccount();
     }


### PR DESCRIPTION
The method canUserAccountBeDeleted() needs to have either public or protected visibility, so that the deleteAccount() method can be modified by modules that extend AccountController.php