### PR TITLE
Basket::formatDiscount: Added check if variable is an array before counting it...

### DIFF
--- a/source/Application/Model/Basket.php
+++ b/source/Application/Model/Basket.php
@@ -1618,7 +1618,7 @@ class Basket extends \OxidEsales\Eshop\Core\Base
         // discount information
         // formatting discount value
         $this->aDiscounts = $this->getDiscounts();
-        if (count($this->aDiscounts) > 0) {
+        if (is_array($this->aDiscounts) && count($this->aDiscounts) > 0) {
             $oLang = \OxidEsales\Eshop\Core\Registry::getLang();
             foreach ($this->aDiscounts as $oDiscount) {
                 $oDiscount->fDiscount = $oLang->formatCurrency($oDiscount->dDiscount, $this->getBasketCurrency());


### PR DESCRIPTION
since Basket::getDiscounts can return "null" and to be PHP 7.2 compatible:

PHP Warning:  count(): Parameter must be an array or an object that implements Countable in vendor\oxid-esales\oxideshop-ce\source\Application\Model\Basket.php on line 1621


Simple test that the logic isn't affected adding the type check:

```
class Test
{
    public $aDiscounts;
    public function t() {
        var_dump(is_array($this->aDiscounts) && count($this->aDiscounts) > 0);
    }
}

$t = new Test();

// false
$t->t();

// false
$t->aDiscounts = null;
$t->t();

// false
$t->aDiscounts = true;
$t->t();

// false
$t->aDiscounts = 2;
$t->t();

// false
$t->aDiscounts = 'a';
$t->t();

// false
$t->aDiscounts = new stdClass();
$t->t();

// false
$t->aDiscounts = [];
$t->t();

// true
$t->aDiscounts = ['a', 'b'];
$t->t();
```