### PR TITLE
Fixed notices and performance in isVatIncluded

### DIFF
--- a/source/Application/Controller/FrontendController.php
+++ b/source/Application/Controller/FrontendController.php
@@ -2891,16 +2891,6 @@ class FrontendController extends \OxidEsales\Eshop\Core\Controller\BaseControlle
     public function isVatIncluded()
     {
         $config = $this->getConfig();
-        $user = $this->getUser();
-
-        if ($user === false) {
-            $user = oxNew(\OxidEsales\Eshop\Application\Model\User::class);
-        }
-
-        $country = oxNew(\OxidEsales\Eshop\Application\Model\Country::class);
-        $country->load($user->getActiveCountry());
-        $countryBillsNotVat = $country->oxcountry__oxvatstatus->value !== null && $country->oxcountry__oxvatstatus->value == 0;
-
         /*
          * Do not show "inclusive VAT" when:
          *
@@ -2913,9 +2903,21 @@ class FrontendController extends \OxidEsales\Eshop\Core\Controller\BaseControlle
          * oxcountry__oxvatstatus: Vat status: 0 - Do not bill VAT, 1 - Do not bill VAT only if provided valid VAT ID
          * if country is not available (no session) oxvatstatus->value will return null
          */
-        if ($config->getConfigParam('blShowNetPrice') ||
-            $config->getConfigParam('bl_perfCalcVatOnlyForBasketOrder') ||
-            $countryBillsNotVat
+        if ($config->getConfigParam('blShowNetPrice') || $config->getConfigParam('bl_perfCalcVatOnlyForBasketOrder')) {
+            return false;
+        }
+
+        $user = $this->getUser();
+        if ($user === false) {
+            $user = oxNew(\OxidEsales\Eshop\Application\Model\User::class);
+        }
+
+        $country = oxNew(\OxidEsales\Eshop\Application\Model\Country::class);
+        $activeCountry = $user->getActiveCountry();
+        if ($activeCountry !== '' &&
+            $country->load($activeCountry) &&
+            $country->oxcountry__oxvatstatus->value !== null &&
+            $country->oxcountry__oxvatstatus->value == 0
         ) {
             return false;
         }

--- a/source/Application/Controller/FrontendController.php
+++ b/source/Application/Controller/FrontendController.php
@@ -2912,14 +2912,15 @@ class FrontendController extends \OxidEsales\Eshop\Core\Controller\BaseControlle
             $user = oxNew(\OxidEsales\Eshop\Application\Model\User::class);
         }
 
-        $country = oxNew(\OxidEsales\Eshop\Application\Model\Country::class);
         $activeCountry = $user->getActiveCountry();
-        if ($activeCountry !== '' &&
-            $country->load($activeCountry) &&
-            $country->oxcountry__oxvatstatus->value !== null &&
-            $country->oxcountry__oxvatstatus->value == 0
-        ) {
-            return false;
+        if ($activeCountry !== '') {
+            $country = oxNew(\OxidEsales\Eshop\Application\Model\Country::class);
+            if ($country->load($activeCountry) &&
+                $country->oxcountry__oxvatstatus->value !== null &&
+                $country->oxcountry__oxvatstatus->value == 0
+            ) {
+                return false;
+            }
         }
 
         return true;

--- a/source/Application/Controller/FrontendController.php
+++ b/source/Application/Controller/FrontendController.php
@@ -391,6 +391,9 @@ class FrontendController extends \OxidEsales\Eshop\Core\Controller\BaseControlle
     /** @var string Logged in user name. */
     protected $_sActiveUsername = null;
 
+    /** @var boolean is VAT included in prices */
+    protected $_blIsVatIncluded = null;
+
     /** @var array Components which needs to be initialized/rendered (depending on cache and its cache status). */
     protected static $_aCollectedComponentNames = null;
 
@@ -2890,6 +2893,10 @@ class FrontendController extends \OxidEsales\Eshop\Core\Controller\BaseControlle
      */
     public function isVatIncluded()
     {
+        if ($this->_blIsVatIncluded !== null) {
+            return $this->_blIsVatIncluded;
+        }
+
         $config = $this->getConfig();
         /*
          * Do not show "inclusive VAT" when:
@@ -2904,7 +2911,7 @@ class FrontendController extends \OxidEsales\Eshop\Core\Controller\BaseControlle
          * if country is not available (no session) oxvatstatus->value will return null
          */
         if ($config->getConfigParam('blShowNetPrice') || $config->getConfigParam('bl_perfCalcVatOnlyForBasketOrder')) {
-            return false;
+            return $this->_blIsVatIncluded = false;
         }
 
         $user = $this->getUser();
@@ -2919,11 +2926,11 @@ class FrontendController extends \OxidEsales\Eshop\Core\Controller\BaseControlle
                 $country->oxcountry__oxvatstatus->value !== null &&
                 $country->oxcountry__oxvatstatus->value == 0
             ) {
-                return false;
+                return $this->_blIsVatIncluded = false;
             }
         }
 
-        return true;
+        return $this->_blIsVatIncluded = true;
     }
 
     /**

--- a/tests/Unit/Application/Controller/UBaseTest.php
+++ b/tests/Unit/Application/Controller/UBaseTest.php
@@ -2229,8 +2229,7 @@ class UBaseTest extends \OxidTestCase
     {
         $this->getConfig()->setConfigParam('blShowNetPrice', true);
 
-        $oView = $this->getMock(\OxidEsales\Eshop\Application\Controller\FrontendController::class, array('getUser'));
-        $oView->expects($this->once())->method('getUser')->will($this->returnValue($oUser));
+        $oView = oxNew(\OxidEsales\Eshop\Application\Controller\FrontendController::class);
         $this->assertFalse($oView->isVatIncluded());
     }
 

--- a/tests/Unit/Application/Controller/UBaseTest.php
+++ b/tests/Unit/Application/Controller/UBaseTest.php
@@ -2229,9 +2229,6 @@ class UBaseTest extends \OxidTestCase
     {
         $this->getConfig()->setConfigParam('blShowNetPrice', true);
 
-        $oUser = $this->getMock(\OxidEsales\Eshop\Application\Model\User::class, array('getActiveCountry'));
-        $oUser->expects($this->once())->method('getActiveCountry')->will($this->returnValue(''));
-
         $oView = $this->getMock(\OxidEsales\Eshop\Application\Controller\FrontendController::class, array('getUser'));
         $oView->expects($this->once())->method('getUser')->will($this->returnValue($oUser));
         $this->assertFalse($oView->isVatIncluded());


### PR DESCRIPTION
I rearranged the method FrontendController::isVatIncluded to:
(If the user is not logged in)
- Avoid loading Country instance with id "" (empty string)
- Avoid two php notices per call (Country was not successfully loaded)
> Trying to get property of non-object in source/Application/Controller/FrontendController.php line 2894

(If the user is logged in)
- Avoid repeated evaluation on subsequent calls, including loading the same Country object

(In either case)
- Avoid creating unnecessary objects if the method result only depends on the configuration

I'm done with my changes and would appreciate your review. However I think I should have done them on base of branch b-6.x...