### PR TITLE
fix view generation on broken shop

### DIFF
--- a/source/Application/Model/Shop.php
+++ b/source/Application/Model/Shop.php
@@ -343,6 +343,13 @@ class Shop extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel
             $sJoin = $this->_getViewJoinLang($table, $languageId);
         }
 
+        if ("" === $sFields) {
+            //this happens if there is a table in the configuration 
+            //that do not exists. ignoring this issue here allows the user
+            //the user to generate the views and get a running shop.
+            return;
+        }
+
         $sQuery = "{$queryStart} `{$sViewTable}` AS SELECT {$sFields} FROM {$table}{$sJoin}";
         $this->addQuery($sQuery);
     }

--- a/source/Application/Model/Shop.php
+++ b/source/Application/Model/Shop.php
@@ -7,7 +7,7 @@
 
 namespace OxidEsales\EshopCommunity\Application\Model;
 
-use oxRegistry;
+use OxidEsales\Eshop\Core\Registry;
 use oxDb;
 
 /**
@@ -94,7 +94,7 @@ class Shop extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel
         parent::__construct();
 
         if (!$this->isShopValid()) {
-            \OxidEsales\Eshop\Core\Registry::getLogger()->error('Shop is not valid');
+            Registry::getLogger()->error('Shop is not valid');
 
             return;
         }
@@ -279,13 +279,13 @@ class Shop extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel
     protected function _cleanInvalidViews()
     {
         $oDb = \OxidEsales\Eshop\Core\DatabaseProvider::getDb();
-        $oLang = \OxidEsales\Eshop\Core\Registry::getLang();
+        $oLang = Registry::getLang();
         $aLanguages = $oLang->getLanguageIds($this->getId());
 
-        $aMultilangTables = \OxidEsales\Eshop\Core\Registry::getLang()->getMultiLangTables();
+        $aMultilangTables = Registry::getLang()->getMultiLangTables();
         $aMultishopTables = $this->getMultiShopTables();
 
-        $oLang = \OxidEsales\Eshop\Core\Registry::getLang();
+        $oLang = Registry::getLang();
         $aAllShopLanguages = $oLang->getAllShopLanguageIds();
 
         $oViewsValidator = oxNew(\OxidEsales\Eshop\Application\Model\ShopViewValidator::class);
@@ -308,10 +308,10 @@ class Shop extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel
      */
     protected function _prepareViewsQueries()
     {
-        $oLang = \OxidEsales\Eshop\Core\Registry::getLang();
+        $oLang = Registry::getLang();
         $aLanguages = $oLang->getLanguageIds($this->getId());
 
-        $aMultilangTables = \OxidEsales\Eshop\Core\Registry::getLang()->getMultiLangTables();
+        $aMultilangTables = Registry::getLang()->getMultiLangTables();
         $aTables = $this->getTables();
         foreach ($aTables as $sTable) {
             $this->createViewQuery($sTable);
@@ -347,6 +347,7 @@ class Shop extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel
             //this happens if there is a table in the configuration 
             //that do not exists. ignoring this issue here allows the user
             //the user to generate the views and get a running shop.
+            Registry::getLogger()->error("View for $table can not be generated, mabe the table does not exists");
             return;
         }
 
@@ -384,7 +385,7 @@ class Shop extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel
      */
     protected function formDatabaseTablesArray()
     {
-        $multilanguageTables = \OxidEsales\Eshop\Core\Registry::getLang()->getMultiLangTables();
+        $multilanguageTables = Registry::getLang()->getMultiLangTables();
 
         return array_unique($multilanguageTables);
     }


### PR DESCRIPTION
this happens if there is a table in the configuration 
that do not exists. ignoring this issue here allows the user to generate the views and get a running shop.

without this fix there is sql error in that case because there are no fields to build a valid sql