### PR TITLE
ExceptionHandler compatibility with php7

### DIFF
--- a/source/Core/Exception/ExceptionHandler.php
+++ b/source/Core/Exception/ExceptionHandler.php
@@ -107,12 +107,20 @@ class ExceptionHandler
     /**
      * Handler for uncaught exceptions. As this is the las resort no fancy business logic should be applied here.
      *
-     * @param \Exception $exception exception object
+     * @param \Exception|\Throwable $exception exception object
+     *
+     * @throw \InvalidArgumentException
      *
      * @return void
      **/
-    public function handleUncaughtException(\Exception $exception)
+    public function handleUncaughtException($exception)
     {
+        if (! $exception instanceof \Exception
+            && (class_exists('\Throwable') && ! $exception instanceof \Throwable)
+        ) {
+            throw new \InvalidArgumentException('First argument needs to be an instanceof \Exception or \Throwable');
+        }
+
         /**
          * Report the exception
          */
@@ -151,12 +159,20 @@ class ExceptionHandler
     /**
      * Write a formatted log entry to the log file.
      *
-     * @param \Exception $exception
+     * @param \Exception|\Throwable $exception
+     *
+     * @throw \InvalidArgumentException
      *
      * @return int|false The function returns the number of bytes that were written to the file, or false on failure.
      */
-    public function writeExceptionToLog(\Exception $exception)
+    public function writeExceptionToLog($exception)
     {
+        if (! $exception instanceof \Exception
+            && (class_exists('\Throwable') && ! $exception instanceof \Throwable)
+        ) {
+            throw new \InvalidArgumentException('$exception needs to be an instanceof \Exception or \Throwable');
+        }
+
         /** self::_sFileName is @deprecated since v6.0 (2017-03-30); Logging mechanism will change in the future. */
         $logFile = dirname(OX_LOG_FILE) . DIRECTORY_SEPARATOR . $this->_sFileName;
         $logMessage = $this->getFormattedException($exception);
@@ -189,13 +205,21 @@ class ExceptionHandler
     /**
      * Print a debug message to the screen.
      *
-     * @param \Exception $exception  The exception to be treated
-     * @param bool       $logWritten True, if an entry was written to the log file
+     * @param \Exception|\Throwable $exception  The exception to be treated
+     * @param bool                  $logWritten True, if an entry was written to the log file
+     *
+     * @throw \InvalidArgumentException
      *
      * @return null
      */
-    protected function displayDebugMessage(\Exception $exception, $logWritten)
+    protected function displayDebugMessage($exception, $logWritten)
     {
+        if (! $exception instanceof \Exception
+            && (class_exists('\Throwable') && ! $exception instanceof \Throwable)
+        ) {
+            throw new \InvalidArgumentException('$exception needs to be an instanceof \Exception or \Throwable');
+        }
+
         $loggingErrorMessage = $logWritten ? '' : 'Could not write log file' . PHP_EOL;
 
         /** Just display a small note in CLI mode */
@@ -217,12 +241,18 @@ class ExceptionHandler
     /**
      * Return a formatted exception to be written to the log file.
      *
-     * @param \Exception $exception
+     * @param \Exception|\Throwable $exception
      *
      * @return string
      */
-    public function getFormattedException(\Exception $exception)
+    public function getFormattedException($exception)
     {
+        if (! $exception instanceof \Exception
+            && (class_exists('\Throwable') && ! $exception instanceof \Throwable)
+        ) {
+            throw new \InvalidArgumentException('$exception needs to be an instanceof \Exception or \Throwable');
+        }
+
         $time = microtime(true);
         $micro = sprintf("%06d", ($time - floor($time)) * 1000000);
         $date = new \DateTime(date('Y-m-d H:i:s.' . $micro, $time));

--- a/tests/Unit/Core/Exception/ExceptionHandlerTest.php
+++ b/tests/Unit/Core/Exception/ExceptionHandlerTest.php
@@ -197,6 +197,27 @@ class ExceptionHandlerTest extends \OxidEsales\TestingLibrary\UnitTestCase
     }
 
     /**
+     * @covers \OxidEsales\Eshop\Core\Exception\ExceptionHandler::handleUncaughtException
+     */
+    public function testHandleUncaughtExceptionAcceptsThrowables() {
+        if (version_compare(PHP_VERSION, '7.0') < 0) {
+            $this->markTestSkipped('php needs to >= 7.0');
+        }
+
+        $debug = false;
+        /** @var ExceptionHandler|\PHPUnit_Framework_MockObject_MockObject $exceptionHandlerMock */
+        $exceptionHandlerMock = $this->getMock(
+            ExceptionHandler::class,
+            ['writeExceptionToLog','displayOfflinePage'],
+            [$debug]
+        );
+        $exceptionHandlerMock->expects($this->once())->method('displayOfflinePage');
+        $exceptionHandlerMock->expects($this->once())->method('writeExceptionToLog');
+
+        $exceptionHandlerMock->handleUncaughtException(new \Error());
+    }
+
+    /**
      * Data provider for testHandleUncaughtExceptionWillExitApplication
      *
      * @return array
@@ -286,6 +307,34 @@ class ExceptionHandlerTest extends \OxidEsales\TestingLibrary\UnitTestCase
     }
 
     /**
+     * @covers \OxidEsales\Eshop\Core\Exception\ExceptionHandler::writeExceptionToLog()
+     */
+    public function testWriteExceptionToLogAcceptsThrowables()
+    {
+        if (version_compare(PHP_VERSION, '7.0') < 0) {
+            $this->markTestSkipped('php needs to >= 7.0');
+        }
+
+        $fileName = dirname(OX_LOG_FILE) . DIRECTORY_SEPARATOR . __FUNCTION__ . '.log';
+
+        /** @var ExceptionHandler|\PHPUnit_Framework_MockObject_MockObject $exceptionHandlerMock */
+        $exceptionHandlerMock = $this->getMock(
+            ExceptionHandler::class,
+            ['getFormattedException']
+        );
+        $exceptionHandlerMock->setLogFileName($fileName);
+
+        $exceptionHandlerMock->expects($this->once())->method('getFormattedException');
+        $exceptionHandlerMock->writeExceptionToLog(new \Error('message', 1));
+
+        if (file_exists($fileName) && !is_dir($fileName)) {
+            unlink($fileName);
+        } else {
+            $this->fail('test file does not exist or is directory: ' . $fileName);
+        }
+    }
+
+    /**
      * @covers \OxidEsales\Eshop\Core\Exception\ExceptionHandler::getFormattedException()
      */
     public function testGetFormattedException()
@@ -319,5 +368,18 @@ class ExceptionHandlerTest extends \OxidEsales\TestingLibrary\UnitTestCase
         foreach ($expectedLogContents as $expectedField => $expectedValue) {
             $this->assertContains($expectedValue, $logContent, 'Log formatter puts ' . $expectedField);
         }
+    }
+
+    /**
+     * @covers \OxidEsales\Eshop\Core\Exception\ExceptionHandler::getFormattedException()
+     */
+    public function testGetFormattedExceptionAcceptsThrowables()
+    {
+        if (version_compare(PHP_VERSION, '7.0') < 0) {
+            $this->markTestSkipped('php needs to >= 7.0');
+        }
+        $exceptionHandlerMock = oxNew(ExceptionHandler::class);
+        $error = new \Error('message', 1);
+        $exceptionHandlerMock->getFormattedException($error);
     }
 }


### PR DESCRIPTION
ExceptionHandler can now deal with php 7 Errors (warnings, notices). Before the change they lead to catchable fatal errors because of the typehint for \Exception.

I also have a related question: I'm one of those who enable the full error_reporting especially in production as warnings / notices are good indicators of bugs. I would really appreciate it if we could get rid of php warnings and notices, would you be interested in related pull requests?