### PR TITLE
(simplified) As a community developer, I want to be sure, that the OXID-eShop tests are functional in the oxvm_eshop enviroment

### DIFF
--- a/tests/Unit/Core/Smarty/FilesizeTest.php
+++ b/tests/Unit/Core/Smarty/FilesizeTest.php
@@ -8,10 +8,15 @@ namespace OxidEsales\EshopCommunity\Tests\Unit\Core\Smarty;
 use \oxRegistry;
 
 $filePath = oxRegistry::getConfig()->getConfigParam('sCoreDir') . 'Smarty/Plugin/modifier.oxfilesize.php';
+$oxidEsalesFilePath =  __DIR__ . '/../../../../source/Core/Smarty/Plugin/modifier.oxfilesize.php';
+$oxVmFilePath = __DIR__ . '/../../../../vendor/oxid-esales/oxideshop-ce/source/Core/Smarty/Plugin/modifier.oxfilesize.php';
+
 if (file_exists($filePath)) {
     require_once $filePath;
+} else if (file_exists($oxidEsalesFilePath)){
+    require_once $oxidEsalesFilePath;
 } else {
-    require_once dirname(__FILE__) . '/../../../../source/Core/Smarty/Plugin/modifier.oxfilesize.php';
+    require_once $oxVmFilePath;
 }
 
 

--- a/tests/Unit/Core/Smarty/FilesizeTest.php
+++ b/tests/Unit/Core/Smarty/FilesizeTest.php
@@ -8,13 +8,10 @@ namespace OxidEsales\EshopCommunity\Tests\Unit\Core\Smarty;
 use \oxRegistry;
 
 $filePath = oxRegistry::getConfig()->getConfigParam('sCoreDir') . 'Smarty/Plugin/modifier.oxfilesize.php';
-$oxidEsalesFilePath =  __DIR__ . '/../../../../source/Core/Smarty/Plugin/modifier.oxfilesize.php';
 $oxVmFilePath = __DIR__ . '/../../../../vendor/oxid-esales/oxideshop-ce/source/Core/Smarty/Plugin/modifier.oxfilesize.php';
 
 if (file_exists($filePath)) {
     require_once $filePath;
-} else if (file_exists($oxidEsalesFilePath)){
-    require_once $oxidEsalesFilePath;
 } else {
     require_once $oxVmFilePath;
 }

--- a/tests/Unit/Core/Smarty/PluginSmartyOxBlockTest.php
+++ b/tests/Unit/Core/Smarty/PluginSmartyOxBlockTest.php
@@ -11,10 +11,15 @@ use \oxRegistry;
 use \oxTestModules;
 
 $filePath = oxRegistry::getConfig()->getConfigParam( 'sShopDir' ).'Core/Smarty/Plugin/prefilter.oxblock.php';
+$oxidEsalesFilePath = __DIR__ . '/../../../../source/Core/Smarty/Plugin/prefilter.oxblock.php';
+$oxVmFilePath = __DIR__ . '/../../../../vendor/oxid-esales/oxideshop-ce/source/Core/Smarty/Plugin/prefilter.oxblock.php';
+
 if (file_exists($filePath)) {
     require_once $filePath;
-} else {
-    require_once dirname(__FILE__) . '/../../../../source/Core/Smarty/Plugin/prefilter.oxblock.php';
+} elseif (file_exists($oxidEsalesFilePath)){
+    require_once $oxidEsalesFilePath;
+}else{
+    require_once $oxVmFilePath;
 }
 
 class PluginSmartyOxBlockTest extends \OxidTestCase

--- a/tests/Unit/Core/Smarty/PluginSmartyOxBlockTest.php
+++ b/tests/Unit/Core/Smarty/PluginSmartyOxBlockTest.php
@@ -11,13 +11,10 @@ use \oxRegistry;
 use \oxTestModules;
 
 $filePath = oxRegistry::getConfig()->getConfigParam( 'sShopDir' ).'Core/Smarty/Plugin/prefilter.oxblock.php';
-$oxidEsalesFilePath = __DIR__ . '/../../../../source/Core/Smarty/Plugin/prefilter.oxblock.php';
 $oxVmFilePath = __DIR__ . '/../../../../vendor/oxid-esales/oxideshop-ce/source/Core/Smarty/Plugin/prefilter.oxblock.php';
 
 if (file_exists($filePath)) {
     require_once $filePath;
-} elseif (file_exists($oxidEsalesFilePath)){
-    require_once $oxidEsalesFilePath;
 }else{
     require_once $oxVmFilePath;
 }

