### PR TITLE
Deprecate misleading method Article::getDeliveryDate()

### DIFF
--- a/source/Application/Model/Article.php
+++ b/source/Application/Model/Article.php
@@ -2963,13 +2963,24 @@ class Article extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
     /**
      * Returns formatted delivery date. If the date is past or not set ('0000-00-00') returns false.
      *
-     * @return string | bool
+     * @deprecated since v6.2 (2020-02-26); use getRestockDate();
+     * @return false|string
      */
     public function getDeliveryDate()
     {
-        $deliveryDate = $this->getFieldData("oxdelivery");
-        if ($deliveryDate >= date('Y-m-d')) {
-            return \OxidEsales\Eshop\Core\Registry::getUtilsDate()->formatDBDate($deliveryDate);
+        return $this->getRestockDate();
+    }
+
+    /**
+     * Returns formatted delivery date. If the date is past or not set ('0000-00-00') returns false.
+     *
+     * @return false|string
+     */
+    public function getRestockDate()
+    {
+        $restockDate = $this->getFieldData('oxdelivery');
+        if ($restockDate >= date('Y-m-d')) {
+            return Registry::getUtilsDate()->formatDBDate($restockDate);
         }
 
         return false;

--- a/tests/Unit/Application/Model/ArticleTest.php
+++ b/tests/Unit/Application/Model/ArticleTest.php
@@ -5551,7 +5551,7 @@ class ArticleTest extends \OxidTestCase
 
         $sDelDate = date('d.m.Y');
 
-        $this->assertEquals($sDelDate, $oArticle->getDeliveryDate());
+        $this->assertEquals($sDelDate, $oArticle->getRestockDate());
     }
 
     /**
@@ -5562,7 +5562,7 @@ class ArticleTest extends \OxidTestCase
         $oArticle = $this->_createArticle('_testArt');
         $oArticle->oxarticles__oxdelivery = new oxField('0000-00-00', oxField::T_RAW);
         $oArticle->save();
-        $this->assertFalse($oArticle->getDeliveryDate());
+        $this->assertFalse($oArticle->getRestockDate());
     }
 
     /**
@@ -5573,7 +5573,7 @@ class ArticleTest extends \OxidTestCase
         $oArticle = $this->_createArticle('_testArt');
         $oArticle->oxarticles__oxdelivery = new oxField('2017-12-13', oxField::T_RAW);
         $oArticle->save();
-        $this->assertFalse($oArticle->getDeliveryDate());
+        $this->assertFalse($oArticle->getRestockDate());
     }
 
     /**


### PR DESCRIPTION
Hi there,

in `\OxidEsales\EshopCommunity\Application\Model\Article` the method `getDeliveryDate` returns the date on which the specified article will be on stock again, aka restocked.
The word _delivery_ in the shop is always used from the customers point of view, not the merchants one, so I propose we change the wording from _delivery_ to _restock_ to be consistent.

This pull request:
- deprecates the `getDeliveryDate()` method
- adds the `getRestockDate()` method

/Flo