### PR TITLE
Add isActive getter to BaseModel

### DIFF
--- a/source/Core/Model/BaseModel.php
+++ b/source/Core/Model/BaseModel.php
@@ -945,6 +945,38 @@ class BaseModel extends \OxidEsales\Eshop\Core\Base
     }
 
     /**
+     * Will tell if this record is active or not based on the oxactive and (if
+     * exists) oxactivefrom and oxactiveto fields
+     *
+     * @return bool
+     */
+    public function isActive(): bool
+    {
+        if (!isset($this->_aFieldNames['oxactive'])) {
+            return true;
+        }
+        if ((bool)$this->getFieldData('oxactive')) {
+            return true;
+        }
+        if (!isset($this->_aFieldNames['oxactivefrom']) &&
+            !isset($this->_aFieldNames['oxactiveto'])) {
+            return false;
+        }
+        $from = new \DateTimeImmutable(
+            (string)$this->getFieldData('oxactivefrom')
+        );
+        $to = new \DateTimeImmutable(
+            (string)$this->getFieldData('oxactiveto')
+        );
+        $now = new \DateTimeImmutable("now");
+        if ($from <= $now &&
+            $to >= $now) {
+            return true;
+        }
+        return false;
+    }
+
+    /**
      * This function is triggered before the record is updated.
      * If you make any update to the database record manually you should also call beforeUpdate() from your script.
      *


### PR DESCRIPTION
This pull request will add the `isActive` method to `OxidEsales\EshopCommunity\Core\Model\BaseModel` to help query the status if a record is active or not after it was loaded.
We need to take care of this in the GraphQL module (and already implemented something there), but IMHO this kind of functionality belongs into the OXID core.

Open Tasks:

- [ ] write tests