--- a/tests/Unit/Core/Smarty/PluginSmartyOxContentTest.php
+++ b/tests/Unit/Core/Smarty/PluginSmartyOxContentTest.php
@@ -13,10 +13,15 @@ use \oxRegistry;
 use \oxTestModules;
 
 $filePath = oxRegistry::getConfig()->getConfigParam('sShopDir') . 'Core/Smarty/Plugin/function.oxcontent.php';
+$oxidEsalesFilePath =  __DIR__ . '/../../../../source/Core/Smarty/Plugin/function.oxcontent.php';
+$oxVmFilePath = __DIR__ . '/../../../../vendor/oxid-esales/oxideshop-ce/source/Core/Smarty/Plugin/function.oxcontent.php';
+
 if (file_exists($filePath)) {
     require_once $filePath;
+} else if(file_exists($oxidEsalesFilePath)){
+    require_once $oxidEsalesFilePath;
 } else {
-    require_once dirname(__FILE__) . '/../../../../source/Core/Smarty/Plugin/function.oxcontent.php';
+    require_once $oxVmFilePath;
 }
 
 class PluginSmartyOxContentTest extends \OxidTestCase

--- a/tests/Unit/Core/Smarty/PluginSmartyOxContentTest.php
+++ b/tests/Unit/Core/Smarty/PluginSmartyOxContentTest.php
@@ -13,13 +13,10 @@ use \oxRegistry;
 use \oxTestModules;
 
 $filePath = oxRegistry::getConfig()->getConfigParam('sShopDir') . 'Core/Smarty/Plugin/function.oxcontent.php';
-$oxidEsalesFilePath =  __DIR__ . '/../../../../source/Core/Smarty/Plugin/function.oxcontent.php';
 $oxVmFilePath = __DIR__ . '/../../../../vendor/oxid-esales/oxideshop-ce/source/Core/Smarty/Plugin/function.oxcontent.php';
 
 if (file_exists($filePath)) {
     require_once $filePath;
-} else if(file_exists($oxidEsalesFilePath)){
-    require_once $oxidEsalesFilePath;
 } else {
     require_once $oxVmFilePath;
 }

--- a/tests/Unit/Core/Smarty/PluginSmartyOxMailToTest.php
+++ b/tests/Unit/Core/Smarty/PluginSmartyOxMailToTest.php
@@ -9,13 +9,10 @@ use \Smarty;
 use \oxRegistry;
 
 $filePath = oxRegistry::getConfig()->getConfigParam('sShopDir') . 'Core/Smarty/Plugin/function.oxmailto.php';
-$oxidEsalesFilePath =  __DIR__ . '/../../../../source/Core/Smarty/Plugin/function.oxmailto.php';
 $oxVmFilePath = __DIR__ . '/../../../../vendor/oxid-esales/oxideshop-ce/source/Core/Smarty/Plugin/function.oxmailto.php';
 
 if (file_exists($filePath)) {
     require_once $filePath;
-} else if (file_exists($oxidEsalesFilePath)){
-    require_once $oxidEsalesFilePath;
 } else {
     require_once $oxVmFilePath;
 }

--- a/tests/Unit/Core/Smarty/PluginSmartyOxMailToTest.php
+++ b/tests/Unit/Core/Smarty/PluginSmartyOxMailToTest.php
@@ -9,10 +9,15 @@ use \Smarty;
 use \oxRegistry;
 
 $filePath = oxRegistry::getConfig()->getConfigParam('sShopDir') . 'Core/Smarty/Plugin/function.oxmailto.php';
+$oxidEsalesFilePath =  __DIR__ . '/../../../../source/Core/Smarty/Plugin/function.oxmailto.php';
+$oxVmFilePath = __DIR__ . '/../../../../vendor/oxid-esales/oxideshop-ce/source/Core/Smarty/Plugin/function.oxmailto.php';
+
 if (file_exists($filePath)) {
     require_once $filePath;
+} else if (file_exists($oxidEsalesFilePath)){
+    require_once $oxidEsalesFilePath;
 } else {
-    require_once dirname(__FILE__) . '/../../../../source/Core/Smarty/Plugin/function.oxmailto.php';
+    require_once $oxVmFilePath;
 }
 
 class PluginSmartyOxMailToTest extends \OxidTestCase

