### PR TITLE
Refactor calls to deprecated getStr()

### DIFF
--- a/source/Application/Component/CategoriesComponent.php
+++ b/source/Application/Component/CategoriesComponent.php
@@ -6,6 +6,7 @@
 
 namespace OxidEsales\EshopCommunity\Application\Component;
 
+use OxidEsales\Eshop\Core\Str;
 use oxRegistry;
 
 /**
@@ -117,7 +118,7 @@ class CategoriesComponent extends \OxidEsales\Eshop\Core\Controller\BaseControll
 
             $sActManufacturer = $myConfig->getConfigParam('bl_perfLoadManufacturerTree') ? $sActManufacturer : null;
 
-            $sActVendor = (getStr()->preg_match('/^v_.?/i', $sActCat)) ? $sActCat : null;
+            $sActVendor = (Str::getStr()->preg_match('/^v_.?/i', $sActCat)) ? $sActCat : null;
 
             $sActCat = $this->_addAdditionalParams($oProduct, $sActCat, $sActManufacturer, $sActVendor);
         }

--- a/source/Application/Controller/Admin/ActionsMainAjax.php
+++ b/source/Application/Controller/Admin/ActionsMainAjax.php
@@ -10,6 +10,7 @@ use oxRegistry;
 use oxDb;
 use oxField;
 use Exception;
+use OxidEsales\Eshop\Core\Str;
 
 /**
  * Class controls article assignment to action
@@ -111,7 +112,7 @@ class ActionsMainAjax extends \OxidEsales\Eshop\Application\Controller\Admin\Lis
         if ($this->getConfig()->getConfigParam('blVariantsSelection')) {
             $sQ .= ' group by ' . $this->_getViewName('oxarticles') . '.oxid ';
 
-            $oStr = getStr();
+            $oStr = Str::getStr();
             if ($oStr->strpos($sQ, "select count( * ) ") === 0) {
                 $sQ = "select count( * ) from ( {$sQ} ) as _cnttable";
             }

--- a/source/Application/Controller/Admin/AdminListController.php
+++ b/source/Application/Controller/Admin/AdminListController.php
@@ -13,6 +13,7 @@ use stdClass;
 use oxList;
 use oxBase;
 use oxI18n;
+use OxidEsales\Eshop\Core\Str;
 
 /**
  * Admin selectlist list manager.
@@ -252,7 +253,7 @@ class AdminListController extends \OxidEsales\Eshop\Application\Controller\Admin
      */
     protected function _calcListItemsCount($sql)
     {
-        $stringModifier = getStr();
+        $stringModifier = Str::getStr();
 
         // count SQL
         $sql = $stringModifier->preg_replace('/select .* from/i', 'select count(*) from ', $sql);
@@ -358,7 +359,7 @@ class AdminListController extends \OxidEsales\Eshop\Application\Controller\Admin
      */
     protected function _processFilter($fieldValue)
     {
-        $stringModifier = getStr();
+        $stringModifier = Str::getStr();
 
         //removing % symbols
         $fieldValue = $stringModifier->preg_replace("/^%|%$/", "", trim($fieldValue));
@@ -396,7 +397,7 @@ class AdminListController extends \OxidEsales\Eshop\Application\Controller\Admin
      */
     protected function _isSearchValue($fieldValue)
     {
-        return (getStr()->preg_match('/^%/', $fieldValue) && getStr()->preg_match('/%$/', $fieldValue));
+        return (Str::getStr()->preg_match('/^%/', $fieldValue) && Str::getStr()->preg_match('/%$/', $fieldValue));
     }
 
     /**
@@ -574,7 +575,7 @@ class AdminListController extends \OxidEsales\Eshop\Application\Controller\Admin
 
         // looking for date field
         $dateMatches = [];
-        $stringModifier = getStr();
+        $stringModifier = Str::getStr();
         foreach ($datePatterns as $pattern => $type) {
             if ($stringModifier->preg_match($pattern, $date, $dateMatches)) {
                 $date = $dateMatches[$dateFormats[$type][0]] . "-" . $dateMatches[$dateFormats[$type][1]];
@@ -598,7 +599,7 @@ class AdminListController extends \OxidEsales\Eshop\Application\Controller\Admin
         $convertedObject = new \OxidEsales\Eshop\Core\Field();
         $convertedObject->setValue($date);
         \OxidEsales\Eshop\Core\Registry::getUtilsDate()->convertDBDate($convertedObject, true);
-        $stringModifier = getStr();
+        $stringModifier = Str::getStr();
 
         // looking for time field
         $time = substr($fullDate, 11);

--- a/source/Application/Controller/Admin/ArticleList.php
+++ b/source/Application/Controller/Admin/ArticleList.php
@@ -7,6 +7,7 @@
 namespace OxidEsales\EshopCommunity\Application\Controller\Admin;
 
 use OxidEsales\Eshop\Application\Model\Article;
+use OxidEsales\Eshop\Core\Str;
 use oxRegistry;
 use oxDb;
 
@@ -254,7 +255,7 @@ class ArticleList extends \OxidEsales\Eshop\Application\Controller\Admin\AdminLi
             switch ($sType) {
                 // add category
                 case 'cat':
-                    $oStr = getStr();
+                    $oStr = Str::getStr();
                     $sViewName = getViewName("oxobject2category");
                     $sInsert = "from $sTable left join {$sViewName} on {$sTable}.oxid = {$sViewName}.oxobjectid " .
                                "where {$sViewName}.oxcatnid = " . \OxidEsales\Eshop\Core\DatabaseProvider::getDb()->quote($sValue) . " and ";

--- a/source/Application/Controller/Admin/ArticleSeo.php
+++ b/source/Application/Controller/Admin/ArticleSeo.php
@@ -9,6 +9,7 @@ namespace OxidEsales\EshopCommunity\Application\Controller\Admin;
 use oxRegistry;
 use oxDb;
 use oxField;
+use OxidEsales\Eshop\Core\Str;
 
 /**
  * Article seo config class
@@ -39,7 +40,7 @@ class ArticleSeo extends \OxidEsales\Eshop\Application\Controller\Admin\ObjectSe
         $sType = false;
         $aData = \OxidEsales\Eshop\Core\Registry::getConfig()->getRequestParameter("aSeoData");
         if ($aData && isset($aData["oxparams"])) {
-            $oStr = getStr();
+            $oStr = Str::getStr();
             $iEndPos = $oStr->strpos($aData["oxparams"], "#");
             $sType = $oStr->substr($aData["oxparams"], 0, $iEndPos);
         } elseif ($aList = $this->getSelectionList()) {
@@ -64,7 +65,7 @@ class ArticleSeo extends \OxidEsales\Eshop\Application\Controller\Admin\ObjectSe
         $iLang = false;
         $aData = \OxidEsales\Eshop\Core\Registry::getConfig()->getRequestParameter("aSeoData");
         if ($aData && isset($aData["oxparams"])) {
-            $oStr = getStr();
+            $oStr = Str::getStr();
             $iStartPos = $oStr->strpos($aData["oxparams"], "#");
             $iEndPos = $oStr->strpos($aData["oxparams"], "#", $iStartPos + 1);
             $iLang = $oStr->substr($aData["oxparams"], $iEndPos + 1);
@@ -86,7 +87,7 @@ class ArticleSeo extends \OxidEsales\Eshop\Application\Controller\Admin\ObjectSe
         $sId = false;
         $aData = \OxidEsales\Eshop\Core\Registry::getConfig()->getRequestParameter("aSeoData");
         if ($aData && isset($aData["oxparams"])) {
-            $oStr = getStr();
+            $oStr = Str::getStr();
             $iStartPos = $oStr->strpos($aData["oxparams"], "#");
             $iEndPos = $oStr->strpos($aData["oxparams"], "#", $iStartPos + 1);
             $iLen = $oStr->strlen($aData["oxparams"]);

--- a/source/Application/Controller/Admin/AttributeMainAjax.php
+++ b/source/Application/Controller/Admin/AttributeMainAjax.php
@@ -9,6 +9,7 @@ namespace OxidEsales\EshopCommunity\Application\Controller\Admin;
 use oxRegistry;
 use oxDb;
 use oxField;
+use OxidEsales\Eshop\Core\Str;
 
 /**
  * Class manages article attributes
@@ -108,7 +109,7 @@ class AttributeMainAjax extends \OxidEsales\Eshop\Application\Controller\Admin\L
         if ($this->getConfig()->getConfigParam('blVariantsSelection')) {
             $sQ .= ' group by ' . $this->_getViewName('oxarticles') . '.oxid ';
 
-            $oStr = getStr();
+            $oStr = Str::getStr();
             if ($oStr->strpos($sQ, "select count( * ) ") === 0) {
                 $sQ = "select count( * ) from ( {$sQ} ) as _cnttable";
             }

--- a/source/Application/Controller/Admin/ContentMain.php
+++ b/source/Application/Controller/Admin/ContentMain.php
@@ -10,6 +10,7 @@ use oxRegistry;
 use oxDb;
 use oxField;
 use stdClass;
+use OxidEsales\Eshop\Core\Str;
 
 /**
  * Admin content manager.
@@ -199,7 +200,7 @@ class ContentMain extends \OxidEsales\Eshop\Application\Controller\Admin\AdminDe
     protected function _prepareIdent($sIdent)
     {
         if ($sIdent) {
-            return getStr()->preg_replace("/[^a-zA-Z0-9_]*/", "", $sIdent);
+            return Str::getStr()->preg_replace("/[^a-zA-Z0-9_]*/", "", $sIdent);
         }
     }
 

--- a/source/Application/Controller/Admin/DynamicExportBaseController.php
+++ b/source/Application/Controller/Admin/DynamicExportBaseController.php
@@ -9,6 +9,7 @@ namespace OxidEsales\EshopCommunity\Application\Controller\Admin;
 use oxRegistry;
 use oxDb;
 use stdClass;
