### PR TITLE
Fix finalize order doesn't validate payment with user from parameter

### DIFF
--- a/source/Application/Model/Order.php
+++ b/source/Application/Model/Order.php
@@ -1998,7 +1998,7 @@ class Order extends \OxidEsales\Eshop\Core\Model\BaseModel
 
         if (!$iValidState) {
             // validating payment
-            $iValidState = $this->validatePayment($oBasket);
+            $iValidState = $this->validatePayment($oBasket, $oUser);
         }
 
         if (!$iValidState) {
@@ -2101,15 +2101,16 @@ class Order extends \OxidEsales\Eshop\Core\Model\BaseModel
      * Checks if payment used for current order is available and active.
      * Throws exception if not available
      *
-     * @param \OxidEsales\Eshop\Application\Model\Basket $oBasket basket object
+     * @param \OxidEsales\Eshop\Application\Model\Basket    $oBasket basket object
+     * @param \OxidEsales\Eshop\Application\Model\User|null $oUser   user object
      *
      * @return null
      */
-    public function validatePayment($oBasket)
+    public function validatePayment($oBasket, $oUser = null)
     {
         $paymentId = $oBasket->getPaymentId();
 
-        if (!$this->isValidPaymentId($paymentId) || !$this->isValidPayment($oBasket)) {
+        if (!$this->isValidPaymentId($paymentId) || !$this->isValidPayment($oBasket, $oUser)) {
             return self::ORDER_STATE_INVALIDPAYMENT;
         }
     }
@@ -2276,11 +2277,12 @@ class Order extends \OxidEsales\Eshop\Core\Model\BaseModel
     /**
      * Returns true if payment is valid.
      *
-     * @param \OxidEsales\Eshop\Application\Model\Basket $basket
+     * @param \OxidEsales\Eshop\Application\Model\Basket    $basket
+     * @param \OxidEsales\Eshop\Application\Model\User|null $oUser user object
      *
      * @return bool
      */
-    private function isValidPayment($basket)
+    private function isValidPayment($basket, $oUser = null)
     {
         $paymentId = $basket->getPaymentId();
         $paymentModel = oxNew(EshopPayment::class);
@@ -2289,10 +2291,14 @@ class Order extends \OxidEsales\Eshop\Core\Model\BaseModel
         $dynamicValues = $this->getDynamicValues();
         $shopId = $this->getConfig()->getShopId();
 
+        if (!$oUser) {
+            $oUser = $this->getUser();
+        }
+
         return $paymentModel->isValidPayment(
             $dynamicValues,
             $shopId,
-            $this->getUser(),
+            $oUser,
             $basket->getPriceForPayment(),
             $basket->getShippingId()
         );


### PR DESCRIPTION
Some modules finalizes order without set user globally.
Instead they pass user by parameter to Order->finalizeOrder function.
This function calls Order->isValidPayment function.
But here the globally set user is used and it can happen that payment is not valid.