### PR TITLE
Feature fix type annotations

### DIFF
--- a/source/Application/Controller/Admin/ShopConfiguration.php
+++ b/source/Application/Controller/Admin/ShopConfiguration.php
@@ -189,7 +189,7 @@ class ShopConfiguration extends \OxidEsales\Eshop\Application\Controller\Admin\A
      *      'constraints' => constraints list as array[name] = constraint
      *      'grouping'    => grouping info as array[name] = grouping
      *
-     * @param string $shopId Shop id
+     * @param int    $shopId Shop id
      * @param string $moduleId module to load (empty string is for base values)
      *
      * @return array

--- a/source/Application/Model/CategoryList.php
+++ b/source/Application/Model/CategoryList.php
@@ -360,7 +360,7 @@ class CategoryList extends \OxidEsales\Eshop\Core\Model\ListModel
     }
 
     /**
-     * setter for shopID
+     * setter for shopId
      *
      * @param int $sShopID ShopID
      */

--- a/source/Application/Model/User.php
+++ b/source/Application/Model/User.php
@@ -2370,7 +2370,7 @@ class User extends \OxidEsales\Eshop\Core\Model\BaseModel
      *
      * @param string $userName User
      * @param string $password Password
-     * @param int    $shopID   Shop id
+     * @param int    $shopId   Shop id
      *
      * @throws UserException
      *
@@ -2382,12 +2382,12 @@ class User extends \OxidEsales\Eshop\Core\Model\BaseModel
      *
      * @return void
      */
-    protected function _dbLogin(string $userName, $password, $shopID)
+    protected function _dbLogin(string $userName, $password, $shopId)
     {
         $database = \OxidEsales\Eshop\Core\DatabaseProvider::getDb();
-        $userId = $database->getOne($this->_getLoginQuery($userName, $password, $shopID, $this->isAdmin()));
+        $userId = $database->getOne($this->_getLoginQuery($userName, $password, $shopId, $this->isAdmin()));
         if (!$userId) {
-            $userId = $database->getOne($this->_getLoginQueryHashedWithMD5($userName, $password, $shopID, $this->isAdmin()));
+            $userId = $database->getOne($this->_getLoginQueryHashedWithMD5($userName, $password, $shopId, $this->isAdmin()));
         }
 
         /** Return here to give other log-in mechanisms the possibility to be triggered */
@@ -2395,7 +2395,7 @@ class User extends \OxidEsales\Eshop\Core\Model\BaseModel
             return;
         }
 
-        $this->loadAuthenticatedUser($userName, $shopID);
+        $this->loadAuthenticatedUser($userName, $shopId);
         $this->isOutdatedPasswordHashAlgorithmUsed = true;
     }
 

--- a/source/Application/Model/User.php
+++ b/source/Application/Model/User.php
@@ -1295,7 +1295,7 @@ class User extends \OxidEsales\Eshop\Core\Model\BaseModel
      *
      * @param string $userName login name
      * @param string $password login password
-     * @param string $shopId   shopid
+     * @param int    $shopId   shopid
      * @param bool   $isAdmin  admin/non admin mode
      *
      * @deprecated since v6.4.0 (2019-03-15); `\OxidEsales\EshopCommunity\Internal\Domain\Authentication\Bridge\PasswordServiceBridgeInterface`
@@ -2370,7 +2370,7 @@ class User extends \OxidEsales\Eshop\Core\Model\BaseModel
      *
      * @param string $userName User
      * @param string $password Password
-     * @param string $shopID   Shop id
+     * @param int    $shopID   Shop id
      *
      * @throws UserException
      *
@@ -2788,7 +2788,7 @@ class User extends \OxidEsales\Eshop\Core\Model\BaseModel
      * Updates given query. Method is for overriding.
      *
      * @param string $user
-     * @param string $shopId
+     * @param int    $shopId
      *
      * @return string
      */

