### PR TITLE
Simplification, the notation, to get quickly the QueryBuilder

### DIFF
--- a/source/Core/DatabaseProvider.php
+++ b/source/Core/DatabaseProvider.php
@@ -13,7 +13,7 @@ use OxidEsales\Eshop\Core\Exception\DatabaseNotConfiguredException;
 /**
  * Database connection class
  *
- * @deprecated since v6.5.0 (2019-09-24); Use OxidEsales\EshopCommunity\Internal\Framework\Database\QueryBuilderFactoryInterface
+ * @deprecated since v6.5.0 (2019-09-24); Use \OxidEsales\Eshop\Core\Registry::getQueryBuilder()
  */
 class DatabaseProvider
 {

--- a/source/Core/Registry.php
+++ b/source/Core/Registry.php
@@ -329,18 +329,20 @@ class Registry
 
     /**
      * Return Doctrine QueryBuilder
-     * 
+     *
      * @return \OxidEsales\EshopCommunity\Internal\Framework\Database\QueryBuilderFactoryInterface
      */
     public static function getQueryBuilder()
     {
-        $queryBuilderFactory = \OxidEsales\EshopCommunity\Internal\Framework\Database\QueryBuilderFactoryInterface::class;
+        $class = \OxidEsales\EshopCommunity\Internal\Framework\Database\QueryBuilderFactoryInterface::class;
         
-        if (!isset(self::$instances[$queryBuilderFactory])) {
-            self::$instances[$queryBuilderFactory] = \OxidEsales\EshopCommunity\Internal\Container\ContainerFactory::getInstance()->getContainer()->get($queryBuilderFactory);
+        if (!isset(self::$instances[$class])) {
+            self::$instances[$class] = \OxidEsales\EshopCommunity\Internal\Container\ContainerFactory::getInstance()
+                ->getContainer()
+                ->get($class);
         }
         
-        return self::$instances[$queryBuilderFactory];
+        return self::$instances[$class];
     }
 
     /**

--- a/source/Core/Registry.php
+++ b/source/Core/Registry.php
@@ -328,6 +328,22 @@ class Registry
     }
 
     /**
+     * Return Doctrine QueryBuilder
+     * 
+     * @return \OxidEsales\EshopCommunity\Internal\Framework\Database\QueryBuilderFactoryInterface
+     */
+    public static function getQueryBuilder()
+    {
+        $queryBuilderFactory = \OxidEsales\EshopCommunity\Internal\Framework\Database\QueryBuilderFactoryInterface::class;
+        
+        if (!isset(self::$instances[$queryBuilderFactory])) {
+            self::$instances[$queryBuilderFactory] = \OxidEsales\EshopCommunity\Internal\Container\ContainerFactory::getInstance()->getContainer()->get($queryBuilderFactory);
+        }
+        
+        return self::$instances[$queryBuilderFactory];
+    }
+
+    /**
      * Return all class instances, which are currently set in the registry
      *
      * @return array

--- a/tests/Unit/Core/RegistryTest.php
+++ b/tests/Unit/Core/RegistryTest.php
@@ -465,7 +465,8 @@ class RegistryTest extends \OxidEsales\TestingLibrary\UnitTestCase
             ['getLang', \OxidEsales\Eshop\Core\Language::class],
             ['getUtils', \OxidEsales\Eshop\Core\Utils::class],
             ['getUtilsObject', \OxidEsales\Eshop\Core\UtilsObject::class],
-            ['getLogger', LoggerInterface::class]
+            ['getLogger', LoggerInterface::class],
+            ['getQueryBuilder', \OxidEsales\EshopCommunity\Internal\Framework\Database\QueryBuilderFactoryInterface::class],
         ];
     }
 
@@ -508,6 +509,7 @@ class RegistryTest extends \OxidEsales\TestingLibrary\UnitTestCase
             ['getUtils'],
             ['getUtilsObject'],
             ['getLogger'],
+            ['getQueryBuilder'],
         ];
     }
 }


### PR DESCRIPTION
Code should be easy and quick to read. I would suggest to call it as usual via the Registry::class.

This is how it looks now in v6.5.0:

```php
\OxidEsales\EshopCommunity\Internal\Container\ContainerFactory::getInstance()
    ->getContainer()
    ->get(\OxidEsales\EshopCommunity\Internal\Framework\Database\QueryBuilderFactoryInterface::class)
    ->create()
        ->select('oxarticels')
        ->where('oxid = :oxid')
        ->setParameter('oxid', 'a1b2b3')
        ->execute();
```

and it could look like this:

```php
Registry::getQueryBuilder()
    ->create()
        ->select('oxarticels')
        ->where('oxid = :oxid')
        ->setParameter('oxid', 'a1b2b3')
        ->execute();
```