### PR TITLE
As a suggestion, rather spend a 404 page than 200.

### DIFF
--- a/source/Core/Controller/BaseController.php
+++ b/source/Core/Controller/BaseController.php
@@ -519,11 +519,10 @@ class BaseController extends \OxidEsales\Eshop\Core\Base
             } else {
                 // was not executed on any level ?
                 if (!$this->_blIsComponent) {
-                    /** @var \OxidEsales\Eshop\Core\Exception\SystemComponentException $oEx */
-                    $oEx = oxNew(\OxidEsales\Eshop\Core\Exception\SystemComponentException::class);
-                    $oEx->setMessage('ERROR_MESSAGE_SYSTEMCOMPONENT_FUNCTIONNOTFOUND' . ' ' . $sFunction);
-                    $oEx->setComponent($sFunction);
-                    throw $oEx;
+                    getLogger()->warning('ERROR_MESSAGE_SYSTEMCOMPONENT_FUNCTIONNOTFOUND' . ' ' . $sFunction);
+                    unset($_POST['fnc']);
+                    unset($_GET['fnc']);
+                    error_404_handler();
                 }
             }
         }

--- a/source/Core/Controller/BaseController.php
+++ b/source/Core/Controller/BaseController.php
@@ -519,10 +519,9 @@ class BaseController extends \OxidEsales\Eshop\Core\Base
             } else {
                 // was not executed on any level ?
                 if (!$this->_blIsComponent) {
-                    \OxidEsales\Eshop\Core\Registry::getLogger()->warning('ERROR_MESSAGE_SYSTEMCOMPONENT_FUNCTIONNOTFOUND' . ' ' . $sFunction);
-                    unset($_POST['fnc']);
-                    unset($_GET['fnc']);
-                    error_404_handler();
+                    throw new \OxidEsales\Eshop\Core\Exception\RoutingException(
+                        sprintf("Controller method is not accessible: %s::%s", self::class, $sFunction)
+                    );
                 }
             }
         }

