### PR TITLE
remove the mysql de-/encode feature

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
         "oxid-esales/oxideshop-demodata-installer": "^v1.1.2",
         "oxid-esales/oxideshop-composer-plugin": "dev-master",
         "oxid-esales/oxideshop-unified-namespace-generator": "^2.0.0",
-        "oxid-esales/testing-library": "dev-master",
+        "oxid-esales/testing-library": "dev-feature-remove-encryption-on-oxconfig",
         "oxid-esales/coding-standards-wrapper": "^v2.0.0",
         "incenteev/composer-parameter-handler": "~v2.0",
         "oxid-esales/oxideshop-ide-helper": "^3.0",
@@ -86,5 +86,11 @@
                 "partial_module_paths": "PARTIAL_MODULE_PATHS"
             }
         }
-    }
+    },
+    "repositories": [
+        {
+            "type": "vcs",
+            "url": "https://github.com/flow-control/testing_library"
+        }
+    ]
 }

--- a/source/Application/Controller/Admin/ShopConfiguration.php
+++ b/source/Application/Controller/Admin/ShopConfiguration.php
@@ -204,9 +204,9 @@ class ShopConfiguration extends \OxidEsales\Eshop\Application\Controller\Admin\A
         $rs = $database->select(
             "select cfg.oxvarname,
                     cfg.oxvartype,
-                    DECODE( cfg.oxvarvalue, " . $database->quote($config->getConfigParam('sConfigKey')) . ") as oxvarvalue,
-                        disp.oxvarconstraint,
-                        disp.oxgrouping
+                    cfg.oxvarvalue,
+                    disp.oxvarconstraint,
+                    disp.oxgrouping
                 from oxconfig as cfg
                     left join oxconfigdisplay as disp
                         on cfg.oxmodule=disp.oxcfgmodule and cfg.oxvarname=disp.oxcfgvarname

--- a/source/Application/Controller/Admin/ShopMain.php
+++ b/source/Application/Controller/Admin/ShopMain.php
@@ -189,8 +189,7 @@ class ShopMain extends \OxidEsales\Eshop\Application\Controller\Admin\AdminDetai
         $nonCopyVars = $this->_getNonCopyConfigVars();
 
         $selectShopConfigurationQuery =
-            "select oxvarname, oxvartype,
-            DECODE( oxvarvalue, " . $db->quote($config->getConfigParam('sConfigKey')) . ") as oxvarvalue, oxmodule
+            "select oxvarname, oxvartype, oxvarvalue, oxmodule
             from oxconfig where oxshopid = '1'";
         $shopConfiguration = $db->select($selectShopConfigurationQuery);
         if ($shopConfiguration != false && $shopConfiguration->count() > 0) {
@@ -200,14 +199,13 @@ class ShopMain extends \OxidEsales\Eshop\Application\Controller\Admin\AdminDetai
                     $newId = $utilsObject->generateUID();
                     $insertNewConfigQuery =
                         "insert into oxconfig (oxid, oxshopid, oxvarname, oxvartype, oxvarvalue, oxmodule)
-                         values (:oxid, :oxshopid, :oxvarname, :oxvartype, ENCODE(:value, :key), :oxmodule)";
+                         values (:oxid, :oxshopid, :oxvarname, :oxvartype, :value, :oxmodule)";
                     $db->execute($insertNewConfigQuery, [
                         ':oxid' => $newId,
                         ':oxshopid' => $shop->getId(),
                         ':oxvarname' => $shopConfiguration->fields[0],
                         ':oxvartype' => $shopConfiguration->fields[1],
                         ':value' => $shopConfiguration->fields[2],
-                        ':key' => $config->getConfigParam('sConfigKey'),
                         ':oxmodule' => $shopConfiguration->fields[3]
                     ]);
                 }

--- a/source/Application/Model/UserPayment.php
+++ b/source/Application/Model/UserPayment.php
@@ -23,13 +23,6 @@ class UserPayment extends \OxidEsales\Eshop\Core\Model\BaseModel
     // CHECK YOUR CREDIT CARD CONTRACT
 
     /**
-     * Payment information encryption key
-     *
-     * @var string.
-     */
-    protected $_sPaymentKey = 'fq45QS09_fqyx09239QQ';
-
-    /**
      * Name of current class
      *
      * @var string
@@ -94,18 +87,7 @@ class UserPayment extends \OxidEsales\Eshop\Core\Model\BaseModel
     {
         parent::__construct();
         $this->init('oxuserpayments');
-        $this->_sPaymentKey = str_rot13($this->_sPaymentKey);
         $this->setStoreCreditCardInfo(\OxidEsales\Eshop\Core\Registry::getConfig()->getConfigParam('blStoreCreditCardInfo'));
-    }
-
-    /**
-     * Returns payment key used for DB value decription
-     *
-     * @return string
-     */
-    public function getPaymentKey()
-    {
-        return $this->_sPaymentKey;
     }
 
     /**
@@ -117,7 +99,7 @@ class UserPayment extends \OxidEsales\Eshop\Core\Model\BaseModel
      */
     public function load($sOxId)
     {
-        $sSelect = 'select oxid, oxuserid, oxpaymentsid, DECODE( oxvalue, "' . $this->getPaymentKey() . '" ) as oxvalue
+        $sSelect = 'select oxid, oxuserid, oxpaymentsid, oxvalue
                     from oxuserpayments where oxid = ' . \OxidEsales\Eshop\Core\DatabaseProvider::getDb()->quote($sOxId);
 
         return $this->assignRecord($sSelect);
@@ -137,50 +119,7 @@ class UserPayment extends \OxidEsales\Eshop\Core\Model\BaseModel
             return true;
         }
 
-        //encode sensitive data
-        $sEncodedValue = '';
-        if ($sValue = $this->oxuserpayments__oxvalue->value) {
-            // Function is called from inside a transaction in Category::save (see ESDEV-3804 and ESDEV-3822).
-            // No need to explicitly force master here.
-            $database = \OxidEsales\Eshop\Core\DatabaseProvider::getDb();
-            $sEncodedValue = $database->getOne("select encode( " . $database->quote($sValue) . ", '" . $this->getPaymentKey() . "' )");
-            $this->oxuserpayments__oxvalue->setValue($sEncodedValue);
-        }
-
         $blRet = parent::_insert();
-
-        //restore, as encoding was needed only for saving
-        if ($sEncodedValue) {
-            $this->oxuserpayments__oxvalue->setValue($sValue);
-        }
-
-        return $blRet;
-    }
-
-    /**
-     * Updates payment record in DB. Returns update status.
-     *
-     * @return bool
-     */
-    protected function _update()
-    {
-
-        //encode sensitive data
-        if ($sValue = $this->oxuserpayments__oxvalue->value) {
-            // Function is called from inside a transaction in Category::save (see ESDEV-3804 and ESDEV-3822).
-            // No need to explicitly force master here.
-            $database = \OxidEsales\Eshop\Core\DatabaseProvider::getDb();
-
-            $sEncodedValue = $database->getOne("select encode( " . $database->quote($sValue) . ", '" . $this->getPaymentKey() . "' )");
-            $this->oxuserpayments__oxvalue->setValue($sEncodedValue);
-        }
-
-        $blRet = parent::_update();
-
-        //restore, as encoding was needed only for saving
-        if ($sEncodedValue) {
-            $this->oxuserpayments__oxvalue->setValue($sValue);
-        }
 
         return $blRet;
     }

