### PR TITLE
Fix: Run-time warning in inc_error.tpl

### DIFF
--- a/source/Application/views/admin/tpl/inc_error.tpl
+++ b/source/Application/views/admin/tpl/inc_error.tpl
@@ -1,5 +1,5 @@
 [{block name="admin_inc_error"}]
-    [{if count($Errors.default)>0}]
+    [{if is_array($Errors.default) && count($Errors.default)>0}]
     <div class="errorbox">
         [{foreach from=$Errors.default item=oEr key=key}]
             <p>[{$oEr->getOxMessage()}]</p>


### PR DESCRIPTION
Warning: count(): Parameter must be an array or an object that implements Countable in /source/tmp/smarty/9f82ed8fbbbe090e6a26df004c8d6113^%%47^47B^47B0D5FE%%inc_error.tpl.php on line 4

See screenshot.

![bildschirmfoto vom 2019-02-23 00-03-03](https://user-images.githubusercontent.com/3224960/53274060-91f73080-36fe-11e9-8631-956e2a25ce53.png)

