### PR TITLE
Bugfix for MultilanguageModel

### DIFF
--- a/source/Core/Model/MultiLanguageModel.php
+++ b/source/Core/Model/MultiLanguageModel.php
@@ -463,7 +463,7 @@ class MultiLanguageModel extends \OxidEsales\Eshop\Core\Model\BaseModel
                 $insertSql = "insert into $langTable set " . $this->_getUpdateFieldsForTable($langTable, $this->getUseSkipSaveFields()) .
                              " on duplicate key update " . $this->_getUpdateFieldsForTable($langTable);
 
-                $ret = (bool) $this->executeDatabaseQuery($insertSql);
+                $this->executeDatabaseQuery($insertSql);
             }
         }
 


### PR DESCRIPTION
A bug occurs while editing a content page in the VCMS for the 8th language.
SEO-URL for oxcontent can't be updated if all other values (title, content, etc.) stay unchanged.
Because no values have to be updated in the table "oxcontents_set1" the function executeDatabaseQuery returns 0 for the amount of affected rows. In this case the update function would return false although the content has been saved successfully.