+use OxidEsales\Eshop\Core\Str;
 
 /**
  * Error constants
@@ -326,7 +327,7 @@ class DynamicExportBaseController extends \OxidEsales\Eshop\Application\Controll
         // remove html entities, remove html tags
         $sInput = $this->_unHTMLEntities(strip_tags($sInput));
 
-        $oStr = getStr();
+        $oStr = Str::getStr();
         if ($oStr->strlen($sInput) > $iMaxSize - 3) {
             $sInput = $oStr->substr($sInput, 0, $iMaxSize - 5) . "...";
         }
@@ -526,7 +527,7 @@ class DynamicExportBaseController extends \OxidEsales\Eshop\Application\Controll
      */
     public function assureContent($sInput, $sReplace = null)
     {
-        $oStr = getStr();
+        $oStr = Str::getStr();
         if (!$oStr->strlen($sInput)) {
             if (!isset($sReplace) || !$oStr->strlen($sReplace)) {
                 $sReplace = "-";

--- a/source/Application/Controller/Admin/ListComponentAjax.php
+++ b/source/Application/Controller/Admin/ListComponentAjax.php
@@ -6,6 +6,7 @@
 
 namespace OxidEsales\EshopCommunity\Application\Controller\Admin;
 
+use OxidEsales\Eshop\Core\Str;
 use OxidEsales\EshopCommunity\Internal\Transition\ShopEvents\AfterRequestProcessedEvent;
 
 /**
@@ -358,7 +359,7 @@ class ListComponentAjax extends \OxidEsales\Eshop\Core\Base
         if (is_array($aFilter) && count($aFilter)) {
             $aCols = $this->_getVisibleColNames();
             $oDb = \OxidEsales\Eshop\Core\DatabaseProvider::getDb();
-            $oStr = getStr();
+            $oStr = Str::getStr();
 
             foreach ($aFilter as $sCol => $sValue) {
                 // skipping empty filters

--- a/source/Application/Controller/Admin/ListReview.php
+++ b/source/Application/Controller/Admin/ListReview.php
@@ -7,6 +7,7 @@
 namespace OxidEsales\EshopCommunity\Application\Controller\Admin;
 
 use oxAdminList;
+use OxidEsales\Eshop\Core\Str;
 
 /**
  * user list "view" class.
@@ -73,7 +74,7 @@ class ListReview extends \OxidEsales\Eshop\Application\Controller\Admin\ArticleL
 
         //removing parent id checking from sql
         $sStr = "/\s+and\s+" . $sArtTable . "\.oxparentid\s*=\s*''/";
-        $sQ = getStr()->preg_replace($sStr, " ", $sQ);
+        $sQ = Str::getStr()->preg_replace($sStr, " ", $sQ);
 
         return " $sQ and {$sArtTable}.oxid is not null ";
     }
@@ -96,7 +97,7 @@ class ListReview extends \OxidEsales\Eshop\Application\Controller\Admin\ArticleL
         // if searching in article title field, updating sql for this case
         if ($this->_aWhere[$sArtTitleField]) {
             $sSqlForTitle = " (CONCAT( {$sArtTable}.oxtitle, if(isnull(oxparentarticles.oxtitle), '', oxparentarticles.oxtitle), {$sArtTable}.oxvarselect)) ";
-            $sSql = getStr()->preg_replace("/{$sArtTable}\.oxtitle\s+like/", "$sSqlForTitle like", $sSql);
+            $sSql = Str::getStr()->preg_replace("/{$sArtTable}\.oxtitle\s+like/", "$sSqlForTitle like", $sSql);
         }
 
         return $sSql;

--- a/source/Application/Controller/Admin/LoginController.php
+++ b/source/Application/Controller/Admin/LoginController.php
@@ -8,6 +8,7 @@ namespace OxidEsales\EshopCommunity\Application\Controller\Admin;
 
 use OxidEsales\Eshop\Core\Exception\UserException;
 use OxidEsales\Eshop\Core\ShopVersion;
+use OxidEsales\Eshop\Core\Str;
 
 /**
  * Administrator login form.
@@ -120,7 +121,7 @@ class LoginController extends \OxidEsales\Eshop\Application\Controller\Admin\Adm
             }
         } catch (UserException $oEx) {
             $myUtilsView->addErrorToDisplay('LOGIN_ERROR');
-            $oStr = getStr();
+            $oStr = Str::getStr();
             $this->addTplParam('user', $oStr->htmlspecialchars($sUser));
             $this->addTplParam('pwd', $oStr->htmlspecialchars($sPass));
             $this->addTplParam('profile', $oStr->htmlspecialchars($sProfile));
@@ -128,7 +129,7 @@ class LoginController extends \OxidEsales\Eshop\Application\Controller\Admin\Adm
             return;
         } catch (\OxidEsales\Eshop\Core\Exception\CookieException $oEx) {
             $myUtilsView->addErrorToDisplay('LOGIN_NO_COOKIE_SUPPORT');
-            $oStr = getStr();
+            $oStr = Str::getStr();
             $this->addTplParam('user', $oStr->htmlspecialchars($sUser));
             $this->addTplParam('pwd', $oStr->htmlspecialchars($sPass));
             $this->addTplParam('profile', $oStr->htmlspecialchars($sProfile));

--- a/source/Application/Controller/Admin/ModuleConfiguration.php
+++ b/source/Application/Controller/Admin/ModuleConfiguration.php
@@ -131,7 +131,7 @@ class ModuleConfiguration extends \OxidEsales\Eshop\Application\Controller\Admin
                             $sValue = $aValue["value"];
                             break;
                     }
-                    $sValue = getStr()->htmlentities($sValue);
+                    $sValue = Str::getStr()->htmlentities($sValue);
                 } else {
                     $sDbType = $this->_getDbConfigTypeName($sType);
                     $sValue = $aDbVariables['vars'][$sDbType][$sName];

--- a/source/Application/Controller/Admin/NavigationTree.php
+++ b/source/Application/Controller/Admin/NavigationTree.php
@@ -14,6 +14,7 @@ use stdClass;
 use OxidEsales\Eshop\Core\Edition\EditionRootPathProvider;
 use OxidEsales\Eshop\Core\Edition\EditionPathProvider;
 use OxidEsales\Eshop\Core\Edition\EditionSelector;
+use OxidEsales\Eshop\Core\Str;
 
 /**
  * Navigation tree control class
@@ -106,7 +107,7 @@ class NavigationTree extends \OxidEsales\Eshop\Core\Base
             $merge = true;
         } elseif (is_readable($menuFile) && ($xml = @file_get_contents($menuFile))) {
             // looking for non supported character encoding
-            if (getStr()->preg_match("/encoding\=(.*)\?\>/", $xml, $matches) !== 0) {
+            if (Str::getStr()->preg_match("/encoding\=(.*)\?\>/", $xml, $matches) !== 0) {
                 if (isset($matches[1])) {
                     $currEncoding = trim($matches[1], "\"");
                     if (!in_array(strtolower($currEncoding), $this->_aSupportedExpathXmlEncodings)) {
@@ -207,7 +208,7 @@ class NavigationTree extends \OxidEsales\Eshop\Core\Base
     {
         $url = $this->_getAdminUrl();
         $xPath = new DomXPath($dom);
-        $str = getStr();
+        $str = Str::getStr();
         foreach (['url', 'link'] as $attrType) {
             foreach ($xPath->query("//OXMENU//*[@$attrType]") as $node) {
                 $localUrl = $node->getAttribute($attrType);

--- a/source/Application/Controller/Admin/ShopConfiguration.php
+++ b/source/Application/Controller/Admin/ShopConfiguration.php
@@ -7,6 +7,7 @@
 namespace OxidEsales\EshopCommunity\Application\Controller\Admin;
 
 use OxidEsales\Eshop\Core\Registry;
+use OxidEsales\Eshop\Core\Str;
 use OxidEsales\EshopCommunity\Internal\Container\ContainerFactory;
 use OxidEsales\EshopCommunity\Internal\Framework\FormConfiguration\FieldConfigurationInterface;
 use OxidEsales\EshopCommunity\Internal\Domain\Contact\Form\ContactFormBridgeInterface;
@@ -305,7 +306,7 @@ class ShopConfiguration extends \OxidEsales\Eshop\Application\Controller\Admin\A
      */
     public function _unserializeConfVar($type, $name, $value)
     {
-        $str = getStr();
+        $str = Str::getStr();
         $data = null;
 
         switch ($type) {
@@ -448,7 +449,7 @@ class ShopConfiguration extends \OxidEsales\Eshop\Application\Controller\Admin\A
      */
     protected function _multilineToAarray($multiline)
     {
-        $string = getStr();
+        $string = Str::getStr();
         $array = [];
         $lines = explode("\n", $multiline);
         foreach ($lines as $line) {

--- a/source/Application/Controller/Admin/ToolsList.php
+++ b/source/Application/Controller/Admin/ToolsList.php
@@ -10,6 +10,7 @@ use oxRegistry;
 use oxDb;
 use oxStr;
 use Exception;
+use OxidEsales\Eshop\Core\Str;
 
 /**
  * Admin systeminfo manager.
@@ -57,7 +58,7 @@ class ToolsList extends \OxidEsales\Eshop\Application\Controller\Admin\AdminList
             }
 
             $sUpdateSQL = trim(stripslashes($sUpdateSQL));
-            $oStr = getStr();
+            $oStr = Str::getStr();
             $iLen = $oStr->strlen($sUpdateSQL);
             if ($this->_prepareSQL($sUpdateSQL, $iLen)) {
                 $aQueries = $this->aSQLs;
@@ -76,7 +77,7 @@ class ToolsList extends \OxidEsales\Eshop\Application\Controller\Admin\AdminList
                         $sUpdateSQL = trim($sUpdateSQL);
 
                         if ($oStr->strlen($sUpdateSQL) > 0) {
-                            $aPassedQueries[$iQueriesCounter] = nl2br(\OxidEsales\Eshop\Core\Str::getStr()->htmlentities($sUpdateSQL));
+                            $aPassedQueries[$iQueriesCounter] = nl2br($oStr->htmlentities($sUpdateSQL));
                             if ($oStr->strlen($aPassedQueries[$iQueriesCounter]) > 200) {
                                 $aPassedQueries[$iQueriesCounter] = $oStr->substr($aPassedQueries[$iQueriesCounter], 0, 200) . "...";
                             }
@@ -93,8 +94,8 @@ class ToolsList extends \OxidEsales\Eshop\Application\Controller\Admin\AdminList
                                 $aQAffectedRows[$iQueriesCounter] = $oDB->execute($sUpdateSQL);
                             } catch (Exception $exception) {
                                 // Report errors
-                                $aQErrorMessages[$iQueriesCounter] = \OxidEsales\Eshop\Core\Str::getStr()->htmlentities($exception->getMessage());
-                                $aQErrorNumbers[$iQueriesCounter] = \OxidEsales\Eshop\Core\Str::getStr()->htmlentities($exception->getCode());
+                                $aQErrorMessages[$iQueriesCounter] = $oStr->htmlentities($exception->getMessage());
+                                $aQErrorNumbers[$iQueriesCounter] = $oStr->htmlentities($exception->getCode());
                                 // Trigger breaking the loop
                                 $blStop = true;
                             }
@@ -170,7 +171,7 @@ class ToolsList extends \OxidEsales\Eshop\Application\Controller\Admin\AdminList
     {
         $sStrStart = "";
         $blString = false;
-        $oStr = getStr();
+        $oStr = Str::getStr();
 
         //removing "mysqldump" application comments
         while ($oStr->preg_match("/^\-\-.*\n/", $sSQL)) {

--- a/source/Application/Controller/ArticleListController.php
+++ b/source/Application/Controller/ArticleListController.php
@@ -10,6 +10,7 @@ use OxidEsales\Eshop\Application\Model\Category;
 use OxidEsales\Eshop\Core\Field;
 use OxidEsales\Eshop\Core\Registry;
 use OxidEsales\Eshop\Core\Request;
+use OxidEsales\Eshop\Core\Str;
 
 /**
  * List of articles for a selected product group.
@@ -462,7 +463,7 @@ class ArticleListController extends \OxidEsales\Eshop\Application\Controller\Fro
 
             //fetching category path
             if (is_array($categoryTreePath = $this->getCatTreePath())) {
-                $stringModifier = getStr();
+                $stringModifier = Str::getStr();
                 $this->_sCatPathString = '';
                 foreach ($categoryTreePath as $category) {
                     if ($this->_sCatPathString) {
@@ -505,10 +506,11 @@ class ArticleListController extends \OxidEsales\Eshop\Application\Controller\Fro
         }
 
         // making safe for output
-        $description = getStr()->html_entity_decode($description);
-        $description = getStr()->strip_tags($description);
-        $description = getStr()->cleanStr($description);
-        $description = getStr()->htmlspecialchars($description);
+        $str = Str::getStr();
+        $description = $str->html_entity_decode($description);
+        $description = $str->strip_tags($description);
+        $description = $str->cleanStr($description);
+        $description = $str->htmlspecialchars($description);
 
         return trim($description);
     }
@@ -625,7 +627,7 @@ class ArticleListController extends \OxidEsales\Eshop\Application\Controller\Fro
         $text = '';
 
         if (count($articleList = $this->getArticleList())) {
-            $stringModifier = getStr();
+            $stringModifier = Str::getStr();
             foreach ($articleList as $article) {
                 /** @var \OxidEsales\Eshop\Application\Model\Article $article */
                 $description = $stringModifier->strip_tags(

--- a/source/Application/Controller/ContentController.php
+++ b/source/Application/Controller/ContentController.php
@@ -7,6 +7,7 @@
 namespace OxidEsales\EshopCommunity\Application\Controller;
 
 use OxidEsales\Eshop\Core\Registry;
+use OxidEsales\Eshop\Core\Str;
 use oxRegistry;
 
 /**
@@ -337,7 +338,7 @@ class ContentController extends \OxidEsales\Eshop\Application\Controller\Fronten
             $sTplName = basename($sTplName);
 
             //checking if it is template name, not content id
-            if (!getStr()->preg_match("/\.tpl$/", $sTplName)) {
+            if (!Str::getStr()->preg_match("/\.tpl$/", $sTplName)) {
                 $sTplName = null;
             } else {
                 $sTplName = 'message/' . $sTplName;

--- a/source/Application/Controller/FrontendController.php
+++ b/source/Application/Controller/FrontendController.php
@@ -1051,7 +1051,7 @@ class FrontendController extends \OxidEsales\Eshop\Core\Controller\BaseControlle
             if ($content->loadByIdent($metaIdent) &&
                 $content->oxcontents__oxactive->value
             ) {
-                return getStr()->strip_tags($content->oxcontents__oxcontent->value);
+                return Str::getStr()->strip_tags($content->oxcontents__oxcontent->value);
             }
         }
     }
@@ -1265,7 +1265,7 @@ class FrontendController extends \OxidEsales\Eshop\Core\Controller\BaseControlle
     protected function _prepareMetaDescription($meta, $length = 1024, $removeDuplicatedWords = false)
     {
         if ($meta) {
-            $stringModifier = getStr();
+            $stringModifier = Str::getStr();
             if ($length != -1) {
                 /* *
                  * performance - we do not need a huge amount of initial text.
@@ -1329,7 +1329,7 @@ class FrontendController extends \OxidEsales\Eshop\Core\Controller\BaseControlle
      */
     protected function _removeDuplicatedWords($input, $skipTags = [])
     {
-        $stringModifier = getStr();
+        $stringModifier = Str::getStr();
         if (is_array($input)) {
             $input = implode(" ", $input);
         }

--- a/source/Application/Controller/RssController.php
+++ b/source/Application/Controller/RssController.php
@@ -7,6 +7,7 @@
 namespace OxidEsales\EshopCommunity\Application\Controller;
 
 use OxidEsales\Eshop\Application\Model\RssFeed;
+use OxidEsales\Eshop\Core\Str;
 use OxidEsales\EshopCommunity\Internal\Framework\Templating\TemplateRendererBridgeInterface;
 use OxidEsales\EshopCommunity\Internal\Framework\Templating\TemplateRendererInterface;
 
@@ -107,7 +108,7 @@ class RssController extends \OxidEsales\Eshop\Application\Controller\FrontendCon
      */
     protected function _processOutput($sInput)
     {
-        return getStr()->recodeEntities($sInput);
+        return Str::getStr()->recodeEntities($sInput);
     }
 
     /**

--- a/source/Application/Model/Article.php
+++ b/source/Application/Model/Article.php
@@ -10,6 +10,7 @@ use Exception;
 use oxField;
 use OxidEsales\Eshop\Core\Field;
 use OxidEsales\Eshop\Core\Registry;
+use OxidEsales\Eshop\Core\Str;
 use oxList;
 
 // defining supported link types
@@ -1735,7 +1736,7 @@ class Article extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
             // if the oxcategory instance of this article is not cached
             if (!isset($this->_aCategoryCache[$sOXID])) {
                 startPRofile('getCategory');
-                $oStr = getStr();
+                $oStr = Str::getStr();
                 $sWhere = $oCategory->getSqlActiveSnippet();
                 $sSelect = $this->_generateSearchStr($sOXID);
                 $sSelect .= ($oStr->strstr(
@@ -2348,7 +2349,7 @@ class Article extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
             $iActPicId = \OxidEsales\Eshop\Core\Registry::getConfig()->getRequestParameter('actpicid');
         }
 
-        $oStr = getStr();
+        $oStr = Str::getStr();
         $iCntr = 0;
         $iPicCount = $myConfig->getConfigParam('iPicCount');
         $blCheckActivePicId = true;

--- a/source/Application/Model/Attribute.php
+++ b/source/Application/Model/Attribute.php
@@ -9,6 +9,7 @@ namespace OxidEsales\EshopCommunity\Application\Model;
 use oxDb;
 use oxRegistry;
 use oxField;
+use OxidEsales\Eshop\Core\Str;
 
 /**
  * Article attributes manager.
@@ -142,7 +143,7 @@ class Attribute extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel
         $sAttViewName = getViewName('oxattribute');
 
         return $oDb->getOne("select oxid from $sAttViewName where LOWER(oxtitle) = :oxtitle ", [
-            ':oxtitle' => getStr()->strtolower($sSelTitle)
+            ':oxtitle' => Str::getStr()->strtolower($sSelTitle)
         ]);
     }
 
@@ -207,7 +208,7 @@ class Attribute extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel
      */
     public function setTitle($sTitle)
     {
-        $this->_sTitle = getStr()->htmlspecialchars($sTitle);
+        $this->_sTitle = Str::getStr()->htmlspecialchars($sTitle);
     }
 
     /**
@@ -227,7 +228,7 @@ class Attribute extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel
      */
     public function addValue($sValue)
     {
-        $this->_aValues[] = getStr()->htmlspecialchars($sValue);
+        $this->_aValues[] = Str::getStr()->htmlspecialchars($sValue);
     }
 
     /**
@@ -237,7 +238,7 @@ class Attribute extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel
      */
     public function setActiveValue($sValue)
     {
-        $this->_sActiveValue = getStr()->htmlspecialchars($sValue);
+        $this->_sActiveValue = Str::getStr()->htmlspecialchars($sValue);
     }
 
     /**

--- a/source/Application/Model/OrderArticle.php
+++ b/source/Application/Model/OrderArticle.php
@@ -7,6 +7,7 @@
 namespace OxidEsales\EshopCommunity\Application\Model;
 
 use OxidEsales\EshopCommunity\Application\Model\Contract\ArticleInterface;
+use OxidEsales\Eshop\Core\Str;
 
 /**
  * Order article manager.
@@ -401,7 +402,7 @@ class OrderArticle extends \OxidEsales\Eshop\Core\Model\BaseModel implements Art
 
             if ($oArticle = $this->_getOrderArticle($sArtId)) {
                 $aList = explode(", ", $sOrderArtSelList);
-                $oStr = getStr();
+                $oStr = Str::getStr();
 
                 $aArticleSelList = $oArticle->getSelectLists();
 

--- a/source/Application/Model/RssFeed.php
+++ b/source/Application/Model/RssFeed.php
@@ -8,6 +8,7 @@ namespace OxidEsales\EshopCommunity\Application\Model;
 
 use OxidEsales\Eshop\Core\Edition\EditionSelector;
 use OxidEsales\Eshop\Core\Registry;
+use OxidEsales\Eshop\Core\Str;
 use stdClass;
 
 /**
@@ -215,7 +216,7 @@ class RssFeed extends \OxidEsales\Eshop\Core\Base
         $myUtilsUrl = Registry::getUtilsUrl();
         $aItems = [];
         $oLang = Registry::getLang();
-        $oStr = getStr();
+        $oStr = Str::getStr();
 
         foreach ($oList as $oArticle) {
             $oItem = new stdClass();
@@ -319,7 +320,7 @@ class RssFeed extends \OxidEsales\Eshop\Core\Base
     protected function _getShopUrl()
     {
         $sUrl = $this->getConfig()->getShopUrl();
-        $oStr = getStr();
+        $oStr = Str::getStr();
         if ($oStr->strpos($sUrl, '?') !== false) {
             if (!$oStr->preg_match('/[?&](amp;)?$/i', $sUrl)) {
                 $sUrl .= '&amp;';
@@ -578,7 +579,7 @@ class RssFeed extends \OxidEsales\Eshop\Core\Base
      */
     public function getSearchArticlesTitle($sSearch, $sCatId, $sVendorId, $sManufacturerId)
     {
-        return $this->_prepareFeedName(getStr()->htmlspecialchars($this->_getSearchParamsTranslation('SEARCH_FOR_PRODUCTS_CATEGORY_VENDOR_MANUFACTURER', $sSearch, $sCatId, $sVendorId, $sManufacturerId)));
+        return $this->_prepareFeedName(Str::getStr()->htmlspecialchars($this->_getSearchParamsTranslation('SEARCH_FOR_PRODUCTS_CATEGORY_VENDOR_MANUFACTURER', $sSearch, $sCatId, $sVendorId, $sManufacturerId)));
     }
 
     /**
@@ -724,7 +725,7 @@ class RssFeed extends \OxidEsales\Eshop\Core\Base
             null,
             //self::RSS_SEARCHARTS.md5($sSearch.$sCatId.$sVendorId),
             $this->getSearchArticlesTitle($sSearch, $sCatId, $sVendorId, $sManufacturerId),
-            $this->_getSearchParamsTranslation('SEARCH_FOR_PRODUCTS_CATEGORY_VENDOR_MANUFACTURER', getStr()->htmlspecialchars($sSearch), $sCatId, $sVendorId, $sManufacturerId),
+            $this->_getSearchParamsTranslation('SEARCH_FOR_PRODUCTS_CATEGORY_VENDOR_MANUFACTURER', Str::getStr()->htmlspecialchars($sSearch), $sCatId, $sVendorId, $sManufacturerId),
             $this->_getArticleItems($oArtList),
             $this->getSearchArticlesUrl($sSearch, $sCatId, $sVendorId, $sManufacturerId),
             $this->_getShopUrl() . "cl=search&amp;" . $this->_getSearchParamsUrl($sSearch, $sCatId, $sVendorId, $sManufacturerId)

--- a/source/Application/Model/SelectList.php
+++ b/source/Application/Model/SelectList.php
@@ -8,6 +8,7 @@ namespace OxidEsales\EshopCommunity\Application\Model;
 
 use oxRegistry;
 use oxDb;
+use OxidEsales\Eshop\Core\Str;
 
 /**
  * Select list manager
@@ -71,7 +72,7 @@ class SelectList extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel impleme
         if ($this->_aFieldList == null && $this->oxselectlist__oxvaldesc->value) {
             $this->_aFieldList = \OxidEsales\Eshop\Core\Registry::getUtils()->assignValuesFromText($this->oxselectlist__oxvaldesc->value, $dVat);
             foreach ($this->_aFieldList as $sKey => $oField) {
-                $this->_aFieldList[$sKey]->name = getStr()->strip_tags($this->_aFieldList[$sKey]->name);
+                $this->_aFieldList[$sKey]->name = Str::getStr()->strip_tags($this->_aFieldList[$sKey]->name);
             }
         }
 
@@ -147,7 +148,7 @@ class SelectList extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel impleme
             $aList = \OxidEsales\Eshop\Core\Registry::getUtils()->assignValuesFromText($this->oxselectlist__oxvaldesc->getRawValue(), $this->getVat());
             foreach ($aList as $sKey => $oField) {
                 if ($oField->name) {
-                    $this->_aList[$sKey] = oxNew(\OxidEsales\Eshop\Application\Model\Selection::class, getStr()->strip_tags($oField->name), $sKey, false, $this->_aList === false ? true : false);
+                    $this->_aList[$sKey] = oxNew(\OxidEsales\Eshop\Application\Model\Selection::class, Str::getStr()->strip_tags($oField->name), $sKey, false, $this->_aList === false ? true : false);
                 }
             }
         }

--- a/source/Application/Model/Selection.php
+++ b/source/Application/Model/Selection.php
@@ -6,6 +6,8 @@
 
 namespace OxidEsales\EshopCommunity\Application\Model;
 
+use OxidEsales\Eshop\Core\Str;
+
 /**
  * Variant selection container class
  *
@@ -73,7 +75,7 @@ class Selection
      */
     public function getName()
     {
-        return getStr()->htmlspecialchars($this->_sName);
+        return Str::getStr()->htmlspecialchars($this->_sName);
     }
 
     /**

--- a/source/Application/Model/VariantSelectList.php
+++ b/source/Application/Model/VariantSelectList.php
@@ -6,6 +6,8 @@
 
 namespace OxidEsales\EshopCommunity\Application\Model;
 
+use OxidEsales\Eshop\Core\Str;
+
 /**
  * Variant selection lists manager class
  *
@@ -59,7 +61,7 @@ class VariantSelectList implements \OxidEsales\Eshop\Core\Contract\ISelectList
      */
     public function getLabel()
     {
-        return getStr()->htmlspecialchars($this->_sLabel);
+        return Str::getStr()->htmlspecialchars($this->_sLabel);
     }
 
     /**

--- a/source/Application/Model/Vendor.php
+++ b/source/Application/Model/Vendor.php
@@ -107,7 +107,7 @@ class Vendor extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements 
      *
      * @param string $sOxid object id
      *
-     * @return bool 
+     * @return bool
      */
     public function load($sOxid)
     {

--- a/source/Core/Field.php
+++ b/source/Core/Field.php
@@ -6,6 +6,8 @@
 
 namespace OxidEsales\EshopCommunity\Core;
 
+use OxidEsales\Eshop\Core\Str;
+
 /**
  * Database field description object.
  *
@@ -104,7 +106,7 @@ class Field // extends \OxidEsales\Eshop\Core\Base
                 break;
             case 'value':
                 if (is_string($this->rawValue)) {
-                    $this->value = getStr()->htmlspecialchars($this->rawValue);
+                    $this->value = Str::getStr()->htmlspecialchars($this->rawValue);
                 } else {
                     // TODO: call htmlentities for each value (recursively?)
                     $this->value = $this->rawValue;
@@ -144,7 +146,7 @@ class Field // extends \OxidEsales\Eshop\Core\Base
      */
     public function convertToPseudoHtml()
     {
-        $this->setValue(str_replace("\r", '', nl2br(getStr()->htmlspecialchars($this->rawValue))), self::T_RAW);
+        $this->setValue(str_replace("\r", '', nl2br(Str::getStr()->htmlspecialchars($this->rawValue))), self::T_RAW);
     }
 
     /**

--- a/source/Core/InputValidator.php
+++ b/source/Core/InputValidator.php
@@ -10,6 +10,7 @@ use OxidEsales\Eshop\Application\Model\Address;
 use OxidEsales\Eshop\Application\Model\User;
 use OxidEsales\Eshop\Core\Exception\ArticleInputException;
 use OxidEsales\Eshop\Core\Exception\StandardException;
+use OxidEsales\Eshop\Core\Str;
 
 /**
  * Class for validating input.
@@ -208,14 +209,14 @@ class InputValidator extends \OxidEsales\Eshop\Core\Base
     public function checkPassword($user, $newPassword, $confirmationPassword, $shouldCheckPasswordLength = false)
     {
         //  no password at all
-        if ($shouldCheckPasswordLength && getStr()->strlen($newPassword) == 0) {
+        if ($shouldCheckPasswordLength && Str::getStr()->strlen($newPassword) == 0) {
             $exception = oxNew(\OxidEsales\Eshop\Core\Exception\InputException::class);
             $exception->setMessage(\OxidEsales\Eshop\Core\Registry::getLang()->translateString('ERROR_MESSAGE_INPUT_EMPTYPASS'));
 
             return $this->_addValidationError("oxuser__oxpassword", $exception);
         }
 
-        if ($shouldCheckPasswordLength && getStr()->strlen($newPassword) < $this->getPasswordLength()) {
+        if ($shouldCheckPasswordLength && Str::getStr()->strlen($newPassword) < $this->getPasswordLength()) {
             $exception = oxNew(\OxidEsales\Eshop\Core\Exception\InputException::class);
             $exception->setMessage(\OxidEsales\Eshop\Core\Registry::getLang()->translateString('ERROR_MESSAGE_PASSWORD_TOO_SHORT'));
 
@@ -525,7 +526,7 @@ class InputValidator extends \OxidEsales\Eshop\Core\Base
      */
     protected function _validateOldDebitInfo($debitInfo)
     {
-        $stringHelper = getStr();
+        $stringHelper = Str::getStr();
         $debitInfo = $this->_fixAccountNumber($debitInfo);
 
         $validationResult = true;
@@ -553,7 +554,7 @@ class InputValidator extends \OxidEsales\Eshop\Core\Base
      */
     protected function _fixAccountNumber($debitInfo)
     {
-        $oStr = getStr();
+        $oStr = Str::getStr();
 
         if ($oStr->strlen($debitInfo['lsktonr']) < 10) {
             $sNewNum = str_repeat(

--- a/source/Core/Language.php
+++ b/source/Core/Language.php
@@ -7,8 +7,9 @@
 namespace OxidEsales\EshopCommunity\Core;
 
 use OxidEsales\EshopCommunity\Internal\Framework\Theme\Bridge\AdminThemeBridgeInterface;
-use stdClass;
 use OxidEsales\Eshop\Core\Registry;
+use OxidEsales\Eshop\Core\Str;
+use stdClass;
 
 /**
  * Language related utility class
@@ -546,8 +547,7 @@ class Language extends \OxidEsales\Eshop\Core\Base
     {
         $iDecPos = 0;
         $sValue = ( string ) $dValue;
-        /** @var \OxidEsales\Eshop\Core\StrRegular $oStr */
-        $oStr = getStr();
+        $oStr = Str::getStr();
         if (($iDotPos = $oStr->strpos($sValue, '.')) !== false) {
             $iDecPos = $oStr->strlen($oStr->substr($sValue, $iDotPos + 1));
         }
@@ -1177,8 +1177,7 @@ class Language extends \OxidEsales\Eshop\Core\Base
         $iLang = isset($iLang) ? $iLang : $this->getBaseLanguage();
         $iDefaultLang = (int) \OxidEsales\Eshop\Core\Registry::getConfig()->getConfigParam('sDefaultLang');
         $iBrowserLanguage = (int) $this->detectLanguageByBrowser();
-        /** @var \OxidEsales\Eshop\Core\StrRegular $oStr */
-        $oStr = getStr();
+        $oStr = Str::getStr();
 
         if (!$this->isAdmin()) {
             $sParam = $this->getUrlLang($iLang);

--- a/source/Core/Output.php
+++ b/source/Core/Output.php
@@ -6,6 +6,8 @@
 
 namespace OxidEsales\EshopCommunity\Core;
 
+use OxidEsales\Eshop\Core\Str;
+
 /**
  * class for output processing
  */
@@ -180,7 +182,7 @@ class Output extends \OxidEsales\Eshop\Core\Base
     {
         switch ($this->_sOutputFormat) {
             case self::OUTPUT_FORMAT_JSON:
-                echo getStr()->jsonEncode($this->_aBuffer);
+                echo Str::getStr()->jsonEncode($this->_aBuffer);
                 break;
             case self::OUTPUT_FORMAT_HTML:
             default:

--- a/source/Core/Request.php
+++ b/source/Core/Request.php
@@ -3,7 +3,10 @@
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
 namespace OxidEsales\EshopCommunity\Core;
+
+use OxidEsales\Eshop\Core\Str;
 
 /**
  * Request represents an HTTP request.
@@ -72,7 +75,7 @@ class Request
 
             // trying to resolve controller file name
             if ($rawRequestUrl && ($iPos = stripos($rawRequestUrl, '?')) !== false) {
-                $string = getStr();
+                $string = Str::getStr();
                 // formatting request url
                 $requestUrl = 'index.php' . $string->substr($rawRequestUrl, $iPos);
 

--- a/source/Core/SeoDecoder.php
+++ b/source/Core/SeoDecoder.php
@@ -6,6 +6,8 @@
 
 namespace OxidEsales\EshopCommunity\Core;
 
+use OxidEsales\Eshop\Core\Str;
+
 /**
  * Seo encoder base
  */
@@ -21,7 +23,7 @@ class SeoDecoder extends \OxidEsales\Eshop\Core\Base
      */
     public function parseStdUrl($sUrl)
     {
-        $oStr = getStr();
+        $oStr = Str::getStr();
         $aRet = [];
         $sUrl = $oStr->html_entity_decode($sUrl);
 
@@ -55,7 +57,7 @@ class SeoDecoder extends \OxidEsales\Eshop\Core\Base
      */
     public function decodeUrl($seoUrl)
     {
-        $stringObject = getStr();
+        $stringObject = Str::getStr();
         $baseUrl = $this->getConfig()->getShopURL();
         if ($stringObject->strpos($seoUrl, $baseUrl) === 0) {
             $seoUrl = $stringObject->substr($seoUrl, $stringObject->strlen($baseUrl));
@@ -97,7 +99,7 @@ class SeoDecoder extends \OxidEsales\Eshop\Core\Base
      */
     protected function _decodeOldUrl($seoUrl)
     {
-        $stringObject = getStr();
+        $stringObject = Str::getStr();
         $database = \OxidEsales\Eshop\Core\DatabaseProvider::getDb(\OxidEsales\Eshop\Core\DatabaseProvider::FETCH_MODE_ASSOC);
         $baseUrl = $this->getConfig()->getShopURL();
         if ($stringObject->strpos($seoUrl, $baseUrl) === 0) {
@@ -314,7 +316,7 @@ class SeoDecoder extends \OxidEsales\Eshop\Core\Base
      */
     protected function _getParams($sRequest, $sPath)
     {
-        $oStr = getStr();
+        $oStr = Str::getStr();
 
         $sParams = $oStr->preg_replace('/\?.*/', '', $sRequest);
         $sPath = preg_quote($sPath, '/');

--- a/source/Core/SeoEncoder.php
+++ b/source/Core/SeoEncoder.php
@@ -6,6 +6,7 @@
 
 namespace OxidEsales\EshopCommunity\Core;
 
+use OxidEsales\Eshop\Core\Str;
 use Exception;
 
 /**
@@ -101,7 +102,7 @@ class SeoEncoder extends \OxidEsales\Eshop\Core\Base
         if ($iLang != $iDefLang &&
             isset($aLangIds[$iLang]) &&
             // #0006407 bugfix, we should not search for the string saved in the db but for the escaped string
-            getStr()->strpos($sSeoUrl, $this->replaceSpecialChars($aLangIds[$iLang]) . '/') !== 0
+            Str::getStr()->strpos($sSeoUrl, $this->replaceSpecialChars($aLangIds[$iLang]) . '/') !== 0
         ) {
             $sSeoUrl = $aLangIds[$iLang] . '/' . $sSeoUrl;
         }
@@ -294,7 +295,7 @@ class SeoEncoder extends \OxidEsales\Eshop\Core\Base
     protected function _getUniqueSeoUrl($sSeoUrl, $sObjectId = null, $iObjectLang = null)
     {
         $sSeoUrl = $this->_prepareUri($sSeoUrl, $iObjectLang);
-        $oStr = getStr();
+        $oStr = Str::getStr();
         $sExt = '';
         if ($oStr->preg_match('/(\.html?|\/)$/i', $sSeoUrl, $aMatched)) {
             $sExt = $aMatched[0];
@@ -567,7 +568,7 @@ class SeoEncoder extends \OxidEsales\Eshop\Core\Base
         if (!isset(self::$_aReservedEntryKeys) || !is_array(self::$_aReservedEntryKeys)) {
             $sDir = getShopBasePath();
             self::$_aReservedEntryKeys = array_map('preg_quote', self::$_aReservedWords, ['#']);
-            $oStr = getStr();
+            $oStr = Str::getStr();
             foreach (glob("$sDir/*") as $sFile) {
                 if ($oStr->preg_match('/^(.+)\.php[0-9]*$/i', basename($sFile), $aMatches)) {
                     self::$_aReservedEntryKeys[] = preg_quote($aMatches[0], '#');
@@ -596,7 +597,7 @@ class SeoEncoder extends \OxidEsales\Eshop\Core\Base
         $sUri = $this->encodeString($sUri, true, $iLang);
 
         // basic string preparation
-        $oStr = getStr();
+        $oStr = Str::getStr();
         $sUri = $oStr->strip_tags($sUri);
 
         // if found ".html" or "/" at the end - removing it temporary
@@ -669,7 +670,7 @@ class SeoEncoder extends \OxidEsales\Eshop\Core\Base
         $sRegExp = '/[^A-Za-z0-9\/' . preg_quote(self::$_sPrefix, '/') . preg_quote($sSep, '/') . ']+/';
         $sTitle = preg_replace(["#/+#", $sRegExp, "# +#", "#(" . preg_quote($sSep, '/') . ")+#"], $sSep, $sTitle);
 
-        $oStr = getStr();
+        $oStr = Str::getStr();
         // smart truncate
         if (!$blSkipTruncate && $oStr->strlen($sTitle) > $this->_iIdLength) {
             $iFirstSpace = $oStr->strpos($sTitle, $sSep, $this->_iIdLength);
@@ -824,7 +825,7 @@ class SeoEncoder extends \OxidEsales\Eshop\Core\Base
     protected function _trimUrl($sUrl, $iLang = null)
     {
         $myConfig = $this->getConfig();
-        $oStr = getStr();
+        $oStr = Str::getStr();
         $sUrl = str_replace([$myConfig->getShopUrl($iLang, false), $myConfig->getSslShopUrl($iLang)], '', $sUrl);
         $sUrl = $oStr->preg_replace('/(\?|&(amp;)?)(force_)?(admin_)?sid=[a-z0-9\.]+&?(amp;)?/i', '\1', $sUrl);
         $sUrl = $oStr->preg_replace('/(\?|&(amp;)?)shp=[0-9]+&?(amp;)?/i', '\1', $sUrl);
@@ -874,7 +875,7 @@ class SeoEncoder extends \OxidEsales\Eshop\Core\Base
     public function encodeString($sString, $blReplaceChars = true, $iLang = false)
     {
         // decoding entities
-        $sString = getStr()->html_entity_decode($sString);
+        $sString = Str::getStr()->html_entity_decode($sString);
 
         if ($blReplaceChars) {
             if ($iLang === false || !is_numeric($iLang)) {
@@ -1179,7 +1180,7 @@ class SeoEncoder extends \OxidEsales\Eshop\Core\Base
         if ($this->_saveToDb($sType, $sObjectId, $sStdUrl, $sSeoUrl, $iLang, $iShopId, $blFixed, $sParams)) {
             $oDb = \OxidEsales\Eshop\Core\DatabaseProvider::getDb();
 
-            $oStr = getStr();
+            $oStr = Str::getStr();
             if ($sKeywords !== false) {
                 $sKeywords = $oStr->htmlspecialchars($this->encodeString($oStr->strip_tags($sKeywords), false, $iLang));
             }
@@ -1345,7 +1346,7 @@ class SeoEncoder extends \OxidEsales\Eshop\Core\Base
         if (!is_string($stringWithSpecialChars)) {
             return "";
         }
-        $oStr = \OxidEsales\Eshop\Core\Str::getStr();
+        $oStr = Str::getStr();
         $sQuotedPrefix = preg_quote(self::$_sSeparator . self::$_sPrefix, '/');
         $sRegExp = '/[^A-Za-z0-9' . $sQuotedPrefix . '\/]+/';
         $sanitized = $oStr->preg_replace(

--- a/source/Core/SepaBICValidator.php
+++ b/source/Core/SepaBICValidator.php
@@ -6,6 +6,8 @@
 
 namespace OxidEsales\EshopCommunity\Core;
 
+use OxidEsales\Eshop\Core\Str;
+
 /**
  * SEPA (Single Euro Payments Area) BIC validation class
  *
@@ -29,6 +31,6 @@ class SepaBICValidator
     {
         $sBIC = strtoupper(trim($sBIC));
 
-        return (bool) getStr()->preg_match("(^[A-Z]{4}[A-Z]{2}[A-Z0-9]{2}([A-Z0-9]{3})?$)", $sBIC);
+        return (bool) Str::getStr()->preg_match("(^[A-Z]{4}[A-Z]{2}[A-Z0-9]{2}([A-Z0-9]{3})?$)", $sBIC);
     }
 }

--- a/source/Core/SepaIBANValidator.php
+++ b/source/Core/SepaIBANValidator.php
@@ -6,6 +6,8 @@
 
 namespace OxidEsales\EshopCommunity\Core;
 
+use OxidEsales\Eshop\Core\Str;
+
 /**
  * SEPA (Single Euro Payments Area) validation class
  *
@@ -93,7 +95,7 @@ class SepaIBANValidator
      */
     protected function _isLengthValid($sIBAN)
     {
-        $iActualLength = getStr()->strlen($sIBAN);
+        $iActualLength = Str::getStr()->strlen($sIBAN);
 
         $iCorrectLength = $this->_getLengthForCountry($sIBAN);
 
@@ -112,7 +114,7 @@ class SepaIBANValidator
     {
         $aIBANRegistry = $this->getCodeLengths();
 
-        $sCountryCode = getStr()->substr($sIBAN, 0, 2);
+        $sCountryCode = Str::getStr()->substr($sIBAN, 0, 2);
 
         $iCorrectLength = (isset($aIBANRegistry[$sCountryCode])) ? $aIBANRegistry[$sCountryCode] : null;
 
@@ -144,7 +146,7 @@ class SepaIBANValidator
      */
     protected function _moveInitialCharactersToEnd($sIBAN)
     {
-        $oStr = getStr();
+        $oStr = Str::getStr();
 
         $sInitialChars = $oStr->substr($sIBAN, 0, 4);
         $sIBAN = $oStr->substr($sIBAN, 4);

--- a/source/Core/Session.php
+++ b/source/Core/Session.php
@@ -6,9 +6,10 @@
 
 namespace OxidEsales\EshopCommunity\Core;
 
-use \OxidEsales\Eshop\Application\Model\Basket;
-use \OxidEsales\Eshop\Application\Model\BasketItem;
-use \OxidEsales\Eshop\Application\Model\User;
+use OxidEsales\Eshop\Application\Model\Basket;
+use OxidEsales\Eshop\Application\Model\BasketItem;
+use OxidEsales\Eshop\Application\Model\User;
+use OxidEsales\Eshop\Core\Str;
 
 /**
  * Session manager.
@@ -774,7 +775,7 @@ class Session extends \OxidEsales\Eshop\Core\Base
             if ($sSid) {
                 $this->sidToUrlEvent();
 
-                $oStr = getStr();
+                $oStr = Str::getStr();
                 $aUrlParts = explode('#', $sUrl);
                 if (!$oStr->preg_match('/(\?|&(amp;)?)sid=/i', $aUrlParts[0]) && (false === $oStr->strpos($aUrlParts[0], $sSid))) {
                     if (!$oStr->preg_match('/(\?|&(amp;)?)$/', $sUrl)) {

--- a/source/Core/Smarty/Plugin/Emos.php
+++ b/source/Core/Smarty/Plugin/Emos.php
@@ -41,6 +41,8 @@
 
 namespace OxidEsales\EshopCommunity\Core\Smarty\Plugin;
 
+use OxidEsales\Eshop\Core\Str;
+
 /**
  * PHP Helper Class to construct a ECONDA Monitor statement for the later
  * inclusion in a HTML/PHP Page.
@@ -466,7 +468,7 @@ class Emos
         }
 
         if ($sCip) {
-            $ort .= getStr()->substr($sCip, 0, 1)."/".getStr()->substr($sCip, 0, 2)."/";
+            $ort .= Str::getStr()->substr($sCip, 0, 1)."/".Str::getStr()->substr($sCip, 0, 2)."/";
         }
 
         if ($sCity) {
@@ -531,7 +533,7 @@ class Emos
 
         //$sStr = urldecode($sStr);
         $sStr = htmlspecialchars_decode($sStr, ENT_QUOTES);
-        $sStr = getStr()->html_entity_decode($sStr);
+        $sStr = Str::getStr()->html_entity_decode($sStr);
         $sStr = strip_tags($sStr);
         $sStr = trim($sStr);
 
@@ -556,7 +558,7 @@ class Emos
         $sStr = str_replace(" /", "/", $sStr);
         $sStr = str_replace("/ ", "/", $sStr);
 
-        $sStr = getStr()->substr($sStr, 0, 254);
+        $sStr = Str::getStr()->substr($sStr, 0, 254);
         //$sStr = rawurlencode( $sStr );
         return $sStr;
     }

--- a/source/Core/Smarty/Plugin/EmosAdapter.php
+++ b/source/Core/Smarty/Plugin/EmosAdapter.php
@@ -39,6 +39,8 @@
 
 namespace OxidEsales\EshopCommunity\Core\Smarty\Plugin;
 
+use OxidEsales\Eshop\Core\Str;
+
 /**
  * This class is a reference implementation of a PHP Function to include
  * ECONDA Trackiong into a Shop-System.
@@ -418,8 +420,7 @@ class EmosAdapter extends \OxidEsales\Eshop\Core\Base
         $oConfig = $this->getConfig();
         $oCurrentView = $oConfig->getActiveView();
         $sFunction = $oCurrentView->getFncName();
-        /** @var \OxidEsales\Eshop\Core\StrRegular $oStr */
-        $oStr = getStr();
+        $oStr = Str::getStr();
         $sTplName = $this->_getTplName();
         /** @var \OxidEsales\Eshop\Application\Model\User $oUser */
         $oUser = oxNew(\OxidEsales\Eshop\Application\Model\User::class);

--- a/source/Core/Smarty/Plugin/block.oxifcontent.php
+++ b/source/Core/Smarty/Plugin/block.oxifcontent.php
@@ -4,6 +4,8 @@
  * See LICENSE file for license details.
  */
 
+use OxidEsales\Eshop\Core\Str;
+
 /**
  * Smarty plugin
  * -------------------------------------------------------------
@@ -62,7 +64,7 @@ function smarty_block_oxifcontent($params, $content, &$smarty, &$repeat)
         }
         $repeat = $blLoaded;
     } else {
-        $oStr = getStr();
+        $oStr = Str::getStr();
         $blHasSmarty = $oStr->strstr($content, '[{');
         if ($blHasSmarty) {
             $content = \OxidEsales\Eshop\Core\Registry::getUtilsView()->parseThroughSmarty($content, $sIdent.md5($content), $myConfig->getActiveView());

--- a/source/Core/Smarty/Plugin/modifier.oxaddparams.php
+++ b/source/Core/Smarty/Plugin/modifier.oxaddparams.php
@@ -4,6 +4,8 @@
  * See LICENSE file for license details.
  */
 
+use OxidEsales\Eshop\Core\Str;
+
 /**
  * Smarty function
  * -------------------------------------------------------------
@@ -18,7 +20,7 @@
  */
 function smarty_modifier_oxaddparams($sUrl, $sDynParams)
 {
-    $oStr = getStr();
+    $oStr = Str::getStr();
     // removing empty parameters
     $sDynParams = $sDynParams?$oStr->preg_replace([ '/^\?/', '/^\&(amp;)?$/' ], '', $sDynParams):false;
     if ($sDynParams) {

--- a/source/Core/Smarty/Plugin/modifier.oxlower.php
+++ b/source/Core/Smarty/Plugin/modifier.oxlower.php
@@ -4,6 +4,8 @@
  * See LICENSE file for license details.
  */
 
+use OxidEsales\Eshop\Core\Str;
+
 /**
  * Smarty lower modifier
  * -------------------------------------------------------------
@@ -17,5 +19,5 @@
  */
 function smarty_modifier_oxlower($sString)
 {
-    return getStr()->strtolower($sString);
+    return Str::getStr()->strtolower($sString);
 }

--- a/source/Core/Smarty/Plugin/modifier.oxtruncate.php
+++ b/source/Core/Smarty/Plugin/modifier.oxtruncate.php
@@ -4,6 +4,8 @@
  * See LICENSE file for license details.
  */
 
+use OxidEsales\Eshop\Core\Str;
+
 /**
  * This method replaces existing Smarty function for truncating strings
  * (check Smarty documentation for details). When truncating strings
@@ -29,16 +31,16 @@ function smarty_modifier_oxtruncate($sString, $iLength = 80, $sSufix = '...', $b
 {
     if ($iLength == 0) {
         return '';
-    } elseif ($iLength > 0 && getStr()->strlen($sString) > $iLength) {
-        $iLength -= getStr()->strlen($sSufix);
+    } elseif ($iLength > 0 && Str::getStr()->strlen($sString) > $iLength) {
+        $iLength -= Str::getStr()->strlen($sSufix);
 
         $sString = str_replace(['&#039;', '&quot;'], [ "'",'"' ], $sString);
 
         if (!$blBreakWords) {
-            $sString = getStr()->preg_replace('/\s+?(\S+)?$/', '', getStr()->substr($sString, 0, $iLength + 1));
+            $sString = Str::getStr()->preg_replace('/\s+?(\S+)?$/', '', Str::getStr()->substr($sString, 0, $iLength + 1));
         }
 
-        $sString = getStr()->substr($sString, 0, $iLength).$sSufix;
+        $sString = Str::getStr()->substr($sString, 0, $iLength).$sSufix;
 
         return str_replace([ "'",'"' ], ['&#039;', '&quot;'], $sString);
     }

--- a/source/Core/Smarty/Plugin/modifier.oxupper.php
+++ b/source/Core/Smarty/Plugin/modifier.oxupper.php
@@ -4,6 +4,8 @@
  * See LICENSE file for license details.
  */
 
+use OxidEsales\Eshop\Core\Str;
+
 /**
  * Smarty upper modifier
  * -------------------------------------------------------------
@@ -18,5 +20,5 @@
 
 function smarty_modifier_oxupper($sString)
 {
-    return getStr()->strtoupper($sString);
+    return Str::getStr()->strtoupper($sString);
 }

--- a/source/Core/Smarty/Plugin/modifier.oxwordwrap.php
+++ b/source/Core/Smarty/Plugin/modifier.oxwordwrap.php
@@ -4,6 +4,7 @@
  * See LICENSE file for license details.
  */
 
+use OxidEsales\Eshop\Core\Str;
 
 /**
  * Smarty wordwrap modifier
@@ -21,5 +22,5 @@
  */
 function smarty_modifier_oxwordwrap($sString, $iLength = 80, $sWraper = "\n", $blCut = false)
 {
-    return getStr()->wordwrap($sString, $iLength, $sWraper, $blCut);
+    return Str::getStr()->wordwrap($sString, $iLength, $sWraper, $blCut);
 }

--- a/source/Core/Utils.php
+++ b/source/Core/Utils.php
@@ -6,8 +6,9 @@
 
 namespace OxidEsales\EshopCommunity\Core;
 
-use stdClass;
 use Exception;
+use OxidEsales\Eshop\Core\Str;
+use stdClass;
 
 /**
  * General utils class
@@ -1000,7 +1001,7 @@ class Utils extends \OxidEsales\Eshop\Core\Base
      */
     public function isValidAlpha($sField)
     {
-        return (boolean) getStr()->preg_match('/^[a-zA-Z0-9_]*$/', $sField);
+        return (boolean) Str::getStr()->preg_match('/^[a-zA-Z0-9_]*$/', $sField);
     }
 
     /**
@@ -1139,7 +1140,7 @@ class Utils extends \OxidEsales\Eshop\Core\Base
      */
     protected function _addUrlParameters($sUrl, $aParams)
     {
-        $sDelimiter = ((getStr()->strpos($sUrl, '?') !== false)) ? '&' : '?';
+        $sDelimiter = ((Str::getStr()->strpos($sUrl, '?') !== false)) ? '&' : '?';
         foreach ($aParams as $sName => $sVal) {
             $sUrl = $sUrl . $sDelimiter . $sName . '=' . $sVal;
             $sDelimiter = '&';
@@ -1170,7 +1171,7 @@ class Utils extends \OxidEsales\Eshop\Core\Base
             $oObject->price = isset($aPrice[1]) ? $aPrice[1] : 0;
             $aName[0] = isset($aPrice[0]) ? $aPrice[0] : '';
 
-            $iPercPos = getStr()->strpos($oObject->price, '%');
+            $iPercPos = Str::getStr()->strpos($oObject->price, '%');
             if ($iPercPos !== false) {
                 $oObject->priceUnit = '%';
                 $oObject->fprice = $oObject->price;
@@ -1205,7 +1206,7 @@ class Utils extends \OxidEsales\Eshop\Core\Base
             }
         } elseif (isset($aPrice[0]) && isset($aPrice[1])) {
             // A. removing unused part of information
-            $aName[0] = getStr()->preg_replace("/!P!.*/", "", $aName[0]);
+            $aName[0] = Str::getStr()->preg_replace("/!P!.*/", "", $aName[0]);
         }
 
         $oObject->name = $aName[0];
@@ -1420,7 +1421,7 @@ class Utils extends \OxidEsales\Eshop\Core\Base
      */
     public function checkUrlEndingSlash($sUrl)
     {
-        if (!getStr()->preg_match("/\/$/", $sUrl)) {
+        if (!Str::getStr()->preg_match("/\/$/", $sUrl)) {
             $sUrl .= '/';
         }
 
@@ -1476,7 +1477,7 @@ class Utils extends \OxidEsales\Eshop\Core\Base
      */
     public function extractDomain($sHost)
     {
-        $oStr = getStr();
+        $oStr = Str::getStr();
         if (!$oStr->preg_match('/[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}/', $sHost) &&
             ($iLastDot = strrpos($sHost, '.')) !== false
         ) {

--- a/source/Core/UtilsDate.php
+++ b/source/Core/UtilsDate.php
@@ -7,6 +7,7 @@
 namespace OxidEsales\EshopCommunity\Core;
 
 use DateTime;
+use OxidEsales\Eshop\Core\Str;
 
 /**
  * Date manipulation utility class
@@ -28,7 +29,7 @@ class UtilsDate extends \OxidEsales\Eshop\Core\Base
             return null;
         }
 
-        $oStr = getStr();
+        $oStr = Str::getStr();
         if ($blForceEnglishRet && $oStr->strstr($sDBDateIn, '-')) {
             return $sDBDateIn;
         }
@@ -112,7 +113,7 @@ class UtilsDate extends \OxidEsales\Eshop\Core\Base
         }
 
         $blDefDateFound = false;
-        $oStr = getStr();
+        $oStr = Str::getStr();
 
         // looking for default values that are formatted by MySQL
         foreach (array_keys($aDefDatePatterns) as $sDefDatePattern) {
@@ -216,7 +217,7 @@ class UtilsDate extends \OxidEsales\Eshop\Core\Base
         $sSQLTimeStampPattern = "/^([0-9]{4})([0-9]{2})([0-9]{2})([0-9]{2})([0-9]{2})([0-9]{2})$/";
         $sISOTimeStampPattern = "/^([0-9]{4})-([0-9]{2})-([0-9]{2}) ([0-9]{2}):([0-9]{2}):([0-9]{2})$/";
         $aMatches = [];
-        $oStr = getStr();
+        $oStr = Str::getStr();
 
         // preparing value to save
         if ($blToTimeStamp) {
@@ -285,7 +286,7 @@ class UtilsDate extends \OxidEsales\Eshop\Core\Base
         $aDefTimePatterns = $this->_defaultTimePattern();
         $aDFormats = $this->_defineDateFormattingRules();
         $aTFormats = $this->_defineTimeFormattingRules();
-        $oStr = getStr();
+        $oStr = Str::getStr();
 
         foreach (array_keys($aDefTimePatterns) as $sDefTimePattern) {
             if ($oStr->preg_match($sDefTimePattern, $sDate)) {

--- a/source/Core/UtilsFile.php
+++ b/source/Core/UtilsFile.php
@@ -6,6 +6,8 @@
 
 namespace OxidEsales\EshopCommunity\Core;
 
+use OxidEsales\Eshop\Core\Str;
+
 /**
  * File manipulation utility class
  */
@@ -168,7 +170,7 @@ class UtilsFile extends \OxidEsales\Eshop\Core\Base
      */
     public function copyDir($sSourceDir, $sTargetDir)
     {
-        $oStr = getStr();
+        $oStr = Str::getStr();
         $handle = opendir($sSourceDir);
         while (false !== ($file = readdir($handle))) {
             if ($file != '.' && $file != '..') {
@@ -269,8 +271,6 @@ class UtilsFile extends \OxidEsales\Eshop\Core\Base
             $sFileType = trim($aFilename[count($aFilename) - 1]);
 
             if (isset($sFileType)) {
-                $oStr = getStr();
-
                 // unallowed files ?
                 if (in_array($sFileType, $this->_aBadFiles) || ($blDemo && !in_array($sFileType, $this->_aAllowedFiles))) {
                     \OxidEsales\Eshop\Core\Registry::getUtils()->showMessageAndExit("File didn't pass our allowed files filter.");
@@ -283,7 +283,7 @@ class UtilsFile extends \OxidEsales\Eshop\Core\Base
 
                 $sFName = '';
                 if (isset($aFilename[0])) {
-                    $sFName = $oStr->preg_replace('/[^a-zA-Z0-9()_\.-]/', '', implode('.', $aFilename));
+                    $sFName = Str::getStr()->preg_replace('/[^a-zA-Z0-9()_\.-]/', '', implode('.', $aFilename));
                 }
 
                 $sValue = $this->_getUniqueFileName($sImagePath, "{$sFName}", $sFileType, "", $blUnique);
@@ -550,7 +550,7 @@ class UtilsFile extends \OxidEsales\Eshop\Core\Base
         }
 
         //wrong chars in file name?
-        if (!getStr()->preg_match('/^[\-_a-z0-9\.]+$/i', $aFileInfo['name'])) {
+        if (!Str::getStr()->preg_match('/^[\-_a-z0-9\.]+$/i', $aFileInfo['name'])) {
             throw oxNew(\OxidEsales\Eshop\Core\Exception\StandardException::class, 'EXCEPTION_FILENAMEINVALIDCHARS');
         }
 
@@ -597,7 +597,7 @@ class UtilsFile extends \OxidEsales\Eshop\Core\Base
         $sFilePath = $this->normalizeDir($sFilePath);
         $iFileCounter = 0;
         $sTempFileName = $sFileName;
-        $oStr = getStr();
+        $oStr = Str::getStr();
 
         //file exists ?
         while ($blUnique && file_exists($sFilePath . "/" . $sFileName . $sSufix . "." . $sFileExt)) {

--- a/source/Core/UtilsServer.php
+++ b/source/Core/UtilsServer.php
@@ -7,6 +7,7 @@
 namespace OxidEsales\EshopCommunity\Core;
 
 use OxidEsales\EshopCommunity\Application\Model\User;
+use OxidEsales\Eshop\Core\Str;
 
 /**
  * Server data manipulation class
@@ -373,7 +374,7 @@ class UtilsServer extends \OxidEsales\Eshop\Core\Base
     public function processUserAgentInfo($sAgent)
     {
         if ($sAgent) {
-            $sAgent = getStr()->preg_replace("/MSIE(\s)?(\S)*(\s)/", "", (string) $sAgent);
+            $sAgent = Str::getStr()->preg_replace("/MSIE(\s)?(\S)*(\s)/", "", (string) $sAgent);
         }
 
         return $sAgent;

--- a/source/Core/UtilsString.php
+++ b/source/Core/UtilsString.php
@@ -6,6 +6,8 @@
 
 namespace OxidEsales\EshopCommunity\Core;
 
+use OxidEsales\Eshop\Core\Str;
+
 /**
  * String manipulation class
  */
@@ -27,7 +29,7 @@ class UtilsString
      */
     public function prepareCSVField($sInField)
     {
-        $oStr = getStr();
+        $oStr = Str::getStr();
         if ($oStr->strstr($sInField, '"')) {
             return '"' . str_replace('"', '""', $sInField) . '"';
         } elseif ($oStr->strstr($sInField, ';')) {
@@ -51,7 +53,7 @@ class UtilsString
     {
         //leading and ending whitespaces
         $sString = trim($sString);
-        $oStr = getStr();
+        $oStr = Str::getStr();
 
         //multiple whitespaces
         $sString = $oStr->preg_replace("/[ \t\n\r]+/", " ", $sString);
@@ -71,7 +73,7 @@ class UtilsString
      */
     public function prepareStrForSearch($sSearchStr)
     {
-        $oStr = getStr();
+        $oStr = Str::getStr();
         if ($oStr->hasSpecialChars($sSearchStr)) {
             return $oStr->recodeEntities($sSearchStr, true, ['&amp;'], ['&']);
         }

--- a/source/Core/UtilsUrl.php
+++ b/source/Core/UtilsUrl.php
@@ -6,6 +6,8 @@
 
 namespace OxidEsales\EshopCommunity\Core;
 
+use OxidEsales\Eshop\Core\Str;
+
 /**
  * URL utility class
  */
@@ -67,8 +69,7 @@ class UtilsUrl extends \OxidEsales\Eshop\Core\Base
      */
     public function prepareUrlForNoSession($sUrl)
     {
-        /** @var \OxidEsales\Eshop\Core\StrRegular $oStr */
-        $oStr = getStr();
+        $oStr = Str::getStr();
 
         // cleaning up session id..
         $sUrl = $oStr->preg_replace('/(\?|&(amp;)?)(force_)?(admin_)?sid=[a-z0-9\._]+&?(amp;)?/i', '\1', $sUrl);
@@ -115,8 +116,7 @@ class UtilsUrl extends \OxidEsales\Eshop\Core\Base
     public function prepareCanonicalUrl($sUrl)
     {
         $oConfig = $this->getConfig();
-        /** @var \OxidEsales\Eshop\Core\StrRegular $oStr */
-        $oStr = getStr();
+        $oStr = Str::getStr();
 
         // cleaning up session id..
         $sUrl = $oStr->preg_replace('/(\?|&(amp;)?)(force_)?(admin_)?sid=[a-z0-9\._]+&?(amp;)?/i', '\1', $sUrl);
@@ -183,8 +183,7 @@ class UtilsUrl extends \OxidEsales\Eshop\Core\Base
      */
     public function cleanUrl($sUrl, $aParams = null)
     {
-        /** @var \OxidEsales\Eshop\Core\StrRegular $oStr */
-        $oStr = getStr();
+        $oStr = Str::getStr();
         if (is_array($aParams)) {
             foreach ($aParams as $sParam) {
                 $sUrl = $oStr->preg_replace(
@@ -395,8 +394,7 @@ class UtilsUrl extends \OxidEsales\Eshop\Core\Base
         $sUrl = $aUrlParts[0];
         $sUrlParams = $aUrlParts[1];
 
-        /** @var \OxidEsales\Eshop\Core\StrRegular $oStrUtils */
-        $oStrUtils = getStr();
+        $oStrUtils = Str::getStr();
         $sUrlParams = $oStrUtils->preg_replace(
             ['@(\&(amp;){1,})@ix', '@\&{1,}@', '@\?&@x'],
             ['&', '&', '?'],
@@ -568,8 +566,7 @@ class UtilsUrl extends \OxidEsales\Eshop\Core\Base
      */
     private function getUrlParametersSeparator($url)
     {
-        /** @var \OxidEsales\Eshop\Core\StrRegular $oStr */
-        $oStr = getStr();
+        $oStr = Str::getStr();
 
         $urlSeparator = '&amp;';
         if ($oStr->preg_match('/(\?|&(amp;)?)$/i', $url)) {
@@ -628,6 +625,6 @@ class UtilsUrl extends \OxidEsales\Eshop\Core\Base
      */
     private function rightTrimAmp($url)
     {
-        return getStr()->preg_replace('/(\?|&(amp;)?)$/i', '', $url);
+        return Str::getStr()->preg_replace('/(\?|&(amp;)?)$/i', '', $url);
     }
 }

--- a/source/Core/ViewConfig.php
+++ b/source/Core/ViewConfig.php
@@ -8,6 +8,7 @@ namespace OxidEsales\EshopCommunity\Core;
 
 use OxidEsales\Eshop\Core\Edition\EditionSelector;
 use OxidEsales\Eshop\Core\Registry;
+use OxidEsales\Eshop\Core\Str;
 use OxidEsales\EshopCommunity\Internal\Framework\Module\Setup\Bridge\ModuleActivationBridgeInterface;
 
 /**
@@ -84,11 +85,11 @@ class ViewConfig extends \OxidEsales\Eshop\Core\Base
                     $sValue,
                     \OxidEsales\Eshop\Core\Registry::getUtilsUrl()->getBaseAddUrlParams()
                 );
-                $sValue = getStr()->preg_replace('/(\?|&(amp;)?)$/', '', $sValue);
+                $sValue = Str::getStr()->preg_replace('/(\?|&(amp;)?)$/', '', $sValue);
             }
 
             if (!$sValue) {
-                $sValue = getStr()->preg_replace('#index.php\??$#', '', $this->getSelfLink());
+                $sValue = Str::getStr()->preg_replace('#index.php\??$#', '', $this->getSelfLink());
             }
 
             $this->setViewConfigParam('homeLink', $sValue);
@@ -980,7 +981,7 @@ class ViewConfig extends \OxidEsales\Eshop\Core\Base
     public function getNavFormParams()
     {
         if (($sParams = $this->getViewConfigParam('navformparams')) === null) {
-            $oStr = getStr();
+            $oStr = Str::getStr();
             $sParams = '';
             $aNavParams = $this->getConfig()->getTopActiveView()->getNavigationParams();
             foreach ($aNavParams as $sName => $sValue) {

--- a/source/Core/ViewHelper/JavaScriptRegistrator.php
+++ b/source/Core/ViewHelper/JavaScriptRegistrator.php
@@ -6,6 +6,8 @@
 
 namespace OxidEsales\EshopCommunity\Core\ViewHelper;
 
+use OxidEsales\Eshop\Core\Str;
+
 /**
  * Class for preparing JavaScript.
  */
@@ -78,7 +80,7 @@ class JavaScriptRegistrator
         }
 
         if (empty($url) && $config->getConfigParam('iDebug') != 0) {
-            $error = "{oxscript} resource not found: " . getStr()->htmlspecialchars($file);
+            $error = "{oxscript} resource not found: " . Str::getStr()->htmlspecialchars($file);
             trigger_error($error, E_USER_WARNING);
         }
 

--- a/source/Core/ViewHelper/StyleRegistrator.php
+++ b/source/Core/ViewHelper/StyleRegistrator.php
@@ -6,6 +6,8 @@
 
 namespace OxidEsales\EshopCommunity\Core\ViewHelper;
 
+use OxidEsales\Eshop\Core\Str;
+
 /**
  * Class for preparing JavaScript.
  */
@@ -65,7 +67,7 @@ class StyleRegistrator
         }
 
         if (empty($url) && $config->getConfigParam('iDebug') != 0) {
-            $error = "{oxstyle} resource not found: " . getStr()->htmlspecialchars($file);
+            $error = "{oxstyle} resource not found: " . Str::getStr()->htmlspecialchars($file);
             trigger_error($error, E_USER_WARNING);
         }
 

--- a/source/Internal/Transition/Adapter/TemplateLogic/AddUrlParametersLogic.php
+++ b/source/Internal/Transition/Adapter/TemplateLogic/AddUrlParametersLogic.php
@@ -6,6 +6,8 @@
 
 namespace OxidEsales\EshopCommunity\Internal\Transition\Adapter\TemplateLogic;
 
+use OxidEsales\Eshop\Core\Str;
+
 class AddUrlParametersLogic
 {
 
@@ -19,9 +21,8 @@ class AddUrlParametersLogic
      */
     public function addUrlParameters(string $sUrl, string $sDynParams): string
     {
-        $oStr = getStr();
         // removing empty parameters
-        $sDynParams = $sDynParams ? $oStr->preg_replace(['/^\?/', '/^\&(amp;)?$/'], '', $sDynParams) : false;
+        $sDynParams = $sDynParams ? Str::getStr()->preg_replace(['/^\?/', '/^\&(amp;)?$/'], '', $sDynParams) : false;
         if ($sDynParams) {
             $sUrl .= ((strpos($sUrl, '?') !== false) ? "&amp;" : "?") . $sDynParams;
         }

--- a/source/Internal/Transition/Adapter/TemplateLogic/TruncateLogic.php
+++ b/source/Internal/Transition/Adapter/TemplateLogic/TruncateLogic.php
@@ -6,6 +6,8 @@
 
 namespace OxidEsales\EshopCommunity\Internal\Transition\Adapter\TemplateLogic;
 
+use OxidEsales\Eshop\Core\Str;
+
 class TruncateLogic
 {
     /**
@@ -21,16 +23,16 @@ class TruncateLogic
     {
         if ($iLength == 0) {
             return '';
-        } elseif ($iLength > 0 && getStr()->strlen($sString) > $iLength) {
-            $iLength -= getStr()->strlen($sSufix);
+        } elseif ($iLength > 0 && Str::getStr()->strlen($sString) > $iLength) {
+            $iLength -= Str::getStr()->strlen($sSufix);
 
             $sString = str_replace(['&#039;', '&quot;'], ["'", '"'], $sString);
 
             if (!$blBreakWords) {
-                $sString = getStr()->preg_replace('/\s+?(\S+)?$/', '', getStr()->substr($sString, 0, $iLength + 1));
+                $sString = Str::getStr()->preg_replace('/\s+?(\S+)?$/', '', Str::getStr()->substr($sString, 0, $iLength + 1));
             }
 
-            $sString = getStr()->substr($sString, 0, $iLength) . $sSufix;
+            $sString = Str::getStr()->substr($sString, 0, $iLength) . $sSufix;
 
             return str_replace(["'", '"'], ['&#039;', '&quot;'], $sString);
         }

--- a/source/Internal/Transition/Adapter/TemplateLogic/WordwrapLogic.php
+++ b/source/Internal/Transition/Adapter/TemplateLogic/WordwrapLogic.php
@@ -6,6 +6,8 @@
 
 namespace OxidEsales\EshopCommunity\Internal\Transition\Adapter\TemplateLogic;
 
+use OxidEsales\Eshop\Core\Str;
+
 class WordwrapLogic
 {
     /**
@@ -18,6 +20,6 @@ class WordwrapLogic
      */
     public function wordwrap(string $string, int $length = 80, string $wrapper = "\n", bool $cut = false): string
     {
-        return getStr()->wordwrap($string, $length, $wrapper, $cut);
+        return Str::getStr()->wordwrap($string, $length, $wrapper, $cut);
     }
 }


### PR DESCRIPTION
Replaces all calls to `getStr()` method which was deprecated with `v6.0.0` on 2016-05-16 with calls to `\OxidEsales\Eshop\Core\Str::getStr()`