### PR TITLE
Added possibility to add a custom offline-page

### DIFF
--- a/source/bootstrap.php
+++ b/source/bootstrap.php
@@ -228,8 +228,7 @@ function oxTriggerOfflinePageDisplay()
 
         /**
          * Render an error message.
-         * If offline.php exists its content is displayed.
-         * Like this the error message is overridable within that file.
+         * If offline.html exists its content is displayed.
          */
         if (is_readable(OX_OFFLINE_FILE)) {
             echo file_get_contents(OX_OFFLINE_FILE);

--- a/source/bootstrap.php
+++ b/source/bootstrap.php
@@ -215,6 +215,14 @@ function oxTriggerOfflinePageDisplay()
 {
     // Do not display the offline page, if this running in CLI mode
     if ('cli' !== strtolower(php_sapi_name())) {
+
+        // Add your own offline-page. Don't forget to set 50X/Retry-After headers in cust_offline.php!
+        $customOfflinePageFile = OX_BASE_PATH . 'cust_offline.php';
+        if (file_exists($customOfflinePageFile) && is_readable($customOfflinePageFile)) {
+            require_once $customOfflinePageFile;
+            return;
+        };
+
         header("HTTP/1.1 500 Internal Server Error");
         header("Connection: close");
 


### PR DESCRIPTION
It should be possible to overwrite the static 500-status offline.html
This standard-page and status-code isn't good for SEO at all.