### PR TITLE
Deal with broken modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -100,6 +100,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Increase default quantity of productimages to 12 (from 7) [PR-514](https://github.com/OXID-eSales/oxideshop_ce/pull/514)
 - Make adding template blocks more fast andn reliable [PR-580](https://github.com/OXID-eSales/oxideshop_ce/pull/580)
 - Support PHP 7.2
+- Modules will not be disabled on class loading errors anymore, Error is just logged [PR-661](https://github.com/OXID-eSales/oxideshop_ce/pull/661)
 
 ### Removed
 - Removed old not used blAutoSearchOnCat option from shop_config tab [PR-654](https://github.com/OXID-eSales/oxideshop_ce/pull/654)
@@ -112,6 +113,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - `\OxidEsales\EshopCommunity\Core\Email::$_oConfig`
 - `\OxidEsales\EshopCommunity\Core\Email::setConfig`
 - `\OxidEsales\EshopCommunity\Core\Email::getConfig`
+- `blDoNotDisableModuleOnError` config option
 
 
 ## [6.3.2] - Unreleased

--- a/source/Core/Module/ModuleChainsGenerator.php
+++ b/source/Core/Module/ModuleChainsGenerator.php
@@ -449,6 +449,8 @@ class ModuleChainsGenerator
 
     /**
      * @return mixed
+     *
+     * @deprecated since v6.3.2 (2018-12-19); This method and config variable will be removed completely.
      */
     protected function getConfigBlDoNotDisableModuleOnError()
     {

--- a/source/Core/Module/ModuleChainsGenerator.php
+++ b/source/Core/Module/ModuleChainsGenerator.php
@@ -389,17 +389,16 @@ class ModuleChainsGenerator
     }
 
     /**
-     * If blDoNotDisableModuleOnError config value is false, disables bad module.
-     * To avoid problems with unit tests it only throw an exception if class does not exist.
+     * Writes/logs an error on module extension creation problem
      *
      * @param string $moduleClass
-     *
-     * @throws \OxidEsales\EshopCommunity\Core\Exception\SystemComponentException
      */
-    protected function onModuleExtensionCreationError($moduleClass)
-    {
-        $module = oxNew(\OxidEsales\Eshop\Core\Module\Module::class);
+    protected function onModuleExtensionCreationError($moduleClass) {
+        //not using oxNew withing this method to avoid endless loops
+        $module = new \OxidEsales\Eshop\Core\Module\Module;
         $moduleId = $module->getIdByPath($moduleClass);
+        $moduleId = $moduleId ? $moduleId : "(module id not availible)";
+
         $message = sprintf('Module class %s not found. Module ID %s', $moduleClass, $moduleId);
         $exception = new \OxidEsales\Eshop\Core\Exception\SystemComponentException($message);
         \OxidEsales\Eshop\Core\Registry::getLogger()->error($exception->getMessage(), [$exception]);

--- a/source/Core/Module/ModuleChainsGenerator.php
+++ b/source/Core/Module/ModuleChainsGenerator.php
@@ -343,7 +343,7 @@ class ModuleChainsGenerator
             /**
              * Test if the class could be loaded
              */
-            if (!class_exists($moduleClass)) {
+            if (!class_exists($moduleClass, false)) {
                 $this->handleSpecialCases($parentClass);
                 $this->onModuleExtensionCreationError($moduleClassPath);
 
@@ -398,27 +398,11 @@ class ModuleChainsGenerator
      */
     protected function onModuleExtensionCreationError($moduleClass)
     {
-        $disableModuleOnError = !$this->getConfigBlDoNotDisableModuleOnError();
-        if ($disableModuleOnError) {
-            if ($this->disableModule($moduleClass)) {
-                /**
-                 * The business logic does allow to throw an exception here, but just at least the disabling of the
-                 * module must be logged
-                 */
-                $module = oxNew(\OxidEsales\Eshop\Core\Module\Module::class);
-                $moduleId = $module->getIdByPath($moduleClass);
-                $message = sprintf('Module class %s not found. Module ID %s disabled', $moduleClass, $moduleId);
-                $exception = new \OxidEsales\Eshop\Core\Exception\SystemComponentException($message);
-                \OxidEsales\Eshop\Core\Registry::getLogger()->error($exception->getMessage(), [$exception]);
-            }
-        } else {
-            $exception =  new \OxidEsales\Eshop\Core\Exception\SystemComponentException();
-            /** Use setMessage here instead of passing it in constructor in order to test exception message */
-            $exception->setMessage('EXCEPTION_SYSTEMCOMPONENT_CLASSNOTFOUND' . ' ' . $moduleClass);
-            $exception->setComponent($moduleClass);
-
-            throw $exception;
-        }
+        $module = oxNew(\OxidEsales\Eshop\Core\Module\Module::class);
+        $moduleId = $module->getIdByPath($moduleClass);
+        $message = sprintf('Module class %s not found. Module ID %s', $moduleClass, $moduleId);
+        $exception = new \OxidEsales\Eshop\Core\Exception\SystemComponentException($message);
+        \OxidEsales\Eshop\Core\Registry::getLogger()->error($exception->getMessage(), [$exception]);
     }
 
     /**

--- a/source/config.inc.php.dist
+++ b/source/config.inc.php.dist
@@ -140,6 +140,7 @@ $this->aMultiLangTables = null;
 $this->blUseCron = false;
 
 // Do not disable module if class from extension path does not exist.
+// @deprecated since v6.3.2 (2018-12-19); This method and config variable will be removed completely.
 $this->blDoNotDisableModuleOnError = false;
 
 // Enable temporarily in case you can't access the backend due to broken views

--- a/tests/Acceptance/Admin/ModuleTest.php
+++ b/tests/Acceptance/Admin/ModuleTest.php
@@ -271,14 +271,15 @@ class ModuleTest extends ModuleBaseTest
 
         $this->openShop();
         $this->open(shopURL."en/About-Us/");
-        $this->assertTextNotPresent(strtoupper("About Us + info6"));
+        //Text can not have the info 6 postfix because responsible code was renamed
+        $this->assertNotTextPresent("About Us + info6");
         $this->clearCache();
         $this->openShop();
-        $this->assertTextNotPresent("Module #6 title EN");
+        $this->assertTextPresent("Module #6 title EN");
         $this->switchLanguage("Deutsch");
-        $this->assertTextNotPresent("Module #6 title DE");
+        $this->assertTextPresent("Module #6 title DE");
 
-        //checking if module is deactive after  vendor file rename
+        //checking if module is still active after  vendor file rename
         $this->loginAdmin("Extensions", "Modules");
         $this->frame("edit");
         $this->assertTextPresent("Invalid modules were detected");
@@ -286,18 +287,18 @@ class ModuleTest extends ModuleBaseTest
         $this->assertTextPresent("OxidEsales\\Eshop\\Application\\Controller\\ContentController => oxid/test6/view/myinfo6test");
         $this->clickAndWaitFrame("yesButton");
         $this->openListItem("link=Test module #6 (in vendor dir)");
-        $this->assertElementNotPresent("//form[@id='myedit']//input[@value='Deactivate']");
+        $this->assertElementPresent("//form[@id='myedit']//input[@value='Deactivate']");
 
-        //checking if module (oxblock, menu.xml) is disabled in shop after vendor file rename
+        //checking if module (oxblock, menu.xml) is still in shop after vendor file rename
         $this->clearCache();
         $this->openShop();
-        $this->assertTextNotPresent("Module #6 title EN");
+        $this->assertTextPresent("Module #6 title EN");
         $this->switchLanguage("Deutsch");
-        $this->assertTextNotPresent("Module #6 title DE");
+        $this->assertTextPresent("Module #6 title DE");
         $this->clearCache();
         $this->openShop();
         $this->open(shopURL."en/About-Us/");
-        $this->assertTextNotPresent("About Us + info6");
+        $this->assertTextPresent("About Us + info6");
 
         //file name is reset to the original
         $aModules = array('content' => 'oxid/test6/view/myinfo6');
@@ -341,13 +342,12 @@ class ModuleTest extends ModuleBaseTest
 
         //vendor dir name is changed from test6 to test6test
         $this->updateInformationAboutShopExtension('oxid/test6/view/myinfo6', 'oxid/test6test/view/myinfo6');
-
+        $this->clearCache();
         $this->openShop();
         $this->open(shopURL."en/About-Us/");
         $this->assertTextNotPresent("About Us + info6");
-        $this->assertTextPresent("About Us");
 
-        //checking if module is deactivated after /dir rename
+        //checking if module comes back again after /dir rename
         $this->loginAdmin("Extensions", "Modules");
         $this->frame("edit");
         $this->assertTextPresent("Invalid modules were detected");
@@ -357,22 +357,21 @@ class ModuleTest extends ModuleBaseTest
         $this->frame("list");
         $this->clickAndWait("link=Test module #6 (in vendor dir)");
         $this->frame("edit");
-        $this->assertElementNotPresent("//form[@id='myedit']//input[@value='Deactivate']");
+        $this->assertElementPresent("//form[@id='myedit']//input[@value='Deactivate']");
         $this->assertTextNotPresent("Invalid modules were detected");
 
-        //checking if module (oxblock, menu.xml) is disabled in shop after vendor dir rename
+        //checking if module (oxblock, menu.xml) is enabled in shop after vendor dir rename
         //NOTE: we need functionality to clean the tmp folder before reimplementing he check for oxblock
         $this->clearCache();
         $this->openShop();
         $this->clickAndWait("link=%HOME%");
 
-        $this->assertTextNotPresent("Module #6 title EN");
+        $this->assertTextPresent("Module #6 title EN");
         $this->switchLanguage("Deutsch");
-        $this->assertTextNotPresent("Module #6 title DE");
-        $this->clearCache();
+        $this->assertTextPresent("Module #6 title DE");
         $this->openShop();
         $this->open(shopURL."en/About-Us/");
-        $this->assertTextNotPresent("About Us + info6");
+        $this->assertTextPresent("About Us + info6");
 
         //checking if is restore the vendor dir name to original
         Registry::getConfig()->saveShopConfVar("aarr", "aModules", array());

--- a/tests/Integration/Modules/ModuleNamespaceTest.php
+++ b/tests/Integration/Modules/ModuleNamespaceTest.php
@@ -29,7 +29,6 @@ class ModuleNamespaceTest extends BaseModuleTestCase
     {
         parent::setUp();
 
-        $this->getConfig()->setConfigParam('blDoNotDisableModuleOnError', true);
         $this->assertPrice();
     }
 

--- a/tests/Unit/Core/Module/ModuleChainsGeneratorTest.php
+++ b/tests/Unit/Core/Module/ModuleChainsGeneratorTest.php
@@ -72,29 +72,24 @@ class ModuleChainsGeneratorTest extends \OxidEsales\TestingLibrary\UnitTestCase
     }
 
     /**
-     * @dataProvider dataProviderTestOnModuleExtensionCreationError
      *
      * @covers \OxidEsales\EshopCommunity\Core\Module\ModuleChainsGenerator::onModuleExtensionCreationError
      */
-    public function testOnModuleExtensionCreationError($blDoNotDisableModuleOnError, $expectedException, $message)
+    public function testOnModuleExtensionCreationError()
     {
-        if ($expectedException) {
-            $this->expectException($expectedException);
-        }
-
-        $moduleChainsGeneratorMock = $this->generateModuleChainsGeneratorWithNonExistingFileConfiguration($blDoNotDisableModuleOnError);
+        $moduleChainsGeneratorMock = $this->generateModuleChainsGeneratorWithNonExistingFileConfiguration();
 
         $actualClassName = $moduleChainsGeneratorMock->createClassChain('content');
 
-        $this->assertEquals('content', $actualClassName, $message);
+        $this->assertEquals('content', $actualClassName);
+        $this->assertLoggedException(SystemComponentException::class);
     }
 
     /**
-     * @param bool $blDoNotDisableModuleOnError
      *
      * @return \OxidEsales\EshopCommunity\Core\Module\ModuleChainsGenerator
      */
-    private function generateModuleChainsGeneratorWithNonExistingFileConfiguration($blDoNotDisableModuleOnError)
+    private function generateModuleChainsGeneratorWithNonExistingFileConfiguration()
     {
         /** @var ModuleVariablesLocator|MockObject $oUtilsObject */
         $moduleVariablesLocatorMock = $this->getMock(
@@ -105,7 +100,7 @@ class ModuleChainsGeneratorTest extends \OxidEsales\TestingLibrary\UnitTestCase
             false
         );
         $valueMap = [
-            ['aModules', ['content' => 'content&notExistingClass']],
+            ['aModules', ['content' => 'notExistingClass']],
             ['aDisabledModules', []]
         ];
         $moduleVariablesLocatorMock
@@ -115,13 +110,9 @@ class ModuleChainsGeneratorTest extends \OxidEsales\TestingLibrary\UnitTestCase
 
         $moduleChainsGeneratorMock = $this->getMock(
             \OxidEsales\EshopCommunity\Core\Module\ModuleChainsGenerator::class,
-            ['getConfigBlDoNotDisableModuleOnError', 'getConfigDebugMode', 'isUnitTest'],
+            ['getConfigDebugMode', 'isUnitTest'],
             [$moduleVariablesLocatorMock]
         );
-        $moduleChainsGeneratorMock
-            ->expects($this->any())
-            ->method('getConfigBlDoNotDisableModuleOnError')
-            ->will($this->returnValue($blDoNotDisableModuleOnError));
 
         /**
          * It is fake not to be a unit test in order to execute the error handling, which is not done for the rest of
@@ -135,22 +126,5 @@ class ModuleChainsGeneratorTest extends \OxidEsales\TestingLibrary\UnitTestCase
         return $moduleChainsGeneratorMock;
     }
 
-    public function dataProviderTestOnModuleExtensionCreationError()
-    {
-        return [
-          [
-            'blDoNotDisableModuleOnError' => 0,
-            'expectedException' => null,
-            'message' => 'If blDoNotDisableModuleOnError is false, no Exception will be thrown.
-                          In this case the module will be disabled and createClassChain will return the shop class and
-                          not the module class.'
-          ],
-          [
-            'blDoNotDisableModuleOnError' => 1,
-            'expectedException' => SystemComponentException::class,
-            'message' => 'If blDoNotDisableModuleOnError is true, an Exception will be thrown.
-                          In this case the module will not be disabled.'
-          ],
-        ];
-    }
+
 }

--- a/tests/Unit/Core/UtilsobjectTest.php
+++ b/tests/Unit/Core/UtilsobjectTest.php
@@ -75,7 +75,6 @@ class UtilsobjectTest extends \OxidEsales\TestingLibrary\UnitTestCase
         $oArticle = oxNew('oxArticle');
         $oArticle->delete('testArticle');
 
-        oxRegistry::get("oxConfigFile")->setVar('blDoNotDisableModuleOnError', $this->getConfigParam('blDoNotDisableModuleOnError'));
         oxRegistry::get("oxConfigFile")->setVar("sShopDir", $this->getConfigParam('sShopDir'));
 
         parent::tearDown();
@@ -257,8 +256,6 @@ class UtilsobjectTest extends \OxidEsales\TestingLibrary\UnitTestCase
     
     public function testGetClassName_classNotExistDoNotDisableModuleOnError_errorThrow()
     {
-        oxRegistry::get("oxConfigFile")->setVar('blDoNotDisableModuleOnError', true);
-
         $sClassName = 'oxorder';
         $sClassNameWhichExtends = 'oemodulenameoxorder_different4';
         $oUtilsObject = $this->_prepareFakeModule($sClassName, $sClassNameWhichExtends);

--- a/tests/Unit/Core/UtilsobjectTest.php
+++ b/tests/Unit/Core/UtilsobjectTest.php
@@ -249,23 +249,12 @@ class UtilsobjectTest extends \OxidEsales\TestingLibrary\UnitTestCase
 
         $sClassNameWhichExtends = 'oemodulenameoxorder_different2';
         $oUtilsObject = $this->prepareFakeModuleNonExistentClass($sClassName, $sClassNameWhichExtends);
-
         $this->assertSame($sClassNameExpect, $oUtilsObject->getClassName($sClassName));
+        $expectedExceptionClass = SystemComponentException::class;
+        $this->assertLoggedException($expectedExceptionClass);
     }
-
-    public function testGetClassName_classNotExistDoDisableModuleOnError_originalClassReturn()
-    {
-        $sClassName = 'oxorder';
-        $sClassNameExpect = 'oxorder';
-
-        oxRegistry::get("oxConfigFile")->setVar('blDoNotDisableModuleOnError', false);
-
-        $sClassNameWhichExtends = 'oemodulenameoxorder_different3';
-        $oUtilsObject = $this->prepareFakeModuleNonExistentClass($sClassName, $sClassNameWhichExtends);
-
-        $this->assertSame($sClassNameExpect, $oUtilsObject->getClassName($sClassName));
-    }
-
+    
+    
     public function testGetClassName_classNotExistDoNotDisableModuleOnError_errorThrow()
     {
         oxRegistry::get("oxConfigFile")->setVar('blDoNotDisableModuleOnError', true);


### PR DESCRIPTION
With this commit the Oxid shop is able to handle broken modules in a proper way, by logging the exception without trying to disable the module. The old configurable behavior was eighter to throw a exception and by that stopping the shop from working or to disable the module, which could lead to endless loop or to unwanted behavior.
Todo

- [x] talk to architects 
- [x] fix code style
- [x] understand failing test / fix duplicate log entries
- [x] improve code comments
- [x] fix acceptance test 