### PR TITLE
added human readable results for file permission checks

### DIFF
--- a/source/Core/SystemRequirements.php
+++ b/source/Core/SystemRequirements.php
@@ -269,6 +269,10 @@ class SystemRequirements
     {
         clearstatcache();
         $sPath = $sPath ? $sPath : getShopBasePath();
+        $aPathCheckResults = [
+        	"missing" => [],
+        	"notwritable" => []
+        ];
 
         // special config file check
         $sFullPath = $sPath . "config.inc.php";
@@ -302,8 +306,9 @@ class SystemRequirements
         while ($sPathToCheck) {
             // missing file/folder?
             if (!file_exists($sPathToCheck)) {
+            	$aPathCheckResults["missing"][] = str_replace($sPath, '', $sPathToCheck);
                 $iModStat = 0;
-                break;
+                //break;
             }
 
             if (is_dir($sPathToCheck)) {
@@ -318,14 +323,24 @@ class SystemRequirements
 
             // testing if file permissions >= $iMinPerm
             if (!is_readable($sPathToCheck) || !is_writable($sPathToCheck)) {
+                $aPathCheckResults["notwritable"][] = str_replace($sPath, '', $sPathToCheck);
                 $iModStat = 0;
-                break;
+                //break;
             }
 
             $sPathToCheck = next($aPathsToCheck);
         }
 
+        $this->_setServerPermissionCheckResults($aPathCheckResults);
         return $iModStat;
+    }
+
+    /**
+     * saves details of filesystem permission checks in session
+     */
+    protected function _setServerPermissionCheckResults($value) {
+        if(!isset($_COOKIE["PHPSESSID"])) session_start();
+        $_SESSION["aPathCheckResults"] = $value;
     }
 
 

--- a/source/Setup/De/lang.php
+++ b/source/Setup/De/lang.php
@@ -63,6 +63,8 @@ $aLang = [
 
 'MOD_MOD_REWRITE'                               => 'Apache mod_rewrite Modul',
 'MOD_SERVER_PERMISSIONS'                        => 'Dateizugriffsrechte',
+'MOD_SERVER_PERMISSIONS_MISSING'                => 'Fehlende Pfade:',
+'MOD_SERVER_PERMISSIONS_NOTWRITABLE'            => 'Fehlende Schreibrechte:',
 'MOD_ALLOW_URL_FOPEN'                           => 'allow_url_fopen und fsockopen auf Port 80',
 'MOD_PHP4_COMPAT'                               => 'Zend Kompatibilitätsmodus muss ausgeschaltet sein',
 'MOD_PHP_VERSION'                               => 'PHP Version 7.1 oder 7.2',

--- a/source/Setup/En/lang.php
+++ b/source/Setup/En/lang.php
@@ -63,6 +63,8 @@ $aLang = [
 
 'MOD_MOD_REWRITE'                               => 'Apache mod_rewrite module',
 'MOD_SERVER_PERMISSIONS'                        => 'Files/folders access rights',
+'MOD_SERVER_PERMISSIONS_MISSING'                => 'Folders missing:',
+'MOD_SERVER_PERMISSIONS_NOTWRITABLE'            => 'Folders not writable:',
 'MOD_ALLOW_URL_FOPEN'                           => 'allow_url_fopen and fsockopen to port 80',
 'MOD_PHP4_COMPAT'                               => 'Zend compatibility mode must be off',
 'MOD_PHP_VERSION'                               => 'PHP version 7.1 or 7.2',

--- a/source/Setup/tpl/systemreq.php
+++ b/source/Setup/tpl/systemreq.php
@@ -41,17 +41,19 @@ require "_header.php"; ?>
     <?php
     $aGroupModuleInfo = $this->getViewParam("aGroupModuleInfo");
     foreach ($aGroupModuleInfo as $sGroupName => $aGroupInfo) {
-        ?><li class="group"><?php echo $sGroupName; ?><ul><?php
-foreach ($aGroupInfo as $aModuleInfo) {
-    ?><li id="<?php echo $aModuleInfo['module']; ?>" class="<?php echo $aModuleInfo['class']; ?>"><?php
-if ($aModuleInfo['class'] == "fail" || $aModuleInfo['class'] == "pmin" || $aModuleInfo['class'] == "null") {
-    ?><a href="<?php $this->getReqInfoUrl($aModuleInfo['module']); ?>" target="_blank"><?php
-}
-    echo $aModuleInfo['modulename'];
-if ($aModuleInfo['class'] == "fail" || $aModuleInfo['class'] == "pmin" || $aModuleInfo['class'] == "null") {
-    ?></a><?php
-} ?></li><?php
-} ?></ul></li><?php
+        print '<li class="group">'.$sGroupName.'<ul>';
+        foreach ($aGroupInfo as $aModuleInfo) {
+            print '<li id="'.$aModuleInfo['module'].'" class="'.$aModuleInfo['class'].'">' .
+                ( $aModuleInfo['class'] == "fail" || $aModuleInfo['class'] == "pmin" || $aModuleInfo['class'] == "null" ? "<a href='".$this->getReqInfoUrl($aModuleInfo['module'],false)."' target='_blank'>" : '' ) .
+                $aModuleInfo['modulename'] .
+                ( $aModuleInfo['class'] == "fail" || $aModuleInfo['class'] == "pmin" || $aModuleInfo['class'] == "null" ? '</a>' : '' ) .
+                '</li>';
+            if ($aModuleInfo['module'] === "server_permissions" && isset($_SESSION["aPathCheckResults"])) {
+                if(count($_SESSION["aPathCheckResults"]["missing"]) > 0 ) echo "<li><b>".$this->getText("MOD_SERVER_PERMISSIONS_MISSING",false)."</b></li><li>&nbsp;".join("</li><li>&nbsp;",$_SESSION["aPathCheckResults"]["missing"])."</li>";
+                if(count($_SESSION["aPathCheckResults"]["notwritable"]) > 0 ) echo "<li><b>".$this->getText("MOD_SERVER_PERMISSIONS_NOTWRITABLE",false)."</b></li><li>&nbsp;".join("</li><li>&nbsp;",$_SESSION["aPathCheckResults"]["notwritable"])."</li>";
+            }
+        }
+        print '</ul></li>';
     }
     ?><li class="clear"></li></ul>
     <?php $this->getText('STEP_0_TEXT'); ?>


### PR DESCRIPTION
Hi, 
there is new directory ``var`` which needs to be writable, but is not mentioned in the [documentation](https://docs.oxid-esales.com/eshop/en/6.1/installation/new-installation/completing-installation.html), and many shop owners struggle on the file permissions check without knowing whats actually wrong, so I decided to collect check results while permission checks and output them during setup. 
Here is the preview:
![image](https://user-images.githubusercontent.com/1874024/74200307-e7f21a80-4c66-11ea-8b95-0852525523a0.png)