--- a/source/Core/Controller/BaseController.php
+++ b/source/Core/Controller/BaseController.php
@@ -519,7 +519,7 @@ class BaseController extends \OxidEsales\Eshop\Core\Base
             } else {
                 // was not executed on any level ?
                 if (!$this->_blIsComponent) {
-                    getLogger()->warning('ERROR_MESSAGE_SYSTEMCOMPONENT_FUNCTIONNOTFOUND' . ' ' . $sFunction);
+                    \OxidEsales\Eshop\Core\Registry::getLogger()->warning('ERROR_MESSAGE_SYSTEMCOMPONENT_FUNCTIONNOTFOUND' . ' ' . $sFunction);
                     unset($_POST['fnc']);
                     unset($_GET['fnc']);
                     error_404_handler();

--- a/source/Core/Exception/RoutingException.php
+++ b/source/Core/Exception/RoutingException.php
@@ -8,28 +8,11 @@
 namespace OxidEsales\EshopCommunity\Core\Exception;
 
 /**
- * e.g.:
- * - no match for requested controller id
+ * Cases:
+ *
+ * - Controller not found
+ * - Controller action cannot be found/accessed
  */
 class RoutingException extends \OxidEsales\Eshop\Core\Exception\StandardException
 {
-    /**
-     * Exception type
-     *
-     * @var string
-     */
-    protected $type = 'RoutingException';
-
-    /**
-     * RoutingException constructor.
-     *
-     * This exception is thrown in case no controller class can be found for a supplied controller Id.
-     *
-     * @param string $controllerId
-     */
-    public function __construct($controllerId)
-    {
-        $message = sprintf('No controller defined for id %s', $controllerId);
-        parent::__construct($message);
-    }
 }

--- a/source/Core/ShopControl.php
+++ b/source/Core/ShopControl.php
@@ -677,10 +677,8 @@ class ShopControl extends \OxidEsales\Eshop\Core\Base
      */
     protected function handleRoutingException($exception)
     {
-        /**
-         * @todo after removal of the BC layer this method will retrow the exception
-         * throw $exception
-         */
+        getLogger()->warning($exception->getMessage());
+        error_404_handler();
     }
 
     /**
@@ -886,7 +884,6 @@ class ShopControl extends \OxidEsales\Eshop\Core\Base
             $controllerClass = $this->resolveControllerClass($controllerKey);
         } catch (\OxidEsales\Eshop\Core\Exception\RoutingException $exception) {
             $this->handleRoutingException($exception);
-            $controllerClass = $controllerKey;
         }
 
         return $controllerClass;

--- a/source/Core/ShopControl.php
+++ b/source/Core/ShopControl.php
@@ -677,7 +677,7 @@ class ShopControl extends \OxidEsales\Eshop\Core\Base
      */
     protected function handleRoutingException($exception)
     {
-        getLogger()->warning($exception->getMessage());
+        \OxidEsales\Eshop\Core\Registry::getLogger()->warning($exception->getMessage());
         error_404_handler();
     }
 

--- a/source/Core/ShopControl.php
+++ b/source/Core/ShopControl.php
@@ -290,17 +290,22 @@ class ShopControl extends \OxidEsales\Eshop\Core\Base
 
     /**
      * Executes provided function on view object.
-     * If this function can not be executed (is protected or so), oxSystemComponentException exception is thrown.
+     * If this function can not be executed (is protected or so), a 404 Page will be show.
      *
      * @param FrontendController $view
      * @param string             $functionName
-     *
-     * @throws \oxSystemComponentException
      */
     protected function executeAction($view, $functionName)
     {
         if (!$this->canExecuteFunction($view, $functionName)) {
-            throw oxNew(\oxSystemComponentException::class, 'Non public method cannot be accessed');
+            unset($_GET['fnc'], $_POST['fnc']);
+            $this->handleRoutingException(
+                new StandardException(sprintf(
+                    'Non public method cannot be accessed. %s::%s()',
+                    $view->getClassKey(),
+                    $functionName
+                ))
+            );
         }
 
         $view->executeFunction($functionName);
@@ -673,7 +678,7 @@ class ShopControl extends \OxidEsales\Eshop\Core\Base
     /**
      * Handle routing exception, which is thrown, if the class name for the requested controller id could not be resolved.
      *
-     * @param RoutingException $exception
+     * @param RoutingException|StandardException $exception
      */
     protected function handleRoutingException($exception)
     {

--- a/tests/Unit/Application/Controller/ShopControlTest.php
+++ b/tests/Unit/Application/Controller/ShopControlTest.php
@@ -592,28 +592,7 @@ class ShopControlTest extends \OxidTestCase
 
         $control->start();
     }
-
-    /**
-     * Test case that requested controller id does not match any known class.
-     *
-     * @return null
-     */
-    public function testStartWithUnmatchedRequestControllerIdDebugModeOn()
-    {
-        $controllerId = 'unmatchedControllerId';
-        $routingException = new \OxidEsales\Eshop\Core\Exception\RoutingException($controllerId);
-
-        $this->setRequestParameter('cl', $controllerId);
-        $this->setRequestParameter('fnc', 'testFnc');
-
-        $control = $this->getMock(\OxidEsales\Eshop\Core\ShopControl::class, array('process', 'handleRoutingException', 'isDebugMode'), array(), '', false, false, true);
-        $control->expects($this->once())->method('process')->with($this->equalTo($controllerId));
-        $control->expects($this->any())->method('isDebugMode')->will($this->returnValue(true));
-        $control->expects($this->once())->method('handleRoutingException')->with($this->equalTo($routingException));
-
-        $control->start();
-    }
-
+    
     protected function tearDown(): void
     {
         parent::tearDown();

--- a/tests/Unit/Application/Controller/ShopControlTest.php
+++ b/tests/Unit/Application/Controller/ShopControlTest.php
@@ -108,7 +108,7 @@ class ShopControlTest extends \OxidTestCase
 
         $logger = $this->getMockBuilder(LoggerInterface::class)->getMock();
         $logger->expects($this->once())
-               ->method('warning');
+               ->method('error');
 
         Registry::set('logger', $logger);
 
@@ -565,10 +565,11 @@ class ShopControlTest extends \OxidTestCase
         $oView = $this->getMock($sCL, array('executeFunction', 'getFncName', 'getClassKey'));
         $oView->expects($this->never())->method('executeFunction');
         $oView->expects($this->once())->method('getFncName')->will($this->returnValue($sFNC));
-        $oView->expects($this->once())->method('getClassKey')->will($this->returnValue($sCL));
 
         Registry::set('logger', $this->getMockBuilder(LoggerInterface::class)->getMock());
-        Registry::getLogger()->expects($this->once())->method('warning')->with("Non public method cannot be accessed. {$sCL}::{$sFNC}()");
+        $className = get_class($oView);
+        Registry::getLogger()->expects($this->once())->method('error')
+            ->with("Non public method cannot be accessed: {$className}::{$sFNC}");
 
         Registry::set(\OxidEsales\Eshop\Core\Utils::class, $this->getMockBuilder(\OxidEsales\Eshop\Core\Utils::class)->getMock());
         Registry::getUtils()->expects($this->once())->method('handlePageNotFoundError')->will($this->returnCallback(function () {

--- a/tests/Unit/Application/Controller/ViewTest.php
+++ b/tests/Unit/Application/Controller/ViewTest.php
@@ -8,6 +8,7 @@
 namespace OxidEsales\EshopCommunity\Tests\Unit\Application\Controller;
 
 use OxidEsales\Eshop\Core\Controller\BaseController;
+use OxidEsales\Eshop\Core\Registry;
 use OxidEsales\Eshop\Core\ShopVersion;
 use OxidEsales\EshopCommunity\Internal\Framework\Config\DataObject\ShopConfigurationSetting;
 use oxSystemComponentException;
@@ -16,6 +17,7 @@ use \oxView;
 use \oxField;
 use \oxRegistry;
 use \oxTestModules;
+use Psr\Log\LoggerInterface;
 
 require_once TEST_LIBRARY_HELPERS_PATH . 'oxUtilsHelper.php';
 
@@ -294,21 +296,33 @@ class ViewTest extends \OxidTestCase
         $this->assertNull($oCmp->executeFunction('yyy'));
     }
 
-    public function testExecuteFunctionThrowsExeption()
+    public function testExecuteNonExistsFunctionCall404ErrorHandler()
     {
-        $oView = $this->getMock(\OxidEsales\EshopCommunity\Tests\Unit\Application\Controller\modOxView::class, array('xxx'));
-        $oView->expects($this->never())->method('xxx');
+        //Arrange
+        $oView = new \OxidEsales\Eshop\Core\Controller\BaseController();
+        $_POST['fnc'] = 'unkownFunction';
+        $_GET['fnc'] = 'unkownFunction';
 
+        //Mock Asserts
+        $logger = $this->getMockBuilder(LoggerInterface::class)->getMock();
+        $logger->expects($this->once())
+               ->method('warning');
 
-        try {
-            $oView->executeFunction('yyy');
-        } catch (oxSystemComponentException $oEx) {
-            $this->assertEquals("ERROR_MESSAGE_SYSTEMCOMPONENT_FUNCTIONNOTFOUND yyy", $oEx->getMessage());
+        Registry::set('logger', $logger);
 
-            return;
-        }
+        $utils = $this->getMockBuilder(\OxidEsales\Eshop\Core\Utils::class)->getMock();
+        $utils
+            ->expects($this->once())
+            ->method('handlePageNotFoundError');
 
-        $this->fail("No exception thrown by executeFunction");
+        Registry::set(\OxidEsales\Eshop\Core\Utils::class, $utils);
+
+        //Act
+        $oView->executeFunction('unkownFunction');
+
+        //Assert
+        $this->assertArrayNotHasKey('fnc', $_POST);
+        $this->assertArrayNotHasKey('fnc', $_GET);
     }
 
     public function testExecuteFunctionExecutesOnlyOnce()

--- a/tests/Unit/Application/Controller/ViewTest.php
+++ b/tests/Unit/Application/Controller/ViewTest.php
@@ -305,24 +305,15 @@ class ViewTest extends \OxidTestCase
 
         //Mock Asserts
         $logger = $this->getMockBuilder(LoggerInterface::class)->getMock();
-        $logger->expects($this->once())
-               ->method('warning');
+        $logger->expects($this->never())->method('error');
 
         Registry::set('logger', $logger);
 
-        $utils = $this->getMockBuilder(\OxidEsales\Eshop\Core\Utils::class)->getMock();
-        $utils
-            ->expects($this->once())
-            ->method('handlePageNotFoundError');
-
-        Registry::set(\OxidEsales\Eshop\Core\Utils::class, $utils);
-
         //Act
-        $oView->executeFunction('unkownFunction');
+        $this->expectException(\OxidEsales\Eshop\Core\Exception\RoutingException::class);
+        $this->expectExceptionMessage('Controller method is not accessible: OxidEsales\EshopCommunity\Core\Controller\BaseController::unkownFunction');
 
-        //Assert
-        $this->assertArrayNotHasKey('fnc', $_POST);
-        $this->assertArrayNotHasKey('fnc', $_GET);
+        $oView->executeFunction('unkownFunction');
     }
 
     public function testExecuteFunctionExecutesOnlyOnce()


### PR DESCRIPTION
Logically, I'd find it if a controller or function wasn't found. A 404 page comes instead of a 200 Status. Because the route is wrong. Like a Wrong Url.

Triggered by:
- /index.php?cl=non-existent-controller
- /index.php?cl=start&fnc=non-existent-function