### PR TITLE
Bugfix/filecache race conditions

### DIFF
--- a/source/Core/FileCache.php
+++ b/source/Core/FileCache.php
@@ -53,7 +53,10 @@ class FileCache
     public function setToCache($key, $value)
     {
         $fileName = $this->getCacheFilePath($key);
-        file_put_contents($fileName, serialize($value), LOCK_EX);
+        $tmpFile = '/tmp/' . basename($fileName) . '.' . uniqid('', true) . '.tmp';
+        file_put_contents($tmpFile, serialize($value), LOCK_EX);
+
+        rename($tmpFile, $fileName);
     }
 
     /**

--- a/source/Core/Utils.php
+++ b/source/Core/Utils.php
@@ -1383,8 +1383,13 @@ class Utils extends \OxidEsales\Eshop\Core\Base
     public function setLangCache($sCacheName, $aLangCache)
     {
         $sCache = "<?php\n\$aLangCache = " . var_export($aLangCache, true) . ";\n?>";
+        $sFileName = $this->getCacheFilePath($sCacheName);
+        $sTmpFile = 'tmp/' . basename($sFileName) . '.' . uniqid('', true) . '.tmp';
+        $blRes = file_put_contents($sTmpFile, $sCache, LOCK_EX);
 
-        return file_put_contents($this->getCacheFilePath($sCacheName), $sCache, LOCK_EX);
+        rename($sTmpFile, $sFileName);
+
+        return $blRes;
     }
 
     /**

--- a/source/Core/Utils.php
+++ b/source/Core/Utils.php
@@ -1384,7 +1384,7 @@ class Utils extends \OxidEsales\Eshop\Core\Base
     {
         $sCache = "<?php\n\$aLangCache = " . var_export($aLangCache, true) . ";\n?>";
         $sFileName = $this->getCacheFilePath($sCacheName);
-        $sTmpFile = 'tmp/' . basename($sFileName) . '.' . uniqid('', true) . '.tmp';
+        $sTmpFile = '/tmp/' . basename($sFileName) . '.' . uniqid('', true) . '.tmp';
         $blRes = file_put_contents($sTmpFile, $sCache, LOCK_EX);
 
         rename($sTmpFile, $sFileName);


### PR DESCRIPTION
Simultaneous read/write operations on file caches lead to race conditions (missing or incomplete cache files)

-------------
file_get_contents(/XXXX/htdocs/tmp/config.1.adisabledmodules.txt): failed to open stream: No such file or directory
-------------
Parse error: syntax error, unexpected ''Dieser Online-Shop verwendet ' (T_ENCAPSED_AND_WHITESPACE) in /XXXX/htdocs/tmp/oxeec_langcache_0_0_1_premiumstore_default.txt on line 704