### PR TITLE
Fixed several notices caused by uninitialized / null variables (second try)

### DIFF
--- a/source/Application/Component/BasketComponent.php
+++ b/source/Application/Component/BasketComponent.php
@@ -377,8 +377,11 @@ class BasketComponent extends \OxidEsales\Eshop\Core\Controller\BaseController
 
         foreach ($products as $addProductId => $productInfo) {
             $data = $this->prepareProductInformation($addProductId, $productInfo);
-            $productAmount = $basketInfo->aArticles[$data['id']];
-            $products[$addProductId]['oldam'] = isset($productAmount) ? $productAmount : 0;
+            $productAmount = 0;
+            if (isset($basketInfo->aArticles[$data['id']])) {
+                $productAmount = $basketInfo->aArticles[$data['id']];
+            }
+            $products[$addProductId]['oldam'] = $productAmount;
 
             //If we already changed articles so they now exactly match existing ones,
             //we need to make sure we get the amounts correct
@@ -388,8 +391,14 @@ class BasketComponent extends \OxidEsales\Eshop\Core\Controller\BaseController
 
             $basketItem = $this->addItemToBasket($basket, $data, $errorDestination);
 
-            if (($basketItem instanceof \OxidEsales\Eshop\Application\Model\BasketItem) && $basketItem->getBasketItemKey()) {
-                $basketItemAmounts[$basketItem->getBasketItemKey()] += $data['amount'];
+            if (($basketItem instanceof \OxidEsales\Eshop\Application\Model\BasketItem)) {
+                $basketItemKey = $basketItem->getBasketItemKey();
+                if ($basketItemKey) {
+                    if (! isset($basketItemAmounts[$basketItemKey])) {
+                        $basketItemAmounts[$basketItemKey] = 0;
+                    }
+                    $basketItemAmounts[$basketItemKey] += $data['amount'];
+                }
             }
 
             if (!$basketItem) {

--- a/source/Application/Component/CurrencyComponent.php
+++ b/source/Application/Component/CurrencyComponent.php
@@ -107,7 +107,7 @@ class CurrencyComponent extends \OxidEsales\Eshop\Core\Controller\BaseController
 
         if ($this->getConfig()->getConfigParam('bl_perfLoadCurrency')) {
             reset($this->aCurrencies);
-            while (list(, $oItem) = each($this->aCurrencies)) {
+            foreach ($this->aCurrencies as $oItem) {
                 $oItem->link = $oUrlUtils->processUrl($sUrl, true, ["cur" => $oItem->id]);
             }
         }

--- a/source/Application/Component/LanguageComponent.php
+++ b/source/Application/Component/LanguageComponent.php
@@ -36,8 +36,8 @@ class LanguageComponent extends \OxidEsales\Eshop\Core\Controller\BaseController
         if ($this->getConfig()->getConfigParam('bl_perfLoadLanguages')) {
             $aLanguages = \OxidEsales\Eshop\Core\Registry::getLang()->getLanguageArray(null, true, true);
             reset($aLanguages);
-            while (list($sKey, $oVal) = each($aLanguages)) {
-                $aLanguages[$sKey]->link = $this->getConfig()->getTopActiveView()->getLink($oVal->id);
+            foreach ($aLanguages as $oVal) {
+                $oVal->link = $this->getConfig()->getTopActiveView()->getLink($oVal->id);
             }
 
             return $aLanguages;

--- a/source/Application/Controller/Admin/AdminListController.php
+++ b/source/Application/Controller/Admin/AdminListController.php
@@ -413,7 +413,7 @@ class AdminListController extends \OxidEsales\Eshop\Application\Controller\Admin
     {
         if (count($whereQuery)) {
             $myUtilsString = \OxidEsales\Eshop\Core\Registry::getUtilsString();
-            while (list($identifierName, $fieldValue) = each($whereQuery)) {
+            foreach ($whereQuery as $identifierName => $fieldValue) {
                 $fieldValue = trim($fieldValue);
 
                 //check if this is search string (contains % sign at beginning and end of string)

--- a/source/Application/Controller/Admin/ArticleExtendAjax.php
+++ b/source/Application/Controller/Admin/ArticleExtendAjax.php
@@ -82,7 +82,7 @@ class ArticleExtendAjax extends \OxidEsales\Eshop\Application\Controller\Admin\L
             $minimalPosition = null;
             $minimalValue = null;
             reset($dataFields);
-            while (list($position, $fields) = each($dataFields)) {
+            foreach ($dataFields as $position => $fields) {
                 // already set ?
                 if ($fields['_3'] == '0') {
                     $minimalPosition = null;

--- a/source/Application/Controller/Admin/DynamicExportBaseController.php
+++ b/source/Application/Controller/Admin/DynamicExportBaseController.php
@@ -133,7 +133,7 @@ class DynamicExportBaseController extends \OxidEsales\Eshop\Application\Controll
 
         // assign all member variables to template
         $aClassVars = get_object_vars($this);
-        while (list($name, $value) = each($aClassVars)) {
+        foreach ($aClassVars as $name => $value) {
             $this->_aViewData[$name] = $value;
         }
 

--- a/source/Application/Controller/Admin/SystemInfoController.php
+++ b/source/Application/Controller/Admin/SystemInfoController.php
@@ -36,7 +36,7 @@ class SystemInfoController extends \OxidEsales\Eshop\Application\Controller\Admi
             $aSystemInfo = [];
             $aSystemInfo['pkg.info'] = $myConfig->getPackageInfo();
             $oSmarty = \OxidEsales\Eshop\Core\Registry::getUtilsView()->getSmarty();
-            while (list($name, $value) = each($aClassVars)) {
+            foreach ($aClassVars as $name => $value) {
                 if (gettype($value) == "object") {
                     continue;
                 }

--- a/source/Application/Controller/Admin/ToolsList.php
+++ b/source/Application/Controller/Admin/ToolsList.php
@@ -126,7 +126,7 @@ class ToolsList extends \OxidEsales\Eshop\Application\Controller\Admin\AdminList
     {
         if (isset($_FILES['myfile']['name'])) {
             // process all files
-            while (list($key, $value) = each($_FILES['myfile']['name'])) {
+            foreach ($_FILES['myfile']['name'] as $key => $value) {
                 $aSource = $_FILES['myfile']['tmp_name'];
                 $sSource = $aSource[$key];
                 $aFiletype = explode("@", $key);

--- a/source/Application/Controller/Admin/UserMain.php
+++ b/source/Application/Controller/Admin/UserMain.php
@@ -64,7 +64,7 @@ class UserMain extends \OxidEsales\Eshop\Application\Controller\Admin\AdminDetai
             if (!($oUser->oxuser__oxrights->value == "malladmin" && !$blisMallAdmin)) {
                 // generate selected right
                 reset($aUserRights);
-                while (list(, $val) = each($aUserRights)) {
+                foreach ($aUserRights as $val) {
                     if ($val->id == $oUser->oxuser__oxrights->value) {
                         $val->selected = 1;
                         break;

--- a/source/Application/Controller/FrontendController.php
+++ b/source/Application/Controller/FrontendController.php
@@ -2948,11 +2948,12 @@ class FrontendController extends \OxidEsales\Eshop\Core\Controller\BaseControlle
         }
 
         $user = $this->getUser();
-        if ($user === false) {
+        if ($user !== false) {
+            if ($user->oxuser__oxustid->value !== null && $user->oxuser__oxustidstatus->value == 1) {
+                return $this->_blIsVatIncluded = false;
+            }
+        } else {
             $user = oxNew(\OxidEsales\Eshop\Application\Model\User::class);
-        }
-        if ($user->oxuser__oxustid->value !== null && $user->oxuser__oxustidstatus->value == 1) {
-            return $this->_blIsVatIncluded = false;
         }
 
         $activeCountry = $user->getActiveCountry();

--- a/source/Application/Controller/FrontendController.php
+++ b/source/Application/Controller/FrontendController.php
@@ -1897,7 +1897,7 @@ class FrontendController extends \OxidEsales\Eshop\Core\Controller\BaseControlle
             $languageService = \OxidEsales\Eshop\Core\Registry::getLang();
             if ($this->getConfig()->getConfigParam('bl_perfLoadLanguages')) {
                 $languages = $languageService->getLanguageArray();
-                while (list($key, $language) = each($languages)) {
+                foreach ($languages as $language) {
                     if ($language->selected) {
                         $this->_sActiveLangAbbr = $language->abbr;
                         break;

--- a/source/Application/Model/Basket.php
+++ b/source/Application/Model/Basket.php
@@ -1503,13 +1503,19 @@ class Basket extends \OxidEsales\Eshop\Core\Base
 
                 foreach ($aCatIds as $sCatId) {
                     if (!isset($this->_aBasketSummary->aCategories[$sCatId])) {
-                        $this->_aBasketSummary->aCategories[$sCatId] = new stdClass();
+                        $priceObject = new stdClass();
+                        $priceObject->dPrice = 0;
+                        $priceObject->dDiscountablePrice = 0;
+                        $priceObject->dAmount = 0;
+                        $priceObject->iCount = 0;
+                        $this->_aBasketSummary->aCategories[$sCatId] = $priceObject;
                     }
 
-                    $this->_aBasketSummary->aCategories[$sCatId]->dPrice += $dPrice * $oBasketItem->getAmount();
-                    $this->_aBasketSummary->aCategories[$sCatId]->dDiscountablePrice += $dDiscountablePrice * $oBasketItem->getAmount();
-                    $this->_aBasketSummary->aCategories[$sCatId]->dAmount += $oBasketItem->getAmount();
-                    $this->_aBasketSummary->aCategories[$sCatId]->iCount++;
+                    $categorySummaryPrice = $this->_aBasketSummary->aCategories[$sCatId];
+                    $categorySummaryPrice->dPrice += $dPrice * $oBasketItem->getAmount();
+                    $categorySummaryPrice->dDiscountablePrice += $dDiscountablePrice * $oBasketItem->getAmount();
+                    $categorySummaryPrice->dAmount += $oBasketItem->getAmount();
+                    $categorySummaryPrice->iCount++;
                 }
 
                 // variant handling

--- a/source/Application/Model/Basket.php
+++ b/source/Application/Model/Basket.php
@@ -619,7 +619,7 @@ class Basket extends \OxidEsales\Eshop\Core\Base
     protected function _clearBundles()
     {
         reset($this->_aBasketContents);
-        while (list($sItemKey, $oBasketItem) = each($this->_aBasketContents)) {
+        foreach ($this->_aBasketContents as $sItemKey => $oBasketItem) {
             if ($oBasketItem->isBundle()) {
                 $this->removeItem($sItemKey);
             }
@@ -1852,7 +1852,7 @@ class Basket extends \OxidEsales\Eshop\Core\Base
                     $aSelList = $oBasketItem->getSelList();
                     if (is_array($aSelList) && ($aSelectlist = $oProduct->getSelectLists($sItemKey))) {
                         reset($aSelList);
-                        while (list($conkey, $iSel) = each($aSelList)) {
+                        foreach ($aSelList as $conkey => $iSel) {
                             $aSelectlist[$conkey][$iSel]->selected = 1;
                         }
                         $oProduct->setSelectlist($aSelectlist);

--- a/source/Application/Model/BasketItem.php
+++ b/source/Application/Model/BasketItem.php
@@ -787,7 +787,7 @@ class BasketItem extends \OxidEsales\Eshop\Core\Base
         $this->_aSelList = $aSelList;
 
         //
-        if (count($this->_aSelList) && is_array($this->_aSelList)) {
+        if (is_array($this->_aSelList) && count($this->_aSelList)) {
             foreach ($this->_aSelList as $conkey => $iSel) {
                 $this->_aChosenSelectlist[$conkey] = new stdClass();
                 $this->_aChosenSelectlist[$conkey]->name = $aSelectLists[$conkey]['name'];

--- a/source/Application/Model/DeliveryList.php
+++ b/source/Application/Model/DeliveryList.php
@@ -148,7 +148,7 @@ class DeliveryList extends \OxidEsales\Eshop\Core\Model\ListModel
 
         // defining initial filter parameters
         $sUserId = null;
-        $aGroupIds = null;
+        $aGroupIds = [];
 
         // checking for current session user which gives additional restrictions for user itself, users group and country
         if ($oUser) {

--- a/source/Application/Model/DeliverySetList.php
+++ b/source/Application/Model/DeliverySetList.php
@@ -128,7 +128,7 @@ class DeliverySetList extends \OxidEsales\Eshop\Core\Model\ListModel
 
         // defining initial filter parameters
         $sUserId = null;
-        $aGroupIds = null;
+        $aGroupIds = [];
 
         // checking for current session user which gives additional restrictions for user itself, users group and country
         if ($oUser) {

--- a/source/Core/Config.php
+++ b/source/Core/Config.php
@@ -1622,7 +1622,7 @@ class Config extends \OxidEsales\Eshop\Core\Base
         // processing currency configuration data
         $currencies = [];
         reset($confCurrencies);
-        while (list($key, $val) = each($confCurrencies)) {
+        foreach ($confCurrencies as $key => $val) {
             if ($val) {
                 $cur = new stdClass();
                 $cur->id = $key;

--- a/source/Core/DebugInfo.php
+++ b/source/Core/DebugInfo.php
@@ -22,7 +22,7 @@ class DebugInfo
     {
         $log = '';
         reset($viewData);
-        while (list($viewName, $viewDataObject) = each($viewData)) {
+        foreach ($viewData as $viewName => $viewDataObject) {
             // show debbuging information
             $log .= "TemplateData[$viewName] : <br />\n";
             $log .= print_r($viewDataObject, 1);

--- a/source/Core/Language.php
+++ b/source/Core/Language.php
@@ -303,7 +303,7 @@ class Language extends \OxidEsales\Eshop\Core\Base
         if (is_array($aConfLanguages)) {
             $i = 0;
             reset($aConfLanguages);
-            while (list($key, $val) = each($aConfLanguages)) {
+            foreach ($aConfLanguages as $key => $val) {
                 if ($blOnlyActive && is_array($aLangParams)) {
                     //skipping non active languages
                     if (!$aLangParams[$key]['active']) {

--- a/source/Core/Model/BaseModel.php
+++ b/source/Core/Model/BaseModel.php
@@ -471,7 +471,9 @@ class BaseModel extends \OxidEsales\Eshop\Core\Base
         }
 
         $oxidField = $this->_getFieldLongName('oxid');
-        $this->_sOXID = $this->$oxidField->value;
+        if ($this->$oxidField instanceof Field) {
+            $this->_sOXID = $this->$oxidField->value;
+        }
     }
 
     /**

--- a/source/Core/Model/BaseModel.php
+++ b/source/Core/Model/BaseModel.php
@@ -381,7 +381,7 @@ class BaseModel extends \OxidEsales\Eshop\Core\Base
     public function oxClone($object)
     {
         $classVariables = get_object_vars($object);
-        while (list($name, $value) = each($classVariables)) {
+        foreach ($classVariables as $name => $value) {
             if (is_object($object->$name)) {
                 $this->$name = clone $object->$name;
             } else {
@@ -697,7 +697,7 @@ class BaseModel extends \OxidEsales\Eshop\Core\Base
 
         if ($whereCondition) {
             reset($whereCondition);
-            while (list($name, $value) = each($whereCondition)) {
+            foreach ($whereCondition as $name => $value) {
                 $query .= ' and ' . $name . ' = ' . $database->quote($value);
             }
         }

--- a/source/Core/Smarty/Plugin/function.oxcontent.php
+++ b/source/Core/Smarty/Plugin/function.oxcontent.php
@@ -39,7 +39,7 @@ function smarty_function_oxcontent( $params, &$smarty )
         if ( $blLoaded && $oContent->oxcontents__oxactive->value ) {
             // set value
             $sField = "oxcontent";
-            if ( $params['field'] ) {
+            if (isset($params['field'])) {
                 $sField = $params['field'];
             }
             // set value

--- a/source/Core/Smarty/Plugin/function.oxstyle.php
+++ b/source/Core/Smarty/Plugin/function.oxstyle.php
@@ -27,8 +27,16 @@
  */
 function smarty_function_oxstyle($params, &$smarty)
 {
-    $widget = !empty($params['widget']) ? $params['widget'] : '';
-    $forceRender = !empty($params['inWidget']) ? $params['inWidget'] : false;
+    $defaults = [
+        'widget' => '',
+        'inWidget' => false,
+        'if' => null,
+        'include' => null,
+    ];
+    $params = array_merge($defaults, $params);
+
+    $widget = $params['widget'];
+    $forceRender = $params['inWidget'];
     $isDynamic = isset($smarty->_tpl_vars["__oxid_include_dynamic"]) ? (bool)$smarty->_tpl_vars["__oxid_include_dynamic"] : false;
 
     $output = '';

--- a/source/Core/Str.php
+++ b/source/Core/Str.php
@@ -34,7 +34,7 @@ class Str
     /**
      * Static method initializing new string handler or returning the existing one.
      *
-     * @return oxStrRegular|oxStrMb
+     * @return StrRegular|StrMb
      */
     public static function getStr()
     {

--- a/source/Core/Utils.php
+++ b/source/Core/Utils.php
@@ -103,7 +103,7 @@ class Utils extends \OxidEsales\Eshop\Core\Base
     {
         $aRet = [];
         $aPieces = explode('@@', $sIn);
-        while (list($sKey, $sVal) = each($aPieces)) {
+        foreach ($aPieces as $sVal) {
             if ($sVal) {
                 $aName = explode('__', $sVal);
                 if (isset($aName[0]) && isset($aName[1])) {
@@ -126,7 +126,7 @@ class Utils extends \OxidEsales\Eshop\Core\Base
     {
         $sRet = "";
         reset($aIn);
-        while (list($sKey, $sVal) = each($aIn)) {
+        foreach ($aIn as $sKey => $sVal) {
             $sRet .= $sKey;
             $sRet .= "__";
             $sRet .= $sVal;

--- a/source/Core/UtilsFile.php
+++ b/source/Core/UtilsFile.php
@@ -424,7 +424,7 @@ class UtilsFile extends \OxidEsales\Eshop\Core\Base
 
             $oEx = oxNew(\OxidEsales\Eshop\Core\Exception\ExceptionToDisplay::class);
             // process all files
-            while (list($sKey, $sValue) = each($aFiles['myfile']['name'])) {
+            foreach ($aFiles['myfile']['name'] as $sKey => $sValue) {
                 $sSource = $aSource[$sKey];
                 $iError = $aError[$sKey];
                 $aFiletype = explode("@", $sKey);

--- a/source/Core/ViewHelper/JavaScriptRegistrator.php
+++ b/source/Core/ViewHelper/JavaScriptRegistrator.php
@@ -70,8 +70,9 @@ class JavaScriptRegistrator
         $config = \OxidEsales\Eshop\Core\Registry::getConfig();
         $parts = explode('?', $file);
         $url = $config->getResourceUrl($parts[0], $config->isAdmin());
-        $parameters = $parts[1];
-        if (empty($parameters)) {
+        if (isset($parts[1])) {
+            $parameters = $parts[1];
+        } else {
             $path = $config->getResourcePath($file, $config->isAdmin());
             $parameters = filemtime($path);
         }

--- a/tests/Unit/Application/Model/UserTest.php
+++ b/tests/Unit/Application/Model/UserTest.php
@@ -233,7 +233,7 @@ class UserTest extends \OxidTestCase
         $oPayment->setDynValues($oUtils->assignValuesFromText($oPayment->oxpayments__oxvaldesc->value, true, true, true));
 
         $aDynValues = $oPayment->getDynValues();
-        while (list($key, $oVal) = each($aDynValues)) {
+        foreach ($aDynValues as $key => $oVal) {
             $oVal = new oxField($aDynValue[$oVal->name], oxField::T_RAW);
             $oPayment->setDynValue($key, $oVal);
             $aDynVal[$oVal->name] = $oVal->value;

--- a/tests/Unit/Core/BaseTest.php
+++ b/tests/Unit/Core/BaseTest.php
@@ -1004,7 +1004,7 @@ class BaseTest extends \OxidTestCase
         $oBase = new _oxBase();
         $oBase->init("oxactions");
         $rs = array("oxid" => "oxstart", "oxtitle" => "Startseite unten");
-        while (list($name, $value) = each($rs)) {
+        foreach ($rs as $name => $value) {
             $oBase->setFieldData($name, $value);
         }
         $this->assertEquals($oBase->oxactions__oxid->value, "oxstart");
@@ -1021,7 +1021,7 @@ class BaseTest extends \OxidTestCase
         $oBase = new _oxBase();
         $oBase->init("oxactions");
         $rs = array("oxid" => "oxstart", "oxactions__oxtitle" => "Startseite unten");
-        while (list($name, $value) = each($rs)) {
+        foreach ($rs as $name => $value) {
             $oBase->setFieldData($name, $value);
         }
         $this->assertEquals($oBase->oxactions__oxid->value, "oxstart");
@@ -1039,7 +1039,7 @@ class BaseTest extends \OxidTestCase
         $oBase->setClassVar("_blUseLazyLoading", true);
         $oBase->init("oxactions");
         $rs = array("oxid" => "oxstart", "oxactions__oxtestval" => "Startseite unten", "oxtestval2" => "TestVal2");
-        while (list($name, $value) = each($rs)) {
+        foreach ($rs as $name => $value) {
             $oBase->setFieldData($name, $value);
         }
         //standard field
@@ -1065,7 +1065,7 @@ class BaseTest extends \OxidTestCase
         $aFieldNames = $oBase->getNonPublicVar('_aFieldNames');
         $this->assertFalse(isset($aFieldNames['oxtitle']));
         $rs = array("oxid" => "oxstart", "oxtitle" => "Startseite unten");
-        while (list($name, $value) = each($rs)) {
+        foreach ($rs as $name => $value) {
             $oBase->UNITsetFieldData($name, $value);
         }
         //standard field

--- a/tests/Unit/Core/ListTest.php
+++ b/tests/Unit/Core/ListTest.php
@@ -428,7 +428,7 @@ class ListTest extends \OxidTestCase
         $iTotal = count($oList);
         $this->assertEquals(4, $iTotal);
         reset($oList);
-        while (list($sKey, $sVal) = each($oList->aList)) {
+        foreach ($oList->aList as $sKey => $sVal) {
             $this->assertEquals($iTotal, count($oList));
             $this->assertEquals('cnt' . $iTotal, $sVal);
 


### PR DESCRIPTION
(After messing up pull request #650, here comes the second try. I apologize for any inconvenience)

Fixed most of the php notices I've found so far.

However I've found one issue I'm not sure how to deal with: In FrontendController::isVatIncluded the database field oxuser__oxustidstatus is used - but it doesn't seem to exist in the community edition. I've found an eight years old and resolved ticket, but it is not mentioned how it was resolved / if that's intentional.

Can the database field be added to CE or the field be removed from production code?