### PR TITLE
Migrate from PHP 7.4snapshot to 7.4 in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,13 +9,13 @@ php:
   - "7.1"
   - "7.2"
   - "7.3"
-  - "7.4snapshot"
+  - "7.4"
 
 matrix:
   fast_finish: true
   allow_failures:
     - php: "7.3"
-    - php: "7.4snapshot"
+    - php: "7.4"
 
 # Numeric values of error reporting levels:
 # 32767: E_ALL


### PR DESCRIPTION
As PHP `7.4` is now official released, Travis upgraded their images too and PHP `7.4` can now be used without the `snapshot` suffix