### PR TITLE
Removed "http://" from value of oxarticles__oxexturl input.

### DIFF
--- a/source/Application/views/admin/tpl/article_extend.tpl
+++ b/source/Application/views/admin/tpl/article_extend.tpl
@@ -130,7 +130,7 @@ function processUnitInput( oSelect, sInputId )
                   [{oxmultilang ident="ARTICLE_EXTEND_EXTURL"}]
                 </td>
                 <td class="edittext">
-                  <input type="text" class="editinput" size="40" maxlength="[{$edit->oxarticles__oxexturl->fldmax_length}]" name="editval[oxarticles__oxexturl]" value="http://[{$edit->oxarticles__oxexturl->value}]" [{$readonly}]>
+                  <input type="text" class="editinput" size="40" maxlength="[{$edit->oxarticles__oxexturl->fldmax_length}]" name="editval[oxarticles__oxexturl]" value="[{$edit->oxarticles__oxexturl->value}]" [{$readonly}]>
                   [{oxinputhelp ident="HELP_ARTICLE_EXTEND_EXTURL"}]
                 </td>
               </tr>


### PR DESCRIPTION
Hardcoded prefix "http://" has been removed from theme **flow** and **wave**. 

Discussion in forum: [https://forum.oxid-esales.com/t/externe-url-und-https/94781](https://forum.oxid-esales.com/t/externe-url-und-https/94781)

Prefix in admin template makes no sense anymore. You save "https://example.com", after reload there's "http://https://example.com" in input field.