### PR TITLE
Remove GD v1 support

### DIFF
--- a/source/Application/views/admin/tpl/shop_config.tpl
+++ b/source/Application/views/admin/tpl/shop_config.tpl
@@ -637,17 +637,6 @@ function editThis(sID)
             <a href="#" onclick="_groupExp(this);return false;" class="rc"><b>[{oxmultilang ident="SHOP_OPTIONS_GROUP_PICTURES"}]</b></a>
             <dl>
                 <dt>
-                    <input type=text class="txt" name=confstrs[iUseGDVersion] value="[{$confstrs.iUseGDVersion}]" [{$readonly}]>
-                    [{oxinputhelp ident="HELP_SHOP_CONFIG_USEGDVERSION"}]
-                </dt>
-                <dd>
-                    [{oxmultilang ident="SHOP_CONFIG_USEGDVERSION"}]
-                </dd>
-                <div class="spacer"></div>
-            </dl>
-
-            <dl>
-                <dt>
                     <input type=hidden name=confbools[blAutoIcons] value=false>
                     <input type=checkbox name=confbools[blAutoIcons] value=true  [{if ($confbools.blAutoIcons)}]checked[{/if}] [{$readonly}]>
                     [{oxinputhelp ident="HELP_SHOP_CONFIG_AUTOICONS"}]

--- a/source/Core/UtilsPic.php
+++ b/source/Core/UtilsPic.php
@@ -35,19 +35,15 @@ class UtilsPic extends \OxidEsales\Eshop\Core\Base
      */
     public function resizeImage($sSrc, $sTarget, $iDesiredWidth, $iDesiredHeight)
     {
-        // use this GD Version
-        if (($iUseGDVersion = getGdVersion()) && function_exists('imagecreate') &&
-            file_exists($sSrc) && ($aImageInfo = @getimagesize($sSrc))
-        ) {
+        if (file_exists($sSrc) && ($aImageInfo = @getimagesize($sSrc))) {
             $myConfig = $this->getConfig();
             list($iWidth, $iHeight) = calcImageSize($iDesiredWidth, $iDesiredHeight, $aImageInfo[0], $aImageInfo[1]);
 
-            return $this->_resize($aImageInfo, $sSrc, null, $sTarget, $iWidth, $iHeight, $iUseGDVersion, $myConfig->getConfigParam('blDisableTouch'), $myConfig->getConfigParam('sDefaultImageQuality'));
+            return $this->_resize($aImageInfo, $sSrc, null, $sTarget, $iWidth, $iHeight, getGdVersion(), $myConfig->getConfigParam('blDisableTouch'), $myConfig->getConfigParam('sDefaultImageQuality'));
         }
 
         return false;
     }
-
 
     /**
      * deletes the given picutre and checks before if the picture is deletable
@@ -182,7 +178,7 @@ class UtilsPic extends \OxidEsales\Eshop\Core\Base
      * @param int    $iNewHeight      new height
      * @param int    $iOriginalWidth  original width
      * @param int    $iOriginalHeigth original height
-     * @param int    $iGDVer          GD packet version
+     * @param int    $iGDVer          GD packet version @deprecated
      * @param bool   $blDisableTouch  false if "touch()" should be called
      *
      * @return bool
@@ -201,7 +197,7 @@ class UtilsPic extends \OxidEsales\Eshop\Core\Base
      * @param string $sTarget           Resized Image target
      * @param int    $iNewWidth         Resized Image's width
      * @param int    $iNewHeight        Resized Image's height
-     * @param mixed  $iGdVer            used GDVersion, if null or false returns false
+     * @param mixed  $iGdVer            used GDVersion, if null or false returns false @deprecated
      * @param bool   $blDisableTouch    false if "touch()" should be called for gif resizing
      * @param string $iDefQuality       quality for "imagejpeg" function
      *
@@ -246,7 +242,7 @@ class UtilsPic extends \OxidEsales\Eshop\Core\Base
      * @param int    $iNewHeight        new height of the image
      * @param array  $aImageInfo        additional info
      * @param string $sTarget           target file path
-     * @param int    $iGdVer            used gd version
+     * @param int    $iGdVer            used gd version @deprecated
      * @param bool   $blDisableTouch    wether Touch() should be called or not
      *
      * @return null

--- a/source/Core/utils/oxpicgenerator.php
+++ b/source/Core/utils/oxpicgenerator.php
@@ -27,20 +27,14 @@ if (!function_exists("copyAlteredImage")) {
      * @param int    $iNewWidth         new width of the image
      * @param int    $iNewHeight        new height of the image
      * @param array  $aImageInfo        additional info
-     * @param string $sTarget           target file path
-     * @param int    $iGdVer            used gd version
+     * @param string $sTarget           target file path @deprecated
+     * @param int    $iGdVer            used gd version @deprecated
      *
      * @return bool
      */
     function copyAlteredImage($sDestinationImage, $sSourceImage, $iNewWidth, $iNewHeight, $aImageInfo, $sTarget, $iGdVer)
     {
-        if ($iGdVer == 1) {
-            $blSuccess = imagecopyresized($sDestinationImage, $sSourceImage, 0, 0, 0, 0, $iNewWidth, $iNewHeight, $aImageInfo[0], $aImageInfo[1]);
-        } else {
-            $blSuccess = imagecopyresampled($sDestinationImage, $sSourceImage, 0, 0, 0, 0, $iNewWidth, $iNewHeight, $aImageInfo[0], $aImageInfo[1]);
-        }
-
-        return $blSuccess;
+        return imagecopyresampled($sDestinationImage, $sSourceImage, 0, 0, 0, 0, $iNewWidth, $iNewHeight, $aImageInfo[0], $aImageInfo[1]);
     }
 }
 
