### PR TITLE
do not throw an exception if the correct controller is already present

### DIFF
--- a/source/Internal/Framework/Module/Setup/Validator/ControllersValidator.php
+++ b/source/Internal/Framework/Module/Setup/Validator/ControllersValidator.php
@@ -142,7 +142,13 @@ class ControllersValidator implements ModuleConfigurationValidatorInterface
         $controllerClassNameSpaces = [];
 
         foreach ($controllers as $controller) {
-            $controllerClassNameSpaces[] = $controller->getControllerClassNameSpace();
+            $controllerClassname = $controller->getControllerClassNameSpace();
+            if (
+                !isset($controllerClassMap[$controller->getId()])
+                || $controllerClassMap[$controller->getId()] !== $controllerClassname
+            ) {
+                $controllerClassNameSpaces[] = $controller->getControllerClassNameSpace();
+            }
         }
 
         return array_intersect($controllerClassNameSpaces, $controllerClassMap);


### PR DESCRIPTION
I don't know the exact steps to reproduce this, but I already saw this a couple of times:

![image](https://user-images.githubusercontent.com/1001186/75044262-9dbc3500-54c1-11ea-8a13-02514590f0a6.png)

Sometimes the controllers are already in the database (previously configured?) and are correct, so I think we should only complain if there is really a problematic scenario, where we try to map two different classes to one controller name.

I'm not sure if this is related to https://github.com/OXIDprojects/oxid-module-internals/issues/103