### PR TITLE
Add PHP nightly to travis pipeline

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,7 @@ before_install:
 
 before_script:
   # remove xdebug
-  - phpenv config-rm xdebug.ini
+  - phpenv config-rm xdebug.ini || echo "xdebug not available"
   # apache setup (https://docs.travis-ci.com/user/languages/php/#apache--php)
   - sudo apt-get install apache2 libapache2-mod-fastcgi
   # enable php-fpm

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,10 @@ matrix:
     - php: nightly
   fast_finish: true
 
+cache:
+    directories:
+        - $HOME/.composer/cache/files
+
 # Numeric values of error reporting levels:
 # 32767: E_ALL
 # 30711: E_ALL & ~E_NOTICE & ~E_STRICT

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,12 +6,15 @@ notifications:
   email: false
 
 php:
-  - "7.1"
-  - "7.2"
-  - "7.3"
-  - "7.4"
+  - 7.1
+  - 7.2
+  - 7.3
+  - 7.4
+  - nightly
 
 matrix:
+  allow_failures:
+    - php: nightly
   fast_finish: true
 
 # Numeric values of error reporting levels:


### PR DESCRIPTION
Now that PHP 7.4 ist finally working, it's time to add the `nightly` release (upcoming 8.0) to our test suite