### PR TITLE
Read config parameter by getConfigParam, not by getRequestParam.

### DIFF
--- a/source/Application/Controller/Admin/ManufacturerMainAjax.php
+++ b/source/Application/Controller/Admin/ManufacturerMainAjax.php
@@ -68,16 +68,16 @@ class ManufacturerMainAjax extends \OxidEsales\Eshop\Application\Controller\Admi
         if (!$manufacturerId) {
             // performance
             $query = ' from ' . $articlesViewName . ' where ' . $articlesViewName . '.oxshopid="' . $config->getShopId() . '" and 1 ';
-            $query .= $config->getRequestParameter('blVariantsSelection') ? '' : " and $articlesViewName.oxparentid = '' and $articlesViewName.oxmanufacturerid != " . $database->quote($syncedManufacturerId);
+            $query .= $config->getConfigParam('blVariantsSelection') ? '' : " and $articlesViewName.oxparentid = '' and $articlesViewName.oxmanufacturerid != " . $database->quote($syncedManufacturerId);
         } elseif ($syncedManufacturerId && $syncedManufacturerId != $manufacturerId) {
             // selected category ?
             $query = " from $objectToCategoryViewName left join $articlesViewName on ";
-            $query .= $config->getRequestParameter('blVariantsSelection') ? " ( $articlesViewName.oxid = $objectToCategoryViewName.oxobjectid or $articlesViewName.oxparentid = $objectToCategoryViewName.oxobjectid )" : " $articlesViewName.oxid = $objectToCategoryViewName.oxobjectid ";
+            $query .= $config->getConfigParam('blVariantsSelection') ? " ( $articlesViewName.oxid = $objectToCategoryViewName.oxobjectid or $articlesViewName.oxparentid = $objectToCategoryViewName.oxobjectid )" : " $articlesViewName.oxid = $objectToCategoryViewName.oxobjectid ";
             $query .= 'where ' . $articlesViewName . '.oxshopid="' . $config->getShopId() . '" and ' . $objectToCategoryViewName . '.oxcatnid = ' . $database->quote($manufacturerId) . ' and ' . $articlesViewName . '.oxmanufacturerid != ' . $database->quote($syncedManufacturerId);
-            $query .= $config->getRequestParameter('blVariantsSelection') ? '' : " and $articlesViewName.oxparentid = '' ";
+            $query .= $config->getConfigParam('blVariantsSelection') ? '' : " and $articlesViewName.oxparentid = '' ";
         } else {
             $query = " from $articlesViewName where $articlesViewName.oxmanufacturerid = " . $database->quote($manufacturerId);
-            $query .= $config->getRequestParameter('blVariantsSelection') ? '' : " and $articlesViewName.oxparentid = '' ";
+            $query .= $config->getConfigParam('blVariantsSelection') ? '' : " and $articlesViewName.oxparentid = '' ";
         }
 
         return $query;

--- a/source/Application/Controller/Admin/ManufacturerMainAjax.php
+++ b/source/Application/Controller/Admin/ManufacturerMainAjax.php
@@ -96,7 +96,7 @@ class ManufacturerMainAjax extends \OxidEsales\Eshop\Application\Controller\Admi
         $query = parent::_addFilter($query);
 
         // display variants or not ?
-        $query .= $this->getConfig()->getRequestParameter('blVariantsSelection') ? ' group by ' . $articleViewName . '.oxid ' : '';
+        $query .= $this->getConfig()->getConfigParam('blVariantsSelection') ? ' group by ' . $articleViewName . '.oxid ' : '';
 
         return $query;
     }

--- a/tests/Unit/Application/Controller/Admin/ManufacturerMainAjaxTest.php
+++ b/tests/Unit/Application/Controller/Admin/ManufacturerMainAjaxTest.php
@@ -71,7 +71,7 @@ class ManufacturerMainAjaxTest extends \OxidTestCase
      */
     public function testGetQueryVariantsSelectionTrue()
     {
-        $this->setConfigParameter("blVariantsSelection", true);
+        $this->getConfig()->setConfigParam("blVariantsSelection", true);
         $oView = oxNew('Manufacturer_Main_Ajax');
         $this->assertEquals("from " . $this->getArticleViewTable() . " where " . $this->getArticleViewTable() . ".oxshopid=\"" . $this->getShopIdTest() . "\" and 1", trim($oView->UNITgetQuery()));
     }
@@ -98,7 +98,7 @@ class ManufacturerMainAjaxTest extends \OxidTestCase
     {
         $sSynchoxid = '_testAction';
         $this->setRequestParameter("synchoxid", $sSynchoxid);
-        $this->setConfigParameter("blVariantsSelection", true);
+        $this->getConfig()->setConfigParam("blVariantsSelection", true);
         $oView = oxNew('Manufacturer_Main_Ajax');
         $this->assertEquals("from " . $this->getArticleViewTable() . " where " . $this->getArticleViewTable() . ".oxshopid=\"" . $this->getShopIdTest() . "\" and 1", trim($oView->UNITgetQuery()));
     }
@@ -143,7 +143,7 @@ class ManufacturerMainAjaxTest extends \OxidTestCase
         $sSynchoxid = '_testActionSynch';
         $this->setRequestParameter("oxid", $sOxid);
         $this->setRequestParameter("synchoxid", $sSynchoxid);
