### PR TITLE
Skip url generation if "Display Currencies" option is disabled

### DIFF
--- a/source/Application/Component/CurrencyComponent.php
+++ b/source/Application/Component/CurrencyComponent.php
@@ -102,10 +102,10 @@ class CurrencyComponent extends \OxidEsales\Eshop\Core\Controller\BaseController
         $oParentView = $this->getParent();
         $oParentView->setActCurrency($this->_oActCur);
 
-        $oUrlUtils = \OxidEsales\Eshop\Core\Registry::getUtilsUrl();
-        $sUrl = $oUrlUtils->cleanUrl($this->getConfig()->getTopActiveView()->getLink(), ["cur"]);
-
         if ($this->getConfig()->getConfigParam('bl_perfLoadCurrency')) {
+            $oUrlUtils = \OxidEsales\Eshop\Core\Registry::getUtilsUrl();
+            $sUrl = $oUrlUtils->cleanUrl($this->getConfig()->getTopActiveView()->getLink(), ["cur"]);
+
             reset($this->aCurrencies);
             foreach ($this->aCurrencies as $oItem) {
                 $oItem->link = $oUrlUtils->processUrl($sUrl, true, ["cur" => $oItem->id]);


### PR DESCRIPTION
This change solves performance problems on article list pages (ArticleListController, SearchController). For every ArticleBox-Widget on the page the CurrencyComponent will be loaded. If the "Display Currencies" option is disabled we don't the URL that will be generated in the components render function. (Tested with OXID EE 6.1.0 + Memcached + Varnish Cache)