### PR TITLE
added symfony/yaml

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,6 +19,7 @@
         "symfony/event-dispatcher": "^3.4",
         "symfony/dependency-injection": "^3.4",
         "symfony/console": "^v3.4.15",
+        "symfony/yaml": "^3.0",
         "webmozart/path-util": "^2.3"
     },
     "require-dev": {


### PR DESCRIPTION
`symfony/yaml` ist necessary for the oxid core (`Internal`)

normally this package ist installed within oxideshop_metapackage_ce. but not everybody uses the metapackage composer file ;-).

for installing oxid (without and 3th party stuff) this packages are sufficient:

> "symfony/yaml": "^3.0",
> "wikimedia/composer-merge-plugin": "v1.4.*",
> "oxid-esales/oxideshop-ce": "v6.3.*",
> "oxid-esales/oxideshop-unified-namespace-generator": "v2.0.*",
> "oxid-esales/oxideshop-doctrine-migration-wrapper": "v2.1.*",
> "oxid-esales/oxideshop-db-views-generator": "v1.2.*",