### PR TITLE
make shop forks work out of box

### DIFF
--- a/source/Setup/functions.php
+++ b/source/Setup/functions.php
@@ -48,10 +48,11 @@ if (!function_exists('getCountryList')) {
      */
     function getCountryList()
     {
+        $cePath = (new Facts)->getCommunityEditionSourcePath();
         $aCountries = [];
         $relativePath = 'Application/Controller/Admin/ShopCountries.php';
-        if (file_exists(getVendorDirectory() . "oxid-esales/oxideshop-ce/source/$relativePath")) {
-            include getVendorDirectory() . "oxid-esales/oxideshop-ce/source/$relativePath";
+        if (file_exists("$cePath/$relativePath")) {
+            include "$cePath/$relativePath";
         } else {
             include __DIR__ . "/../$relativePath";
         }
@@ -68,10 +69,11 @@ if (!function_exists('getLocation')) {
      */
     function getLocation()
     {
+        $cePath = (new Facts)->getCommunityEditionSourcePath();
         $aLocationCountries = [];
         $relativePath = 'Application/Controller/Admin/ShopCountries.php';
-        if (file_exists(getVendorDirectory() . "oxid-esales/oxideshop-ce/source/$relativePath")) {
-            include getVendorDirectory() . "oxid-esales/oxideshop-ce/source/$relativePath";
+        if (file_exists("$cePath/$relativePath")) {
+            include "$cePath/$relativePath";
         } else {
             include __DIR__ . "/../$relativePath";
         }
@@ -87,10 +89,11 @@ if (!function_exists('getLanguages')) {
      */
     function getLanguages()
     {
+        $cePath = (new Facts)->getCommunityEditionSourcePath();
         $aLanguages = [];
         $relativePath = 'Application/Controller/Admin/ShopCountries.php';
-        if (file_exists(getVendorDirectory() . "oxid-esales/oxideshop-ce/source/$relativePath")) {
-            include getVendorDirectory() . "oxid-esales/oxideshop-ce/source/$relativePath";
+        if (file_exists("$cePath/$relativePath")) {
+            include "$cePath/$relativePath";
         } else {
             include __DIR__ . "/../$relativePath";
         }

--- a/source/bootstrap.php
+++ b/source/bootstrap.php
@@ -14,22 +14,6 @@ define('OX_OFFLINE_FILE', OX_BASE_PATH . 'offline.html');
 define('VENDOR_PATH', INSTALLATION_ROOT_PATH . DIRECTORY_SEPARATOR . 'vendor' . DIRECTORY_SEPARATOR);
 
 /**
- * Where CORE_AUTOLOADER_PATH points depends on how OXID eShop has been installed. If it is installed as part of a
- * compilation, the directory 'Core', where the auto load classes are located, does not reside inside OX_BASE_PATH,
- * but inside VENDOR_PATH.
- */
-if (!is_dir(OX_BASE_PATH . 'Core')) {
-    define('CORE_AUTOLOADER_PATH', VENDOR_PATH .
-                                   'oxid-esales' . DIRECTORY_SEPARATOR .
-                                   'oxideshop-ce' . DIRECTORY_SEPARATOR .
-                                   'source' . DIRECTORY_SEPARATOR .
-                                   'Core' . DIRECTORY_SEPARATOR .
-                                   'Autoload' . DIRECTORY_SEPARATOR);
-} else {
-    define('CORE_AUTOLOADER_PATH', OX_BASE_PATH . 'Core' . DIRECTORY_SEPARATOR . 'Autoload' . DIRECTORY_SEPARATOR);
-}
-
-/**
  * Provide a handler for catchable fatal errors, like failed requirement of files.
  * No information about paths or file names must be disclosed to the frontend,
  * as this would be a security problem on productive systems.
@@ -142,6 +126,20 @@ unset($bootstrapConfigFileReader);
  * It will always come first, even if you move it after the other autoloaders as it registers itself with prepend = true
  */
 require_once VENDOR_PATH . 'autoload.php';
+
+/**
+ * Where CORE_AUTOLOADER_PATH points depends on how OXID eShop has been installed. If it is installed as part of a
+ * compilation, the directory 'Core', where the auto load classes are located, does not reside inside OX_BASE_PATH,
+ * but inside VENDOR_PATH.
+ */
+if (!is_dir(OX_BASE_PATH . 'Core')) {
+    define('CORE_AUTOLOADER_PATH',
+            (new \OxidEsales\Facts\Facts)->getCommunityEditionSourcePath() . DIRECTORY_SEPARATOR .
+            'Core' . DIRECTORY_SEPARATOR .
+            'Autoload' . DIRECTORY_SEPARATOR);
+} else {
+    define('CORE_AUTOLOADER_PATH', OX_BASE_PATH . 'Core' . DIRECTORY_SEPARATOR . 'Autoload' . DIRECTORY_SEPARATOR);
+}
 
 /*
  * Register the backwards compatibility autoloader.

--- a/source/bootstrap.php
+++ b/source/bootstrap.php
@@ -133,8 +133,8 @@ require_once VENDOR_PATH . 'autoload.php';
  * but inside VENDOR_PATH.
  */
 if (!is_dir(OX_BASE_PATH . 'Core')) {
-    define('CORE_AUTOLOADER_PATH',
-            (new \OxidEsales\Facts\Facts)->getCommunityEditionSourcePath() . DIRECTORY_SEPARATOR .
+    define('CORE_AUTOLOADER_PATH', (new \OxidEsales\Facts\Facts)->getCommunityEditionSourcePath() .
+            DIRECTORY_SEPARATOR .
             'Core' . DIRECTORY_SEPARATOR .
             'Autoload' . DIRECTORY_SEPARATOR);
 } else {


### PR DESCRIPTION
Hello,

for my private projects I use a fork of the oxid shop (oxidio/shop).
This package is registered on packagist.org and will be copied to "vendor/oxidio/shop" when installed with composer.

To make this constellation executable, I had to patch two places so far:

* https://github.com/oxidio/shop/commit/52e8189c3ac05a119da57f8d57380ee4a60f752d
* https://github.com/oxidio/facts/commit/1f56d43deec740c0ab7c66b374a14cee746428ba

My previous installations were based on db dumps. 
Yesterday, for the first time, I tried to build an environment from scratch.
That did not work, which is the reason for this PR.

For the current adaptation, I presuppose the class `\OxidEsales\Facts\Facts`.
In this context, the question arises:

Why the package `oxide-esales/oxideshop-unified-namespace-generator` and thus also `oxide-esales/oxideshop-facts` are not defined in the `require` composer section?
The `Fact` dependencies occur directly though only in the `Setup` namespace, but over the dependency to the generated classes in
`vendor/oxide-esales/oxideshop-unified-namespace-generator/generated/` the dependencies are also given at runtime.

Basically, I want a solution that allows the forks to run out of box.