### PR TITLE
init session only once

### DIFF
--- a/source/Core/Session.php
+++ b/source/Core/Session.php
@@ -212,6 +212,9 @@ class Session extends \OxidEsales\Eshop\Core\Base
      */
     public function start()
     {
+        if ($this->isSessionStarted()) {
+            return;
+        }
         $myConfig = \OxidEsales\Eshop\Core\Registry::getConfig();
 
         if ($this->isAdmin()) {


### PR DESCRIPTION
If you loop over multiple shops and `reinitialize()` the config, you'll get multiple `Set-Cookie` Headers in that request:
![image](https://user-images.githubusercontent.com/1001186/55798307-ed268c00-5ace-11e9-9465-e274bfceb263.png)

----
You can test this easily with a shop with multiple tenants and this script:
```php
<?php
require 'bootstrap.php';

use OxidEsales\EshopCommunity\Core\Registry;

foreach (Registry::getUtils()->getShops() as $id => $shop) {
    Registry::getConfig()->setShopId($id);
    Registry::getConfig()->reinitialize();
}
```

many thanks to @BernhardScheffold who created the fix initially

I'm not sure if this is somehow related to #657 