### PR TITLE
SEO Thing ... URI and end slash 

### DIFF
--- a/source/Core/SeoDecoder.php
+++ b/source/Core/SeoDecoder.php
@@ -316,7 +316,7 @@ class SeoDecoder extends \OxidEsales\Eshop\Core\Base
 
         // this should not happen on most cases, because this redirect is handled by .htaccess
         if ($sParams && !$oStr->preg_match('/\.html$/', $sParams) && !$oStr->preg_match('/\/$/', $sParams)) {
-            \OxidEsales\Eshop\Core\Registry::getUtils()->redirect(\OxidEsales\Eshop\Core\Registry::getConfig()->getShopURL() . $sParams . '/', false);
+            \OxidEsales\Eshop\Core\Registry::getUtils()->redirect(\OxidEsales\Eshop\Core\Registry::getConfig()->getShopURL() . $sParams . '/', false, 301);
         }
 
         return $sParams;


### PR DESCRIPTION
If the end slash is missing at the URI, then it is clearly a 301 forward and not a temporary forward.

```
     http://oxid.localhost/Kiteboarding/Trapeze  
  -> HTTP-Status 301 
  -> http://oxid.localhost/Kiteboarding/Trapeze/

```