### PR TITLE
trim default value to detect empty string in Database class

### DIFF
--- a/source/Core/Database/Adapter/Doctrine/Database.php
+++ b/source/Core/Database/Adapter/Doctrine/Database.php
@@ -1113,7 +1113,7 @@ class Database implements DatabaseInterface
             $item->auto_increment = strtolower($extra) == 'auto_increment';
             $item->binary = (false !== strpos(strtolower($type), 'blob'));
             $item->unsigned = (false !== strpos(strtolower($type), 'unsigned'));
-            $item->has_default = ('' === $default || is_null($default)) ? false : true;
+            $item->has_default = ('' === trim($default, "'") || is_null($default)) ? false : true;
             if ($item->has_default) {
                 $item->default_value = $default;
             }


### PR DESCRIPTION
If you try to save a field without a value the `default_value` will be inserted instead. If the default value is an empty string you will end up filling `''` into the row.

----

Take a look at this:
```
MariaDB [shop]> DESC oxmanufacturers;
+---------------+--------------+------+-----+---------------------+-------------------------------+
| Field         | Type         | Null | Key | Default             | Extra                         |
+---------------+--------------+------+-----+---------------------+-------------------------------+
| OXID          | char(32)     | NO   | PRI | NULL                |                               |
| OXMAPID       | int(11)      | NO   | MUL | NULL                | auto_increment                |
| OXSHOPID      | int(11)      | NO   | MUL | 1                   |                               |
| OXACTIVE      | tinyint(1)   | NO   | MUL | 1                   |                               |
| OXICON        | varchar(128) | NO   |     |                     |                               |
| OXTITLE       | varchar(255) | NO   |     |                     |                               |
| OXSHORTDESC   | varchar(255) | NO   |     |                     |                               |
| OXTITLE_1     | varchar(255) | NO   |     |                     |                               |
| OXSHORTDESC_1 | varchar(255) | NO   |     |                     |                               |
| OXTITLE_2     | varchar(255) | NO   |     |                     |                               |
| OXSHORTDESC_2 | varchar(255) | NO   |     |                     |                               |
| OXTITLE_3     | varchar(255) | NO   |     |                     |                               |
| OXTITLE_4     | varchar(255) | NO   |     |                     |                               |
| OXTITLE_5     | varchar(255) | NO   |     |                     |                               |
| OXTITLE_6     | varchar(255) | NO   |     |                     |                               |
| OXTITLE_7     | varchar(255) | NO   |     |                     |                               |
| OXSHORTDESC_3 | varchar(255) | NO   |     |                     |                               |
| OXSHORTDESC_4 | varchar(255) | NO   |     |                     |                               |
| OXSHORTDESC_5 | varchar(255) | NO   |     |                     |                               |
| OXSHORTDESC_6 | varchar(255) | NO   |     |                     |                               |
| OXSHORTDESC_7 | varchar(255) | NO   |     |                     |                               |
| OXSHOWSUFFIX  | tinyint(1)   | NO   |     | 1                   |                               |
| OXTIMESTAMP   | timestamp    | NO   |     | current_timestamp() | on update current_timestamp() |
+---------------+--------------+------+-----+---------------------+-------------------------------+
23 rows in set (0.00 sec)
```
Here's the query and the result, which leads to the `''`:
```
MariaDB [shop]> SELECT
    ->   COLUMN_NAME AS `Field`,
    ->   COLUMN_TYPE AS `Type`,
    ->   IS_NULLABLE AS `Null`,
    ->   COLUMN_KEY AS `Key`,
    ->   COLUMN_DEFAULT AS `Default`,
    ->   EXTRA AS `Extra`,
    ->   COLUMN_COMMENT AS `Comment`,
    ->   CHARACTER_SET_NAME AS `CharacterSet`,
    ->   COLLATION_NAME AS `Collation`
    ->     FROM information_schema.COLUMNS
    ->     WHERE
    ->   TABLE_SCHEMA = 'shop'
    ->   AND
    ->   TABLE_NAME = 'oxmanufacturers';
+---------------+--------------+------+-----+---------------------+-------------------------------+-----------------------------------+--------------+-------------------+
| Field         | Type         | Null | Key | Default             | Extra                         | Comment                           | CharacterSet | Collation         |
+---------------+--------------+------+-----+---------------------+-------------------------------+-----------------------------------+--------------+-------------------+
| OXID          | char(32)     | NO   | PRI | NULL                |                               | Manufacturer id                   | latin1       | latin1_general_ci |
| OXMAPID       | int(11)      | NO   | MUL | NULL                | auto_increment                | Integer mapping identifier        | NULL         | NULL              |
| OXSHOPID      | int(11)      | NO   | MUL | 1                   |                               | Shop id (oxshops)                 | NULL         | NULL              |
| OXACTIVE      | tinyint(1)   | NO   | MUL | 1                   |                               | Is active                         | NULL         | NULL              |
| OXICON        | varchar(128) | NO   |     | ''                  |                               | Icon filename                     | utf8         | utf8_general_ci   |
| OXTITLE       | varchar(255) | NO   |     | ''                  |                               | Title (multilanguage)             | utf8         | utf8_general_ci   |
| OXSHORTDESC   | varchar(255) | NO   |     | ''                  |                               | Short description (multilanguage) | utf8         | utf8_general_ci   |
| OXTITLE_1     | varchar(255) | NO   |     | ''                  |                               |                                   | utf8         | utf8_general_ci   |
| OXSHORTDESC_1 | varchar(255) | NO   |     | ''                  |                               |                                   | utf8         | utf8_general_ci   |
| OXTITLE_2     | varchar(255) | NO   |     | ''                  |                               |                                   | utf8         | utf8_general_ci   |
| OXSHORTDESC_2 | varchar(255) | NO   |     | ''                  |                               |                                   | utf8         | utf8_general_ci   |
| OXTITLE_3     | varchar(255) | NO   |     | ''                  |                               |                                   | utf8         | utf8_general_ci   |
| OXTITLE_4     | varchar(255) | NO   |     | ''                  |                               |                                   | utf8         | utf8_general_ci   |
| OXTITLE_5     | varchar(255) | NO   |     | ''                  |                               |                                   | utf8         | utf8_general_ci   |
| OXTITLE_6     | varchar(255) | NO   |     | ''                  |                               |                                   | utf8         | utf8_general_ci   |
| OXTITLE_7     | varchar(255) | NO   |     | ''                  |                               |                                   | utf8         | utf8_general_ci   |
| OXSHORTDESC_3 | varchar(255) | NO   |     | ''                  |                               |                                   | utf8         | utf8_general_ci   |
| OXSHORTDESC_4 | varchar(255) | NO   |     | ''                  |                               |                                   | utf8         | utf8_general_ci   |
| OXSHORTDESC_5 | varchar(255) | NO   |     | ''                  |                               |                                   | utf8         | utf8_general_ci   |
| OXSHORTDESC_6 | varchar(255) | NO   |     | ''                  |                               |                                   | utf8         | utf8_general_ci   |
| OXSHORTDESC_7 | varchar(255) | NO   |     | ''                  |                               |                                   | utf8         | utf8_general_ci   |
| OXSHOWSUFFIX  | tinyint(1)   | NO   |     | 1                   |                               | Show SEO Suffix in Category       | NULL         | NULL              |
| OXTIMESTAMP   | timestamp    | NO   |     | current_timestamp() | on update current_timestamp() | Timestamp                         | NULL         | NULL              |
+---------------+--------------+------+-----+---------------------+-------------------------------+-----------------------------------+--------------+-------------------+
23 rows in set (0.00 sec)
```
