### PR TITLE
remove unnecessary parameters in function call

### DIFF
--- a/source/Application/Controller/ForgotPasswordController.php
+++ b/source/Application/Controller/ForgotPasswordController.php
@@ -73,7 +73,7 @@ class ForgotPasswordController extends \OxidEsales\Eshop\Application\Controller\
         }
         if ($iSuccess !== true) {
             $sError = ($iSuccess === false) ? 'ERROR_MESSAGE_PASSWORD_EMAIL_INVALID' : 'MESSAGE_NOT_ABLE_TO_SEND_EMAIL';
-            Registry::getUtilsView()->addErrorToDisplay($sError, false, true);
+            Registry::getUtilsView()->addErrorToDisplay($sError);
             $this->_sForgotEmail = false;
         }
     }


### PR DESCRIPTION
see https://github.com/OXID-eSales/oxideshop_ce/blob/96dcc008e9d0a4643fb8363e07c359682751faeb/source/Core/UtilsView.php#L139-L146

`$blFull` is already set to false and `$useCustomDestination` makes only sense if you provide also `$customDestination` (which we don't do in this case).