--- a/tests/Unit/Core/Smarty/PluginSmartyOxPriceTest.php
+++ b/tests/Unit/Core/Smarty/PluginSmartyOxPriceTest.php
@@ -12,10 +12,15 @@ use \oxPrice;
 use \Smarty;
 
 $filePath = oxRegistry::getConfig()->getConfigParam('sShopDir') . 'Core/Smarty/Plugin/function.oxprice.php';
+$oxidEsalesFilePath =  __DIR__ . '/../../../../source/Core/Smarty/Plugin/function.oxprice.php';
+$oxVmFilePath = __DIR__ . '/../../../../vendor/oxid-esales/oxideshop-ce/source/Core/Smarty/Plugin/function.oxprice.php';
+
 if (file_exists($filePath)) {
     require_once $filePath;
+} else if(file_exists($oxidEsalesFilePath)) {
+    require_once $oxidEsalesFilePath;
 } else {
-    require_once dirname(__FILE__) . '/../../../../source/Core/Smarty/Plugin/function.oxprice.php';
+    require_once $oxVmFilePath;
 }
 
 class PluginSmartyOxPriceTest extends \OxidTestCase

--- a/tests/Unit/Core/Smarty/PluginSmartyOxPriceTest.php
+++ b/tests/Unit/Core/Smarty/PluginSmartyOxPriceTest.php
@@ -12,13 +12,10 @@ use \oxPrice;
 use \Smarty;
 
 $filePath = oxRegistry::getConfig()->getConfigParam('sShopDir') . 'Core/Smarty/Plugin/function.oxprice.php';
-$oxidEsalesFilePath =  __DIR__ . '/../../../../source/Core/Smarty/Plugin/function.oxprice.php';
 $oxVmFilePath = __DIR__ . '/../../../../vendor/oxid-esales/oxideshop-ce/source/Core/Smarty/Plugin/function.oxprice.php';
 
 if (file_exists($filePath)) {
     require_once $filePath;
-} else if(file_exists($oxidEsalesFilePath)) {
-    require_once $oxidEsalesFilePath;
 } else {
     require_once $oxVmFilePath;
 }

--- a/tests/Unit/Core/Smarty/PluginSmartyOxScriptTest.php
+++ b/tests/Unit/Core/Smarty/PluginSmartyOxScriptTest.php
@@ -9,10 +9,15 @@ use \Smarty;
 use \oxRegistry;
 
 $filePath = oxRegistry::getConfig()->getConfigParam('sShopDir') . 'Core/Smarty/Plugin/function.oxscript.php';
+$oxidEsalesFilePath =  __DIR__ . '/../../../../source/Core/Smarty/Plugin/function.oxscript.php';
+$oxVmFilePath = __DIR__ . '/../../../../vendor/oxid-esales/oxideshop-ce/source/Core/Smarty/Plugin/function.oxscript.php';
+
 if (file_exists($filePath)) {
     require_once $filePath;
+} else if(file_exists($oxidEsalesFilePath)) {
+    require_once $oxidEsalesFilePath;
 } else {
-    require_once dirname(__FILE__) . '/../../../../source/Core/Smarty/Plugin/function.oxscript.php';
+    require_once $oxVmFilePath;
 }
 
 class PluginSmartyOxScriptTest extends \OxidTestCase

--- a/tests/Unit/Core/Smarty/PluginSmartyOxScriptTest.php
+++ b/tests/Unit/Core/Smarty/PluginSmartyOxScriptTest.php
@@ -9,13 +9,10 @@ use \Smarty;
 use \oxRegistry;
 
 $filePath = oxRegistry::getConfig()->getConfigParam('sShopDir') . 'Core/Smarty/Plugin/function.oxscript.php';
-$oxidEsalesFilePath =  __DIR__ . '/../../../../source/Core/Smarty/Plugin/function.oxscript.php';
 $oxVmFilePath = __DIR__ . '/../../../../vendor/oxid-esales/oxideshop-ce/source/Core/Smarty/Plugin/function.oxscript.php';
 
 if (file_exists($filePath)) {
     require_once $filePath;
-} else if(file_exists($oxidEsalesFilePath)) {
-    require_once $oxidEsalesFilePath;
 } else {
     require_once $oxVmFilePath;
 }

