### PR TITLE
Fixed exception after delete of delivery-address

### DIFF
--- a/source/Application/Model/Order.php
+++ b/source/Application/Model/Order.php
@@ -1148,7 +1148,10 @@ class Order extends \OxidEsales\Eshop\Core\Model\BaseModel
         }
         if ($soxAddressId) {
             $oDelAdress = oxNew(\OxidEsales\Eshop\Application\Model\Address::class);
-            $oDelAdress->load($soxAddressId);
+            if( !$oDelAdress->load($soxAddressId) ) {
+                // Could lead to an exception in _setUser(), if not fully loaded object is returned
+                return null;
+            }
 
             //get delivery country name from delivery country id
             if ($oDelAdress->oxaddress__oxcountryid->value && $oDelAdress->oxaddress__oxcountryid->value != -1) {


### PR DESCRIPTION
If user deletes a selected delivery-address and then goes to basket -> exception.
The reason is the not deleted session-var "deladrid", which is used to load delivery-address in Order->getDelAddressInfo()