### PR TITLE
fixed deprecated curly braces syntax in AdminController

### DIFF
--- a/source/Application/Controller/Admin/AdminController.php
+++ b/source/Application/Controller/Admin/AdminController.php
@@ -334,7 +334,7 @@ class AdminController extends \OxidEsales\Eshop\Core\Controller\BaseController
 
         // processing config
         $iMaxFileSize = trim($iMaxFileSize);
-        $sParam = strtolower($iMaxFileSize{strlen($iMaxFileSize) - 1});
+        $sParam = strtolower($iMaxFileSize[strlen($iMaxFileSize) - 1]);
         switch ($sParam) {
             case 'g':
                 $iMaxFileSize *= 1024;


### PR DESCRIPTION
see also https://wiki.php.net/rfc/deprecate_curly_braces_array_access