### PR TITLE
Database driver options config

### DIFF
--- a/source/Core/Database/Adapter/Doctrine/Database.php
+++ b/source/Core/Database/Adapter/Doctrine/Database.php
@@ -186,7 +186,8 @@ class Database implements DatabaseInterface
             'port'     => $connectionParameters['databasePort'],
         ];
 
-        $this->addDriverOptions($pdoMysqlConnectionParameters);
+        $driverOptions = $connectionParameters['databaseDriverOptions'];
+        $this->addDriverOptions($pdoMysqlConnectionParameters, $driverOptions);
         $this->addConnectionCharset(
             $pdoMysqlConnectionParameters,
             $connectionParameters['connectionCharset']
@@ -199,13 +200,16 @@ class Database implements DatabaseInterface
      * Adds the param driverOptions to an existing array of connection parameters
      *
      * @param array $existingParameters
-     *
+     * @param array $driverOptions options defined in config (override default options)
      */
-    protected function addDriverOptions(array &$existingParameters)
+    protected function addDriverOptions(array &$existingParameters, $driverOptions)
     {
-        $existingParameters['driverOptions'] = [
-            PDO::MYSQL_ATTR_INIT_COMMAND => $this->getMySqlInitCommand()
-        ];
+        $existingParameters['driverOptions'] = array_merge(
+            array(
+                PDO::MYSQL_ATTR_INIT_COMMAND => $this->getMySqlInitCommand(),
+            ),
+            $driverOptions
+        );
     }
 
     /**

--- a/source/Core/Database/Adapter/Doctrine/Database.php
+++ b/source/Core/Database/Adapter/Doctrine/Database.php
@@ -204,12 +204,10 @@ class Database implements DatabaseInterface
      */
     protected function addDriverOptions(array &$existingParameters, $driverOptions)
     {
-        $existingParameters['driverOptions'] = array_merge(
-            array(
+        $default = array(
                 PDO::MYSQL_ATTR_INIT_COMMAND => $this->getMySqlInitCommand(),
-            ),
-            $driverOptions
         );
+        $existingParameters['driverOptions'] = $driverOptions + $default;
     }
 
     /**

--- a/source/Core/Database/Adapter/Doctrine/Database.php
+++ b/source/Core/Database/Adapter/Doctrine/Database.php
@@ -187,6 +187,10 @@ class Database implements DatabaseInterface
             'driverOptions' => $connectionParameters['databaseDriverOptions'],
         ];
 
+        if (isset($connectionParameters['databaseUnixSocket'])){
+            $pdoMysqlConnectionParameters['unix_socket'] = $connectionParameters['databaseUnixSocket'];
+        }
+
         $this->addDriverOptions($pdoMysqlConnectionParameters);
         $this->addConnectionCharset(
             $pdoMysqlConnectionParameters,

--- a/source/Core/Database/Adapter/Doctrine/Database.php
+++ b/source/Core/Database/Adapter/Doctrine/Database.php
@@ -178,16 +178,16 @@ class Database implements DatabaseInterface
     protected function getPdoMysqlConnectionParameters(array $connectionParameters)
     {
         $pdoMysqlConnectionParameters = [
-            'driver'   => 'pdo_mysql',
-            'host'     => $connectionParameters['databaseHost'],
-            'dbname'   => $connectionParameters['databaseName'],
-            'user'     => $connectionParameters['databaseUser'],
-            'password' => $connectionParameters['databasePassword'],
-            'port'     => $connectionParameters['databasePort'],
+            'driver'        => 'pdo_mysql',
+            'host'          => $connectionParameters['databaseHost'],
+            'dbname'        => $connectionParameters['databaseName'],
+            'user'          => $connectionParameters['databaseUser'],
+            'password'      => $connectionParameters['databasePassword'],
+            'port'          => $connectionParameters['databasePort'],
+            'driverOptions' => $connectionParameters['databaseDriverOptions'],
         ];
 
-        $driverOptions = $connectionParameters['databaseDriverOptions'];
-        $this->addDriverOptions($pdoMysqlConnectionParameters, $driverOptions);
+        $this->addDriverOptions($pdoMysqlConnectionParameters);
         $this->addConnectionCharset(
             $pdoMysqlConnectionParameters,
             $connectionParameters['connectionCharset']
@@ -197,17 +197,18 @@ class Database implements DatabaseInterface
     }
 
     /**
-     * Adds the param driverOptions to an existing array of connection parameters
+     * Adds default values to driverOptions param
      *
      * @param array $existingParameters
-     * @param array $driverOptions options defined in config (override default options)
      */
-    protected function addDriverOptions(array &$existingParameters, $driverOptions)
+    protected function addDriverOptions(array &$existingParameters)
     {
         $default = array(
-                PDO::MYSQL_ATTR_INIT_COMMAND => $this->getMySqlInitCommand(),
+            PDO::MYSQL_ATTR_INIT_COMMAND => $this->getMySqlInitCommand(),
         );
-        $existingParameters['driverOptions'] = $driverOptions + $default;
+
+        // options defined in config override the default
+        $existingParameters['driverOptions'] += $default;
     }
 
     /**

--- a/source/Core/DatabaseProvider.php
+++ b/source/Core/DatabaseProvider.php
@@ -289,15 +289,23 @@ class DatabaseProvider
          * @var string $databasePassword The password of the database user.
          */
         $databasePassword = $this->getConfigParam('dbPwd');
+        /**
+         * @var string $databaseDriverOptions The options to pass to the database driver.
+         */
+        $databaseDriverOptions = $this->getConfigParam('dbDriverOptions');
+        if (!is_array($databaseDriverOptions)){
+            $databaseDriverOptions = array();
+        }
 
         $connectionParameters = [
             'default' => [
-                'databaseDriver'    => $databaseDriver,
-                'databaseHost'      => $databaseHost,
-                'databasePort'      => $databasePort,
-                'databaseName'      => $databaseName,
-                'databaseUser'      => $databaseUser,
-                'databasePassword'  => $databasePassword,
+                'databaseDriver'        => $databaseDriver,
+                'databaseHost'          => $databaseHost,
+                'databasePort'          => $databasePort,
+                'databaseName'          => $databaseName,
+                'databaseUser'          => $databaseUser,
+                'databasePassword'      => $databasePassword,
+                'databaseDriverOptions' => $databaseDriverOptions,
             ]
         ];
 

--- a/source/Core/DatabaseProvider.php
+++ b/source/Core/DatabaseProvider.php
@@ -296,6 +296,10 @@ class DatabaseProvider
         if (!is_array($databaseDriverOptions)){
             $databaseDriverOptions = array();
         }
+        /**
+         * @var string $databaseUnixSocket The unix_socket path.
+         */
+        $databaseUnixSocket = $this->getConfigParam('dbUnixSocket');
 
         $connectionParameters = [
             'default' => [
@@ -306,7 +310,8 @@ class DatabaseProvider
                 'databaseUser'          => $databaseUser,
                 'databasePassword'      => $databasePassword,
                 'databaseDriverOptions' => $databaseDriverOptions,
-            ]
+                'databaseUnixSocket'    => $databaseUnixSocket,
+            ],
         ];
 
         /**

--- a/source/config.inc.php.dist
+++ b/source/config.inc.php.dist
@@ -12,6 +12,7 @@ $this->dbPort  = 3306; // tcp port to which the database is bound
 $this->dbName = '<dbName>'; // database name
 $this->dbUser = '<dbUser>'; // database user name
 $this->dbPwd  = '<dbPwd>'; // database user password
+$this->dbDriverOptions = []; // database driver options
 $this->sShopURL     = '<sShopURL>'; // eShop base url, required
 $this->sSSLShopURL  = null;            // eShop SSL url, optional
 $this->sAdminSSLURL = null;            // eShop Admin SSL url, optional

--- a/tests/Integration/Core/Database/Adapter/Doctrine/DatabaseTest.php
+++ b/tests/Integration/Core/Database/Adapter/Doctrine/DatabaseTest.php
@@ -519,11 +519,12 @@ class DatabaseTest extends DatabaseInterfaceImplementationTest
         $this->setProtectedClassProperty($this->database, 'connectionParameters', array());
         $connectionParametersFromConfigInc = array(
             'default' => array(
-                'databaseHost'     => 'myDatabaseHost',
-                'databaseName'     => 'myDatabaseName',
-                'databaseUser'     => 'myDatabaseUser',
-                'databasePassword' => 'myDatabasePassword',
-                'databasePort'     => 'myDatabasePort'
+                'databaseHost'          => 'myDatabaseHost',
+                'databaseName'          => 'myDatabaseName',
+                'databaseUser'          => 'myDatabaseUser',
+                'databasePassword'      => 'myDatabasePassword',
+                'databasePort'          => 'myDatabasePort',
+                'databaseDriverOptions' => array('testkey' => 'testvalue'),
             )
         );
         $this->database->setConnectionParameters($connectionParametersFromConfigInc);
@@ -535,7 +536,8 @@ class DatabaseTest extends DatabaseInterfaceImplementationTest
             'password' => 'myDatabasePassword',
             'port'     => 'myDatabasePort',
             'driverOptions' => array(
-                PDO::MYSQL_ATTR_INIT_COMMAND => "SET @@SESSION.sql_mode=''"
+                PDO::MYSQL_ATTR_INIT_COMMAND => "SET @@SESSION.sql_mode=''",
+                'testkey'                    => 'testvalue',
             )
         );
         $this->assertEquals(


### PR DESCRIPTION
Allow to pass custom database driver options from withing config.inc.php. 

For example this is needed to establish a database connection over SSL (to pass a certificate path).

Example with just PDO:
```
<?php
$servername = "test.com";
$username  = "oxid@test";
$password = "test";
$options = array(
	PDO::MYSQL_ATTR_INIT_COMMAND => 'SET NAMES utf8',
	PDO::MYSQL_ATTR_SSL_CA => 'cert.crt.pem',
	PDO::MYSQL_ATTR_SSL_VERIFY_SERVER_CERT => false,
);

try {
    $conn = new PDO("mysql:host=$servername;port=3306;dbname=mysql", $username, $password, $options);
    // set the PDO error mode to exception
    $conn->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
    echo "Connected successfully"; 
        var_dump($conn->query("SHOW STATUS LIKE 'Ssl_cipher';")->fetchAll());
        $conn = null;
}
catch(PDOException $e)
    {
    echo "Connection failed: " . $e->getMessage();
}
?>

```

With OXID, I found it difficult to implement, as I needed to extend both 
`OxidEsales\Eshop\Core\Database\Adapter\Doctrine\Database`
and
`OxidEsales\Eshop\Core\DatabaseProvider`
then initialize the connection in a few places:
- source/modules/functions.php (called from bootstrap) for http requests
- all console scripts (views, config, migrations) - I created wrappers to include bootstrap first

With the proposed change it would be possible to just define custom connection options in config.inc.php like so:
```
$this->dbDriverOptions = [
    PDO::MYSQL_ATTR_INIT_COMMAND => 'SET NAMES utf8',
    PDO::MYSQL_ATTR_SSL_CA => 'cert.crt.pem',
    PDO::MYSQL_ATTR_SSL_VERIFY_SERVER_CERT => false,
];
```