### PR TITLE
Changed the default email encoding to 'base64'

### DIFF
--- a/source/Core/Email.php
+++ b/source/Core/Email.php
@@ -302,6 +302,15 @@ class Email extends PHPMailer
         $this->setLanguage("en", $myConfig->getConfigParam('sShopDir') . "/Core/phpmailer/language/");
 
         $this->_getSmarty();
+		
+        // base64-encoding automatically limits the line length smtp-servers and email-clients see without changing the
+        // actual email content.
+        // email-templates containing/generating long lines may get corrupted (smtp-server issue) or may not get
+        // rendered correctly (e.g. Office365/Outlook users may be affected)
+        // phpmailer uses quoted-printable for emails with long lines, which seems not to be sufficient to prevent such
+        // problems in some cases
+        // base64 side effect: the email-size will increase slightly due to the base64-encoding
+        $this->Encoding='base64';
     }
 
     /**


### PR DESCRIPTION
Prevents issues caused by emails containing long lines in some email-clients like Outlook
(Outlook sometimes decodes emails with 'quoted-printable'-encoding incorrectly if long lines are involved)
Side effect of base64-encoding: the email size will increase slightly

Related: https://bugs.oxid-esales.com/view.php?id=6468