### PR TITLE
Update Language.php

### DIFF
--- a/source/Core/Language.php
+++ b/source/Core/Language.php
@@ -1326,7 +1326,7 @@ class Language extends \OxidEsales\Eshop\Core\Base
                 $aLanguages = $this->_getLanguageIdsFromLanguagesArray($aConfigLanguages);
             }
 
-            $aConfigDecodedValues = array_unique(array_merge($aConfigDecodedValues, $aLanguages));
+            $aConfigDecodedValues = array_unique($aConfigDecodedValues + $aLanguages);
         }
 
         return $aConfigDecodedValues;


### PR DESCRIPTION
the array_merge causes array keys to be lost. Which as a result breaks view generation.

Example before array_merge:

```php
$aLanguages = [
    0 => 'de',
    9 => 'es',
]
```

after: 

```php
$aLanguages = [
    0 => 'de',
    1 => 'es',
]
```

This causes views for example in oxv_oxarticles_es to be generated with OXTITLE_1 instead of OXTITLE_9.

Does anyone have a cleaner solution or was there a change made recently to how view generation is handled?