### PR TITLE
Remove the file xd_receiver.htm

### DIFF
--- a/source/migration/data/Version20190222120038.php
+++ b/source/migration/data/Version20190222120038.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace OxidEsales\EshopCommunity\Migrations;
+
+use Doctrine\DBAL\Migrations\AbstractMigration;
+use Doctrine\DBAL\Schema\Schema;
+use OxidEsales\Eshop\Core\Utils;
+use OxidEsales\Eshop\Core\UtilsFile;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+class Version20190222120038 extends AbstractMigration
+{
+    /**
+     * @param Schema $schema
+     */
+    public function up(Schema $schema)
+    {
+        $pathToXdFile = getShopBasePath() . 'xd_receiver.htm';
+
+        if (file_exists($pathToXdFile)) {
+            unlink($pathToXdFile);
+        }
+    }
+
+    /**
+     * @param Schema $schema
+     */
+    public function down(Schema $schema) {}
+}

--- a/source/xd_receiver.htm
+++ b/source/xd_receiver.htm
@@ -1,1 +1,0 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd"> <html xmlns="http://www.w3.org/1999/xhtml" > <body>  <script src="http://static.ak.connect.facebook.com/js/api_lib/v0.4/XdCommReceiver.js" type="text/javascript"></script> </body> </html>


### PR DESCRIPTION
The feature Facebook Integration came with the version 4.4.0 in 2010: https://oxidforge.org/en/new-features-in-oxid-eshop-version-4-4.html
Since then the file xd_reciever.htm is an ingredient of the shop packages and as of today it is a relic of the Facebook Integration.

The file basically calls a script from the URL http://static.ak.connect.facebook.com/js/api_lib/v0.4/XdCommReceiver.js. The URL isn't callable anymore and so I guess no one uses the included JavaScript file since years. I also didn't find any replacement for it. As a result of this it should be removable easily.

This PR adds a migration script to remove the file from older installations during a migration and it removes the file from the repository.