### PR TITLE
ensure temp file in tmp directory

### DIFF
--- a/source/Core/FileCache.php
+++ b/source/Core/FileCache.php
@@ -55,7 +55,7 @@ class FileCache
         $fileName = $this->getCacheFilePath($key);
         $cacheDirectory = $this->getCacheDir();
 
-        $tmpFile = $cacheDirectory . basename($fileName) . uniqid('.temp', true) . '.txt';
+        $tmpFile = $cacheDirectory . "/" . basename($fileName) . uniqid('.temp', true) . '.txt';
         file_put_contents($tmpFile, serialize($value), LOCK_EX);
 
         rename($tmpFile, $fileName);


### PR DESCRIPTION
with this fix temporary files are ensured to be created within the tmp directory
the issue without the fix is that in a secure envuornment and without a trailing slash in compiledir folder setting  the confic.inc.php the temp file can not be created and for example orders failed.
a workaround for projects is to lower security for writing next to the tmp folder or to add a trailing slash in the setting for the tmp folder.
no bugtracker entry created yet by me