### PR TITLE
Fixed exception after delete of delivery-address

### DIFF
--- a/source/Application/Component/UserComponent.php
+++ b/source/Application/Component/UserComponent.php
@@ -578,6 +578,11 @@ class UserComponent extends \OxidEsales\Eshop\Core\Controller\BaseController
         $address->load($addressId);
         if ($this->canUserDeleteShippingAddress($address) && $this->getSession()->checkSessionChallenge()) {
             $address->delete($addressId);
+            
+            // Unset selection in session of deleted shipping-address
+            if ($addressId === $this->getSession()->getVariable('deladrid')) {
+                $this->getSession()->deleteVariable('deladrid');
+            }
         }
     }
 


### PR DESCRIPTION
If user deletes a selected delivery-address and then goes to basket -> exception.
The reason is the not deleted session-var "deladrid", which is used to load delivery-address in Order->getDelAddressInfo()