### PR TITLE
As a community developer, I want to be sure, that the OXID-eShop tests are functional in the oxvm_eshop enviroment

### DIFF
--- a/tests/Unit/Core/Smarty/FilesizeTest.php
+++ b/tests/Unit/Core/Smarty/FilesizeTest.php
@@ -8,10 +8,15 @@ namespace OxidEsales\EshopCommunity\Tests\Unit\Core\Smarty;
 use \oxRegistry;
 
 $filePath = oxRegistry::getConfig()->getConfigParam('sCoreDir') . 'Smarty/Plugin/modifier.oxfilesize.php';
+$oxidEsalesFilePath =  __DIR__ . '/../../../../source/Core/Smarty/Plugin/modifier.oxfilesize.php';
+$oxVmFilePath = __DIR__ . '/../../../../vendor/oxid-esales/oxideshop-ce/source/Core/Smarty/Plugin/modifier.oxfilesize.php';
+
 if (file_exists($filePath)) {
     require_once $filePath;
+} else if (file_exists($oxidEsalesFilePath)){
+    require_once $oxidEsalesFilePath;
 } else {
-    require_once dirname(__FILE__) . '/../../../../source/Core/Smarty/Plugin/modifier.oxfilesize.php';
+    require_once $oxVmFilePath;
 }
 
 

--- a/tests/Unit/Core/Smarty/PluginSmartyOxBlockTest.php
+++ b/tests/Unit/Core/Smarty/PluginSmartyOxBlockTest.php
@@ -11,10 +11,15 @@ use \oxRegistry;
 use \oxTestModules;
 
 $filePath = oxRegistry::getConfig()->getConfigParam( 'sShopDir' ).'Core/Smarty/Plugin/prefilter.oxblock.php';
+$oxidEsalesFilePath = __DIR__ . '/../../../../source/Core/Smarty/Plugin/prefilter.oxblock.php';
+$oxVmFilePath = __DIR__ . '/../../../../vendor/oxid-esales/oxideshop-ce/source/Core/Smarty/Plugin/prefilter.oxblock.php';
+
 if (file_exists($filePath)) {
     require_once $filePath;
-} else {
-    require_once dirname(__FILE__) . '/../../../../source/Core/Smarty/Plugin/prefilter.oxblock.php';
+} elseif (file_exists($oxidEsalesFilePath)){
+    require_once $oxidEsalesFilePath;
+}else{
+    require_once $oxVmFilePath;
 }
 
 class PluginSmartyOxBlockTest extends \OxidTestCase

--- a/tests/Unit/Core/Smarty/PluginSmartyOxContentTest.php
+++ b/tests/Unit/Core/Smarty/PluginSmartyOxContentTest.php
@@ -13,10 +13,15 @@ use \oxRegistry;
 use \oxTestModules;
 
 $filePath = oxRegistry::getConfig()->getConfigParam('sShopDir') . 'Core/Smarty/Plugin/function.oxcontent.php';
+$oxidEsalesFilePath =  __DIR__ . '/../../../../source/Core/Smarty/Plugin/function.oxcontent.php';
+$oxVmFilePath = __DIR__ . '/../../../../vendor/oxid-esales/oxideshop-ce/source/Core/Smarty/Plugin/function.oxcontent.php';
+
 if (file_exists($filePath)) {
     require_once $filePath;
+} else if(file_exists($oxidEsalesFilePath)){
+    require_once $oxidEsalesFilePath;
 } else {
-    require_once dirname(__FILE__) . '/../../../../source/Core/Smarty/Plugin/function.oxcontent.php';
+    require_once $oxVmFilePath;
 }
 
 class PluginSmartyOxContentTest extends \OxidTestCase

--- a/tests/Unit/Core/Smarty/PluginSmartyOxMailToTest.php
+++ b/tests/Unit/Core/Smarty/PluginSmartyOxMailToTest.php
@@ -9,10 +9,15 @@ use \Smarty;
 use \oxRegistry;
 
 $filePath = oxRegistry::getConfig()->getConfigParam('sShopDir') . 'Core/Smarty/Plugin/function.oxmailto.php';
+$oxidEsalesFilePath =  __DIR__ . '/../../../../source/Core/Smarty/Plugin/function.oxmailto.php';
+$oxVmFilePath = __DIR__ . '/../../../../vendor/oxid-esales/oxideshop-ce/source/Core/Smarty/Plugin/function.oxmailto.php';
+
 if (file_exists($filePath)) {
     require_once $filePath;
+} else if (file_exists($oxidEsalesFilePath)){
+    require_once $oxidEsalesFilePath;
 } else {
-    require_once dirname(__FILE__) . '/../../../../source/Core/Smarty/Plugin/function.oxmailto.php';
+    require_once $oxVmFilePath;
 }
 
 class PluginSmartyOxMailToTest extends \OxidTestCase

