### PR TITLE
Catch PHP Fatal error.

### DIFF
--- a/source/Application/Component/Locator.php
+++ b/source/Application/Component/Locator.php
@@ -69,7 +69,13 @@ class Locator extends \OxidEsales\Eshop\Core\Base
     public function setLocatorData($oCurrArticle, $oLocatorTarget)
     {
         $sLocfnc = "_set{$this->_sType}LocatorData";
-        $this->$sLocfnc($oLocatorTarget, $oCurrArticle);
+
+        try {
+            call_user_func([$this, $sLocfnc], $oLocatorTarget, $oCurrArticle);
+        }catch (\Exception $e) {
+            $this->_sType = '';
+            getLogger()->warning('Locator Type is wrong ' . $this->_sType);
+        }
 
         // passing list type to view
         $oLocatorTarget->setListType($this->_sType);


### PR DESCRIPTION
If a wrong string is entered in the paramerter `listtype=`, a PHP Fatal Error will occur. You will be thrown back to the home page instead of displaying the detail page.

Triggered with uri: /Kiteboarding/Kites/Kite-CORE-GTS.html?listtype=XYZ_BOOM


