### PR TITLE
Simplification, the notation, to get quickly the DI container.

### DIFF
--- a/source/Core/Registry.php
+++ b/source/Core/Registry.php
@@ -328,6 +328,22 @@ class Registry
     }
 
     /**
+     * Return \Symfony\Component\DependencyInjection\Container
+     *
+     * @return \Psr\Container\ContainerInterface
+     */
+    public static function getContainer()
+    {
+        $class = \Psr\Container\ContainerInterface::class;
+
+        if (!isset(self::$instances[$class])) {
+            self::$instances[$class] = \OxidEsales\EshopCommunity\Internal\Application\ContainerFactory::getInstance()->getContainer();
+        }
+
+        return self::$instances[$class];
+    }
+
+    /**
      * Return all class instances, which are currently set in the registry
      *
      * @return array

--- a/source/Core/Registry.php
+++ b/source/Core/Registry.php
@@ -337,7 +337,8 @@ class Registry
         $class = \Psr\Container\ContainerInterface::class;
 
         if (!isset(self::$instances[$class])) {
-            self::$instances[$class] = \OxidEsales\EshopCommunity\Internal\Application\ContainerFactory::getInstance()->getContainer();
+            $containerFactory = \OxidEsales\EshopCommunity\Internal\Container\ContainerFactory::getInstance();
+            self::$instances[$class] = $containerFactory->getContainer();
         }
 
         return self::$instances[$class];

--- a/tests/Unit/Core/RegistryTest.php
+++ b/tests/Unit/Core/RegistryTest.php
@@ -465,7 +465,8 @@ class RegistryTest extends \OxidEsales\TestingLibrary\UnitTestCase
             ['getLang', \OxidEsales\Eshop\Core\Language::class],
             ['getUtils', \OxidEsales\Eshop\Core\Utils::class],
             ['getUtilsObject', \OxidEsales\Eshop\Core\UtilsObject::class],
-            ['getLogger', LoggerInterface::class]
+            ['getLogger', LoggerInterface::class],
+            ['getContainer', \Psr\Container\ContainerInterface::class]
         ];
     }
 
@@ -508,6 +509,7 @@ class RegistryTest extends \OxidEsales\TestingLibrary\UnitTestCase
             ['getUtils'],
             ['getUtilsObject'],
             ['getLogger'],
+            ['getContainer'],
         ];
     }
 }


### PR DESCRIPTION
Code should be easy and quick to read. I would suggest to call it as usual via the Registry::class.

This is how it looks now in v6.5.0:

```php
\OxidEsales\EshopCommunity\Internal\Container\ContainerFactory::getInstance()
    ->getContainer()
    ->get(\OxidEsales\EshopCommunity\Internal\SomeInterface::class)
```

and it could look like this:

```php
Registry::getContainer()->get(\OxidEsales\EshopCommunity\Internal\SomeInterface::class)
```