--- a/tests/Unit/Core/Smarty/PluginSmartyoxIncludeWidgetTest.php
+++ b/tests/Unit/Core/Smarty/PluginSmartyoxIncludeWidgetTest.php
@@ -10,13 +10,10 @@ use \oxRegistry;
 use \oxTestModules;
 
 $filePath = oxRegistry::getConfig()->getConfigParam('sShopDir') . 'Core/Smarty/Plugin/function.oxid_include_widget.php';
-$oxidEsalesFilePath =  __DIR__ . '/../../../../source/Core/Smarty/Plugin/function.oxid_include_widget.php';
 $oxVmFilePath = __DIR__ . '/../../../../vendor/oxid-esales/oxideshop-ce/source/Core/Smarty/Plugin/function.oxid_include_widget.php';
 
 if (file_exists($filePath)) {
     require_once $filePath;
-} else if(file_exists($oxidEsalesFilePath)) {
-    require_once $oxidEsalesFilePath;
 } else {
     require_once $oxVmFilePath;
 }

--- a/tests/Unit/Core/Smarty/PluginSmartyoxIncludeWidgetTest.php
+++ b/tests/Unit/Core/Smarty/PluginSmartyoxIncludeWidgetTest.php
@@ -10,10 +10,15 @@ use \oxRegistry;
 use \oxTestModules;
 
 $filePath = oxRegistry::getConfig()->getConfigParam('sShopDir') . 'Core/Smarty/Plugin/function.oxid_include_widget.php';
+$oxidEsalesFilePath =  __DIR__ . '/../../../../source/Core/Smarty/Plugin/function.oxid_include_widget.php';
+$oxVmFilePath = __DIR__ . '/../../../../vendor/oxid-esales/oxideshop-ce/source/Core/Smarty/Plugin/function.oxid_include_widget.php';
+
 if (file_exists($filePath)) {
     require_once $filePath;
+} else if(file_exists($oxidEsalesFilePath)) {
+    require_once $oxidEsalesFilePath;
 } else {
-    require_once dirname(__FILE__) . '/../../../../source/Core/Smarty/Plugin/function.oxid_include_widget.php';
+    require_once $oxVmFilePath;
 }
 
 class PluginSmartyoxIncludeWidgetTest extends \OxidTestCase

--- a/tests/Unit/Core/Smarty/SmartyFunctionOxMultiLangTest.php
+++ b/tests/Unit/Core/Smarty/SmartyFunctionOxMultiLangTest.php
@@ -10,10 +10,15 @@ use \oxField;
 use \oxRegistry;
 
 $filePath = oxRegistry::getConfig()->getConfigParam('sShopDir') . 'Core/Smarty/Plugin/function.oxmultilang.php';
+$oxidEsalesFilePath =  __DIR__ . '/../../../../source/Core/Smarty/Plugin/function.oxmultilang.php';
+$oxVmFilePath = __DIR__ . '/../../../../vendor/oxid-esales/oxideshop-ce/source/Core/Smarty/Plugin/function.oxmultilang.php';
+
 if (file_exists($filePath)) {
     require_once $filePath;
+} else if(file_exists($oxidEsalesFilePath)) {
+    require_once $oxidEsalesFilePath;
 } else {
-    require_once dirname(__FILE__) . '/../../../../source/Core/Smarty/Plugin/function.oxmultilang.php';
+    require_once $oxVmFilePath;
 }
 
 class SmartyFunctionOxMultiLangTest extends \OxidTestCase

--- a/tests/Unit/Core/Smarty/SmartyFunctionOxMultiLangTest.php
+++ b/tests/Unit/Core/Smarty/SmartyFunctionOxMultiLangTest.php
@@ -10,13 +10,10 @@ use \oxField;
 use \oxRegistry;
 
 $filePath = oxRegistry::getConfig()->getConfigParam('sShopDir') . 'Core/Smarty/Plugin/function.oxmultilang.php';
