### PR TITLE
added config file setting for database encoding

### DIFF
--- a/source/Core/DatabaseProvider.php
+++ b/source/Core/DatabaseProvider.php
@@ -298,13 +298,15 @@ class DatabaseProvider
             ]
         ];
 
-        /** The charset has to be set during the connection to the database */
+        /** 
+         * The charset has to be set during the connection to the database
+         */
         $charset = (string) $this->getConfigParam('dbCharset');
-	//backwards compability with old config files
-        if ( null == $charset ) {
+        //backwards compability with old config files
+        if (null == $charset) {
             $charset = 'utf8';
         }
-
+        
         $connectionParameters['default'] = array_merge($connectionParameters['default'], ['connectionCharset' => $charset]);
 
         return $connectionParameters;

--- a/source/Core/DatabaseProvider.php
+++ b/source/Core/DatabaseProvider.php
@@ -299,7 +299,12 @@ class DatabaseProvider
         ];
 
         /** The charset has to be set during the connection to the database */
-        $charset = 'utf8';
+        $charset = (string) $this->getConfigParam('dbCharset');
+	//backwards compability with old config files
+        if ( null == $charset ) {
+            $charset = 'utf8';
+        }
+
         $connectionParameters['default'] = array_merge($connectionParameters['default'], ['connectionCharset' => $charset]);
 
         return $connectionParameters;

--- a/source/config.inc.php.dist
+++ b/source/config.inc.php.dist
@@ -6,6 +6,7 @@
 
 // Database connection information
 $this->dbType = 'pdo_mysql';
+$this->dbCharset = 'utf8';
 $this->dbHost = '<dbHost>'; // database host name
 $this->dbPort  = 3306; // tcp port to which the database is bound
 $this->dbName = '<dbName>'; // database name


### PR DESCRIPTION
Hi,

please review these small changes, the charset of the db connection is now configurable. Its not a full switch of the shop to utf8mb4 but ppl could decide for themself to convert the shop or single colums.

All Major CMS & Shopsystem support utf8mb4, emojies are an important SEO factor!

Johannes