--- a/source/Core/Config.php
+++ b/source/Core/Config.php
@@ -28,8 +28,6 @@ define('MAX_64BIT_INTEGER', '18446744073709551615');
  */
 class Config extends \OxidEsales\Eshop\Core\Base
 {
-    const DEFAULT_CONFIG_KEY = 'fq45QS09_fqyx09239QQ';
-
     // this column of params are defined in config.inc.php file,
     // so for backwards compatibility. names starts without underscore
 
@@ -294,9 +292,6 @@ class Config extends \OxidEsales\Eshop\Core\Base
      */
     protected $_blInit = false;
 
-    /** @var string Default configuration encryption key for database values. */
-    protected $sConfigKey = self::DEFAULT_CONFIG_KEY;
-
     /**
      * prefix for oxModule field for themes in oxConfig and oxConfigDisplay tables
      *
@@ -553,7 +548,7 @@ class Config extends \OxidEsales\Eshop\Core\Base
           ':oxshopid' => $shopID
         ];
         $select = "select
-                        oxvarname, oxvartype, " . $this->getDecodeValueQuery() . " as oxvarvalue
+                        oxvarname, oxvartype, oxvarvalue
                     from oxconfig
                     where oxshopid = :oxshopid and ";
 
@@ -1849,7 +1844,7 @@ class Config extends \OxidEsales\Eshop\Core\Base
         ]);
 
         $query = "insert into oxconfig (oxid, oxshopid, oxmodule, oxvarname, oxvartype, oxvarvalue)
-                  values (:oxid, :oxshopid, :oxmodule, :oxvarname, :oxvartype, ENCODE(:value, :key))";
+                  values (:oxid, :oxshopid, :oxmodule, :oxvarname, :oxvartype, :value)";
         $db->execute($query, [
             ':oxid' => $newOXID,
             ':oxshopid' => $shopId,
@@ -1857,7 +1852,6 @@ class Config extends \OxidEsales\Eshop\Core\Base
             ':oxvarname' => $varName,
             ':oxvartype' => $varType,
             ':value' => $value ?? '',
-            ':key' => $this->getConfigParam('sConfigKey'),
         ]);
 
         $this->informServicesAfterConfigurationChanged($varName, $shopId, $module);
@@ -1887,7 +1881,7 @@ class Config extends \OxidEsales\Eshop\Core\Base
 
         $db = \OxidEsales\Eshop\Core\DatabaseProvider::getDb(\OxidEsales\Eshop\Core\DatabaseProvider::FETCH_MODE_ASSOC);
 
-        $query = "select oxvartype, " . $this->getDecodeValueQuery() . " as oxvarvalue from oxconfig where oxshopid = :oxshopid and oxmodule = :oxmodule and oxvarname = :oxvarname";
+        $query = "select oxvartype, oxvarvalue from oxconfig where oxshopid = :oxshopid and oxmodule = :oxmodule and oxvarname = :oxvarname";
         $rs = $db->select($query, [
             ':oxshopid' => $shopId,
             ':oxmodule' => $module,
@@ -1921,18 +1915,6 @@ class Config extends \OxidEsales\Eshop\Core\Base
         }
 
         return $value;
-    }
-
-    /**
-     * Returns decode query part user to decode config field value
-     *
-     * @param string $fieldName field name, default "oxvarvalue" [optional]
-     *
-     * @return string
-     */
-    public function getDecodeValueQuery($fieldName = "oxvarvalue")
-    {
-        return " DECODE( {$fieldName}, '" . $this->getConfigParam('sConfigKey') . "') ";
     }
 
     /**

--- a/source/Core/Dao/ApplicationServerDao.php
+++ b/source/Core/Dao/ApplicationServerDao.php
@@ -158,12 +158,11 @@ class ApplicationServerDao implements \OxidEsales\Eshop\Core\Dao\ApplicationServ
      */
     protected function update($appServer)
     {
-        $query = "UPDATE oxconfig SET oxvarvalue = ENCODE(:value, :key)
+        $query = "UPDATE oxconfig SET oxvarvalue = :value
                   WHERE oxvarname = :oxvarname and oxshopid = :oxshopid";
 
         $parameter = [
             ':value' => $this->convertAppServerToConfigOption($appServer),
-            ':key' => $this->config->getConfigParam('sConfigKey'),
             ':oxvarname' => self::CONFIG_NAME_FOR_SERVER_INFO.$appServer->getId(),
             ':oxshopid' => $this->config->getBaseShopId()
         ];
@@ -179,7 +178,7 @@ class ApplicationServerDao implements \OxidEsales\Eshop\Core\Dao\ApplicationServ
     protected function insert($appServer)
     {
         $query = "insert into oxconfig (oxid, oxshopid, oxmodule, oxvarname, oxvartype, oxvarvalue)
-                  values (:oxid, :oxshopid, '', :oxvarname, :oxvartype, ENCODE(:value, :key))";
+                  values (:oxid, :oxshopid, '', :oxvarname, :oxvartype, :value)";
 
         $parameter = [
             ':oxid' => \OxidEsales\Eshop\Core\Registry::getUtilsObject()->generateUID(),
@@ -187,7 +186,6 @@ class ApplicationServerDao implements \OxidEsales\Eshop\Core\Dao\ApplicationServ
             ':oxvarname' => self::CONFIG_NAME_FOR_SERVER_INFO.$appServer->getId(),
             ':oxvartype' => 'arr',
             ':value' => $this->convertAppServerToConfigOption($appServer),
-            ':key' => $this->config->getConfigParam('sConfigKey')
         ];
 
         $this->database->execute($query, $parameter);
@@ -202,8 +200,7 @@ class ApplicationServerDao implements \OxidEsales\Eshop\Core\Dao\ApplicationServ
      */
     private function selectDataById($id)
     {
-        $query = "SELECT " . $this->config->getDecodeValueQuery() .
-            " as oxvarvalue FROM oxconfig 
+        $query = "SELECT oxvarvalue FROM oxconfig 
             WHERE oxvarname = :oxvarname 
               AND oxshopid = :oxshopid FOR UPDATE";
 
@@ -223,7 +220,7 @@ class ApplicationServerDao implements \OxidEsales\Eshop\Core\Dao\ApplicationServ
      */
     private function selectAllData()
     {
-        $query = "SELECT oxvarname, " . $this->config->getDecodeValueQuery() . " as oxvarvalue
+        $query = "SELECT oxvarname, oxvarvalue
                     FROM oxconfig
                     WHERE oxvarname like :oxvarname AND oxshopid = :oxshopid";
 

--- a/source/Core/DynamicImageGenerator.php
+++ b/source/Core/DynamicImageGenerator.php
@@ -414,13 +414,11 @@ namespace OxidEsales\EshopCommunity\Core {
 
                 // any name matching path?
                 if ($names) {
-                    $decodeField = $config->getDecodeValueQuery();
-
                     // selecting shop which image quality matches user given
                     $q = "select oxshopid
                             from oxconfig
                             where oxvarname = 'sDefaultImageQuality' and
-                       {$decodeField} = :quality";
+                            oxvarvalue = :quality";
 
                     $shopIdsArray = $db->getAll($q, [
                         ':quality' => $quality
@@ -439,7 +437,7 @@ namespace OxidEsales\EshopCommunity\Core {
                         $checkSize = "$width*$height";
 
                         // selecting config variables to check
-                        $q = "select oxvartype, {$decodeField} as oxvarvalue from oxconfig
+                        $q = "select oxvartype, oxvarvalue from oxconfig
                            where oxvarname in ( {$names} ) and oxshopid in ( {$shopIds} ) order by oxshopid";
 
                         $values = $db->getAll($q);

--- a/source/Core/Language.php
+++ b/source/Core/Language.php
@@ -1416,7 +1416,7 @@ class Language extends \OxidEsales\Eshop\Core\Base
             ':oxvarname' => $sParamName
         ];
         $sQuery = "
-            select " . $oConfig->getDecodeValueQuery() . " as oxvarvalue
+            select oxvarvalue
             from oxconfig
             where oxvarname = :oxvarname";
 

--- a/source/Core/Module/ModuleVariablesLocator.php
+++ b/source/Core/Module/ModuleVariablesLocator.php
@@ -95,22 +95,6 @@ class ModuleVariablesLocator
     }
 
     /**
-     * Returns configuration key. This method is independent from oxConfig functionality.
-     *
-     * @return string
-     */
-    protected function getConfigurationKey()
-    {
-        if (Registry::instanceExists(\OxidEsales\Eshop\Core\ConfigFile::class)) {
-            $config = Registry::get(\OxidEsales\Eshop\Core\ConfigFile::class);
-        } else {
-            $config = new \OxidEsales\Eshop\Core\ConfigFile(getShopBasePath() . '/config.inc.php');
-            Registry::set(\OxidEsales\Eshop\Core\ConfigFile::class, $config);
-        }
-        return $config->getVar('sConfigKey') ?: Config::DEFAULT_CONFIG_KEY;
-    }
-
-    /**
      * Returns shop module variable value directly from database.
      *
      * @param string $name Module variable name
@@ -123,11 +107,9 @@ class ModuleVariablesLocator
         $masterDb = \OxidEsales\Eshop\Core\DatabaseProvider::getMaster();
 
         $shopId = $this->getShopIdCalculator()->getShopId();
-        $configKey = $this->getConfigurationKey();
 
-        $query = "SELECT DECODE( oxvarvalue , :configkey ) FROM oxconfig WHERE oxvarname = :oxvarname AND oxshopid = :oxshopid";
+        $query = "SELECT oxvarvalue FROM oxconfig WHERE oxvarname = :oxvarname AND oxshopid = :oxshopid";
         $value = $masterDb->getOne($query, [
-            ':configkey' => $configKey,
             ':oxvarname' => $name,
             ':oxshopid'  => $shopId
         ]);

--- a/source/Core/SettingsHandler.php
+++ b/source/Core/SettingsHandler.php
@@ -158,8 +158,7 @@ class SettingsHandler extends \OxidEsales\Eshop\Core\Base
         $shopId = $config->getShopId();
         $module = $this->getModuleConfigId($moduleId);
 
-        $decodeValueQuery = $config->getDecodeValueQuery();
-        $moduleConfigsQuery = "SELECT oxvarname, oxvartype, {$decodeValueQuery} as oxvardecodedvalue FROM oxconfig WHERE oxmodule = :oxmodule AND oxshopid = :oxshopid";
+        $moduleConfigsQuery = "SELECT oxvarname, oxvartype, oxvarvalue FROM oxconfig WHERE oxmodule = :oxmodule AND oxshopid = :oxshopid";
         $dbConfigs = $db->getAll($moduleConfigsQuery, [
             ':oxmodule' => $module,
             ':oxshopid' => $shopId
@@ -167,7 +166,7 @@ class SettingsHandler extends \OxidEsales\Eshop\Core\Base
 
         $result = [];
         foreach ($dbConfigs as $oneModuleConfig) {
-            $result[$oneModuleConfig['oxvarname']] = $config->decodeValue($oneModuleConfig['oxvartype'], $oneModuleConfig['oxvardecodedvalue']);
+            $result[$oneModuleConfig['oxvarname']] = $config->decodeValue($oneModuleConfig['oxvartype'], $oneModuleConfig['oxvarvalue']);
         }
 
         return $result;

--- a/source/Core/ShopIdCalculator.php
+++ b/source/Core/ShopIdCalculator.php
@@ -42,22 +42,6 @@ class ShopIdCalculator
     }
 
     /**
-     * Returns configuration key. This method is independent from oxConfig functionality.
-     *
-     * @return string
-     */
-    protected function _getConfKey()
-    {
-        if (Registry::instanceExists(\OxidEsales\Eshop\Core\ConfigFile::class)) {
-            $config = Registry::get(\OxidEsales\Eshop\Core\ConfigFile::class);
-        } else {
-            $config = new \OxidEsales\Eshop\Core\ConfigFile(getShopBasePath() . '/config.inc.php');
-            Registry::set(\OxidEsales\Eshop\Core\ConfigFile::class, $config);
-        }
-        return $config->getVar('sConfigKey') ?: Config::DEFAULT_CONFIG_KEY;
-    }
-
-    /**
      * Returns shop url to id map from config.
      *
      * @return array
@@ -79,16 +63,14 @@ class ShopIdCalculator
 
         $aMap = [];
 
-        $sConfKey = $this->_getConfKey();
-
-        $sSelect = "SELECT oxshopid, oxvarname, DECODE( oxvarvalue , :configkey ) as oxvarvalue " .
-            "FROM oxconfig WHERE oxvarname in ('aLanguageURLs','sMallShopURL','sMallSSLShopURL')";
+        $sSelect = "
+            SELECT oxshopid, oxvarname, oxvarvalue
+            FROM oxconfig
+            WHERE oxvarname IN ('aLanguageURLs','sMallShopURL','sMallSSLShopURL')";
 
         // We force reading from master to prevent issues with slow replications or open transactions (see ESDEV-3804).
         $masterDb = \OxidEsales\Eshop\Core\DatabaseProvider::getMaster();
-        $oRs = $masterDb->select($sSelect, [
-            ':configkey' => $sConfKey
-        ]);
+        $oRs = $masterDb->select($sSelect);
 
         if ($oRs && $oRs->count() > 0) {
             while (!$oRs->EOF) {

--- a/source/Internal/Framework/Config/Dao/ShopConfigurationSettingDao.php
+++ b/source/Internal/Framework/Config/Dao/ShopConfigurationSettingDao.php
@@ -78,7 +78,7 @@ class ShopConfigurationSettingDao implements ShopConfigurationSettingDaoInterfac
                 'oxshopid'      => ':shopId',
                 'oxvarname'     => ':name',
                 'oxvartype'     => ':type',
-                'oxvarvalue'    => 'encode(:value, :key)',
+                'oxvarvalue'    => ':value',
             ])
             ->setParameters([
                 'id'        => $this->shopAdapter->generateUniqueId(),
@@ -88,8 +88,7 @@ class ShopConfigurationSettingDao implements ShopConfigurationSettingDaoInterfac
                 'value'     => $this->shopSettingEncoder->encode(
                     $shopConfigurationSetting->getType(),
                     $shopConfigurationSetting->getValue()
-                ),
-                'key'       => $this->context->getConfigurationEncryptionKey(),
+                )
             ]);
 
         $queryBuilder->execute();
@@ -113,15 +112,14 @@ class ShopConfigurationSettingDao implements ShopConfigurationSettingDaoInterfac
     {
         $queryBuilder = $this->queryBuilderFactory->create();
         $queryBuilder
-            ->select('decode(oxvarvalue, :key) as value, oxvartype as type, oxvarname as name')
+            ->select('oxvarvalue as value, oxvartype as type, oxvarname as name')
             ->from('oxconfig')
             ->where('oxshopid = :shopId')
             ->andWhere('oxvarname = :name')
             ->andWhere('oxmodule = ""')
             ->setParameters([
                 'shopId'    => $shopId,
-                'name'      => $name,
-                'key'       => $this->context->getConfigurationEncryptionKey(),
+                'name'      => $name
             ]);
 
         $result = $queryBuilder->execute()->fetch();

--- a/source/Internal/Framework/Module/Setting/SettingDao.php
+++ b/source/Internal/Framework/Module/Setting/SettingDao.php
@@ -164,7 +164,7 @@ class SettingDao implements SettingDaoInterface
                 'oxshopid'      => ':shopId',
                 'oxvarname'     => ':name',
                 'oxvartype'     => ':type',
-                'oxvarvalue'    => 'encode(:value, :key)',
+                'oxvarvalue'    => ':value',
             ])
             ->setParameters([
                 'id'        => $this->shopAdapter->generateUniqueId(),
@@ -175,8 +175,7 @@ class SettingDao implements SettingDaoInterface
                 'value'     => $this->shopSettingEncoder->encode(
                     $shopModuleSetting->getType(),
                     $shopModuleSetting->getValue()
-                ),
-                'key'       => $this->context->getConfigurationEncryptionKey(),
+                )
             ]);
 
         $queryBuilder->execute();
@@ -223,7 +222,7 @@ class SettingDao implements SettingDaoInterface
     {
         $queryBuilder = $this->queryBuilderFactory->create();
         $queryBuilder
-            ->select('decode(oxvarvalue, :key) as value, oxvartype as type, oxvarname as name')
+            ->select('oxvarvalue as value, oxvartype as type, oxvarname as name')
             ->from('oxconfig')
             ->where('oxshopid = :shopId')
             ->andWhere('oxmodule = :moduleId')
@@ -231,8 +230,7 @@ class SettingDao implements SettingDaoInterface
             ->setParameters([
                 'shopId'    => $shopId,
                 'moduleId'  => $this->getPrefixedModuleId($moduleId),
-                'name'      => $name,
-                'key'       => $this->context->getConfigurationEncryptionKey(),
+                'name'      => $name
             ]);
 
         $result = $queryBuilder->execute()->fetch();

--- a/source/Internal/Transition/Utility/Context.php
+++ b/source/Internal/Transition/Utility/Context.php
@@ -71,14 +71,6 @@ class Context extends BasicContext implements ContextInterface
     }
 
     /**
-     * @return string
-     */
-    public function getConfigurationEncryptionKey(): string
-    {
-        return $this->getConfigParameter('sConfigKey');
-    }
-
-    /**
      * @return bool
      */
     public function isAdmin(): bool

--- a/source/Internal/Transition/Utility/ContextInterface.php
+++ b/source/Internal/Transition/Utility/ContextInterface.php
@@ -29,11 +29,6 @@ interface ContextInterface extends BasicContextInterface
     public function getRequiredContactFormFields(): array;
 
     /**
-     * @return string
-     */
-    public function getConfigurationEncryptionKey(): string;
-
-    /**
      * @return bool
      */
     public function isEnabledAdminQueryLog(): bool;

--- a/source/Setup/Database.php
+++ b/source/Setup/Database.php
@@ -288,8 +288,6 @@ class Database extends Core
         /** @var Session $oSession */
         $oSession = $this->getInstance("Session");
 
-        $oConfk = new Conf();
-
         $oPdo = $this->getConnection();
 
         $blSendTechnicalInformationToOxid = true;
@@ -313,15 +311,14 @@ class Database extends Core
         // $this->execSql( "delete from oxconfig where oxvarname = 'aLanguageParams'" );
 
         $oInsert = $oPdo->prepare("insert into oxconfig (oxid, oxshopid, oxvarname, oxvartype, oxvarvalue)
-                                             values (:oxid, :shopId, :name, :type, ENCODE(:value, :key))");
+                                             values (:oxid, :shopId, :name, :type, :value)");
         $oInsert->execute(
             [
                 'oxid' => $oUtils->generateUid(),
                 'shopId' => $sBaseShopId,
                 'name' => 'blSendTechnicalInformationToOxid',
                 'type' => 'bool',
-                'value' => $blSendTechnicalInformationToOxid,
-                'key' => $oConfk->sConfigKey
+                'value' => $blSendTechnicalInformationToOxid
             ]
         );
 
@@ -331,8 +328,7 @@ class Database extends Core
                 'shopId' => $sBaseShopId,
                 'name' => 'blCheckForUpdates',
                 'type' => 'bool',
-                'value' => $blCheckForUpdates,
-                'key' => $oConfk->sConfigKey
+                'value' => $blCheckForUpdates
             ]
         );
 
@@ -342,15 +338,14 @@ class Database extends Core
                 'shopId' => $sBaseShopId,
                 'name' => 'sDefaultLang',
                 'type' => 'str',
-                'value' => $sShopLang,
-                'key' => $oConfk->sConfigKey
+                'value' => $sShopLang
             ]
         );
 
-        $this->addConfigValueIfShopInfoShouldBeSent($oUtils, $sBaseShopId, $aParams, $oConfk, $oSession);
+        $this->addConfigValueIfShopInfoShouldBeSent($oUtils, $sBaseShopId, $aParams, $oSession);
 
         //set only one active language
-        $oStatement = $oPdo->query("select oxvarname, oxvartype, DECODE( oxvarvalue, '" . $oConfk->sConfigKey . "') AS oxvarvalue from oxconfig where oxvarname='aLanguageParams'");
+        $oStatement = $oPdo->query("select oxvarname, oxvartype, oxvarvalue from oxconfig where oxvarname='aLanguageParams'");
         if ($oStatement && false !== ($aRow = $oStatement->fetch())) {
             if ($aRow['oxvartype'] == 'arr' || $aRow['oxvartype'] == 'aarr') {
                 $aRow['oxvarvalue'] = unserialize($aRow['oxvarvalue']);
@@ -370,8 +365,7 @@ class Database extends Core
                     'shopId' => $sBaseShopId,
                     'name' => 'aLanguageParams',
                     'type' => 'aarr',
-                    'value' => $sValue,
-                    'key' => $oConfk->sConfigKey
+                    'value' => $sValue
                 ]
             );
         }
@@ -456,10 +450,9 @@ class Database extends Core
      * @param Utilities $utilities  Setup utilities
      * @param string    $baseShopId Shop id
      * @param array     $parameters Parameters
-     * @param Conf      $configKey  Config key loader
      * @param Session   $session    Setup session manager
      */
-    protected function addConfigValueIfShopInfoShouldBeSent($utilities, $baseShopId, $parameters, $configKey, $session)
+    protected function addConfigValueIfShopInfoShouldBeSent($utilities, $baseShopId, $parameters, $session)
     {
         $blSendShopDataToOxid = isset($parameters["blSendShopDataToOxid"]) ? $parameters["blSendShopDataToOxid"] : $session->getSessionParam('blSendShopDataToOxid');
 
@@ -467,7 +460,7 @@ class Database extends Core
         $this->execSql("delete from oxconfig where oxvarname = 'blSendShopDataToOxid'");
         $this->execSql(
             "insert into oxconfig (oxid, oxshopid, oxvarname, oxvartype, oxvarvalue)
-                             values('$sID', '$baseShopId', 'blSendShopDataToOxid', 'bool', ENCODE( '$blSendShopDataToOxid', '" . $configKey->sConfigKey . "'))"
+                             values('$sID', '$baseShopId', 'blSendShopDataToOxid', 'bool', '$blSendShopDataToOxid')"
         );
     }
 }

--- a/source/Setup/functions.php
+++ b/source/Setup/functions.php
@@ -154,7 +154,6 @@ if (!class_exists("Conf", false)) {
         public function __construct()
         {
             $config = new \OxidEsales\EshopCommunity\Core\ConfigFile(getShopBasePath() . "/config.inc.php");
-            $this->sConfigKey = $config->getVar('sConfigKey') ?: \OxidEsales\EshopCommunity\Core\Config::DEFAULT_CONFIG_KEY;
         }
     }
 }

--- a/source/migration/data/Version20180214152228.php
+++ b/source/migration/data/Version20180214152228.php
@@ -24,7 +24,7 @@ class Version20180214152228 extends AbstractMigration
     {
         $facts = new Facts();
         $configFile = new ConfigFile($facts->getSourcePath().'/config.inc.php');
-        $configKey = !is_null($configFile->getVar('sConfigKey')) ? $configFile->getVar('sConfigKey') : Config::DEFAULT_CONFIG_KEY;
+        $configKey = $configFile->getVar('sConfigKey') ?? (defined('Config::DEFAULT_CONFIG_KEY') ? Config::DEFAULT_CONFIG_KEY : 'fq45QS09_fqyx09239QQ');
         $settingName = 'blAllowSuggestArticle';
 
         $this->addSql("INSERT INTO `oxconfig` (`OXID`, `OXSHOPID`, `OXMODULE`, `OXVARNAME`, `OXVARTYPE`, `OXVARVALUE`)

--- a/source/migration/data/Version20180703135728.php
+++ b/source/migration/data/Version20180703135728.php
@@ -24,7 +24,7 @@ class Version20180703135728 extends AbstractMigration
     {
         $facts = new Facts();
         $configFile = new ConfigFile($facts->getSourcePath() . '/config.inc.php');
-        $configKey = is_null($configFile->getVar('sConfigKey')) ? Config::DEFAULT_CONFIG_KEY : $configFile->getVar('sConfigKey');
+        $configKey = $configFile->getVar('sConfigKey') ?? (defined('Config::DEFAULT_CONFIG_KEY') ? Config::DEFAULT_CONFIG_KEY : 'fq45QS09_fqyx09239QQ');
         $varName = 'contactFormRequiredFields';
         $varType = 'arr';
         $rawValue = serialize(['email']);

--- a/source/migration/data/Version20180928072235.php
+++ b/source/migration/data/Version20180928072235.php
@@ -72,6 +72,6 @@ class Version20180928072235 extends AbstractMigration
         $facts = new Facts();
         $configFile = new ConfigFile($facts->getSourcePath() . '/config.inc.php');
 
-        return $configFile->getVar('sConfigKey') ?? Config::DEFAULT_CONFIG_KEY;
+        return $configFile->getVar('sConfigKey') ?? (defined('Config::DEFAULT_CONFIG_KEY') ? Config::DEFAULT_CONFIG_KEY : 'fq45QS09_fqyx09239QQ');
     }
 }

--- a/source/migration/data/Version20191009112914.php
+++ b/source/migration/data/Version20191009112914.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace OxidEsales\EshopCommunity\Migrations;
+
+use Doctrine\DBAL\Migrations\AbstractMigration;
+use Doctrine\DBAL\Schema\Schema;
+use OxidEsales\Eshop\Core\Config;
+use OxidEsales\Eshop\Core\ConfigFile;
+use OxidEsales\Facts\Facts;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+class Version20191009112914 extends AbstractMigration
+{
+    /**
+     * @param Schema $schema
+     */
+    public function up(Schema $schema)
+    {
+        $this->addSql(
+            'ALTER TABLE oxconfig ADD COLUMN OXVARVALUE_TEXT TEXT NULL'
+        );
+        $this->addSql(
+            'UPDATE oxconfig SET OXVARVALUE_TEXT = CONVERT(DECODE(oxvarvalue, ?), CHAR)',
+            [
+                $this->getConfigEncryptionKey()
+            ]
+        );
+        $this->addSql(
+            'ALTER TABLE oxconfig DROP COLUMN OXVARVALUE'
+        );
+        $this->addSql(
+            'ALTER TABLE oxconfig CHANGE COLUMN OXVARVALUE_TEXT OXVARVALUE text NULL COMMENT \'Variable value\' AFTER OXVARTYPE'
+        );
+    }
+
+    /**
+     * @param Schema $schema
+     */
+    public function down(Schema $schema)
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+    }
+
+    /**
+     * @return string
+     */
+    private function getConfigEncryptionKey(): string
+    {
+        $facts = new Facts();
+        $configFile = new ConfigFile($facts->getSourcePath() . '/config.inc.php');
+
+        return $configFile->getVar('sConfigKey') ?? (defined('Config::DEFAULT_CONFIG_KEY') ? Config::DEFAULT_CONFIG_KEY : 'fq45QS09_fqyx09239QQ');
+    }
+}

--- a/tests/Acceptance/Admin/CreatingItemsAdminTest.php
+++ b/tests/Acceptance/Admin/CreatingItemsAdminTest.php
@@ -1530,7 +1530,7 @@ class CreatingItemsAdminTest extends AdminTestCase
         $shopId = ShopIdCalculator::BASE_SHOP_ID;
         $shopId = $this->getTestConfig()->isSubShop() ? 2 : $shopId;
         $id = $this->getTestConfig()->isSubShop() ? 'ee3uioiop3795dea7855be2d1e' : '9d1ef0f8237werea96756e2d1e';
-        $this->executeSql("INSERT INTO `oxconfig` (`OXID`, `OXSHOPID`, `OXVARNAME`, `OXVARTYPE`, `OXVARVALUE`) VALUES ('$id', '$shopId', 'blUseMultidimensionVariants', 'bool', 0x07);");
+        $this->executeSql("INSERT INTO `oxconfig` (`OXID`, `OXSHOPID`, `OXVARNAME`, `OXVARTYPE`, `OXVARVALUE`) VALUES ('$id', '$shopId', 'blUseMultidimensionVariants', 'bool', '1');");
 
         $this->loginAdmin("Administer Products", "Products");
         $this->openListItem("link=10010");

--- a/tests/Acceptance/Admin/testSql/demodata_PE_CE.sql
+++ b/tests/Acceptance/Admin/testSql/demodata_PE_CE.sql
@@ -1,10 +1,10 @@
 SET @@session.sql_mode = '';
 
 # Activate en and de languages
-UPDATE `oxconfig` SET `OXVARVALUE` = 0x4dba832f744c5786a371d9df33778f956ef30fb1e8bb85d97b3b5de43e6bad688dfc6f63a8af34b33290cdd6fc889c8e77cfee0e8a17ade6b94130fda30d062d03e35d8d1bda1c2dc4dd5281fcb1c9538cf114050a3e7118e16151bfe94f5a0706d2eb3d9ff8b4a24f88963788f5dd1c33c573a1ebe3f5b06c072c6a373aaecb11755d907b50a79bbac613054871af686a7d3dbe0b6e1a3e292a109e2f5bc31bcd26ebbe42dac8c9cac3fa53c6fae3c8c7c3c113a4f1a8823d13c78c27dc WHERE `OXVARNAME` = 'aLanguageParams';
+UPDATE `oxconfig` SET `OXVARVALUE` = 'a:2:{s:2:"de";a:4:{s:6:"baseId";i:0;s:6:"active";s:1:"1";s:4:"sort";s:1:"1";s:7:"default";b:0;}s:2:"en";a:4:{s:6:"baseId";i:1;s:6:"active";s:1:"1";s:4:"sort";s:1:"2";s:7:"default";s:1:"1";}}' WHERE `OXVARNAME` = 'aLanguageParams';
 
 # Set en as default language
-UPDATE `oxconfig` SET `OXVARVALUE` = 0x07 WHERE `OXVARNAME` = 'sDefaultLang';
+UPDATE `oxconfig` SET `OXVARVALUE` = '1' WHERE `OXVARNAME` = 'sDefaultLang';
 
 # Activate all coutries
 UPDATE `oxcountry` SET `OXACTIVE` = 1 WHERE `OXISOALPHA2` in ('DE', 'AT', 'CH', 'GB', 'US');
@@ -399,29 +399,29 @@ REPLACE INTO `oxobject2discount` (`OXID`,                        `OXDISCOUNTID`,
                                 ('eac5b1e16a20dd19cd8beebe1f6', 'testvoucher2',    '1003',                       'oxarticles');
 
 #updating oxconfig settings
-UPDATE `oxconfig` SET `OXVARVALUE` = 0x07a1       WHERE `OXVARNAME` = 'dDefaultVAT';
-UPDATE `oxconfig` SET `OXVARVALUE` = 0xde         WHERE `OXVARNAME` = 'iNewBasketItemMessage';
-UPDATE `oxconfig` SET `OXVARVALUE` = 0x93ea1218   WHERE `OXVARNAME` = 'bl_perfUseSelectlistPrice';
-UPDATE `oxconfig` SET `OXVARVALUE` = 0x7900fdf51e WHERE `OXVARNAME` = 'bl_perfShowActionCatArticleCnt';
-UPDATE `oxconfig` SET `OXVARVALUE` = 0x93ea1218   WHERE `OXVARNAME` = 'blOtherCountryOrder';
-UPDATE `oxconfig` SET `OXVARVALUE` = 0x7900fdf51e WHERE `OXVARNAME` = 'blCheckTemplates';
-UPDATE `oxconfig` SET `OXVARVALUE` = 0x93ea1218   WHERE `OXVARNAME` = 'blDisableNavBars';
-UPDATE `oxconfig` SET `OXVARVALUE` = 0x93ea1218   WHERE `OXVARNAME` = 'blAllowUnevenAmounts';
-UPDATE `oxconfig` SET `OXVARVALUE` = 0x07         WHERE `OXVARNAME` = 'blConfirmAGB';
-UPDATE `oxconfig` SET `OXVARVALUE` = 0x4dba222b70e349f0c9d1aba6133981af1e8d79724d7309a19dd3eed099418943829510e114c4f6ffcb2543f5856ec4fea325d58b96e406decb977395c57d7cc79eec7f9f8dd6e30e2f68d198bd9d079dbe8b4f WHERE `OXVARNAME` = 'aNrofCatArticles';
-UPDATE `oxconfig` SET `OXVARVALUE` = 0x4dbace29724a51b6af7d09aac117301142e91c3c5b7eed9a850f85c1e3d58739aa9ea92523f05320a95060d60d57fbb027bad88efdaa0b928ebcd6aacf58084d31dd6ed5e718b833f1079b3805d28203f284492955c82cea3405879ea7588ec610ccde56acede495 WHERE `OXVARNAME` = 'aInterfaceProfiles';
+UPDATE `oxconfig` SET `OXVARVALUE` = '19'       WHERE `OXVARNAME` = 'dDefaultVAT';
+UPDATE `oxconfig` SET `OXVARVALUE` = '0'         WHERE `OXVARNAME` = 'iNewBasketItemMessage';
+UPDATE `oxconfig` SET `OXVARVALUE` = 'true'   WHERE `OXVARNAME` = 'bl_perfUseSelectlistPrice';
+UPDATE `oxconfig` SET `OXVARVALUE` = 'false' WHERE `OXVARNAME` = 'bl_perfShowActionCatArticleCnt';
+UPDATE `oxconfig` SET `OXVARVALUE` = 'true'   WHERE `OXVARNAME` = 'blOtherCountryOrder';
+UPDATE `oxconfig` SET `OXVARVALUE` = 'false' WHERE `OXVARNAME` = 'blCheckTemplates';
+UPDATE `oxconfig` SET `OXVARVALUE` = 'true'   WHERE `OXVARNAME` = 'blDisableNavBars';
+UPDATE `oxconfig` SET `OXVARVALUE` = 'true'   WHERE `OXVARNAME` = 'blAllowUnevenAmounts';
+UPDATE `oxconfig` SET `OXVARVALUE` = '1'         WHERE `OXVARNAME` = 'blConfirmAGB';
+UPDATE `oxconfig` SET `OXVARVALUE` = 'a:6:{i:0;s:2:"10";i:1;s:2:"20";i:2;s:2:"50";i:3;s:3:"100";i:4;s:1:"2";i:5;s:1:"1";}' WHERE `OXVARNAME` = 'aNrofCatArticles';
+UPDATE `oxconfig` SET `OXVARVALUE` = 'a:4:{s:8:"Standard";s:2:"10";s:8:"1024x768";s:2:"10";s:9:"1280x1024";s:2:"17";s:9:"1600x1200";s:2:"22";}' WHERE `OXVARNAME` = 'aInterfaceProfiles';
 DELETE FROM `oxconfig` WHERE `OXVARNAME`='blBasketExcludeEnabled';
 REPLACE INTO `oxconfig` (`OXID`, `OXSHOPID`, `OXMODULE`,   `OXVARNAME`,                     `OXVARTYPE`, `OXVARVALUE`) VALUES
-                       ('fb54', 1, '', 'perf_LoadFullVariantsInLists',  'bool',       0x7900fdf51e),
-                       ('fh90', 1, '', 'bl_perfLoadSelectListsInAList', 'bool',       0x93ea1218),
-                       ('a910', 1, '', 'blLoadSelectBoxAlways',         'bool',       0x93ea1218),
-                       ('4742', 1, '', 'blPerfNoBasketSaving',          'bool',       0x93ea1218),
-                       ('d084', 1, '', 'iMinOrderPrice',                'str',        0xfba4),
-                       ('33bd', 1, '', 'blOverrideZeroABCPrices',       'bool',       0x93ea1218),
-                       ('3c9f', 1, '', 'blShowOrderButtonOnTop',        'bool',       0x93ea1218),
-                       ('24d5', 1, '', 'bl_rssBargain',                 'bool',       0x07),
-                       ('2bf5', 1, '', 'bl_rssRecommLists',             'bool',       0x07),
-                       ('64i5', 1, '', 'bl_rssRecommListArts',          'bool',       0x07),
+                       ('fb54', 1, '', 'perf_LoadFullVariantsInLists',  'bool',       'false'),
+                       ('fh90', 1, '', 'bl_perfLoadSelectListsInAList', 'bool',       'true'),
+                       ('a910', 1, '', 'blLoadSelectBoxAlways',         'bool',       'true'),
+                       ('4742', 1, '', 'blPerfNoBasketSaving',          'bool',       'true'),
+                       ('d084', 1, '', 'iMinOrderPrice',                'str',        '49'),
+                       ('33bd', 1, '', 'blOverrideZeroABCPrices',       'bool',       'true'),
+                       ('3c9f', 1, '', 'blShowOrderButtonOnTop',        'bool',       'true'),
+                       ('24d5', 1, '', 'bl_rssBargain',                 'bool',       '1'),
+                       ('2bf5', 1, '', 'bl_rssRecommLists',             'bool',       '1'),
+                       ('64i5', 1, '', 'bl_rssRecommListArts',          'bool',       '1'),
                        ('c5iu', 1, '', 'blVariantParentBuyable',        'bool',       ''),
                        ('czzz', 1, '', 'blShowVariantReviews',          'bool',       ''),
                        ('a6ba', 1, '', 'blOrderDisWithoutReg',          'bool',       ''),

--- a/tests/Acceptance/Frontend/ContactFormFrontendTest.php
+++ b/tests/Acceptance/Frontend/ContactFormFrontendTest.php
@@ -70,19 +70,18 @@ class ContactFormFrontendTest extends \OxidEsales\EshopCommunity\Tests\Acceptanc
     {
         $facts = new Facts();
         $configFile = new ConfigFile($facts->getSourcePath() . '/config.inc.php');
-        $configKey = is_null($configFile->getVar('sConfigKey')) ? Config::DEFAULT_CONFIG_KEY : $configFile->getVar('sConfigKey');
         $rawValue = serialize($requiredFields);
 
         $query = "
         UPDATE `oxconfig`
         SET
-          `OXVARVALUE` = ENCODE(?,?)
+          `OXVARVALUE` = ?
         WHERE `OXSHOPID`= 1
         AND   `OXVARNAME` = 'contactFormRequiredFields'
         ";
 
         $database = \OxidEsales\Eshop\Core\DatabaseProvider::getDb();
-        $database->execute($query, [$rawValue, $configKey]);
+        $database->execute($query, [$rawValue]);
     }
 
     private function assertFieldIsNotRequired(string $notRequiredInputFieldLocator, string $notRequiredFieldLabelLocator)

--- a/tests/Acceptance/Frontend/testSql/demodata_PE_CE.sql
+++ b/tests/Acceptance/Frontend/testSql/demodata_PE_CE.sql
@@ -1,10 +1,10 @@
 SET @@session.sql_mode = '';
 
 # Activate en and de languages
-UPDATE `oxconfig` SET `OXVARVALUE` = 0x4dba832f744c5786a371d9df33778f956ef30fb1e8bb85d97b3b5de43e6bad688dfc6f63a8af34b33290cdd6fc889c8e77cfee0e8a17ade6b94130fda30d062d03e35d8d1bda1c2dc4dd5281fcb1c9538cf114050a3e7118e16151bfe94f5a0706d2eb3d9ff8b4a24f88963788f5dd1c33c573a1ebe3f5b06c072c6a373aaecb11755d907b50a79bbac613054871af686a7d3dbe0b6e1a3e292a109e2f5bc31bcd26ebbe42dac8c9cac3fa53c6fae3c8c7c3c113a4f1a8823d13c78c27dc WHERE `OXVARNAME` = 'aLanguageParams';
+UPDATE `oxconfig` SET `OXVARVALUE` = 'a:2:{s:2:"de";a:4:{s:6:"baseId";i:0;s:6:"active";s:1:"1";s:4:"sort";s:1:"1";s:7:"default";b:0;}s:2:"en";a:4:{s:6:"baseId";i:1;s:6:"active";s:1:"1";s:4:"sort";s:1:"2";s:7:"default";s:1:"1";}}' WHERE `OXVARNAME` = 'aLanguageParams';
 
 # Set en as default language
-UPDATE `oxconfig` SET `OXVARVALUE` = 0x07 WHERE `OXVARNAME` = 'sDefaultLang';
+UPDATE `oxconfig` SET `OXVARVALUE` = '1' WHERE `OXVARNAME` = 'sDefaultLang';
 
 # Activate all coutries
 UPDATE `oxcountry` SET `OXACTIVE` = 1 WHERE `OXISOALPHA2` in ('DE', 'AT', 'CH', 'GB', 'US');
@@ -398,27 +398,27 @@ REPLACE INTO `oxobject2discount` (`OXID`,                        `OXDISCOUNTID`,
                                 ('eac5b1e16a20dd19cd8beebe1f6', 'testvoucher2',    '1003',                       'oxarticles');
 
 #updating oxconfig settings
-UPDATE `oxconfig` SET `OXVARVALUE` = 0x07a1       WHERE `OXVARNAME` = 'dDefaultVAT';
-UPDATE `oxconfig` SET `OXVARVALUE` = 0x93ea1218   WHERE `OXVARNAME` = 'bl_perfUseSelectlistPrice';
-UPDATE `oxconfig` SET `OXVARVALUE` = 0x7900fdf51e WHERE `OXVARNAME` = 'bl_perfShowActionCatArticleCnt';
-UPDATE `oxconfig` SET `OXVARVALUE` = 0x93ea1218   WHERE `OXVARNAME` = 'blOtherCountryOrder';
-UPDATE `oxconfig` SET `OXVARVALUE` = 0x7900fdf51e WHERE `OXVARNAME` = 'blCheckTemplates';
-UPDATE `oxconfig` SET `OXVARVALUE` = 0x93ea1218   WHERE `OXVARNAME` = 'blDisableNavBars';
-UPDATE `oxconfig` SET `OXVARVALUE` = 0x93ea1218   WHERE `OXVARNAME` = 'blAllowUnevenAmounts';
-UPDATE `oxconfig` SET `OXVARVALUE` = 0x07         WHERE `OXVARNAME` = 'blConfirmAGB';
-UPDATE `oxconfig` SET `OXVARVALUE` = 0x4dbace29724a51b6af7d09aac117301142e91c3c5b7eed9a850f85c1e3d58739aa9ea92523f05320a95060d60d57fbb027bad88efdaa0b928ebcd6aacf58084d31dd6ed5e718b833f1079b3805d28203f284492955c82cea3405879ea7588ec610ccde56acede495 WHERE `OXVARNAME` = 'aInterfaceProfiles';
+UPDATE `oxconfig` SET `OXVARVALUE` = 19      WHERE `OXVARNAME` = 'dDefaultVAT';
+UPDATE `oxconfig` SET `OXVARVALUE` = 'true'  WHERE `OXVARNAME` = 'bl_perfUseSelectlistPrice';
+UPDATE `oxconfig` SET `OXVARVALUE` = 'false' WHERE `OXVARNAME` = 'bl_perfShowActionCatArticleCnt';
+UPDATE `oxconfig` SET `OXVARVALUE` = 'true'  WHERE `OXVARNAME` = 'blOtherCountryOrder';
+UPDATE `oxconfig` SET `OXVARVALUE` = 'false' WHERE `OXVARNAME` = 'blCheckTemplates';
+UPDATE `oxconfig` SET `OXVARVALUE` = 'true'  WHERE `OXVARNAME` = 'blDisableNavBars';
+UPDATE `oxconfig` SET `OXVARVALUE` = 'true'  WHERE `OXVARNAME` = 'blAllowUnevenAmounts';
+UPDATE `oxconfig` SET `OXVARVALUE` = '1'     WHERE `OXVARNAME` = 'blConfirmAGB';
+UPDATE `oxconfig` SET `OXVARVALUE` = 'a:4:{s:8:"Standard";s:2:"10";s:8:"1024x768";s:2:"10";s:9:"1280x1024";s:2:"17";s:9:"1600x1200";s:2:"22";}' WHERE `OXVARNAME` = 'aInterfaceProfiles';
 DELETE FROM `oxconfig` WHERE `OXVARNAME`='blBasketExcludeEnabled';
 REPLACE INTO `oxconfig` (`OXID`, `OXSHOPID`, `OXMODULE`,   `OXVARNAME`,                     `OXVARTYPE`, `OXVARVALUE`) VALUES
-                       ('fb54', 1, '', 'perf_LoadFullVariantsInLists',  'bool',       0x7900fdf51e),
-                       ('fh90', 1, '', 'bl_perfLoadSelectListsInAList', 'bool',       0x93ea1218),
-                       ('a910', 1, '', 'blLoadSelectBoxAlways',         'bool',       0x93ea1218),
-                       ('4742', 1, '', 'blPerfNoBasketSaving',          'bool',       0x93ea1218),
-                       ('d084', 1, '', 'iMinOrderPrice',                'str',        0xfba4),
-                       ('33bd', 1, '', 'blOverrideZeroABCPrices',       'bool',       0x93ea1218),
-                       ('3c9f', 1, '', 'blShowOrderButtonOnTop',        'bool',       0x93ea1218),
-                       ('24d5', 1, '', 'bl_rssBargain',                 'bool',       0x07),
-                       ('2bf5', 1, '', 'bl_rssRecommLists',             'bool',       0x07),
-                       ('64i5', 1, '', 'bl_rssRecommListArts',          'bool',       0x07),
+                       ('fb54', 1, '', 'perf_LoadFullVariantsInLists',  'bool',       'false'),
+                       ('fh90', 1, '', 'bl_perfLoadSelectListsInAList', 'bool',       'true'),
+                       ('a910', 1, '', 'blLoadSelectBoxAlways',         'bool',       'true'),
+                       ('4742', 1, '', 'blPerfNoBasketSaving',          'bool',       'true'),
+                       ('d084', 1, '', 'iMinOrderPrice',                'str',        '49'),
+                       ('33bd', 1, '', 'blOverrideZeroABCPrices',       'bool',       'true'),
+                       ('3c9f', 1, '', 'blShowOrderButtonOnTop',        'bool',       'true'),
+                       ('24d5', 1, '', 'bl_rssBargain',                 'bool',       '1'),
+                       ('2bf5', 1, '', 'bl_rssRecommLists',             'bool',       '1'),
+                       ('64i5', 1, '', 'bl_rssRecommListArts',          'bool',       '1'),
                        ('c5iu', 1, '', 'blVariantParentBuyable',        'bool',       ''),
                        ('czzz', 1, '', 'blShowVariantReviews',          'bool',       ''),
                        ('a6ba', 1, '', 'blOrderDisWithoutReg',          'bool',       ''),

--- a/tests/Acceptance/International/testSql/demodata_PE_CE.sql
+++ b/tests/Acceptance/International/testSql/demodata_PE_CE.sql
@@ -329,35 +329,35 @@ INSERT INTO `oxwrapping` (`OXID`,         `OXSHOPID`,  `OXACTIVE`, `OXACTIVE_1`,
                          ('testwrap5',    1, 1,          0,            0,            0,           'WRAP',   '2 EN Gift Wrapping šųößлы',      '[last] DE Gift Wrapping šųößлы', 5);
 
 #updating oxconfig settings
-UPDATE `oxconfig` SET `OXVARVALUE` = 0x93ea1218   WHERE `OXVARNAME` = 'bl_perfUseSelectlistPrice';
-UPDATE `oxconfig` SET `OXVARVALUE` = 0x7900fdf51e WHERE `OXVARNAME` = 'bl_perfShowActionCatArticleCnt';
-UPDATE `oxconfig` SET `OXVARVALUE` = 0x93ea1218   WHERE `OXVARNAME` = 'blOtherCountryOrder';
-UPDATE `oxconfig` SET `OXVARVALUE` = 0x7900fdf51e WHERE `OXVARNAME` = 'blCheckTemplates';
-UPDATE `oxconfig` SET `OXVARVALUE` = 0x93ea1218   WHERE `OXVARNAME` = 'blDisableNavBars';
-UPDATE `oxconfig` SET `OXVARVALUE` = 0x93ea1218   WHERE `OXVARNAME` = 'blAllowUnevenAmounts';
-UPDATE `oxconfig` SET `OXVARVALUE` = 0x07         WHERE `OXVARNAME` = 'blConfirmAGB';
-UPDATE `oxconfig` SET `OXVARVALUE` = 0x07a1       WHERE `OXVARNAME` = 'dDefaultVAT';
-UPDATE `oxconfig` SET `OXVARVALUE` = 0xde         WHERE `OXVARNAME` = 'iNewBasketItemMessage';
-#UPDATE `oxconfig` SET `OXVARVALUE` = 0x4dba852e75e64cf5ccd4aea5675a0d492fe42584187fbf8c9b11d3b01306b7f34f3e85a640802d63112081e17db027a004c2dc41dc0f34e296365c35ff74e3bb70693767b16bd7114149643668c6b3b9e95da86203264a2444c2881030198857baaa8be9b555b284a88db85ad196bed825c4cf572b2d3b38b50619fd949938aa1d1e21a66ac76896cbf6f9d004781e610189bf1163dc03c89fb6078b WHERE `OXVARNAME` = 'aCurrencies';
-UPDATE `oxconfig` SET `OXVARVALUE` = 0x4dba222b70e349f0c9d1aba6133981af1e8d79724d7309a19dd3eed099418943829510e114c4f6ffcb2543f5856ec4fea325d58b96e406decb977395c57d7cc79eec7f9f8dd6e30e2f68d198bd9d079dbe8b4f WHERE `OXVARNAME` = 'aNrofCatArticles';
-UPDATE `oxconfig` SET `OXVARVALUE` = 0x4dbace29724a51b6af7d09aac117301142e91c3c5b7eed9a850f85c1e3d58739aa9ea92523f05320a95060d60d57fbb027bad88efdaa0b928ebcd6aacf58084d31dd6ed5e718b833f1079b3805d28203f284492955c82cea3405879ea7588ec610ccde56acede495 WHERE `OXVARNAME` = 'aInterfaceProfiles';
+UPDATE `oxconfig` SET `OXVARVALUE` = 'true'  WHERE `OXVARNAME` = 'bl_perfUseSelectlistPrice';
+UPDATE `oxconfig` SET `OXVARVALUE` = 'false' WHERE `OXVARNAME` = 'bl_perfShowActionCatArticleCnt';
+UPDATE `oxconfig` SET `OXVARVALUE` = 'true'  WHERE `OXVARNAME` = 'blOtherCountryOrder';
+UPDATE `oxconfig` SET `OXVARVALUE` = 'false' WHERE `OXVARNAME` = 'blCheckTemplates';
+UPDATE `oxconfig` SET `OXVARVALUE` = 'true'  WHERE `OXVARNAME` = 'blDisableNavBars';
+UPDATE `oxconfig` SET `OXVARVALUE` = 'true'  WHERE `OXVARNAME` = 'blAllowUnevenAmounts';
+UPDATE `oxconfig` SET `OXVARVALUE` = '1'     WHERE `OXVARNAME` = 'blConfirmAGB';
+UPDATE `oxconfig` SET `OXVARVALUE` = '19'    WHERE `OXVARNAME` = 'dDefaultVAT';
+UPDATE `oxconfig` SET `OXVARVALUE` = '0'     WHERE `OXVARNAME` = 'iNewBasketItemMessage';
+#UPDATE `oxconfig` SET `OXVARVALUE` = 'a:3:{i:0;s:38:"EUR@ 1.00@ ,@ .@ <small>EUR</small>@ 2";i:1;s:38:"GBP@ 0.68@ .@  @ <small>GBP</small>@ 2";i:2;s:38:"CHF@ 1.47@ ,@ .@ <small>CHF</small>@ 2";}' WHERE `OXVARNAME` = 'aCurrencies';
+UPDATE `oxconfig` SET `OXVARVALUE` = 'a:6:{i:0;s:2:"10";i:1;s:2:"20";i:2;s:2:"50";i:3;s:3:"100";i:4;s:1:"2";i:5;s:1:"1";}' WHERE `OXVARNAME` = 'aNrofCatArticles';
+UPDATE `oxconfig` SET `OXVARVALUE` = 'a:4:{s:8:"Standard";s:2:"10";s:8:"1024x768";s:2:"10";s:9:"1280x1024";s:2:"17";s:9:"1600x1200";s:2:"22";}' WHERE `OXVARNAME` = 'aInterfaceProfiles';
 
 INSERT INTO `oxconfig` (`OXID`, `OXSHOPID`, `OXMODULE`,   `OXVARNAME`,                     `OXVARTYPE`, `OXVARVALUE`) VALUES
-                       ('fb547ac17e4a10201.92066345', 1, '', 'perf_LoadFullVariantsInLists',  'bool',       0x7900fdf51e),
-                       ('35796d0bdbbda3bb54fcd0fb84', 1, '', 'iMinOrderPrice',                'str',        0xfba4),
-                       ('fb547ac17e4a910c8.33968384', 1, '', 'blLoadSelectBoxAlways',         'bool',       0x93ea1218),
-                       ('fb547ac17e4a97dd3.93417742', 1, '', 'blPerfNoBasketSaving',          'bool',       0x93ea1218),
-                       ('33bd5512d7d7366681eb850502', 1, '', 'blOverrideZeroABCPrices',       'bool',       0x93ea1218),
-                       ('34d266d01313cf456a4a1d2c9f', 1, '', 'blShowOrderButtonOnTop',        'bool',       0x93ea1218),
-                       ('fb547ac17e4a5ba72.64297620', 1, '', 'bl_perfLoadSelectListsInAList', 'bool',       0x93ea1218),
-                       ('2b456gjk7156737a6edc6814c5', 1, '', 'bl_rssBargain',                 'bool',       0x07),
-                       ('2bpte85227eb159aedc68164c5', 1, '', 'bl_rssRecommLists',             'bool',       0x07),
-                       ('2b7lojk77123rtdskdj68164c5', 1, '', 'bl_rssRecommListArts',          'bool',       0x07);
+                       ('fb547ac17e4a10201.92066345', 1, '', 'perf_LoadFullVariantsInLists',  'bool',       'false'),
+                       ('35796d0bdbbda3bb54fcd0fb84', 1, '', 'iMinOrderPrice',                'str',        '49'),
+                       ('fb547ac17e4a910c8.33968384', 1, '', 'blLoadSelectBoxAlways',         'bool',       'true'),
+                       ('fb547ac17e4a97dd3.93417742', 1, '', 'blPerfNoBasketSaving',          'bool',       'true'),
+                       ('33bd5512d7d7366681eb850502', 1, '', 'blOverrideZeroABCPrices',       'bool',       'true'),
+                       ('34d266d01313cf456a4a1d2c9f', 1, '', 'blShowOrderButtonOnTop',        'bool',       'true'),
+                       ('fb547ac17e4a5ba72.64297620', 1, '', 'bl_perfLoadSelectListsInAList', 'bool',       'true'),
+                       ('2b456gjk7156737a6edc6814c5', 1, '', 'bl_rssBargain',                 'bool',       '1'),
+                       ('2bpte85227eb159aedc68164c5', 1, '', 'bl_rssRecommLists',             'bool',       '1'),
+                       ('2b7lojk77123rtdskdj68164c5', 1, '', 'bl_rssRecommListArts',          'bool',       '1');
 
 #azure theme config
 DELETE FROM `oxconfig` WHERE `OXMODULE` = 'theme:azure' AND `OXVARNAME` = 'iTopNaviCatCount';
 INSERT INTO `oxconfig` (`OXID`,                       `OXSHOPID`,   `OXMODULE`,    `OXVARNAME`,        `OXVARTYPE`, `OXVARVALUE`) VALUES
-                       ('bd9f44ba4062387b0678d3ad7a', 1, 'theme:azure', 'iTopNaviCatCount', 'str',        0xb0);
+                       ('bd9f44ba4062387b0678d3ad7a', 1, 'theme:azure', 'iTopNaviCatCount', 'str',        '3');
 
 #updating smtp and email information
 UPDATE `oxshops` SET `OXPRODUCTIVE` = 0, `OXINFOEMAIL` = 'example_test@oxid-esales.dev', `OXORDEREMAIL` = 'example_test@oxid-esales.dev', `OXOWNEREMAIL` = 'example_test@oxid-esales.dev', `OXSMTP` = 'localhost', `OXDEFCAT` = '' WHERE `OXID` = 1;

--- a/tests/Codeception/_data/dump.sql
+++ b/tests/Codeception/_data/dump.sql
@@ -81,11 +81,11 @@ REPLACE INTO `oxstates` (`OXID`, `OXCOUNTRYID`, `OXTITLE`, `OXISOALPHA2`, `OXTIT
 
 
 # createBasketUserAccountWithoutRegistration
-UPDATE `oxconfig` SET `OXVARVALUE` = 0xde         WHERE `OXVARNAME` = 'iNewBasketItemMessage';
+UPDATE `oxconfig` SET `OXVARVALUE` = '0'         WHERE `OXVARNAME` = 'iNewBasketItemMessage';
 UPDATE `oxconfig` SET `OXVARVALUE` = ''           WHERE `OXVARNAME` = 'blDisableNavBars';
 REPLACE INTO `oxconfig` (`OXID`, `OXSHOPID`, `OXMODULE`,   `OXVARNAME`,                     `OXVARTYPE`, `OXVARVALUE`) VALUES
-                       ('4742', 1, '', 'blPerfNoBasketSaving',          'bool',       0x93ea1218),
-                       ('8563fba1965a219c9.51133344', 1, '', 'blUseStock',          'bool',       0x93ea1218);
+                       ('4742', 1, '', 'blPerfNoBasketSaving',          'bool',       'true'),
+                       ('8563fba1965a219c9.51133344', 1, '', 'blUseStock',          'bool',       'true');
 
 # createBasketUserAccountWithoutRegistrationTwice
 UPDATE `oxcountry` SET `OXACTIVE` = 1 WHERE `OXTITLE_1` = 'Belgium';

--- a/tests/Codeception/acceptance.suite.yml
+++ b/tests/Codeception/acceptance.suite.yml
@@ -30,7 +30,6 @@ modules:
               - WebDriver
               - Db
         - \OxidEsales\Codeception\Module\Database:
-            config_key: 'fq45QS09_fqyx09239QQ'
             depends: Db
         - \OxidEsales\Codeception\Module\Translation\TranslationsModule:
             shop_path: '%SHOP_SOURCE_PATH%'

--- a/tests/Fixtures/testdata.sql
+++ b/tests/Fixtures/testdata.sql
@@ -1,10 +1,10 @@
 SET @@session.sql_mode = '';
 
 # Reset theme in config
-UPDATE `oxconfig` SET `OXVARVALUE` = encode('basic', 'fq45QS09_fqyx09239QQ') WHERE `OXVARNAME` = 'sTheme';
+UPDATE `oxconfig` SET `OXVARVALUE` = 'basic' WHERE `OXVARNAME` = 'sTheme';
 
 # Activate en and de languages
-UPDATE `oxconfig` SET `OXVARVALUE` = 0x4dba832f744c5786a371d9df33778f9525f408b6efbc82de7c3c5ae3396caa6f8afb6864afa833b43597cad1fb8f9b8970c8e9098d10aae1be4637faa40a012a04e45a8a1cdd1b2ac3da558638600e58acf70fe8c192b668995bb533dac95be7af7d343b3a9c9b8daeaf4d637f065895346773476d667de331fe40d18765d4b98faf7375e1090587d8dd4bf98ad5005eb30666410920 WHERE `OXVARNAME` = 'aLanguageParams';
+UPDATE `oxconfig` SET `OXVARVALUE` = 'a:2:{s:2:"de";a:3:{s:6:"baseId";i:0;s:6:"active";s:1:"1";s:4:"sort";s:1:"1";}s:2:"en";a:3:{s:6:"baseId";i:1;s:6:"active";s:1:"1";s:4:"sort";s:1:"2";}}' WHERE `OXVARNAME` = 'aLanguageParams';
 
 # Activate all coutries
 UPDATE `oxcountry` SET `OXACTIVE` = 1 WHERE `OXISOALPHA2` in ('DE', 'AT', 'CH', 'GB', 'US');

--- a/tests/Fixtures/testdemodata.sql
+++ b/tests/Fixtures/testdemodata.sql
@@ -791,7 +791,7 @@ INSERT INTO `oxcategory2attribute` (`OXID`, `OXOBJECTID`, `OXATTRID`, `OXSORT`) 
 # Data for table `oxconfig`
 #
 INSERT INTO `oxconfig` (`OXID`, `OXSHOPID`, `OXMODULE`, `OXVARNAME`, `OXVARTYPE`, `OXVARVALUE`) VALUES
-  ('ctf0430a9569214ea666264457dbb3c0', 1, '', 'blEnableDownloads', 'bool', 0x07);
+  ('ctf0430a9569214ea666264457dbb3c0', 1, '', 'blEnableDownloads', 'bool', '1');
 
 #
 # Data for table `oxcounters`

--- a/tests/Integration/Internal/Framework/Module/ShopModuleSetting/SettingDaoTest.php
+++ b/tests/Integration/Internal/Framework/Module/ShopModuleSetting/SettingDaoTest.php
@@ -310,7 +310,7 @@ class SettingDaoTest extends TestCase
                 'oxshopid'      => ':shopId',
                 'oxvarname'     => ':name',
                 'oxvartype'     => ':type',
-                'oxvarvalue'    => 'encode(:value, :key)',
+                'oxvarvalue'    => ':value',
             ])
             ->setParameters([
                 'id'        => $shopAdapter->generateUniqueId(),
@@ -321,8 +321,7 @@ class SettingDaoTest extends TestCase
                 'value'     => $shopSettingEncoder->encode(
                     $shopModuleSetting->getType(),
                     $shopModuleSetting->getValue()
-                ),
-                'key'       => $context->getConfigurationEncryptionKey(),
+                )
             ]);
 
         $queryBuilder->execute();

--- a/tests/Integration/Modules/Environment.php
+++ b/tests/Integration/Modules/Environment.php
@@ -245,10 +245,10 @@ class Environment
     protected function _getConfigValueFromDB($sVarName)
     {
         $db = \OxidEsales\Eshop\Core\DatabaseProvider::getDb();
-        $sQuery = "SELECT " . Registry::getConfig()->getDecodeValueQuery() . "
-                   FROM `oxconfig`
-                   WHERE `OXVARNAME` = '{$sVarName}'
-                   AND `OXSHOPID` = {$this->getShopId()}";
+        $sQuery = "SELECT oxvarvalue
+                   FROM oxconfig
+                   WHERE OXVARNAME = '{$sVarName}'
+                   AND OXSHOPID = {$this->getShopId()}";
 
         $sResult = $db->getOne($sQuery);
         $aExtensionsToCheck = $sResult ? unserialize($sResult) : array();

--- a/tests/Integration/Seo/PaginationSeoTest.php
+++ b/tests/Integration/Seo/PaginationSeoTest.php
@@ -75,7 +75,7 @@ class PaginationSeoTest extends \OxidEsales\TestingLibrary\UnitTestCase
     protected function tearDown()
     {
         //restore theme, do it directly in database as it might be dummy 'basic' theme
-        $query = "UPDATE `oxconfig` SET `OXVARVALUE` = encode('" . $this->origTheme . "', 'fq45QS09_fqyx09239QQ') WHERE `OXVARNAME` = 'sTheme'";
+        $query = "UPDATE `oxconfig` SET `OXVARVALUE` = " . $this->origTheme . " WHERE `OXVARNAME` = 'sTheme'";
         \OxidEsales\Eshop\Core\DatabaseProvider::getDb()->execute($query);
 
         $this->cleanRegistry();

--- a/tests/Unit/Application/Model/UserpaymentTest.php
+++ b/tests/Unit/Application/Model/UserpaymentTest.php
@@ -125,16 +125,6 @@ class UserpaymentTest extends \OxidTestCase
     }
 
     /**
-     * Testing if object type is correct and payment key is correctly generated
-     */
-    public function testOxUserPayment()
-    {
-        $oUpay = oxNew('oxuserpayment');
-        $this->assertEquals('oxuserpayment', $oUpay->getClassName());
-        $this->assertEquals(str_rot13('fq45QS09_fqyx09239QQ'), $oUpay->getPaymentKey('_sPaymentKey'));
-    }
-
-    /**
      * Testing if constructor sets _blStoreCreditCardInfo from oxConfig param
      */
     public function testConstructor()
@@ -155,15 +145,6 @@ class UserpaymentTest extends \OxidTestCase
         $oUpay = oxNew('oxuserpayment');
         $oUpay->load('_testOxId');
         $this->assertEquals('Nachnahme', $oUpay->oxpayments__oxdesc->value);
-    }
-
-    /**
-     * Checking if payment encryption key is good
-     */
-    public function testGetPaymentKey()
-    {
-        $oUpay = oxNew('oxuserpayment');
-        $this->assertEquals(str_rot13('fq45QS09_fqyx09239QQ'), $oUpay->getPaymentKey());
     }
 
     /**

--- a/tests/Unit/Core/ConfigTest.php
+++ b/tests/Unit/Core/ConfigTest.php
@@ -567,7 +567,7 @@ class ConfigTest extends \OxidTestCase
         $sQ = 'select oxvarname from oxconfig where oxvartype="bool" and oxshopid="' . $sShopId . '" and oxmodule="" order by rand()';
         $sVar = oxDb::getDb()->getOne($sQ);
 
-        $sQ = 'select DECODE( oxvarvalue, "' . $oConfig->getConfigParam('sConfigKey') . '") from oxconfig where oxshopid="' . $sShopId . '" and oxvarname="' . $sVar . '" and oxmodule=""';
+        $sQ = 'select oxvarvalue from oxconfig where oxshopid="' . $sShopId . '" and oxvarname="' . $sVar . '" and oxmodule=""';
         $sVal = oxDb::getDb()->getOne($sQ);
 
         $oConfig->UNITloadVarsFromDB($sShopId, array($sVar));
@@ -585,7 +585,7 @@ class ConfigTest extends \OxidTestCase
         $sQ = 'select oxvarname from oxconfig where oxvartype="arr" and oxshopid="' . $sShopId . '"  and oxmodule="" order by rand()';
         $sVar = oxDb::getDb()->getOne($sQ);
 
-        $sQ = 'select DECODE( oxvarvalue, "' . $oConfig->getConfigParam('sConfigKey') . '") from oxconfig where oxshopid="' . $sShopId . '" and oxvarname="' . $sVar . '" and oxmodule=""';
+        $sQ = 'select oxvarvalue from oxconfig where oxshopid="' . $sShopId . '" and oxvarname="' . $sVar . '" and oxmodule=""';
         $sVal = oxDb::getDb()->getOne($sQ);
 
         $oConfig->UNITloadVarsFromDB($sShopId, array($sVar));
@@ -603,7 +603,7 @@ class ConfigTest extends \OxidTestCase
         $sQ = 'select oxvarname from oxconfig where (oxmodule="" or oxmodule="theme:azure") and oxvartype not in ( "bool", "arr", "aarr" )  and oxshopid="' . $sShopId . '"  and oxmodule="" order by rand()';
         $sVar = oxDb::getDb()->getOne($sQ);
 
-        $sQ = 'select DECODE( oxvarvalue, "' . $oConfig->getConfigParam('sConfigKey') . '") from oxconfig where oxshopid="' . $sShopId . '" and oxvarname="' . $sVar . '" and oxmodule=""';
+        $sQ = 'select oxvarvalue from oxconfig where oxshopid="' . $sShopId . '" and oxvarname="' . $sVar . '" and oxmodule=""';
         $sVal = oxDb::getDb()->getOne($sQ);
 
         $oConfig->UNITloadVarsFromDB($sShopId, array($sVar));
@@ -683,7 +683,6 @@ class ConfigTest extends \OxidTestCase
         $oConfig = oxNew('oxConfig');
         $oConfig->init();
         $sShopId = $oConfig->getShopId();
-        $sConfKey = $oConfig->getConfigParam('sConfigKey');
         $oDb = oxDb::getDb(oxDB::FETCH_MODE_ASSOC);
 
         $aVars = array("theme:basic#iNewBasketItemMessage",
@@ -708,7 +707,7 @@ class ConfigTest extends \OxidTestCase
             $sModule = $aData[0] ? $aData[0] : oxConfig::OXMODULE_THEME_PREFIX . $oConfig->getConfigParam('sTheme');
             $sVar = $aData[1];
 
-            $sQ = "select DECODE( oxvarvalue, '{$sConfKey}') from oxconfig where oxshopid='{$sShopId}' and oxmodule = '{$sModule}' and  oxvarname='{$sVar}'";
+            $sQ = "select oxvarvalue from oxconfig where oxshopid='{$sShopId}' and oxmodule = '{$sModule}' and  oxvarname='{$sVar}'";
             $this->assertEquals($oDb->getOne($sQ), $oConfig->getShopConfVar($sVar, $sShopId, $sModule), "\nshop:{$sShopId}; {$sModule}; var:{$sVar}\n");
         }
     }
@@ -720,9 +719,9 @@ class ConfigTest extends \OxidTestCase
         $sShopId = $oConfig->getBaseShopId();
 
         $sQ1 = "insert into oxconfig (oxid, oxshopid, oxvarname, oxvartype, oxvarvalue) values
-                                    ('_test1', '$sShopId', 'testVar1', 'int', 0x071d6980dc7afb6707bb)";
+                                    ('_test1', '$sShopId', 'testVar1', 'int', '1111111111')";
         $sQ2 = "insert into oxconfig (oxid, oxshopid, oxvarname, oxvartype, oxvarvalue) values
-                                    ('_test2', '$sShopId', 'testVar1', 'int', 0x071d6980dc7afb6707bb)";
+                                    ('_test2', '$sShopId', 'testVar1', 'int', '1111111111')";
 
         oxDb::getDb()->execute($sQ1);
         oxDb::getDb()->execute($sQ2);
@@ -2244,18 +2243,6 @@ class ConfigTest extends \OxidTestCase
         $this->assertEquals(true, $oConfig->decodeValue("bool", $blBool));
         $this->assertEquals($aArray, $oConfig->decodeValue("arr", serialize($aArray)));
         $this->assertEquals($aAssocArray, $oConfig->decodeValue("aarr", serialize($aAssocArray)));
-    }
-
-    /**
-     * Test case for oxConfig::getDecodeValueQuery()
-     *
-     * @return null
-     */
-    public function testGetDecodeValueQuery()
-    {
-        $oConfig = oxNew('oxConfig');
-        $sQ = " DECODE( oxvarvalue, '" . $oConfig->getConfigParam('sConfigKey') . "') ";
-        $this->assertEquals($sQ, $oConfig->getDecodeValueQuery());
     }
 
     public function testGetShopMainUrl()

--- a/tests/Unit/Internal/ContextStub.php
+++ b/tests/Unit/Internal/ContextStub.php
@@ -15,7 +15,6 @@ class ContextStub extends BasicContextStub implements ContextInterface
     private $logFilePath;
     private $currentShopId;
     private $shopIds;
-    private $configurationEncryptionKey;
     private $requiredContactFormFields = [];
     private $adminLogFilePath;
     private $doLogAdminQueries;
@@ -33,7 +32,6 @@ class ContextStub extends BasicContextStub implements ContextInterface
         $this->logLevel = $context->getLogLevel();
         $this->shopIds = $context->getAllShopIds();
         $this->currentShopId = $context->getCurrentShopId();
-        $this->configurationEncryptionKey = $context->getConfigurationEncryptionKey();
         $this->logFilePath = $context->getLogFilePath();
         $this->adminLogFilePath = $context->getAdminLogFilePath();
         $this->doLogAdminQueries = $context->isEnabledAdminQueryLog();
@@ -103,14 +101,6 @@ class ContextStub extends BasicContextStub implements ContextInterface
     public function getCurrentShopId(): int
     {
         return $this->currentShopId;
-    }
-
-    /**
-     * @return string
-     */
-    public function getConfigurationEncryptionKey(): string
-    {
-        return $this->configurationEncryptionKey;
     }
 
     /**


### PR DESCRIPTION
This pull request removes the not anymore needed `encode`/`decode` _feature_ for the `oxconfig` and `oxuserpayments` database tables.

you may scream **WHY?!?**

Encoding and decoding configuration variables ..
- does **not** contribute to security in any way
- `ENCODE()` and `DECODE()` were [droped in MySQL 8.0.3](https://dev.mysql.com/doc/refman/8.0/en/encryption-functions.html#function_encode)
- adds complexity to the system (for no profit gained)

This may be a big BC break, that`s why i am targeting master with this PR

**Todos:**
- [x] port the testing library