@@ -138,7 +132,7 @@ if (!function_exists("resizeGif")) {
      * @param int    $iHeight         new height
      * @param int    $iOriginalWidth  original width
      * @param int    $iOriginalHeight original height
-     * @param int    $iGDVer          GD library version
+     * @param int    $iGDVer          GD library version @deprecated
      *
      * @return string | false
      */
@@ -147,18 +141,14 @@ if (!function_exists("resizeGif")) {
         $aResult = checkSizeAndCopy($sSrc, $sTarget, $iWidth, $iHeight, $iOriginalWidth, $iOriginalHeight);
         if (is_array($aResult)) {
             list($iNewWidth, $iNewHeight) = $aResult;
-            $hDestinationImage = ($iGDVer == 1) ? imagecreate($iNewWidth, $iNewHeight) : imagecreatetruecolor($iNewWidth, $iNewHeight);
+            $hDestinationImage = imagecreatetruecolor($iNewWidth, $iNewHeight);
             $hSourceImage = imagecreatefromgif($sSrc);
 
             $iFillColor = imagecolorresolve($hDestinationImage, 255, 255, 255);
             imagefill($hDestinationImage, 0, 0, $iFillColor);
             imagecolortransparent($hDestinationImage, $iFillColor);
 
-            if ($iGDVer == 1) {
-                imagecopyresized($hDestinationImage, $hSourceImage, 0, 0, 0, 0, $iNewWidth, $iNewHeight, $iOriginalWidth, $iOriginalHeight);
-            } else {
-                imagecopyresampled($hDestinationImage, $hSourceImage, 0, 0, 0, 0, $iNewWidth, $iNewHeight, $iOriginalWidth, $iOriginalHeight);
-            }
+            imagecopyresampled($hDestinationImage, $hSourceImage, 0, 0, 0, 0, $iNewWidth, $iNewHeight, $iOriginalWidth, $iOriginalHeight);
 
             imagegif($hDestinationImage, $sTarget);
             imagedestroy($hDestinationImage);
@@ -180,7 +170,7 @@ if (!function_exists("resizePng")) {
      * @param int      $iWidth            new width
      * @param int      $iHeight           new height
      * @param int      $aImageInfo        original width
-     * @param int      $iGdVer            GD library version
+     * @param int      $iGdVer            GD library version @deprecated
      * @param resource $hDestinationImage destination image handle
      *
      * @return string | false
@@ -191,7 +181,7 @@ if (!function_exists("resizePng")) {
         if (is_array($aResult)) {
             list($iNewWidth, $iNewHeight) = $aResult;
             if ($hDestinationImage === null) {
-                $hDestinationImage = $iGdVer == 1 ? imagecreate($iNewWidth, $iNewHeight) : imagecreatetruecolor($iNewWidth, $iNewHeight);
+                $hDestinationImage = imagecreatetruecolor($iNewWidth, $iNewHeight);
             }
             $hSourceImage = imagecreatefrompng($sSrc);
             if (!imageistruecolor($hSourceImage)) {
@@ -227,7 +217,7 @@ if (!function_exists("resizeJpeg")) {
      * @param int      $iWidth            new width
      * @param int      $iHeight           new height
      * @param int      $aImageInfo        original width
-     * @param int      $iGdVer            GD library version
+     * @param int      $iGdVer            GD library version @deprecated
      * @param resource $hDestinationImage destination image handle
      * @param int      $iDefQuality       new image quality
      *
@@ -239,7 +229,7 @@ if (!function_exists("resizeJpeg")) {
         if (is_array($aResult)) {
             list($iNewWidth, $iNewHeight) = $aResult;
             if ($hDestinationImage === null) {
-                $hDestinationImage = $iGdVer == 1 ? imagecreate($iNewWidth, $iNewHeight) : imagecreatetruecolor($iNewWidth, $iNewHeight);
+                $hDestinationImage = imagecreatetruecolor($iNewWidth, $iNewHeight);
             }
             $hSourceImage = imagecreatefromstring(file_get_contents($sSrc));
             if (copyAlteredImage($hDestinationImage, $hSourceImage, $iNewWidth, $iNewHeight, $aImageInfo, $sTarget, $iGdVer)) {


### PR DESCRIPTION
As far as I remember OXID eShop version 3.0.4.1 (EE 2.7.0.3) had this functionality to be able to switch between GD 1 and 2 since PHP 4 was still around. This is not necessary anymore and we can drop this feature.  

The feature checks if GD version 1 is installed **or** any other version. If version 1 is installed (which is likely not to this day), then use _this_ function, otherwise use _that_ function.
So this switch between the function names can be removed. Benefit: Less code, less compares and therefore a bit of performance improve.

Without a check but by looking at the code of the picture handling I would say that we didn't use GD version switches consequently anyway. This means that removing the existing ones are only about removing an old not used feature.

Another scenario: If GD 3 is released and it has BC breaks to version 2, the switch functionality wouldn't work, as it doesn't cover this case. So we would need to decide if version 2 is used or version 3 (and adapting the code accordingly). If GD 3 wouldn't have BC breaks, we wouldn't need the switch anyway.


So I did (or did not, see the explanations) the following changes:

1. 3e00cdbcc43e03e50dd4220a28233ff8df7f19db
Removed the GD version 1 or GD version 2 switch. Also marked the parameters as deprecated (if this isn't the way to go, you can still use it as a search reference (@ deprecated)).


1. 3a173200fc88ef7dcf3f241078a778754963ab38
Removed the input field in the administration area.


1. 3e00cdbcc43e03e50dd4220a28233ff8df7f19db
Drop the check if the function imagecreate is existing. \resizePng (source/Core/utils/oxpicgenerator.php) does use the function imagecreate without a check if it is existing, too. Since we require GD version 2 it is existing for sure. Else the library wouldn't be installed and then we have other problems. Also the setup process would intervene and the system health check would display a warning.  

    **Edit**: Please note: During the rebase and other...things..I merged this Commit with the first one. So this change is also applied with the removing of the GD version switch. 


1. The method \OxidEsales\EshopCommunity\Core\DynamicImageGenerator::validateGdVersion does not really validate if the current needed GD library version is installed. It only checks if any version is installed.
I will not change it as the PR is only about removing GD 1 support.

1. I would recommend to adapt the system requirements check. Currently it only checks if GD is installed but not the version. So any version could be installed. Imagine GD version 3 would be released with BC breaks to version 2. The shop wouldn't be able to handle pictures anymore and the health check would be still fine. I will not change it as the PR is only about removing GD 1 support and this would be another topic. Please see \OxidEsales\EshopCommunity\Core\SystemRequirements::checkGdInfo .


1. I did not change the Acceptance tests:
tests/Acceptance/Frontend/PrivateSalesFrontendTest.php
tests/Acceptance/Frontend/ProductInfoFrontendTest.php
tests/Acceptance/Frontend/NavigationFrontendTest.php


1. I thought about changing the function getGdVersion (source/Core/utils/oxpicgenerator.php) so it will always return the integer 2, since our system requirement states version 2 must be installed: "PHP-Erweiterungen, die installiert sein müssen: [...] GD LIB Version 2.x"
But this point is a bit tricky, also because we have two functions getGdVersion:
    1. source/Core/DynamicImageGenerator.php - getGdVersion
    Returns the actually installed GD version.
    1. source/Core/utils/oxpicgenerator.php - getGdVersion
    Returns the saved configure variable (the setup process writes a 2):
    source/Setup/Sql/initial_data.sql -> _('8563fba1baec55dc8.04115259', 1, '', 'iUseGDVersion', 'str', 0xb6),_

    In my opinion there is no need to have a getter for the wanted GD version anymore. So oxpicgenerator.php::getGdVersion and the record in the table oxconfig could be removed completely.
I recommend to only have one function / method for getting the installed  GD version. I prefer oxpicgenerator.php::getGdVersion as it returns the real version, not the "wanted" one. This information is needed for the system health check.


Summary
I did:
- No GD version switches anymore.
- No use of the GD version parameters anymore.

I did not:
- Changes of the GD version reading / validation (= no migration script to remove the database field, because we still have a config getter for it).
- Changes in tests.
  
I made this PR for b-6.x as it doesn't contain any BC breaks.