### PR TITLE
do not mess with error_reporting server setting

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,7 @@
         "oxid-esales/oxideshop-ide-helper": "dev-master",
         "oxid-esales/azure-theme": "dev-master",
         "oxid-esales/oxideshop-facts": "dev-master",
-        "oxid-esales/testing-library": "dev-master",
+        "oxid-esales/testing-library": "dev-update-vfsstream",
         "squizlabs/php_codesniffer": "^3.5.4",
         "composer/composer": "^1",
         "vimeo/psalm": "^3.8"

--- a/source/Application/Controller/Admin/AdminController.php
+++ b/source/Application/Controller/Admin/AdminController.php
@@ -338,7 +338,7 @@ class AdminController extends \OxidEsales\Eshop\Core\Controller\BaseController
         $iMaxFileSize = $iMaxFileSize ? $iMaxFileSize : '2M';
 
         // processing config
-        $iMaxFileSize = trim($iMaxFileSize);
+        $iMaxFileSize = (int) trim($iMaxFileSize);
         $sParam = strtolower($iMaxFileSize[strlen($iMaxFileSize) - 1]);
         switch ($sParam) {
             case 'g':

--- a/source/Core/Email.php
+++ b/source/Core/Email.php
@@ -1357,7 +1357,7 @@ class Email extends PHPMailer
             $fileUtils = \OxidEsales\Eshop\Core\Registry::getUtilsFile();
             $reSetBody = false;
 
-            // preparing imput
+            // preparing input
             $dynImageDir = $fileUtils->normalizeDir($dynImageDir);
             $imageDir = $fileUtils->normalizeDir($imageDir);
             $imageDirNoSSL = $fileUtils->normalizeDir($imageDirNoSSL);
@@ -1371,7 +1371,7 @@ class Email extends PHPMailer
                 foreach ($matches as $image) {
                     $imageName = $image[1];
                     $fileName = '';
-                    if (strpos($imageName, $dynImageDir) === 0) {
+                    if (is_string($dynImageDir) && strpos($imageName, $dynImageDir) === 0) {
                         $fileName = $fileUtils->normalizeDir($absDynImageDir) . str_replace($dynImageDir, '', $imageName);
                     } elseif (strpos($imageName, $imageDir) === 0) {
                         $fileName = $fileUtils->normalizeDir($absImageDir) . str_replace($imageDir, '', $imageName);

--- a/source/Core/ShopControl.php
+++ b/source/Core/ShopControl.php
@@ -587,8 +587,6 @@ class ShopControl extends \OxidEsales\Eshop\Core\Base
         //session is started, a possible SeoUrl is decoded, globals and environment variables are set.
         $config->init();
 
-        error_reporting($this->_getErrorReportingLevel());
-
         $runOnceExecuted = \OxidEsales\Eshop\Core\Registry::getSession()->getVariable('blRunOnceExecuted');
         if (!$runOnceExecuted && !$this->isAdmin() && $config->isProductiveMode()) {
             // check if setup is still there
@@ -606,29 +604,6 @@ class ShopControl extends \OxidEsales\Eshop\Core\Base
 
             \OxidEsales\Eshop\Core\Registry::getSession()->setVariable('blRunOnceExecuted', true);
         }
-    }
-
-    /**
-     * Returns error reporting level.
-     * Returns disabled error logging if server is misconfigured #2015 E_NONE replaced with 0.
-     *
-     * @return int
-     * @deprecated underscore prefix violates PSR12, will be renamed to "getErrorReportingLevel" in next major
-     */
-    protected function _getErrorReportingLevel() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
-    {
-        $errorReporting = E_ALL ^ E_NOTICE;
-        // some 3rd party libraries still use deprecated functions
-        if (defined('E_DEPRECATED')) {
-            $errorReporting = $errorReporting ^ E_DEPRECATED;
-        }
-
-        if (\OxidEsales\Eshop\Core\Registry::getConfig()->isProductiveMode() && !ini_get('log_errors')) {
-            $errorReporting = 0;
-        }
-
-
-        return $errorReporting;
     }
 
     /**

--- a/source/Setup/index.php
+++ b/source/Setup/index.php
@@ -13,8 +13,6 @@ require_once '../bootstrap.php';
 $moduleAutoload = \OxidEsales\EshopCommunity\Core\Autoload\ModuleAutoload::class ;
 spl_autoload_unregister([$moduleAutoload, 'autoload']);
 
-error_reporting((E_ALL ^ E_NOTICE) | E_STRICT);
-
 require_once 'functions.php';
 
 $oDispatcher = new Dispatcher();

--- a/source/admin/oxajax.php
+++ b/source/admin/oxajax.php
@@ -23,9 +23,6 @@ require_once dirname(__FILE__) . "/../bootstrap.php";
 // processing ..
 $blAjaxCall = (isset($_SERVER['HTTP_X_REQUESTED_WITH']) && $_SERVER['HTTP_X_REQUESTED_WITH'] == 'XMLHttpRequest');
 if ($blAjaxCall) {
-    // Setting error reporting mode
-    error_reporting(E_ALL ^ E_NOTICE);
-
     $myConfig = Registry::getConfig();
 
     // Includes Utility module.

--- a/source/bootstrap.php
+++ b/source/bootstrap.php
@@ -5,9 +5,6 @@
  * See LICENSE file for license details.
  */
 
-error_reporting(E_ALL & ~E_DEPRECATED & ~E_NOTICE);
-ini_set('display_errors', '0');
-
 define('INSTALLATION_ROOT_PATH', dirname(__DIR__));
 define('OX_BASE_PATH', INSTALLATION_ROOT_PATH . DIRECTORY_SEPARATOR . 'source' . DIRECTORY_SEPARATOR);
 define('OX_LOG_FILE', OX_BASE_PATH . 'log' . DIRECTORY_SEPARATOR . 'oxideshop.log');
@@ -112,16 +109,6 @@ if ($configMissing || !is_readable(VENDOR_PATH . 'autoload.php')) {
     trigger_error($message, E_USER_ERROR);
 }
 unset($configMissing);
-
-/**
- * Turn on display errors for debug mode
- */
-$bootstrapConfigFileReader = new \BootstrapConfigFileReader();
-if ($bootstrapConfigFileReader->isDebugMode()) {
-    ini_set('display_errors', '1');
-    error_reporting(E_ALL & ~E_DEPRECATED);
-}
-unset($bootstrapConfigFileReader);
 
 /**
  * Register basic the autoloaders. In this phase we still do not want to use other shop classes to make autoloading

--- a/tests/Unit/Core/UniversallyUniqueIdGeneratorTest.php
+++ b/tests/Unit/Core/UniversallyUniqueIdGeneratorTest.php
@@ -90,7 +90,7 @@ class UniversallyUniqueIdGeneratorTest extends \OxidTestCase
 
         $aIds = array();
         for ($i = 0; $i < 100; $i++) {
-            $aIds[] = $oGenerator->generateV5('seed', 'salt' . $i);
+            $aIds[] = $oGenerator->generateV5('feed', 'salt' . $i);
         }
 
         $this->assertEquals(100, count(array_unique($aIds)));
@@ -105,7 +105,7 @@ class UniversallyUniqueIdGeneratorTest extends \OxidTestCase
 
         $aIds = array();
         for ($i = 0; $i < 100; $i++) {
-            $aIds[] = $oGenerator->generateV5('seed' . $i, 'salt');
+            $aIds[] = $oGenerator->generateV5('feed' . $i, 'salt');
         }
 
         $this->assertEquals(100, count(array_unique($aIds)));
@@ -118,8 +118,8 @@ class UniversallyUniqueIdGeneratorTest extends \OxidTestCase
     {
         $oGenerator = oxNew('oxUniversallyUniqueIdGenerator');
 
-        $sId1 = $oGenerator->generateV5('seed', 'salt');
-        $sId2 = $oGenerator->generateV5('seed', 'salt');
+        $sId1 = $oGenerator->generateV5('feed', 'salt');
+        $sId2 = $oGenerator->generateV5('feed', 'salt');
 
         $this->assertEquals($sId1, $sId2);
     }
@@ -130,7 +130,7 @@ class UniversallyUniqueIdGeneratorTest extends \OxidTestCase
     public function testUUIDV5Structure()
     {
         $oGenerator = oxNew('oxUniversallyUniqueIdGenerator');
-        $sId = $oGenerator->generateV5('seed', 'salt');
+        $sId = $oGenerator->generateV5('feed', 'salt');
 
         $this->assertMatchesRegularExpression('/^[\w]{8}-[\w]{4}-[\w]{4}-[\w]{4}-[\w]{12}$/', $sId);
     }


### PR DESCRIPTION
This pull requests removes resetting the PHP error reporting level via a call to `error_reporting()` in the `ShopControl` class.

I personally think it is not a good idea to mess with server settings in such a way, that it just overrides whatever the server settings are. In most cases the operator put thought in these settings and we should not mess with these.