### PR TITLE
Wrong return value FrontendController.isVatIncluded()

### DIFF
--- a/source/Application/Controller/FrontendController.php
+++ b/source/Application/Controller/FrontendController.php
@@ -2949,7 +2949,7 @@ class FrontendController extends \OxidEsales\Eshop\Core\Controller\BaseControlle
 
         $user = $this->getUser();
         if ($user !== false) {
-            if ( strlen($user->oxuser__oxustid->value) > 0 && $user->oxuser__oxustidstatus->value == 1) {
+            if (strlen($user->oxuser__oxustid->value) > 0 && $user->oxuser__oxustidstatus->value == 1) {
                 return $this->_blIsVatIncluded = false;
             }
         } else {

--- a/source/Application/Controller/FrontendController.php
+++ b/source/Application/Controller/FrontendController.php
@@ -2949,7 +2949,7 @@ class FrontendController extends \OxidEsales\Eshop\Core\Controller\BaseControlle
 
         $user = $this->getUser();
         if ($user !== false) {
-            if ($user->oxuser__oxustid->value !== null && $user->oxuser__oxustidstatus->value == 1) {
+            if ( strlen($user->oxuser__oxustid->value) > 0 && $user->oxuser__oxustidstatus->value == 1) {
                 return $this->_blIsVatIncluded = false;
             }
         } else {


### PR DESCRIPTION
If an registered user is logged in without UStID, the FrontendController returns the wrong value for VAT included.
This is due to a type mismatch in PHP.
The if statement has a explicit type comparison to null, the given value from the database is an empty string ''. (Line: 2952 | Application/Controller/FrontendController.php)

Mantis #6902 (https://bugs.oxid-esales.com/view.php?id=6902)