### PR TITLE
fix persparams check

### DIFF
--- a/source/Application/Component/BasketComponent.php
+++ b/source/Application/Component/BasketComponent.php
@@ -290,7 +290,7 @@ class BasketComponent extends \OxidEsales\Eshop\Core\Controller\BaseController
         if (!is_array($persistedParameters)) {
             return null;
         }
-        return array_filter($persistedParameters, 'trim') ?: null;
+        return array_filter($persistedParameters) ?: null;
     }
 
     /**


### PR DESCRIPTION
callback is not needed to remove empty persparam values AND with trim callback it´s not longer possible to use arrays in persparams