-        $this->setConfigParameter("blVariantsSelection", true);
+        $this->getConfig()->setConfigParam("blVariantsSelection", true);
 
         $oView = oxNew('Manufacturer_Main_Ajax');
         $this->assertEquals("from " . $this->getObject2CategoryViewTable() . " left join " . $this->getArticleViewTable() . " on  ( " . $this->getArticleViewTable() . ".oxid = " . $this->getObject2CategoryViewTable() . ".oxobjectid or " . $this->getArticleViewTable() . ".oxparentid = " . $this->getObject2CategoryViewTable() . ".oxobjectid )where " . $this->getArticleViewTable() . ".oxshopid=\"" . $this->getShopIdTest() . "\" and " . $this->getObject2CategoryViewTable() . ".oxcatnid = '" . $sOxid . "' and " . $this->getArticleViewTable() . ".oxmanufacturerid != '" . $sSynchoxid . "'", trim($oView->UNITgetQuery()));
@@ -167,7 +167,7 @@ class ManufacturerMainAjaxTest extends \OxidTestCase
      */
     public function testAddFilterVariantsSelection()
     {
-        $this->setConfigParameter("blVariantsSelection", true);
+        $this->getConfig()->setConfigParam("blVariantsSelection", true);
         $oView = oxNew('Manufacturer_Main_Ajax');
         $this->assertEquals("group by " . $this->getArticleViewTable() . ".oxid", trim($oView->UNITaddFilter('')));
     }
@@ -179,7 +179,7 @@ class ManufacturerMainAjaxTest extends \OxidTestCase
      */
     public function testAddFilterVariantsSelection2()
     {
-        $this->setConfigParameter("blVariantsSelection", true);
+        $this->getConfig()->setConfigParam("blVariantsSelection", true);
         $oView = oxNew('Manufacturer_Main_Ajax');
         $this->assertEquals("select count( * ) group by " . $this->getArticleViewTable() . ".oxid", trim($oView->UNITaddFilter('select count( * )')));
     }

--- a/tests/Unit/Application/Controller/Admin/ManufacturerMainAjaxTest.php
+++ b/tests/Unit/Application/Controller/Admin/ManufacturerMainAjaxTest.php
@@ -71,7 +71,7 @@ class ManufacturerMainAjaxTest extends \OxidTestCase
      */
     public function testGetQueryVariantsSelectionTrue()
     {
-        $this->setRequestParameter("blVariantsSelection", true);
+        $this->setConfigParameter("blVariantsSelection", true);
         $oView = oxNew('Manufacturer_Main_Ajax');
         $this->assertEquals("from " . $this->getArticleViewTable() . " where " . $this->getArticleViewTable() . ".oxshopid=\"" . $this->getShopIdTest() . "\" and 1", trim($oView->UNITgetQuery()));
     }
@@ -98,7 +98,7 @@ class ManufacturerMainAjaxTest extends \OxidTestCase
     {
         $sSynchoxid = '_testAction';
         $this->setRequestParameter("synchoxid", $sSynchoxid);
-        $this->setRequestParameter("blVariantsSelection", true);
+        $this->setConfigParameter("blVariantsSelection", true);
         $oView = oxNew('Manufacturer_Main_Ajax');
         $this->assertEquals("from " . $this->getArticleViewTable() . " where " . $this->getArticleViewTable() . ".oxshopid=\"" . $this->getShopIdTest() . "\" and 1", trim($oView->UNITgetQuery()));
     }
@@ -143,7 +143,7 @@ class ManufacturerMainAjaxTest extends \OxidTestCase
         $sSynchoxid = '_testActionSynch';
         $this->setRequestParameter("oxid", $sOxid);
         $this->setRequestParameter("synchoxid", $sSynchoxid);
-        $this->setRequestParameter("blVariantsSelection", true);
+        $this->setConfigParameter("blVariantsSelection", true);
 
         $oView = oxNew('Manufacturer_Main_Ajax');
         $this->assertEquals("from " . $this->getObject2CategoryViewTable() . " left join " . $this->getArticleViewTable() . " on  ( " . $this->getArticleViewTable() . ".oxid = " . $this->getObject2CategoryViewTable() . ".oxobjectid or " . $this->getArticleViewTable() . ".oxparentid = " . $this->getObject2CategoryViewTable() . ".oxobjectid )where " . $this->getArticleViewTable() . ".oxshopid=\"" . $this->getShopIdTest() . "\" and " . $this->getObject2CategoryViewTable() . ".oxcatnid = '" . $sOxid . "' and " . $this->getArticleViewTable() . ".oxmanufacturerid != '" . $sSynchoxid . "'", trim($oView->UNITgetQuery()));
@@ -167,7 +167,7 @@ class ManufacturerMainAjaxTest extends \OxidTestCase
      */
     public function testAddFilterVariantsSelection()
     {
-        $this->setRequestParameter("blVariantsSelection", true);
+        $this->setConfigParameter("blVariantsSelection", true);
         $oView = oxNew('Manufacturer_Main_Ajax');
         $this->assertEquals("group by " . $this->getArticleViewTable() . ".oxid", trim($oView->UNITaddFilter('')));
     }
@@ -179,7 +179,7 @@ class ManufacturerMainAjaxTest extends \OxidTestCase
      */
     public function testAddFilterVariantsSelection2()
     {
-        $this->setRequestParameter("blVariantsSelection", true);
+        $this->setConfigParameter("blVariantsSelection", true);
         $oView = oxNew('Manufacturer_Main_Ajax');
         $this->assertEquals("select count( * ) group by " . $this->getArticleViewTable() . ".oxid", trim($oView->UNITaddFilter('select count( * )')));
     }


### PR DESCRIPTION
By calling getRequestParam('blVariantSelection') we will always get null, as this request is never made and leads to this bug: https://bugs.oxid-esales.com/view.php?id=6968