### PR TITLE
added arguments to oxNew method signature

### DIFF
--- a/source/Core/UtilsObject.php
+++ b/source/Core/UtilsObject.php
@@ -185,15 +185,14 @@ class UtilsObject
      * error message.
      *
      * @param string $className Name of class
+     * @param array  $arguments constructor arguments
      *
      * @throws SystemComponentException in case that class does not exists
      *
      * @return object
      */
-    public function oxNew($className)
+    public function oxNew($className, ...$arguments)
     {
-        $arguments = func_get_args();
-        array_shift($arguments);
         $argumentsCount = count($arguments);
         $shouldUseCache = $this->shouldCacheObject($className, $arguments);
         if (!\OxidEsales\Eshop\Core\NamespaceInformationProvider::isNamespacedClass($className)) {

--- a/source/oxfunctions.php
+++ b/source/oxfunctions.php
@@ -96,11 +96,10 @@ function cmpart($a, $b)
  *
  * @return object
  */
-function oxNew($className)
+function oxNew($className, ...$args)
 {
     startProfile('oxNew');
-    $arguments = func_get_args();
-    $object = call_user_func_array([UtilsObject::getInstance(), "oxNew"], $arguments);
+    $object = call_user_func_array([UtilsObject::getInstance(), "oxNew"], array_merge([$className], $args));
     stopProfile('oxNew');
 
     return $object;

--- a/tests/Unit/Application/Controller/CmpCategoriesTest.php
+++ b/tests/Unit/Application/Controller/CmpCategoriesTest.php
@@ -311,7 +311,7 @@ class CmpCategoriesTest extends \OxidTestCase
 
     public function testLoadManufacturerTreeIsNotNeeded()
     {
-        oxTestModules::addFunction('oxUtilsObject', 'oxNew($cl)', '{if ("oxmanufacturerlist" == $cl) return \Unit\Application\Controller\CmpCategoriesTest::$oCL; return parent::oxNew($cl);}');
+        oxTestModules::addFunction('oxUtilsObject', 'oxNew($cl, ...$arguments)', '{if ("oxmanufacturerlist" == $cl) return \Unit\Application\Controller\CmpCategoriesTest::$oCL; return parent::oxNew($cl, ...$arguments);}');
 
         $oCfg = $this->getMock(Config::class, array('getConfigParam'));
         $oCfg->expects($this->at(0))->method('getConfigParam')->with($this->equalTo('bl_perfLoadManufacturerTree'))->will($this->returnValue(false));


### PR DESCRIPTION
This makes static code analysis easier, I just had an error with psalm:

```
ERROR: TooManyArguments - Path/To/File.php:43:30 - Too many arguments for method oxNew - expecting 1 but saw 4
                $object = oxNew(File::class, $param1, $param2, $param3);
```