--- a/source/Core/Config.php
+++ b/source/Core/Config.php
@@ -558,7 +558,7 @@ class Config extends \OxidEsales\Eshop\Core\Base
     /**
      * Load config values from DB
      *
-     * @param string $shopID   shop ID to load parameters
+     * @param int    $shopID   shop ID to load parameters
      * @param array  $onlyVars array of params to load (optional)
      * @param string $module   module vars to load, empty for base options
      *
@@ -799,7 +799,7 @@ class Config extends \OxidEsales\Eshop\Core\Base
     /**
      * Active Shop id setter
      *
-     * @param string $shopId shop id
+     * @param int    $shopId shop id
      */
     public function setShopId($shopId)
     {
@@ -1845,7 +1845,7 @@ class Config extends \OxidEsales\Eshop\Core\Base
      * @param string $varType Variable Type
      * @param string $varName Variable name
      * @param mixed  $varVal  Variable value (can be string, integer or array)
-     * @param string $shopId  Shop ID, default is current shop
+     * @param int    $shopId  Shop ID, default is current shop
      * @param string $module  Module name (empty for base options)
      */
     public function saveShopConfVar($varType, $varName, $varVal, $shopId = null, $module = '')
@@ -1909,7 +1909,7 @@ class Config extends \OxidEsales\Eshop\Core\Base
      * Retrieves shop configuration parameters from DB.
      *
      * @param string $varName Variable name
-     * @param string $shopId  Shop ID
+     * @param int    $shopId  Shop ID
      * @param string $module  module identifier
      *
      * @return object - raw configuration value in DB
@@ -2318,7 +2318,7 @@ class Config extends \OxidEsales\Eshop\Core\Base
     /**
      * Returns whether given shop id is valid.
      *
-     * @param string $shopId
+     * @param int    $shopId
      *
      * @return bool
      */

--- a/source/Core/Config.php
+++ b/source/Core/Config.php
@@ -386,17 +386,17 @@ class Config extends \OxidEsales\Eshop\Core\Base
      * Initialize configuration variables
      *
      * @throws \OxidEsales\Eshop\Core\Exception\DatabaseException
-     * @param int $shopID
+     * @param int $shopId
      */
-    public function initVars($shopID)
+    public function initVars($shopId)
     {
         $this->_loadVarsFromFile();
 
         $this->_setDefaults();
 
-        $configLoaded = $this->_loadVarsFromDb($shopID);
+        $configLoaded = $this->_loadVarsFromDb($shopId);
         // loading shop config
-        if (empty($shopID) || !$configLoaded) {
+        if (empty($shopId) || !$configLoaded) {
             // if no config values where loaded (some problems with DB), throwing an exception
             $exception = new \OxidEsales\Eshop\Core\Exception\DatabaseException(
                 "Unable to load shop config values from database",
@@ -407,15 +407,15 @@ class Config extends \OxidEsales\Eshop\Core\Base
         }
 
         // loading theme config options
-        $this->_loadVarsFromDb($shopID, null, Config::OXMODULE_THEME_PREFIX . $this->getConfigParam('sTheme'));
+        $this->_loadVarsFromDb($shopId, null, Config::OXMODULE_THEME_PREFIX . $this->getConfigParam('sTheme'));
 
         // checking if custom theme (which has defined parent theme) config options should be loaded over parent theme (#3362)
         if ($this->getConfigParam('sCustomTheme')) {
-            $this->_loadVarsFromDb($shopID, null, Config::OXMODULE_THEME_PREFIX . $this->getConfigParam('sCustomTheme'));
+            $this->_loadVarsFromDb($shopId, null, Config::OXMODULE_THEME_PREFIX . $this->getConfigParam('sCustomTheme'));
         }
 
         // loading modules config
-        $this->_loadVarsFromDb($shopID, null, Config::OXMODULE_MODULE_PREFIX);
+        $this->_loadVarsFromDb($shopId, null, Config::OXMODULE_MODULE_PREFIX);
 
         $this->loadAdditionalConfiguration();
 
@@ -558,18 +558,18 @@ class Config extends \OxidEsales\Eshop\Core\Base
     /**
      * Load config values from DB
      *
-     * @param int    $shopID   shop ID to load parameters
+     * @param int    $shopId   shop ID to load parameters
      * @param array  $onlyVars array of params to load (optional)
      * @param string $module   module vars to load, empty for base options
      *
      * @return bool
      */
-    protected function _loadVarsFromDb($shopID, $onlyVars = null, $module = '')
+    protected function _loadVarsFromDb($shopId, $onlyVars = null, $module = '')
     {
         $db = \OxidEsales\Eshop\Core\DatabaseProvider::getDb();
 
         $params = [
-          ':oxshopid' => $shopID
+          ':oxshopid' => $shopId
         ];
         $select = "select
                         oxvarname, oxvartype, " . $this->getDecodeValueQuery() . " as oxvarvalue

--- a/source/Core/Model/BaseModel.php
+++ b/source/Core/Model/BaseModel.php
@@ -529,8 +529,8 @@ class BaseModel extends \OxidEsales\Eshop\Core\Base
             if ($this->getCoreTableName() == 'oxobject2category') {
                 $objectId = $this->oxobject2category__oxobjectid;
                 $categoryId = $this->oxobject2category__oxcatnid;
-                $shopID = $this->oxobject2category__oxshopid;
-                $this->_sOXID = md5($objectId . $categoryId . $shopID);
+                $shopId = $this->oxobject2category__oxshopid;
+                $this->_sOXID = md5($objectId . $categoryId . $shopId);
             } else {
                 $this->_sOXID = \OxidEsales\Eshop\Core\Registry::getUtilsObject()->generateUID();
             }
@@ -996,13 +996,13 @@ class BaseModel extends \OxidEsales\Eshop\Core\Base
      * Returns actual object view or table name
      *
      * @param string $table  Original table name
-     * @param int    $shopID Shop ID
+     * @param int    $shopId Shop ID
      *
      * @return string
      */
-    protected function _getObjectViewName($table, $shopID = null)
+    protected function _getObjectViewName($table, $shopId = null)
     {
-        return getViewName($table, -1, $shopID);
+        return getViewName($table, -1, $shopId);
     }
 
     /**

--- a/source/Core/Model/MultiLanguageModel.php
+++ b/source/Core/Model/MultiLanguageModel.php
@@ -521,17 +521,17 @@ class MultiLanguageModel extends \OxidEsales\Eshop\Core\Model\BaseModel
      * Returns actual object view or table name
      *
      * @param string $table  Original table name
-     * @param int    $shopID Shop ID
+     * @param int    $shopId Shop ID
      *
      * @return string
      */
-    protected function _getObjectViewName($table, $shopID = null)
+    protected function _getObjectViewName($table, $shopId = null)
     {
         if (!$this->_blEmployMultilanguage) {
-            return parent::_getObjectViewName($table, $shopID);
+            return parent::_getObjectViewName($table, $shopId);
         }
 
-        return getViewName($table, $this->getLanguage(), $shopID);
+        return getViewName($table, $this->getLanguage(), $shopId);
     }
 
     /**

--- a/source/Core/Module/ModuleTemplateBlockRepository.php
+++ b/source/Core/Module/ModuleTemplateBlockRepository.php
@@ -19,7 +19,7 @@ class ModuleTemplateBlockRepository
      * Return how many blocks of provided module overrides any template for active shop.
      *
      * @param array  $modulesId list of modules to check if their template blocks overrides some shop block.
-     * @param string $shopId    shop id to check if some module block overrides some template blocks in this Shop.
+     * @param int    $shopId    shop id to check if some module block overrides some template blocks in this Shop.
      *
      * @return string count of blocks for Shop=$shopId from modules=$modulesId.
      */
@@ -44,7 +44,7 @@ class ModuleTemplateBlockRepository
      *
      * @param string $shopTemplateName shop template file name.
      * @param array  $activeModulesId  list of modules to get information about.
-     * @param string $shopId           in which Shop modules must be active.
+     * @param int    $shopId           in which Shop modules must be active.
      * @param array  $themesId         list of themes to get information about.
      *
      * @return array

--- a/source/Core/TableViewNameGenerator.php
+++ b/source/Core/TableViewNameGenerator.php
@@ -42,7 +42,7 @@ class TableViewNameGenerator
      *
      * @param string $table      Table name
      * @param int    $languageId Language id [optional]
-     * @param string $shopId     Shop id, otherwise config->getShopId() is used [optional]
+     * @param int    $shopId     Shop id, otherwise config->getShopId() is used [optional]
      *
      * @return string
      */

--- a/source/overridablefunctions.php
+++ b/source/overridablefunctions.php
@@ -165,7 +165,7 @@ if (!function_exists('getViewName')) {
      *
      * @param string $table      table name
      * @param int    $languageId language id [optional]
-     * @param string $shopId     shop id, otherwise config->myshopid is used [optional]
+     * @param int    $shopId     shop id, otherwise config->myshopid is used [optional]
      *
      * @deprecated since v6.0.0 (2016-05-16); Use oxTableViewNameGenerator::getViewName().
      *


### PR DESCRIPTION
While working on https://github.com/OXID-eSales/graphql-example-module/pull/5 I saw that the type hints for `$shopId` are `string` instead of `int` in some occasions. 

This pull request
- changes the type hints from `string` to `int` where they are wrong for `$shopId` argument
- changes naming from `$shopID` to `$shopId` to be consistent throughout the source

This is no BC break