### PR TITLE
using one controler instance per widget

### DIFF
--- a/source/Core/Smarty/Plugin/function.oxid_include_widget.php
+++ b/source/Core/Smarty/Plugin/function.oxid_include_widget.php
@@ -27,6 +27,6 @@ function smarty_function_oxid_include_widget($params, &$oSmarty)
         unset($params["_parent"]);
     }
 
-    $widgetControl = \OxidEsales\Eshop\Core\Registry::get(\OxidEsales\Eshop\Core\WidgetControl::class);
+    $widgetControl = oxNew(\OxidEsales\Eshop\Core\WidgetControl::class);
     return $widgetControl->start($class, null, $params, $parentViews);
 }


### PR DESCRIPTION
widget class does have member variables and by reusing the singleton this get mixed up during nested start calls
so using a new instance allows using nested widget without errors.