### PR TITLE
avoid race conditions on a slow db with a big basket

### DIFF
--- a/source/Application/Model/Basket.php
+++ b/source/Application/Model/Basket.php
@@ -1691,10 +1691,11 @@ class Basket extends \OxidEsales\Eshop\Core\Base
                 $oSavedBasket->oxuserbaskets__oxtitle = new \oxField('savedbasket');
 
                 //switching baskets within transaction to avoid race conditions
-                oxDb::getDb()->startTransaction();
+                $database = \OxidEsales\Eshop\Core\DatabaseProvider::getDb();
+                $database->startTransaction();
                 $oldSavedBasket->save();
                 $oSavedBasket->save();
-                oxDb::getDb()->commitTransaction();
+                $databse->commitTransaction();
 
                 $oUser->setBasket('savedbasket', $oSavedBasket);
                 $oldSavedBasket->delete();

--- a/source/Application/Model/Basket.php
+++ b/source/Application/Model/Basket.php
@@ -1687,8 +1687,8 @@ class Basket extends \OxidEsales\Eshop\Core\Base
                 }
 
                 $oldSavedBasket = $oUser->getBasket('savedbasket');
-                $oldSavedBasket->oxuserbaskets__oxtitle = new oxField('savedbasketold');
-                $oSavedBasket->oxuserbaskets__oxtitle = new oxField('savedbasket');
+                $oldSavedBasket->oxuserbaskets__oxtitle = new \oxField('savedbasketold');
+                $oSavedBasket->oxuserbaskets__oxtitle = new \oxField('savedbasket');
 
                 //switching baskets within transaction to avoid race conditions
                 oxDb::getDb()->startTransaction();

--- a/source/Application/Model/Basket.php
+++ b/source/Application/Model/Basket.php
@@ -1665,30 +1665,44 @@ class Basket extends \OxidEsales\Eshop\Core\Base
         }
     }
 
-    /**
+   /**
      * Saves existing basket to database
      */
     protected function _save()
     {
         if ($this->isSaveToDataBaseEnabled()) {
+
             if ($oUser = $this->getBasketUser()) {
                 //first delete all contents
                 //#2039
-                $oSavedBasket = $oUser->getBasket('savedbasket');
+                $oSavedBasket = $oUser->getBasket('savedbasket_tmp');
                 $oSavedBasket->delete();
 
                 //then save
-                /** @var \oxBasketItem $oBasketItem */
                 foreach ($this->_aBasketContents as $oBasketItem) {
                     // discount or bundled products will be added automatically if available
                     if (!$oBasketItem->isBundle() && !$oBasketItem->isDiscountArticle()) {
                         $oSavedBasket->addItemToBasket($oBasketItem->getProductId(), $oBasketItem->getAmount(), $oBasketItem->getSelList(), true, $oBasketItem->getPersParams());
                     }
                 }
+
+                $oldSavedBasket = $oUser->getBasket('savedbasket');
+                $oldSavedBasket->oxuserbaskets__oxtitle = new oxField('savedbasketold');
+                $oSavedBasket->oxuserbaskets__oxtitle = new oxField('savedbasket');
+
+                //switching baskets within transaction to avoid race conditions
+                oxDb::getDb()->startTransaction();
+                $oldSavedBasket->save();
+                $oSavedBasket->save();
+                oxDb::getDb()->commitTransaction();
+
+                $oUser->setBasket('savedbasket', $oSavedBasket);
+                $oldSavedBasket->delete();
+
             }
         }
     }
-
+    
     /**
      * Cleans up saved basket data. This method usually is initiated by
      * \OxidEsales\Eshop\Application\Model\Basket::deleteBasket() method which cleans up basket data when

--- a/source/Application/Model/Basket.php
+++ b/source/Application/Model/Basket.php
@@ -1695,7 +1695,7 @@ class Basket extends \OxidEsales\Eshop\Core\Base
                 $database->startTransaction();
                 $oldSavedBasket->save();
                 $oSavedBasket->save();
-                $databse->commitTransaction();
+                $database->commitTransaction();
 
                 $oUser->setBasket('savedbasket', $oSavedBasket);
                 $oldSavedBasket->delete();

--- a/source/Application/Model/User.php
+++ b/source/Application/Model/User.php
@@ -962,6 +962,15 @@ class User extends \OxidEsales\Eshop\Core\Model\BaseModel
 
         return $this->_aBaskets[$sName];
     }
+    
+    /**
+    * sets a userbasket
+    * @param string $name name/type of basket
+    * @param object $basket the basket
+    **/
+    public function setBasket($name, $basket) {
+       $this->_aBaskets[$name] = $basket; 
+    } 
 
     /**
      * User birthday converter. Usually this data comes in array form, so before


### PR DESCRIPTION
avoid race conditions
using a transaction to make the action atomic, (saving the changed basket or saving it not)
 (It was reported that randomly some basket items got lost on big baskets > 350 items ((and slow database))
To avoid long running locks, the new implementation writes the changed basket with a new id and name and after writing all basket items to the databases it updates the name and the current id within a transaction.

TODO:
- [ ] contact support