-$oxidEsalesFilePath =  __DIR__ . '/../../../../source/Core/Smarty/Plugin/function.oxmultilang.php';
 $oxVmFilePath = __DIR__ . '/../../../../vendor/oxid-esales/oxideshop-ce/source/Core/Smarty/Plugin/function.oxmultilang.php';
 
 if (file_exists($filePath)) {
     require_once $filePath;
-} else if(file_exists($oxidEsalesFilePath)) {
-    require_once $oxidEsalesFilePath;
 } else {
     require_once $oxVmFilePath;
 }

--- a/tests/Unit/Core/Smarty/SmartyModifierColonTest.php
+++ b/tests/Unit/Core/Smarty/SmartyModifierColonTest.php
@@ -8,13 +8,10 @@ namespace OxidEsales\EshopCommunity\Tests\Unit\Core\Smarty;
 use \oxRegistry;
 
 $filePath = oxRegistry::getConfig()->getConfigParam('sShopDir') . 'Core/Smarty/Plugin/modifier.colon.php';
-$oxidEsalesFilePath =  __DIR__ . '/../../../../source/Core/Smarty/Plugin/modifier.colon.php';
 $oxVmFilePath = __DIR__ . '/../../../../vendor/oxid-esales/oxideshop-ce/source/Core/Smarty/Plugin/modifier.colon.php';
 
 if (file_exists($filePath)) {
     require_once $filePath;
-} else if (file_exists($oxidEsalesFilePath)){
-    require_once $oxidEsalesFilePath;
 } else {
     require_once $oxVmFilePath;
 }

--- a/tests/Unit/Core/Smarty/SmartyModifierColonTest.php
+++ b/tests/Unit/Core/Smarty/SmartyModifierColonTest.php
@@ -8,10 +8,15 @@ namespace OxidEsales\EshopCommunity\Tests\Unit\Core\Smarty;
 use \oxRegistry;
 
 $filePath = oxRegistry::getConfig()->getConfigParam('sShopDir') . 'Core/Smarty/Plugin/modifier.colon.php';
+$oxidEsalesFilePath =  __DIR__ . '/../../../../source/Core/Smarty/Plugin/modifier.colon.php';
+$oxVmFilePath = __DIR__ . '/../../../../vendor/oxid-esales/oxideshop-ce/source/Core/Smarty/Plugin/modifier.colon.php';
+
 if (file_exists($filePath)) {
     require_once $filePath;
+} else if (file_exists($oxidEsalesFilePath)){
+    require_once $oxidEsalesFilePath;
 } else {
-    require_once dirname(__FILE__) . '/../../../../source/Core/Smarty/Plugin/modifier.colon.php';
+    require_once $oxVmFilePath;
 }
 
 class SmartyModifierColonTest extends \OxidTestCase

--- a/tests/Unit/Core/Smarty/SmartyModifierOxNumberFormatTest.php
+++ b/tests/Unit/Core/Smarty/SmartyModifierOxNumberFormatTest.php
@@ -8,10 +8,15 @@ namespace OxidEsales\EshopCommunity\Tests\Unit\Core\Smarty;
 use \oxRegistry;
 
 $filePath = oxRegistry::getConfig()->getConfigParam('sShopDir') . 'Core/Smarty/Plugin/modifier.oxnumberformat.php';
+$oxidEsalesFilePath =  __DIR__ . '/../../../../source/Core/Smarty/Plugin/modifier.oxnumberformat.php';
+$oxVmFilePath = __DIR__ . '/../../../../vendor/oxid-esales/oxideshop-ce/source/Core/Smarty/Plugin/modifier.oxnumberformat.php';
+
 if (file_exists($filePath)) {
     require_once $filePath;
+} else if (file_exists($oxidEsalesFilePath)){
+    require_once $oxidEsalesFilePath;
 } else {
-    require_once dirname(__FILE__) . '/../../../../source/Core/Smarty/Plugin/modifier.oxnumberformat.php';
+    require_once $oxVmFilePath;
 }
 
 class SmartyModifierOxNumberFormatTest extends \OxidTestCase

--- a/tests/Unit/Core/Smarty/SmartyModifierOxNumberFormatTest.php
+++ b/tests/Unit/Core/Smarty/SmartyModifierOxNumberFormatTest.php
@@ -8,13 +8,10 @@ namespace OxidEsales\EshopCommunity\Tests\Unit\Core\Smarty;
 use \oxRegistry;
 
 $filePath = oxRegistry::getConfig()->getConfigParam('sShopDir') . 'Core/Smarty/Plugin/modifier.oxnumberformat.php';
