### PR TITLE
changed _getDbConfigTypeName from private to protected

### DIFF
--- a/source/Application/Controller/Admin/ModuleConfiguration.php
+++ b/source/Application/Controller/Admin/ModuleConfiguration.php
@@ -334,7 +334,6 @@ class ModuleConfiguration extends \OxidEsales\Eshop\Application\Controller\Admin
      */
     protected function getDbConfigTypeName($type)
     {
-       parent::getDbConfigTypeName($type);
-       return $type === 'colorpicker' ? 'str' : $type;
+        return $type === 'password' ? 'str' : $type;
     }
 }

--- a/source/Application/Controller/Admin/ModuleConfiguration.php
+++ b/source/Application/Controller/Admin/ModuleConfiguration.php
@@ -332,8 +332,9 @@ class ModuleConfiguration extends \OxidEsales\Eshop\Application\Controller\Admin
      *
      * @return string
      */
-    protected function _getDbConfigTypeName($type)
+    protected function getDbConfigTypeName($type)
     {
-        return $type === 'password' ? 'str' : $type;
+       parent::getDbConfigTypeName($type);
+       return $type === 'colorpicker' ? 'str' : $type;
     }
 }

--- a/source/Application/Controller/Admin/ModuleConfiguration.php
+++ b/source/Application/Controller/Admin/ModuleConfiguration.php
@@ -332,7 +332,7 @@ class ModuleConfiguration extends \OxidEsales\Eshop\Application\Controller\Admin
      *
      * @return string
      */
-    private function _getDbConfigTypeName($type)
+    protected function _getDbConfigTypeName($type)
     {
         return $type === 'password' ? 'str' : $type;
     }


### PR DESCRIPTION
changing private to protected makes it really easy to add new settings (for example a colorpicker) in the metadata.

Extending ModuleConfiguration like that, adds a new type "colorpicker" to the metadata.php.

```
public function init()
    {
        $this->_aConfParams["colorpicker"]    = 'confclr';
        parent::init(); // TODO: Change the autogenerated stub
    }

protected function getDbConfigTypeName($type)
    {
        parent::getDbConfigTypeName($type);
        return $type === 'colorpicker' ? 'str' : $type;
    }

```

using block "admin_module_config_var_types" in module_config.tpl allows us to add the new type to the template
```
[{$smarty.block.parent}]
[{if $var_type == 'colorpicker'}]
<input type="color"  name="confclr[[{$module_var}]]" value="[{$confclr.$module_var}]" >
 [{/if}]
```

In the metadata.php you can add the colorpicker with
```
'settings' => array(
                  array('group' =>  'color_main', 'name'  =>  'color_picker', 'type'  =>  'colorpicker', 'value' =>  '#ff9b00')
    )
```