### PR TITLE
Fix: ini_set allowed shown as red

### DIFF
--- a/source/Core/SystemRequirements.php
+++ b/source/Core/SystemRequirements.php
@@ -741,7 +741,7 @@ class SystemRequirements
      */
     public function checkIniSet()
     {
-        return (@ini_set('session.name', 'sid') !== false) ? 2 : 0;
+        return (@ini_set('memory_limit', @ini_get('memory_limit')) !== false) ? 2 : 0;
     }
 
     /**


### PR DESCRIPTION
Try to set memory_limit with its same value, is a non invasive method to check if ini_set is possible. Dont see a reason to config a fully setup session.

Tested with Oxid PE 6.1.2