### PR TITLE
Fixed return type in Basket::getDiscounts()

### DIFF
--- a/source/Application/Model/Basket.php
+++ b/source/Application/Model/Basket.php
@@ -2137,7 +2137,7 @@ class Basket extends \OxidEsales\Eshop\Core\Base
     public function getDiscounts()
     {
         if ($this->getTotalDiscount() && $this->getTotalDiscount()->getBruttoPrice() == 0 && count($this->_aItemDiscounts) == 0) {
-            return null;
+            return [];
         }
 
         return array_merge($this->_aItemDiscounts, $this->_aDiscounts);

--- a/tests/Unit/Application/Model/BasketTest.php
+++ b/tests/Unit/Application/Model/BasketTest.php
@@ -2758,7 +2758,7 @@ class BasketTest extends \OxidTestCase
         $oBasket->setNonPublicVar('_aDiscounts', array($oDiscount2));
         $oBasket->UNITcalcBasketTotalDiscount();
 
-        $this->assertNull($oBasket->getDiscounts());
+        $this->assertSame([], $oBasket->getDiscounts());
     }
 
     /**


### PR DESCRIPTION
If there are no discounts in your basket, the `return null;` in this method leads to a

> E_WARNING: count(): Parameter must be an array or an object that implements Countable

in Basket::formatDiscount()