### PR TITLE
Added php warnings for not executed db statements

### DIFF
--- a/source/Application/Model/Order.php
+++ b/source/Application/Model/Order.php
@@ -899,7 +899,7 @@ class Order extends \OxidEsales\Eshop\Core\Model\BaseModel
      * deletes order and returns * error code 2.
      *
      * @param \OxidEsales\Eshop\Application\Model\Basket $oBasket      basket object
-     * @param object                                              $oUserpayment user payment object
+     * @param object                                     $oUserpayment user payment object
      *
      * @return  integer 2 or an error code
      */

--- a/source/Core/Database/Adapter/Doctrine/Database.php
+++ b/source/Core/Database/Adapter/Doctrine/Database.php
@@ -308,7 +308,7 @@ class Database implements DatabaseInterface
                 $this->handleException($exception);
             }
         } else {
-            trigger_error('Given statement does not produce output and was not executed', \E_USER_WARNING);
+            \OxidEsales\Eshop\Core\Registry::getLogger()->warning('Given statement does not produce output and was not executed');
         }
 
         return false;
@@ -1020,7 +1020,7 @@ class Database implements DatabaseInterface
         if ($this->doesStatementProduceOutput($query)) {
             $result = $statement->fetchAll();
         } else {
-            trigger_error('Given statement does not produce output and was not executed', \E_USER_WARNING);
+            \OxidEsales\Eshop\Core\Registry::getLogger()->warning('Given statement does not produce output and was not executed');
         }
 
         return $result;

--- a/source/Core/Database/Adapter/Doctrine/Database.php
+++ b/source/Core/Database/Adapter/Doctrine/Database.php
@@ -307,6 +307,8 @@ class Database implements DatabaseInterface
                 $exception = $this->convertException($exception);
                 $this->handleException($exception);
             }
+        } else {
+            trigger_error('Given statement does not produce output and was not executed', \E_USER_WARNING);
         }
 
         return false;
@@ -1017,6 +1019,8 @@ class Database implements DatabaseInterface
 
         if ($this->doesStatementProduceOutput($query)) {
             $result = $statement->fetchAll();
+        } else {
+            trigger_error('Given statement does not produce output and was not executed', \E_USER_WARNING);
         }
 
         return $result;

--- a/source/Core/Exception/ExceptionHandler.php
+++ b/source/Core/Exception/ExceptionHandler.php
@@ -110,7 +110,7 @@ class ExceptionHandler
     /**
      * Handler for uncaught exceptions. As this is the las resort no fancy business logic should be applied here.
      *
-     * @param \Throwable $exception exception object
+     * @param \Throwable|\Exception $exception exception object
      *
      * @return void
      **/

--- a/tests/Unit/Application/Controller/Admin/ShopSeoTest.php
+++ b/tests/Unit/Application/Controller/Admin/ShopSeoTest.php
@@ -23,7 +23,7 @@ class ShopSeoTest extends \OxidTestCase
      */
     protected function tearDown()
     {
-        oxDb::getDb()->getOne("delete from oxseo where oxobjectid = 'testObjectId' and oxshopid = '1'");
+        oxDb::getDb()->execute("delete from oxseo where oxobjectid = 'testObjectId' and oxshopid = '1'");
         parent::tearDown();
     }
 

--- a/tests/Unit/Application/Controller/RecommlistTest.php
+++ b/tests/Unit/Application/Controller/RecommlistTest.php
@@ -54,8 +54,8 @@ class RecommlistTest extends \OxidTestCase
         $myDB->execute($sDelete);
 
         // testing db for records
-        $myDB->getOne("delete from oxratings where oxobjectid = 'testRecommListId'");
-        $myDB->getOne("delete from oxreviews where oxobjectid = 'testRecommListId'");
+        $myDB->execute("delete from oxratings where oxobjectid = 'testRecommListId'");
+        $myDB->execute("delete from oxreviews where oxobjectid = 'testRecommListId'");
 
         parent::tearDown();
     }


### PR DESCRIPTION
Reading DB statements are not executed when used with the wrong doctrine methods. While migrating from Oxid 4 and sometimes during development we experience the silent return of empty results, therefore I added a warning whenever a statement is not executed.
I preferred the warning over a simple log entry as it can be handled and automatically contains a stack trance.

(We also had additional trouble as we are heavily using WITH clauses)