### PR TITLE
load SystemRequirements via oxNew

### DIFF
--- a/source/Application/Controller/Admin/NavigationController.php
+++ b/source/Application/Controller/Admin/NavigationController.php
@@ -157,7 +157,7 @@ class NavigationController extends \OxidEsales\Eshop\Application\Controller\Admi
 
         if (\OxidEsales\Eshop\Core\Registry::getConfig()->getConfigParam('blCheckSysReq') !== false) {
             // check if system reguirements are ok
-            $oSysReq = new \OxidEsales\Eshop\Core\SystemRequirements();
+            $oSysReq = oxNew(\OxidEsales\Eshop\Core\SystemRequirements::class);
             if (!$oSysReq->getSysReqStatus()) {
                 $aMessage['warning'] = \OxidEsales\Eshop\Core\Registry::getLang()->translateString('NAVIGATION_SYSREQ_MESSAGE');
                 $aMessage['warning'] .= '<a href="?cl=sysreq&amp;stoken=' . $this->getSession()->getSessionChallengeToken() . '" target="basefrm">';

--- a/source/Application/Controller/Admin/SystemRequirementsMain.php
+++ b/source/Application/Controller/Admin/SystemRequirementsMain.php
@@ -24,7 +24,7 @@ class SystemRequirementsMain extends \OxidEsales\Eshop\Application\Controller\Ad
     {
         parent::render();
 
-        $oSysReq = new \OxidEsales\Eshop\Core\SystemRequirements();
+        $oSysReq = oxNew(\OxidEsales\Eshop\Core\SystemRequirements::class);
 
         $this->_aViewData['aInfo'] = $oSysReq->getSystemInfo();
         $this->_aViewData['aCollations'] = $oSysReq->checkCollation();
@@ -67,7 +67,7 @@ class SystemRequirementsMain extends \OxidEsales\Eshop\Application\Controller\Ad
      */
     public function getReqInfoUrl($sIdent)
     {
-        $oSysReq = new \OxidEsales\Eshop\Core\SystemRequirements();
+        $oSysReq = oxNew(\OxidEsales\Eshop\Core\SystemRequirements::class);
 
         return $oSysReq->getReqInfoUrl($sIdent);
     }


### PR DESCRIPTION
Makes `SystemRequirements` extendable (except Setup, which should be ok for most cases). We have to do this in one project to disable a check.