--- a/tests/Unit/Core/Smarty/PluginSmartyOxPriceTest.php
+++ b/tests/Unit/Core/Smarty/PluginSmartyOxPriceTest.php
@@ -12,10 +12,15 @@ use \oxPrice;
 use \Smarty;
 
 $filePath = oxRegistry::getConfig()->getConfigParam('sShopDir') . 'Core/Smarty/Plugin/function.oxprice.php';
+$oxidEsalesFilePath =  __DIR__ . '/../../../../source/Core/Smarty/Plugin/function.oxprice.php';
+$oxVmFilePath = __DIR__ . '/../../../../vendor/oxid-esales/oxideshop-ce/source/Core/Smarty/Plugin/function.oxprice.php';
+
 if (file_exists($filePath)) {
     require_once $filePath;
+} else if(file_exists($oxidEsalesFilePath)) {
+    require_once $oxidEsalesFilePath;
 } else {
-    require_once dirname(__FILE__) . '/../../../../source/Core/Smarty/Plugin/function.oxprice.php';
+    require_once $oxVmFilePath;
 }
 
 class PluginSmartyOxPriceTest extends \OxidTestCase

--- a/tests/Unit/Core/Smarty/PluginSmartyOxScriptTest.php
+++ b/tests/Unit/Core/Smarty/PluginSmartyOxScriptTest.php
@@ -9,10 +9,15 @@ use \Smarty;
 use \oxRegistry;
 
 $filePath = oxRegistry::getConfig()->getConfigParam('sShopDir') . 'Core/Smarty/Plugin/function.oxscript.php';
+$oxidEsalesFilePath =  __DIR__ . '/../../../../source/Core/Smarty/Plugin/function.oxscript.php';
+$oxVmFilePath = __DIR__ . '/../../../../vendor/oxid-esales/oxideshop-ce/source/Core/Smarty/Plugin/function.oxscript.php';
+
 if (file_exists($filePath)) {
     require_once $filePath;
+} else if(file_exists($oxidEsalesFilePath)) {
+    require_once $oxidEsalesFilePath;
 } else {
-    require_once dirname(__FILE__) . '/../../../../source/Core/Smarty/Plugin/function.oxscript.php';
+    require_once $oxVmFilePath;
 }
 
 class PluginSmartyOxScriptTest extends \OxidTestCase

--- a/tests/Unit/Core/Smarty/PluginSmartyoxIncludeWidgetTest.php
+++ b/tests/Unit/Core/Smarty/PluginSmartyoxIncludeWidgetTest.php
@@ -10,10 +10,15 @@ use \oxRegistry;
 use \oxTestModules;
 
 $filePath = oxRegistry::getConfig()->getConfigParam('sShopDir') . 'Core/Smarty/Plugin/function.oxid_include_widget.php';
+$oxidEsalesFilePath =  __DIR__ . '/../../../../source/Core/Smarty/Plugin/function.oxid_include_widget.php';
+$oxVmFilePath = __DIR__ . '/../../../../vendor/oxid-esales/oxideshop-ce/source/Core/Smarty/Plugin/function.oxid_include_widget.php';
+
 if (file_exists($filePath)) {
     require_once $filePath;
+} else if(file_exists($oxidEsalesFilePath)) {
+    require_once $oxidEsalesFilePath;
 } else {
-    require_once dirname(__FILE__) . '/../../../../source/Core/Smarty/Plugin/function.oxid_include_widget.php';
+    require_once $oxVmFilePath;
 }
 
 class PluginSmartyoxIncludeWidgetTest extends \OxidTestCase

--- a/tests/Unit/Core/Smarty/SmartyFunctionOxMultiLangTest.php
+++ b/tests/Unit/Core/Smarty/SmartyFunctionOxMultiLangTest.php
@@ -10,10 +10,15 @@ use \oxField;
 use \oxRegistry;
 
 $filePath = oxRegistry::getConfig()->getConfigParam('sShopDir') . 'Core/Smarty/Plugin/function.oxmultilang.php';
+$oxidEsalesFilePath =  __DIR__ . '/../../../../source/Core/Smarty/Plugin/function.oxmultilang.php';
+$oxVmFilePath = __DIR__ . '/../../../../vendor/oxid-esales/oxideshop-ce/source/Core/Smarty/Plugin/function.oxmultilang.php';
+
 if (file_exists($filePath)) {
     require_once $filePath;
+} else if(file_exists($oxidEsalesFilePath)) {
+    require_once $oxidEsalesFilePath;
 } else {
-    require_once dirname(__FILE__) . '/../../../../source/Core/Smarty/Plugin/function.oxmultilang.php';
+    require_once $oxVmFilePath;
 }
 
 class SmartyFunctionOxMultiLangTest extends \OxidTestCase

