### PR TITLE
Pass fetchAll parameters to get more control

### DIFF
--- a/source/Core/Database/Adapter/Doctrine/ResultSet.php
+++ b/source/Core/Database/Adapter/Doctrine/ResultSet.php
@@ -84,14 +84,17 @@ class ResultSet implements \IteratorAggregate, ResultSetInterface
     /**
      * Returns an array containing all of the result set rows
      *
+     * @param integer $iFetchArguments controlls how PDO should format result array.
+     * @param integer $sFetchClass will initiate a class for each row if needed.
+     *
      * @return array
      */
-    public function fetchAll()
+    public function fetchAll($iFetchArguments = null, $sFetchClass = null)
     {
         $this->close();
         $this->getStatement()->execute();
 
-        return $this->getStatement()->fetchAll();
+        return $this->getStatement()->fetchAll($iFetchArguments, $iFetchClass);
     }
 
     /**


### PR DESCRIPTION
PDO::fetchAll has some arguments, which can control the output. If we use `SELECT OXID FROM oxarticles;`, we would get 

```
Array
(
    [0] => Array
        (
            [0] => 022ec39af56268f3cd232d69494b8fc5
        )

    [1] => Array
        (
            [0] => 0292f9ba6f4dffff4e4c4bf66328163a
        )

    [2] => Array
        (
            [0] => 03022a216baaee246aa6790572264309
        )
....
```

But with `->fetchAll(\PDO::FETCH_COLUMN)` we would get:

```
Array
(
    [0] => 022ec39af56268f3cd232d69494b8fc5
    [1] => 0292f9ba6f4dffff4e4c4bf66328163a
    [2] => 03022a216baaee246aa6790572264309
    ....
```

This would help to make some modules much more performent, because ppl do not need to walk every row in a while-loop or use array_walk or something.

What do u think about it?