### PR TITLE
return type of oxNew is the classname given

### DIFF
--- a/source/Core/Registry.php
+++ b/source/Core/Registry.php
@@ -37,11 +37,13 @@ class Registry
      * to the corresponding class name from the Unified Namespace, as they store and retrieve the same instances.
      * But be aware, that support for old class names will be dropped in the future.
      *
-     * @param string $className The class name from the Unified Namespace.
+     * @template T
+     * @param class-string<T> $className The class name from the Unified Namespace.
+     * param mixed  ...$args   constructor arguments
      *
      * @static
      *
-     * @return object
+     * @return T
      */
     public static function get($className)
     {
@@ -413,9 +415,13 @@ class Registry
     /**
      * Return a well known object from the registry
      *
-     * @param string $className A unified namespace class name
+     * @template T
+     * @param class-string<T> $className A unified namespace class name
+     * param mixed  ...$args   constructor arguments
      *
-     * @return mixed
+     * @static
+     *
+     * @return T
      */
     protected static function getObject($className)
     {

--- a/source/oxfunctions.php
+++ b/source/oxfunctions.php
@@ -91,10 +91,11 @@ function cmpart($a, $b)
  * Creates and returns new object. If creation is not available, dies and outputs
  * error message.
  *
- * @param string $className Name of class
- * @param mixed  ...$args   constructor arguments
+ * @template T
+ * @param class-string<T> $className
+ * param mixed  ...$args   constructor arguments
  *
- * @return object
+ * @return T
  */
 function oxNew($className)
 {


### PR DESCRIPTION
Using the variable return type declaration fixes PHPstan warnings when scanning my modules