### PR TITLE
Prevent usage of thankyou-controller in no order-context

### DIFF
--- a/source/Application/Controller/ThankYouController.php
+++ b/source/Application/Controller/ThankYouController.php
@@ -107,6 +107,12 @@ class ThankYouController extends \OxidEsales\Eshop\Application\Controller\Fronte
         // delete it from the session
         $oBasket->deleteBasket();
         \OxidEsales\Eshop\Core\Registry::getSession()->deleteVariable('sess_challenge');
+        
+        // if not in order-context, redirect to start
+        $oOrder = $this->getOrder();
+        if( !$oOrder || !$oOrder->oxorder__oxordernr->value ) {
+            \OxidEsales\Eshop\Core\Registry::getUtils()->redirect($this->getConfig()->getShopHomeURL() . '&cl=start', true, 302);
+        }
     }
 
     /**


### PR DESCRIPTION
If you have at least 1 article in basket, you can access the thankyou-page (www.domain.de/?cl=thankyou). If you log stats on this page (e.g. econda) this bug could distort them. Especially mobile users often do not close their browser-tab (thankyou-page) after ordering.