-$oxidEsalesFilePath =  __DIR__ . '/../../../../source/Core/Smarty/Plugin/modifier.oxnumberformat.php';
 $oxVmFilePath = __DIR__ . '/../../../../vendor/oxid-esales/oxideshop-ce/source/Core/Smarty/Plugin/modifier.oxnumberformat.php';
 
 if (file_exists($filePath)) {
     require_once $filePath;
-} else if (file_exists($oxidEsalesFilePath)){
-    require_once $oxidEsalesFilePath;
 } else {
     require_once $oxVmFilePath;
 }

--- a/tests/Unit/Core/Smarty/SmartyModifieroxmultilangassignTest.php
+++ b/tests/Unit/Core/Smarty/SmartyModifieroxmultilangassignTest.php
@@ -10,13 +10,10 @@ use \oxField;
 use \oxRegistry;
 
 $filePath = oxRegistry::getConfig()->getConfigParam('sShopDir') . 'Core/Smarty/Plugin/modifier.oxmultilangassign.php';
-$oxidEsalesFilePath =  __DIR__ . '/../../../../source/Core/Smarty/Plugin/modifier.oxmultilangassign.php';
 $oxVmFilePath = __DIR__ . '/../../../../vendor/oxid-esales/oxideshop-ce/source/Core/Smarty/Plugin/modifier.oxmultilangassign.php';
 
 if (file_exists($filePath)) {
     require_once $filePath;
-} else if(file_exists($oxidEsalesFilePath)){
-    require_once $oxidEsalesFilePath;
 } else {
     require_once $oxVmFilePath;
 }

--- a/tests/Unit/Core/Smarty/SmartyModifieroxmultilangassignTest.php
+++ b/tests/Unit/Core/Smarty/SmartyModifieroxmultilangassignTest.php
@@ -10,10 +10,15 @@ use \oxField;
 use \oxRegistry;
 
 $filePath = oxRegistry::getConfig()->getConfigParam('sShopDir') . 'Core/Smarty/Plugin/modifier.oxmultilangassign.php';
+$oxidEsalesFilePath =  __DIR__ . '/../../../../source/Core/Smarty/Plugin/modifier.oxmultilangassign.php';
+$oxVmFilePath = __DIR__ . '/../../../../vendor/oxid-esales/oxideshop-ce/source/Core/Smarty/Plugin/modifier.oxmultilangassign.php';
+
 if (file_exists($filePath)) {
     require_once $filePath;
+} else if(file_exists($oxidEsalesFilePath)){
+    require_once $oxidEsalesFilePath;
 } else {
-    require_once dirname(__FILE__) . '/../../../../source/Core/Smarty/Plugin/modifier.oxmultilangassign.php';
+    require_once $oxVmFilePath;
 }
 
 class SmartyModifieroxmultilangassignTest extends \OxidTestCase
@@ -21,6 +26,7 @@ class SmartyModifieroxmultilangassignTest extends \OxidTestCase
 
     /**
      * Provides data to testSimpleAssignments
+     *
      *
      * @return array
      */


### PR DESCRIPTION
This pull request is a simplified version of the [pull request 682](https://github.com/OXID-eSales/oxideshop_ce/pull/682)

The second condition, which was build as a fallback is removed in all changed unit tests. 

### Scenario / Steps to reproduce
* same as in  [pull request 682](https://github.com/OXID-eSales/oxideshop_ce/pull/682)
### Accepted
* same as in  [pull request 682](https://github.com/OXID-eSales/oxideshop_ce/pull/682)

### Current
* same as in  [pull request 682](https://github.com/OXID-eSales/oxideshop_ce/pull/682)

### Solution
* fix the path for the core directory in an  [oxvm_eshop](https://github.com/OXID-eSales/oxvm_eshop)  environment and remove the fallback path. e.g. https://github.com/OXID-eSales/oxideshop_ce/pull/682/files#diff-3b52b5d2a09de94f4fee05148b85d3dcR17

### Technical details
* same as in  [pull request 682](https://github.com/OXID-eSales/oxideshop_ce/pull/682)
