### PR TITLE
Fixing UtilsCount.php class comment

### DIFF
--- a/source/Core/UtilsCount.php
+++ b/source/Core/UtilsCount.php
@@ -8,7 +8,7 @@
 namespace OxidEsales\EshopCommunity\Core;
 
 /**
- * Date manipulation utility class
+ * Counting utility class
  */
 class UtilsCount extends \OxidEsales\Eshop\Core\Base
 {


### PR DESCRIPTION
Currently the UtilsCount class comment uses the class comment of UtilsDate.php