### PR TITLE
bugfix 6582: itm-discount works only with assigned articles or categories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 - Fixed return type in Basket::getDiscounts [PR-659](https://github.com/OXID-eSales/oxideshop_ce/pull/659)
 - Remove unused variables, decrease complexity [PR-668](https://github.com/OXID-eSales/oxideshop_ce/pull/668)
+- If an item-discount is not assigned to an article or a category it should be available to all articles [PR-679](https://github.com/OXID-eSales/oxideshop_ce/pull/679) [0006582](https://bugs.oxid-esales.com/view.php?id=6582)
 
 ### Added
 - New methods:

--- a/source/Application/Model/Discount.php
+++ b/source/Application/Model/Discount.php
@@ -320,6 +320,10 @@ class Discount extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel
             return false;
         }
 
+        if ($this->isGlobalDiscount()) {
+            return true;
+        }
+
         $oDb = \OxidEsales\Eshop\Core\DatabaseProvider::getDb();
         $sQ = "select 1 from oxobject2discount where oxdiscountid=" . $oDb->quote($this->getId());
         $sQ .= $this->_getProductCheckQuery($oArticle);

--- a/tests/Unit/Application/Model/DiscountTest.php
+++ b/tests/Unit/Application/Model/DiscountTest.php
@@ -761,7 +761,7 @@ class DiscountTest extends \OxidTestCase
         $oArticle->setId($testAid);
 
         $oDiscount = $this->getMock(\OxidEsales\Eshop\Application\Model\Discount::class, array('_checkForArticleCategories'));
-        $oDiscount->expects($this->once())->method('_checkForArticleCategories')->with($this->isInstanceOf('\OxidEsales\EshopCommunity\Application\Model\Article'));
+        $oDiscount->expects($this->never())->method('_checkForArticleCategories')->with($this->isInstanceOf('\OxidEsales\EshopCommunity\Application\Model\Article'));
         $oDiscount->oxdiscount__oxaddsumtype = new oxField('itm');
         $oDiscount->setId('testdid');
 
@@ -1056,6 +1056,32 @@ class DiscountTest extends \OxidTestCase
         $this->assertTrue($oDiscount->isForBundleItem($oParentProduct));
         $this->assertTrue($oDiscount->isForBundleItem($oProduct));
         $this->assertFalse($oDiscount->isForBundleItem($oUnrelatedProduct));
+    }
+
+    /**
+     * Test case for #0006582: itm discount should work without assigning any article or category
+     *
+     * When an itm discount is created without an assignment to an article or a category, the discount should be
+     * available for every product like any other discount.
+     *
+     * @return null
+     */
+    public function testForCase6582()
+    {
+        // creating test discount
+        $sDiscountId = '_' . uniqid(rand());
+
+        // inserting test discount
+        $query = "insert into oxdiscount ( oxid, oxshopid, oxactive, oxtitle, oxamount, oxamountto, oxpriceto, oxaddsumtype, oxaddsum )
+               values ( '{$sDiscountId}', '" . $this->getConfig()->getBaseShopId() . "', '1', 'Test', '5', '10', '0', 'itm', '10' )";
+        $this->addToDatabase($query, 'oxdiscount');
+
+        $oProduct = $this->getMock(\OxidEsales\Eshop\Application\Model\Article::class);
+
+        // testing
+        $oDiscount = oxNew('oxDiscount');
+        $oDiscount->load($sDiscountId);
+        $this->assertTrue($oDiscount->isForBundleItem($oProduct));
     }
 
     public function testGetNextOxsortReturnsIncrementedValue() {


### PR DESCRIPTION
fixes [0006582](https://bugs.oxid-esales.com/view.php?id=6582)

There are some failing tests:
```
1) OxidEsales\EshopCommunity\Tests\Unit\Application\Model\BasketTest::testGetItemBundlesItemHasBundles
Failed asserting that two arrays are equal.
--- Expected
+++ Actual
@@ @@
 Array (
-    'xxx' => 2.0
+    'xxx' => '2'
+    'yyy' => 2.0
/home/travis/build/alfredbez/oxideshop_ce/tests/Unit/Application/Model/BasketTest.php:1181
/home/travis/build/alfredbez/oxideshop_ce/vendor/oxid-esales/testing-library/library/UnitTestCase.php:148
2) OxidEsales\EshopCommunity\Tests\Unit\Application\Model\BasketTest::testGetItemBundlesItemHasBundlesMultiplay
Failed asserting that two arrays are equal.
--- Expected
+++ Actual
@@ @@
 Array (
     'xxx' => 6.0
+    'yyy' => 2.0
/home/travis/build/alfredbez/oxideshop_ce/tests/Unit/Application/Model/BasketTest.php:1196
/home/travis/build/alfredbez/oxideshop_ce/vendor/oxid-esales/testing-library/library/UnitTestCase.php:148
3) OxidEsales\EshopCommunity\Tests\Unit\Application\Model\OrderTest::testForBugEntry2255
Failed asserting that '4' matches expected 3.
/home/travis/build/alfredbez/oxideshop_ce/tests/Unit/Application/Model/OrderTest.php:3498
/home/travis/build/alfredbez/oxideshop_ce/vendor/oxid-esales/testing-library/library/UnitTestCase.php:148
```