### PR TITLE
Fix query command detection

### DIFF
--- a/source/Core/Database/Adapter/Doctrine/Database.php
+++ b/source/Core/Database/Adapter/Doctrine/Database.php
@@ -1330,8 +1330,9 @@ class Database implements DatabaseInterface
      */
     protected function getFirstCommandInStatement($query)
     {
+        $singleLineQuery = str_replace(["\r", "\n"], ' ', $query);
         $sqlComments = '@(([\'"]).*?[^\\\]\2)|((?:\#|--).*?$|/\*(?:[^/*]|/(?!\*)|\*(?!/)|(?R))*\*\/)\s*|(?<=;)\s+@ms';
-        $uncommentedQuery = preg_replace($sqlComments, '$1', $query);
+        $uncommentedQuery = preg_replace($sqlComments, '$1', $singleLineQuery);
 
         $command = strtoupper(
             trim(


### PR DESCRIPTION
The query command detection fails for the following query:

```MySQL
SELECT
1 FROM test
```

The result of `getFirstCommandInStatement` is `SELECT 1` instead of `SELECT`, see http://sandbox.onlinephpfunctions.com/code/7d64d49e511e2b3729a82287bc9f7e75cba15df9 for an example. The reason is that the regex doesn't detect the line break after the SELECT with `.*` even if the `s` modifier is set. To fix this we first replace all line breaks with a space. So `getOne` works for all queries instead of returning `false`.