### PR TITLE
0007051: added resetFilter

### DIFF
--- a/source/Application/Controller/ArticleListController.php
+++ b/source/Application/Controller/ArticleListController.php
@@ -346,6 +346,17 @@ class ArticleListController extends \OxidEsales\Eshop\Application\Controller\Fro
     }
 
     /**
+     * Reset filter.
+     */
+    public function resetFilter()
+    {
+        $activeCategory = \OxidEsales\Eshop\Core\Registry::getConfig()->getRequestParameter('cnid');
+        $sessionFilter = \OxidEsales\Eshop\Core\Registry::getSession()->getVariable('session_attrfilter');
+        unset($sessionFilter[$activeCategory]);
+        \OxidEsales\Eshop\Core\Registry::getSession()->setVariable('session_attrfilter', $sessionFilter);
+    }
+
+    /**
      * Loads and returns article list of active category.
      *
      * @param \OxidEsales\Eshop\Application\Model\Category $category category object


### PR DESCRIPTION
Fix for https://bugs.oxid-esales.com/view.php?id=7051

When resetting Filter on ArticleList an error occurs:
ERROR_MESSAGE_SYSTEMCOMPONENT_FUNCTIONNOTFOUND resetFilter ["[object] (OxidEsales\\Eshop\\Core\\Exception\\SystemComponentException(code: 0):