--- a/tests/Unit/Core/Smarty/SmartyModifierColonTest.php
+++ b/tests/Unit/Core/Smarty/SmartyModifierColonTest.php
@@ -8,10 +8,15 @@ namespace OxidEsales\EshopCommunity\Tests\Unit\Core\Smarty;
 use \oxRegistry;
 
 $filePath = oxRegistry::getConfig()->getConfigParam('sShopDir') . 'Core/Smarty/Plugin/modifier.colon.php';
+$oxidEsalesFilePath =  __DIR__ . '/../../../../source/Core/Smarty/Plugin/modifier.colon.php';
+$oxVmFilePath = __DIR__ . '/../../../../vendor/oxid-esales/oxideshop-ce/source/Core/Smarty/Plugin/modifier.colon.php';
+
 if (file_exists($filePath)) {
     require_once $filePath;
+} else if (file_exists($oxidEsalesFilePath)){
+    require_once $oxidEsalesFilePath;
 } else {
-    require_once dirname(__FILE__) . '/../../../../source/Core/Smarty/Plugin/modifier.colon.php';
+    require_once $oxVmFilePath;
 }
 
 class SmartyModifierColonTest extends \OxidTestCase

--- a/tests/Unit/Core/Smarty/SmartyModifierOxNumberFormatTest.php
+++ b/tests/Unit/Core/Smarty/SmartyModifierOxNumberFormatTest.php
@@ -8,10 +8,15 @@ namespace OxidEsales\EshopCommunity\Tests\Unit\Core\Smarty;
 use \oxRegistry;
 
 $filePath = oxRegistry::getConfig()->getConfigParam('sShopDir') . 'Core/Smarty/Plugin/modifier.oxnumberformat.php';
+$oxidEsalesFilePath =  __DIR__ . '/../../../../source/Core/Smarty/Plugin/modifier.oxnumberformat.php';
+$oxVmFilePath = __DIR__ . '/../../../../vendor/oxid-esales/oxideshop-ce/source/Core/Smarty/Plugin/modifier.oxnumberformat.php';
+
 if (file_exists($filePath)) {
     require_once $filePath;
+} else if (file_exists($oxidEsalesFilePath)){
+    require_once $oxidEsalesFilePath;
 } else {
-    require_once dirname(__FILE__) . '/../../../../source/Core/Smarty/Plugin/modifier.oxnumberformat.php';
+    require_once $oxVmFilePath;
 }
 
 class SmartyModifierOxNumberFormatTest extends \OxidTestCase

--- a/tests/Unit/Core/Smarty/SmartyModifieroxmultilangassignTest.php
+++ b/tests/Unit/Core/Smarty/SmartyModifieroxmultilangassignTest.php
@@ -10,10 +10,15 @@ use \oxField;
 use \oxRegistry;
 
 $filePath = oxRegistry::getConfig()->getConfigParam('sShopDir') . 'Core/Smarty/Plugin/modifier.oxmultilangassign.php';
+$oxidEsalesFilePath =  __DIR__ . '/../../../../source/Core/Smarty/Plugin/modifier.oxmultilangassign.php';
+$oxVmFilePath = __DIR__ . '/../../../../vendor/oxid-esales/oxideshop-ce/source/Core/Smarty/Plugin/modifier.oxmultilangassign.php';
+
 if (file_exists($filePath)) {
     require_once $filePath;
+} else if(file_exists($oxidEsalesFilePath)){
+    require_once $oxidEsalesFilePath;
 } else {
-    require_once dirname(__FILE__) . '/../../../../source/Core/Smarty/Plugin/modifier.oxmultilangassign.php';
+    require_once $oxVmFilePath;
 }
 
 class SmartyModifieroxmultilangassignTest extends \OxidTestCase
@@ -21,6 +26,7 @@ class SmartyModifieroxmultilangassignTest extends \OxidTestCase
 
     /**
      * Provides data to testSimpleAssignments
+     *
      *
      * @return array
      */


