### PR TITLE
bugfix 6671

### DIFF
--- a/source/Application/Model/AmountPriceList.php
+++ b/source/Application/Model/AmountPriceList.php
@@ -80,7 +80,7 @@ class AmountPriceList extends \OxidEsales\Eshop\Core\Model\ListModel
     {
         $sArticleId = $this->getArticle()->getId();
 
-        if (!$this->isAdmin() && $this->getConfig()->getConfigParam('blVariantInheritAmountPrice') && $this->getArticle()->getParentId()) {
+        if ($this->getConfig()->getConfigParam('blVariantInheritAmountPrice') && $this->getArticle()->getParentId()) {
             $sArticleId = $this->getArticle()->getParentId();
         }
 


### PR DESCRIPTION
Using the amount prices in the backend when recalculating the basket.
Currently the amount prices are just working in the frontend (basket).

Bugfix for the following issue:
https://bugs.oxid-esales.com/view.php?id=6671