### PR TITLE
Set PHP 7.1 as maximal recommended version

### DIFF
--- a/source/Core/SystemRequirements.php
+++ b/source/Core/SystemRequirements.php
@@ -557,7 +557,7 @@ class SystemRequirements
 
         $minimalRequiredVersion = '5.5.0';
         $minimalRecommendedVersion = '5.6.0';
-        $maximalRecommendedVersion = '7.0.9999';
+        $maximalRecommendedVersion = '7.1.9999';
 
         $installedPhpVersion = $this->getPhpVersion();
 

--- a/tests/Unit/Core/SystemRequirementsTest.php
+++ b/tests/Unit/Core/SystemRequirementsTest.php
@@ -429,8 +429,10 @@ class SystemRequirementsTest extends \OxidTestCase
             array('7.0.0', 2),
             array('7.0.8-0ubuntu0.16.04.3', 2),
             array('7.0.12-2ubuntu2', 2),
-            array('7.1.0', 1),
-            array('7.1.22', 1),
+            array('7.1.0', 2),
+            array('7.1.22', 2),
+            array('7.2.0', 1),
+            array('7.2.22', 1),
         );
     }
 


### PR DESCRIPTION
I think there is no reason for not setting PHP 7.1 as maximal recommended version since CI passes using that PHP version.