### PR TITLE
Doctrine's QueryBuilder feature

### DIFF
--- a/source/Core/Database/Adapter/DatabaseInterface.php
+++ b/source/Core/Database/Adapter/DatabaseInterface.php
@@ -400,4 +400,11 @@ interface DatabaseInterface
      * @return string|int Row ID
      */
     public function getLastInsertId();
+
+    /**
+     * A QueryBuilder to dynamically create SQL queries.
+     *
+     * @return object
+     */
+    public function createQueryBuilder();
 }

--- a/source/Core/Database/Adapter/Doctrine/Database.php
+++ b/source/Core/Database/Adapter/Doctrine/Database.php
@@ -1418,4 +1418,19 @@ class Database implements DatabaseInterface
 
         return $code;
     }
+
+    /**
+     * A QueryBuilder to dynamically create SQL queries. Use origin Doctrine's QueryBuilder
+     *
+     * @see http://docs.doctrine-project.org/projects/doctrine-dbal/en/latest/reference/query-builder.html
+     * @return \Doctrine\DBAL\Query\QueryBuilder
+     */
+    public function createQueryBuilder()
+    {
+        if (is_null($this->connection)) {
+            $this->connect();
+        }
+
+        return $this->getConnection()->createQueryBuilder();
+    }
 }

--- a/tests/Integration/Core/Database/Adapter/Doctrine/DatabaseTest.php
+++ b/tests/Integration/Core/Database/Adapter/Doctrine/DatabaseTest.php
@@ -572,6 +572,12 @@ class DatabaseTest extends DatabaseInterfaceImplementationTest
         );
     }
 
+    public function testGetInstanceOfDoctrineQueryBuilder()
+    {
+        $actualResult = $this->database->createQueryBuilder();
+        $this->assertInstanceOf('\\Doctrine\\DBAL\\Query\\QueryBuilder', $actualResult);
+    }
+
     /**
      * Assert, that the given array is unique.
      *


### PR DESCRIPTION
Open [QueryBuilder feature](http://docs.doctrine-project.org/projects/doctrine-dbal/en/latest/reference/query-builder.html) of Doctrine, please!

Than we can write code like:

```php
$database     = DatabaseProvider::getDb(DatabaseProvider::FETCH_MODE_ASSOC);
$flexibleSql = $database->createQueryBuilder();

$flexibleSql->select('*')
            ->from(getViewName('oxarticles'))
            ->where('oxtitle like :value')
            ->setParameter(':value', "%Sessel%");

$result = $database->getAll($flexibleSql->getSQL(), $flexibleSql->getParameters());
```

We have a flexible sql object. To change it easy in other function like:

```php
...
addActiveSnippet($flexibleSql);
...
$result = $database->getAll($flexibleSql->getSQL(), $flexibleSql->getParameters());

function addActiveSnippet(QueryBuilder $flexibleSql) {
    $flexibleSql->andWhere('oxactive = 1');
}
```