### PR DESCRIPTION
### Scenario  /  Steps to reproduce
- fire up the [oxvm_eshop](https://github.com/OXID-eSales/oxvm_eshop) 
- navigate to /var/www/oxideshop
- run the command `php vendor/bin/runtests`

### Accepted
- The build in test will pass with no error

### Current
- The tests will crash with the following error message
`Adding unit tests from /var/www/oxideshop/tests/Unit/Core/Module/*Test\.php
Adding unit tests from /var/www/oxideshop/tests/Unit/Core/Service/*Test\.php
Adding unit tests from /var/www/oxideshop/tests/Unit/Core/Smarty/*Test\.php
PHP Warning:  require_once(/var/www/oxideshop/tests/Unit/Core/Smarty/../../../../source/Core/Smarty/Plugin/prefilter.oxblock.php): failed to open stream: No such file or directory in /var/www/oxideshop/tests/Unit/Core/Smarty/PluginSmartyOxBlockTest.php on line 17
PHP Stack trace:
PHP   1. {main}() /var/www/oxideshop/vendor/phpunit/phpunit/phpunit:0
PHP   2. PHPUnit_TextUI_Command::main() /var/www/oxideshop/vendor/phpunit/phpunit/phpunit:47
PHP   3. PHPUnit_TextUI_Command->run() /var/www/oxideshop/vendor/phpunit/phpunit/src/TextUI/Command.php:100
PHP   4. PHPUnit_TextUI_TestRunner->getTest() /var/www/oxideshop/vendor/phpunit/phpunit/src/TextUI/Command.php:122
PHP   5. ReflectionMethod->invoke() /var/www/oxideshop/vendor/phpunit/phpunit/src/Runner/BaseTestRunner.php:86
PHP   6. AllTestsRunner::suite() /var/www/oxideshop/vendor/phpunit/phpunit/src/Runner/BaseTestRunner.php:86
PHP   7. AllTestsRunner::_addFilesToSuite() /var/www/oxideshop/vendor/oxid-esales/testing-library/AllTestsRunner.php:54
PHP   8. PHPUnit_Framework_TestSuite->addTestFile() /var/www/oxideshop/vendor/oxid-esales/testing-library/AllTestsRunner.php:142
PHP   9. PHPUnit_Util_Fileloader::checkAndLoad() /var/www/oxideshop/vendor/phpunit/phpunit/src/Framework/TestSuite.php:335
PHP  10. PHPUnit_Util_Fileloader::load() /var/www/oxideshop/vendor/phpunit/phpunit/src/Util/Fileloader.php:38
PHP  11. include_once() /var/www/oxideshop/vendor/phpunit/phpunit/src/Util/Fileloader.php:56
PHP Fatal error:  require_once(): Failed opening required '/var/www/oxideshop/tests/Unit/Core/Smarty/../../../../source/Core/Smarty/Plugin/prefilter.oxblock.php' (include_path='/var/www/oxideshop/vendor/symfony/yaml:.:/usr/share/php') in /var/www/oxideshop/tests/Unit/Core/Smarty/PluginSmartyOxBlockTest.php on line 17
PHP Stack trace:
PHP   1. {main}() /var/www/oxideshop/vendor/phpunit/phpunit/phpunit:0
PHP   2. PHPUnit_TextUI_Command::main() /var/www/oxideshop/vendor/phpunit/phpunit/phpunit:47
PHP   3. PHPUnit_TextUI_Command->run() /var/www/oxideshop/vendor/phpunit/phpunit/src/TextUI/Command.php:100
PHP   4. PHPUnit_TextUI_TestRunner->getTest() /var/www/oxideshop/vendor/phpunit/phpunit/src/TextUI/Command.php:122
PHP   5. ReflectionMethod->invoke() /var/www/oxideshop/vendor/phpunit/phpunit/src/Runner/BaseTestRunner.php:86
PHP   6. AllTestsRunner::suite() /var/www/oxideshop/vendor/phpunit/phpunit/src/Runner/BaseTestRunner.php:86
PHP   7. AllTestsRunner::_addFilesToSuite() /var/www/oxideshop/vendor/oxid-esales/testing-library/AllTestsRunner.php:54
PHP   8. PHPUnit_Framework_TestSuite->addTestFile() /var/www/oxideshop/vendor/oxid-esales/testing-library/AllTestsRunner.php:142
PHP   9. PHPUnit_Util_Fileloader::checkAndLoad() /var/www/oxideshop/vendor/phpunit/phpunit/src/Framework/TestSuite.php:335
PHP  10. PHPUnit_Util_Fileloader::load() /var/www/oxideshop/vendor/phpunit/phpunit/src/Util/Fileloader.php:38
PHP  11. include_once() /var/www/oxideshop/vendor/phpunit/phpunit/src/Util/Fileloader.php:56
Uncaught exception. See error log for more information.`

### Solution
- fix the path for the core directory in an  [oxvm_eshop](https://github.com/OXID-eSales/oxvm_eshop)  environment.

### Technical details
 - oxvm_eshop b-6.1
 - oxideshop-metapackage-ce v6.1.2
 - oxid eshop_ce reference [05b11e27abb4d6fd894ef2d0c983569be2f198ad](https://github.com/OXID-eSales/oxideshop_ce/commit/05b11e27abb4d6fd894ef2d0c983569be2f198ad)

### Commit Message
- add different require_once path for smarty tests, to make them functional in the official oxvm_eshop environment