### PR TITLE
Fix unusable shop after activation of a module with migrated metadata (v2)

### DIFF
--- a/source/Core/Module/ModuleExtensionsCleaner.php
+++ b/source/Core/Module/ModuleExtensionsCleaner.php
@@ -87,11 +87,22 @@ class ModuleExtensionsCleaner
     {
         $garbage = $moduleInstalledExtensions;
 
-        foreach ($moduleMetaDataExtensions as $className => $classPath) {
-            if (isset($garbage[$className])) {
-                unset($garbage[$className][array_search($classPath, $garbage[$className])]);
-                if (count($garbage[$className]) == 0) {
-                    unset($garbage[$className]);
+        foreach ($garbage as $installedClassName => $installedClassPaths) {
+            if (isset($moduleMetaDataExtensions[$installedClassName])) {
+                // In case more than one extension is specified per module.
+                $metaDataExtensionPaths = $moduleMetaDataExtensions[$installedClassName];
+                if (!is_array($metaDataExtensionPaths)) {
+                    $metaDataExtensionPaths = [$metaDataExtensionPaths];
+                }
+
+                foreach ($installedClassPaths as $index => $installedClassPath) {
+                    if (in_array($installedClassPath, $metaDataExtensionPaths)) {
+                        unset($garbage[$installedClassName][$index]);
+                    }
+                }
+
+                if (count($garbage[$installedClassName]) == 0) {
+                    unset($garbage[$installedClassName]);
                 }
             }
         }


### PR DESCRIPTION
When a module that was previously activated with metadata v1 is activated after its metadata has been migrated to v2, the old extensions are currently not correctly purged from the database.

Due to the way `ModuleExtensionsCleaner::getModuleExtensionsGarbage()` is currently written, it cannot purge v1-style class references from the database (because it checks for v2-style class references). This results in v1-style extensions such as "vendor/modulename/application/models/modulename_oxconfig" being left in the database.

Additionally, the ModuleChainsGenerator now correctly handles special cases where two modules have extensions to oxconfig and one of them is not available anymore (e.g. because of migrated metadata).

`ModuleChainsGenerator::handleSpecialCases()` currently only checks if the direct parent class is `oxconfig`. This works fine as long as only one OXID module is extending `oxconfig`. When two extensions to `oxconfig` are present, the check will fail (because the class checked by `handleSpecialCases()` might be `modulename_oxconfig` and not `oxconfig`) and allow the modules chain generation to enter an infinite loop.

These two bugs together can cause a shop to become unusable when
1. Two OXID modules are extending `oxconfig`
2. One of these modules is second in the `oxconfig` chain
3. That module is migrated from metadata v1 to metadata v2

When these conditions are met, the faulty `ModuleExtensionsCleaner::getModuleExtensionsGarbage()` will not purge the old-style extensions from the database, and the `oxconfig` chain generation will enter an infinite loop. Any attempt to load the shop will throw a PHP Fatal Error - Maximum Nesting Level reached that can only be solved by editing the values in the `oxconfig` database table directly (more likely, deleting them and re-activating all modules).

The provided OXID function in the "Installed shop modules" tab on the extensions page in the backend, which correctly alerts the admin to the fact that some legacy module extensions are present in the database, results in *all module settings* (including admin-set values etc.) being deleted from the database, which is not useful in the context of upgrading a module to metadata v2.

The proposed commit fixes both these issues.