### PR TITLE
Cleanup PHPCodeSniffer usage and reported errors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ cache:
 #
 # Keep TRAVIS_ERROR_LEVEL in sync with the value in vendor/oxid-esales/testing-library/base.php
 #
-env: TRAVIS_ERROR_LEVEL=32767 OX_BASE_PATH="$TRAVIS_BUILD_DIR/source/" OXID_ESHOP_CS_THRESHOLD=4066
+env: TRAVIS_ERROR_LEVEL=32767 OX_BASE_PATH="$TRAVIS_BUILD_DIR/source/"
 
 services: mysql
 
@@ -71,5 +71,5 @@ before_script:
   - COMPOSER_MEMORY_LIMIT=-1 SHOP_PATH='source' SHOP_TESTS_PATH='tests' MODULES_PATH='' composer install
 
 script:
-  - php vendor/bin/oe-eshop-phpcs_with_thresholds
+  - php vendor/bin/phpcs
   - php vendor/bin/runtests

--- a/composer.json
+++ b/composer.json
@@ -34,11 +34,11 @@
         "oxid-esales/oxideshop-composer-plugin": "v4.1.0",
         "oxid-esales/oxideshop-unified-namespace-generator": "^2.0.0",
         "oxid-esales/testing-library": "^v7.1.0",
-        "oxid-esales/coding-standards-wrapper": "^v3.0.0",
         "incenteev/composer-parameter-handler": "~v2.0",
         "oxid-esales/oxideshop-ide-helper": "^3.0",
         "oxid-esales/azure-theme": "^v1.4.1",
-        "oxid-esales/oxideshop-facts": "^2.3.1"
+        "oxid-esales/oxideshop-facts": "^2.3.1",
+        "squizlabs/php_codesniffer": "^3.5.4"
     },
     "autoload": {
         "psr-4": {

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -7,9 +7,7 @@
     <arg name="colors"/>
     <arg value="p"/>
     <arg value="n"/>
-    <arg name="parallel" value="75" />
+    <arg name="parallel" value="75"/>
     <arg name="extensions" value="php"/>
-    <rule ref="PSR12">
-        <exclude name="PSR2.Methods.MethodDeclaration.Underscore"/>
-    </rule>
+    <rule ref="PSR12"/>
 </ruleset>

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -1,0 +1,15 @@
+<?xml version="1.0"?>
+<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="PHP_CodeSniffer" xsi:noNamespaceSchemaLocation="phpcs.xsd">
+    <description>The coding standard for PHP_CodeSniffer itself.</description>
+    <file>source</file>
+    <exclude-pattern>*source/Application/views/.*$</exclude-pattern>
+    <exclude-pattern>*source/tmp/.*$</exclude-pattern>
+    <arg name="colors"/>
+    <arg value="p"/>
+    <arg value="n"/>
+    <arg name="parallel" value="75" />
+    <arg name="extensions" value="php"/>
+    <rule ref="PSR12">
+        <exclude name="PSR2.Methods.MethodDeclaration.Underscore"/>
+    </rule>
+</ruleset>

--- a/source/Application/Component/BasketComponent.php
+++ b/source/Application/Component/BasketComponent.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
@@ -129,7 +130,8 @@ class BasketComponent extends \OxidEsales\Eshop\Core\Controller\BaseController
      */
     public function toBasket($sProductId = null, $dAmount = null, $aSel = null, $aPersParam = null, $blOverride = false)
     {
-        if (Registry::getSession()->getId() &&
+        if (
+            Registry::getSession()->getId() &&
             Registry::getSession()->isActualSidInCookie() &&
             !Registry::getSession()->checkSessionChallenge()
         ) {
@@ -262,7 +264,7 @@ class BasketComponent extends \OxidEsales\Eshop\Core\Controller\BaseController
      *
      * @return string   $sClass.$sPosition  redirection URL
      */
-    protected function _getRedirectUrl()
+    protected function _getRedirectUrl() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
 
         // active controller id
@@ -325,7 +327,7 @@ class BasketComponent extends \OxidEsales\Eshop\Core\Controller\BaseController
      *
      * @return mixed
      */
-    protected function _getItems(
+    protected function _getItems( // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
         $sProductId = null,
         $dAmount = null,
         $aSel = null,
@@ -385,7 +387,7 @@ class BasketComponent extends \OxidEsales\Eshop\Core\Controller\BaseController
      *
      * @return  object  $oBasketItem    last added basket item
      */
-    protected function _addItems($products)
+    protected function _addItems($products) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $activeView = $this->getConfig()->getActiveView();
         $errorDestination = $activeView->getErrorDestination();
@@ -446,7 +448,7 @@ class BasketComponent extends \OxidEsales\Eshop\Core\Controller\BaseController
      * @param array  $aProductInfo data which comes from request when you press button "to basket"
      * @param array  $aBasketInfo  array returned by \OxidEsales\Eshop\Application\Model\Basket::getBasketSummary()
      */
-    protected function _setLastCall($sCallName, $aProductInfo, $aBasketInfo)
+    protected function _setLastCall($sCallName, $aProductInfo, $aBasketInfo) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         Registry::getSession()->setVariable('aLastcall', [$sCallName => $aProductInfo]);
     }
@@ -456,7 +458,7 @@ class BasketComponent extends \OxidEsales\Eshop\Core\Controller\BaseController
      *
      * @param string $sCallName name of action ('tobasket', 'changebasket')
      */
-    protected function _setLastCallFnc($sCallName)
+    protected function _setLastCallFnc($sCallName) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $this->_sLastCallFnc = $sCallName;
     }
@@ -466,7 +468,7 @@ class BasketComponent extends \OxidEsales\Eshop\Core\Controller\BaseController
      *
      * @return string
      */
-    protected function _getLastCallFnc()
+    protected function _getLastCallFnc() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         return $this->_sLastCallFnc;
     }

--- a/source/Application/Component/CategoriesComponent.php
+++ b/source/Application/Component/CategoriesComponent.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
@@ -58,7 +59,8 @@ class CategoriesComponent extends \OxidEsales\Eshop\Core\Controller\BaseControll
 
         // Performance
         $myConfig = $this->getConfig();
-        if ($myConfig->getConfigParam('blDisableNavBars') &&
+        if (
+            $myConfig->getConfigParam('blDisableNavBars') &&
             $myConfig->getTopActiveView()->getIsOrderStep()
         ) {
             return;
@@ -104,7 +106,7 @@ class CategoriesComponent extends \OxidEsales\Eshop\Core\Controller\BaseControll
      *
      * @return string
      */
-    protected function _getActCat()
+    protected function _getActCat() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $sActManufacturer = \OxidEsales\Eshop\Core\Registry::getConfig()->getRequestParameter('mnid');
 
@@ -140,7 +142,7 @@ class CategoriesComponent extends \OxidEsales\Eshop\Core\Controller\BaseControll
      *
      * @param string $sActCat active category id
      */
-    protected function _loadCategoryTree($sActCat)
+    protected function _loadCategoryTree($sActCat) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         /** @var \OxidEsales\Eshop\Application\Model\CategoryList $oCategoryTree */
         $oCategoryTree = oxNew(\OxidEsales\Eshop\Application\Model\CategoryList::class);
@@ -161,7 +163,7 @@ class CategoriesComponent extends \OxidEsales\Eshop\Core\Controller\BaseControll
      *
      * @param string $sActManufacturer active Manufacturer id
      */
-    protected function _loadManufacturerTree($sActManufacturer)
+    protected function _loadManufacturerTree($sActManufacturer) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $myConfig = $this->getConfig();
         if ($myConfig->getConfigParam('bl_perfLoadManufacturerTree')) {
@@ -216,7 +218,7 @@ class CategoriesComponent extends \OxidEsales\Eshop\Core\Controller\BaseControll
      *
      * @return string $sActCat
      */
-    protected function _addAdditionalParams($oProduct, $sActCat, $sActManufacturer, $sActVendor)
+    protected function _addAdditionalParams($oProduct, $sActCat, $sActManufacturer, $sActVendor) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $sSearchPar = \OxidEsales\Eshop\Core\Registry::getConfig()->getRequestParameter('searchparam');
         $sSearchCat = \OxidEsales\Eshop\Core\Registry::getConfig()->getRequestParameter('searchcnid');
@@ -260,7 +262,7 @@ class CategoriesComponent extends \OxidEsales\Eshop\Core\Controller\BaseControll
      *
      * @return array
      */
-    protected function _getDefaultParams($oProduct)
+    protected function _getDefaultParams($oProduct) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $sListType = null;
         $aArticleCats = $oProduct->getCategoryIds(true);

--- a/source/Application/Component/CurrencyComponent.php
+++ b/source/Application/Component/CurrencyComponent.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Application/Component/LanguageComponent.php
+++ b/source/Application/Component/LanguageComponent.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Application/Component/Locator.php
+++ b/source/Application/Component/Locator.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
@@ -87,7 +88,7 @@ class Locator extends \OxidEsales\Eshop\Core\Base
      * @param FrontendController $oLocatorTarget view object
      * @param Article            $oCurrArticle   current article
      */
-    protected function _setListLocatorData($oLocatorTarget, $oCurrArticle)
+    protected function _setListLocatorData($oLocatorTarget, $oCurrArticle) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         // if no active category is loaded - lets check for category passed by post/get
         if (($oCategory = $oLocatorTarget->getActiveCategory())) {
@@ -130,7 +131,7 @@ class Locator extends \OxidEsales\Eshop\Core\Base
      * @param FrontendController $oLocatorTarget FrontendController object
      * @param Article            $oCurrArticle   current article
      */
-    protected function _setVendorLocatorData($oLocatorTarget, $oCurrArticle)
+    protected function _setVendorLocatorData($oLocatorTarget, $oCurrArticle) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         if (($oVendor = $oLocatorTarget->getActVendor())) {
             $sVendorId = $oVendor->getId();
@@ -174,7 +175,7 @@ class Locator extends \OxidEsales\Eshop\Core\Base
      * @param FrontendController $oLocatorTarget FrontendController object
      * @param Article            $oCurrArticle   current article
      */
-    protected function _setManufacturerLocatorData($oLocatorTarget, $oCurrArticle)
+    protected function _setManufacturerLocatorData($oLocatorTarget, $oCurrArticle) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         if (($oManufacturer = $oLocatorTarget->getActManufacturer())) {
             $sManufacturerId = $oManufacturer->getId();
@@ -228,7 +229,7 @@ class Locator extends \OxidEsales\Eshop\Core\Base
      * @param FrontendController $oLocatorTarget FrontendController object
      * @param Article            $oCurrArticle   current article
      */
-    protected function _setSearchLocatorData($oLocatorTarget, $oCurrArticle)
+    protected function _setSearchLocatorData($oLocatorTarget, $oCurrArticle) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         if (($oSearchCat = $oLocatorTarget->getActSearch())) {
             // #1834/1184M - specialchar search
@@ -297,7 +298,7 @@ class Locator extends \OxidEsales\Eshop\Core\Base
      *
      * @deprecated since v5.3 (2016-06-17); Listmania will be moved to an own module.
      */
-    protected function _setRecommlistLocatorData($oLocatorTarget, $oCurrArticle)
+    protected function _setRecommlistLocatorData($oLocatorTarget, $oCurrArticle) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         if (($oRecommList = $oLocatorTarget->getActiveRecommList())) {
             // loading data for article navigation
@@ -358,7 +359,7 @@ class Locator extends \OxidEsales\Eshop\Core\Base
      *
      * @return object
      */
-    protected function _loadIdsInList($oCategory, $oCurrArticle, $sOrderBy = null)
+    protected function _loadIdsInList($oCategory, $oCurrArticle, $sOrderBy = null) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $oIdList = oxNew(\OxidEsales\Eshop\Application\Model\ArticleList::class);
         $oIdList->setCustomSorting($sOrderBy);
@@ -389,7 +390,7 @@ class Locator extends \OxidEsales\Eshop\Core\Base
      *
      * @return string
      */
-    protected function _makeLink($sLink, $sParams)
+    protected function _makeLink($sLink, $sParams) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         if ($sParams) {
             $sLink .= ((strpos($sLink, '?') !== false) ? '&amp;' : '?') . $sParams;
@@ -408,7 +409,7 @@ class Locator extends \OxidEsales\Eshop\Core\Base
      *
      * @return int
      */
-    protected function _findActPageNumber($iPageNr, $oIdList = null, $oArticle = null)
+    protected function _findActPageNumber($iPageNr, $oIdList = null, $oArticle = null) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         //page number
         $iPageNr = (int) $iPageNr;
@@ -433,7 +434,7 @@ class Locator extends \OxidEsales\Eshop\Core\Base
      *
      * @return string $sPageNum
      */
-    protected function _getPageNumber($iPageNr)
+    protected function _getPageNumber($iPageNr) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         //page number
         $iPageNr = (int) $iPageNr;
@@ -450,7 +451,7 @@ class Locator extends \OxidEsales\Eshop\Core\Base
      *
      * @return integer
      */
-    protected function _getProductPos($oArticle, $oIdList, $oLocatorTarget)
+    protected function _getProductPos($oArticle, $oIdList, $oLocatorTarget) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         // variant handling
         $sOxid = $oArticle->oxarticles__oxparentid->value

--- a/source/Application/Component/NewsComponent.php
+++ b/source/Application/Component/NewsComponent.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
@@ -39,7 +40,8 @@ class NewsComponent extends \OxidEsales\Eshop\Core\Controller\BaseController
         $oActView = $myConfig->getActiveView();
 
         // news loading is disabled
-        if (!$myConfig->getConfigParam('bl_perfLoadNews') ||
+        if (
+            !$myConfig->getConfigParam('bl_perfLoadNews') ||
             ($myConfig->getConfigParam('blDisableNavBars') &&
              $oActView->getIsOrderStep())
         ) {
@@ -47,7 +49,8 @@ class NewsComponent extends \OxidEsales\Eshop\Core\Controller\BaseController
         }
 
         // if news must be displayed only on start page ?
-        if ($myConfig->getConfigParam('bl_perfLoadNewsOnlyStart') &&
+        if (
+            $myConfig->getConfigParam('bl_perfLoadNewsOnlyStart') &&
             $oActView->getClassName() != "start"
         ) {
             return;

--- a/source/Application/Component/ShopComponent.php
+++ b/source/Application/Component/ShopComponent.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Application/Component/UserComponent.php
+++ b/source/Application/Component/UserComponent.php
@@ -257,7 +257,7 @@ class UserComponent extends \OxidEsales\Eshop\Core\Controller\BaseController
      * Executes oxcmp_user::login() method. After loggin user will not be
      * redirected to user or payment screens.
      */
-    public function login_noredirect() //phpcs:ignore
+    public function login_noredirect() //phpcs:ignore PSR1.Methods.CamelCapsMethodName.NotCamelCaps
     {
         $blAgb = Registry::getConfig()->getRequestParameter('ord_agb');
 
@@ -362,7 +362,7 @@ class UserComponent extends \OxidEsales\Eshop\Core\Controller\BaseController
      *
      * @return null
      */
-    public function changeuser_testvalues() //phpcs:ignore
+    public function changeuser_testvalues() //phpcs:ignore PSR1.Methods.CamelCapsMethodName.NotCamelCaps
     {
         // skip updating user info if this is just form reload
         // on selecting delivery address
@@ -644,7 +644,7 @@ class UserComponent extends \OxidEsales\Eshop\Core\Controller\BaseController
      *
      * @return  bool true on success, false otherwise
      */
-    protected function _changeUser_noRedirect() //phpcs:ignore
+    protected function _changeUser_noRedirect() //phpcs:ignore PSR1.Methods.CamelCapsMethodName.NotCamelCaps
     {
         return $this->changeUserWithoutRedirect();
     }

--- a/source/Application/Component/UserComponent.php
+++ b/source/Application/Component/UserComponent.php
@@ -257,7 +257,7 @@ class UserComponent extends \OxidEsales\Eshop\Core\Controller\BaseController
      * Executes oxcmp_user::login() method. After loggin user will not be
      * redirected to user or payment screens.
      */
-    public function login_noredirect()
+    public function login_noredirect() //phpcs:ignore
     {
         $blAgb = Registry::getConfig()->getRequestParameter('ord_agb');
 
@@ -362,7 +362,7 @@ class UserComponent extends \OxidEsales\Eshop\Core\Controller\BaseController
      *
      * @return null
      */
-    public function changeuser_testvalues()
+    public function changeuser_testvalues() //phpcs:ignore
     {
         // skip updating user info if this is just form reload
         // on selecting delivery address
@@ -644,7 +644,7 @@ class UserComponent extends \OxidEsales\Eshop\Core\Controller\BaseController
      *
      * @return  bool true on success, false otherwise
      */
-    protected function _changeUser_noRedirect()
+    protected function _changeUser_noRedirect() //phpcs:ignore
     {
         return $this->changeUserWithoutRedirect();
     }

--- a/source/Application/Component/UserComponent.php
+++ b/source/Application/Component/UserComponent.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
@@ -125,7 +126,7 @@ class UserComponent extends \OxidEsales\Eshop\Core\Controller\BaseController
      *  (1) login page;
      *  (2) terms agreement page;
      */
-    protected function _checkPsState()
+    protected function _checkPsState() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $oConfig = $this->getConfig();
         if ($this->getParent()->isEnabledPrivateSales()) {
@@ -149,7 +150,7 @@ class UserComponent extends \OxidEsales\Eshop\Core\Controller\BaseController
      *
      * @return null
      */
-    protected function _loadSessionUser()
+    protected function _loadSessionUser() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $myConfig = $this->getConfig();
         $oUser = $this->getUser();
@@ -232,7 +233,7 @@ class UserComponent extends \OxidEsales\Eshop\Core\Controller\BaseController
      *
      * @return string
      */
-    protected function _afterLogin($oUser)
+    protected function _afterLogin($oUser) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $oSession = $this->getSession();
         if ($oSession->isSessionStarted()) {
@@ -287,7 +288,7 @@ class UserComponent extends \OxidEsales\Eshop\Core\Controller\BaseController
      * session parameters as user chosen payment id, delivery
      * address id, active delivery set.
      */
-    protected function _afterLogout()
+    protected function _afterLogout() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         Registry::getSession()->deleteVariable('paymentid');
         Registry::getSession()->deleteVariable('sShipSet');
@@ -606,7 +607,7 @@ class UserComponent extends \OxidEsales\Eshop\Core\Controller\BaseController
     /**
      * Saves invitor ID
      */
-    protected function _saveInvitor()
+    protected function _saveInvitor() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         if ($this->getConfig()->getConfigParam('blInvitationsEnabled')) {
             $this->getInvitor();
@@ -617,7 +618,7 @@ class UserComponent extends \OxidEsales\Eshop\Core\Controller\BaseController
     /**
      * Saving show/hide delivery address state
      */
-    protected function _saveDeliveryAddressState()
+    protected function _saveDeliveryAddressState() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $oSession = Registry::getSession();
 
@@ -644,7 +645,7 @@ class UserComponent extends \OxidEsales\Eshop\Core\Controller\BaseController
      *
      * @return  bool true on success, false otherwise
      */
-    protected function _changeUser_noRedirect() //phpcs:ignore PSR1.Methods.CamelCapsMethodName.NotCamelCaps
+    protected function _changeUser_noRedirect() // phpcs:ignore PSR1.Methods.CamelCapsMethodName.NotCamelCaps,PSR2.Methods.MethodDeclaration.Underscore
     {
         return $this->changeUserWithoutRedirect();
     }
@@ -751,7 +752,7 @@ class UserComponent extends \OxidEsales\Eshop\Core\Controller\BaseController
      *
      * @return array
      */
-    protected function _getDelAddressData()
+    protected function _getDelAddressData() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         // if user company name, user name and additional info has special chars
         $blShowShipAddressParameter = Registry::getConfig()->getRequestParameter('blshowshipaddress');
@@ -779,7 +780,7 @@ class UserComponent extends \OxidEsales\Eshop\Core\Controller\BaseController
      *
      * @return string $sLogoutLink
      */
-    protected function _getLogoutLink()
+    protected function _getLogoutLink() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $oConfig = $this->getConfig();
 

--- a/source/Application/Component/UtilsComponent.php
+++ b/source/Application/Component/UtilsComponent.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
@@ -133,7 +134,7 @@ class UtilsComponent extends \OxidEsales\Eshop\Core\Controller\BaseController
      * @param double $dAmount    product amount
      * @param array  $aSel       product selection list
      */
-    protected function _toList($sListType, $sProductId, $dAmount, $aSel)
+    protected function _toList($sListType, $sProductId, $dAmount, $aSel) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         // only if user is logged in
         if ($oUser = $this->getUser()) {
@@ -145,7 +146,7 @@ class UtilsComponent extends \OxidEsales\Eshop\Core\Controller\BaseController
             // processing amounts
             $dAmount = str_replace(',', '.', $dAmount);
             if (!$this->getConfig()->getConfigParam('blAllowUnevenAmounts')) {
-                $dAmount = round(( string ) $dAmount);
+                $dAmount = round((string) $dAmount);
             }
 
             $oBasket = $oUser->getBasket($sListType);

--- a/source/Application/Component/Widget/Actions.php
+++ b/source/Application/Component/Widget/Actions.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
@@ -48,7 +49,7 @@ class Actions extends \OxidEsales\Eshop\Application\Component\Widget\WidgetContr
      *
      * @return string
      */
-    protected function _getLoadActionsParam()
+    protected function _getLoadActionsParam() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $this->_blLoadActions = $this->getConfig()->getConfigParam('bl_perfLoadAktion');
 

--- a/source/Application/Component/Widget/ArticleBox.php
+++ b/source/Application/Component/Widget/ArticleBox.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
@@ -248,7 +249,7 @@ class ArticleBox extends \OxidEsales\Eshop\Application\Component\Widget\WidgetCo
      *
      * @return bool
      */
-    protected function _addDynParamsToLink($sAddDynParams, $oArticle)
+    protected function _addDynParamsToLink($sAddDynParams, $oArticle) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $blAddedParams = false;
         if ($sAddDynParams) {
@@ -271,7 +272,7 @@ class ArticleBox extends \OxidEsales\Eshop\Application\Component\Widget\WidgetCo
      *
      * @return \OxidEsales\Eshop\Application\Model\Article
      */
-    protected function _getArticleById($sArticleId)
+    protected function _getArticleById($sArticleId) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         /** @var \OxidEsales\Eshop\Application\Model\Article $oArticle */
         $oArticle = oxNew(\OxidEsales\Eshop\Application\Model\Article::class);

--- a/source/Application/Component/Widget/ArticleDetails.php
+++ b/source/Application/Component/Widget/ArticleDetails.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
@@ -225,7 +226,7 @@ class ArticleDetails extends \OxidEsales\Eshop\Application\Component\Widget\Widg
      *
      * @return Article
      */
-    protected function _getParentProduct($sParentId)
+    protected function _getParentProduct($sParentId) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         if ($sParentId && $this->_oParentProd === null) {
             $this->_oParentProd = false;
@@ -244,7 +245,7 @@ class ArticleDetails extends \OxidEsales\Eshop\Application\Component\Widget\Widg
      *
      * @return string|null
      */
-    protected function _getAddUrlParams()
+    protected function _getAddUrlParams() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         if ($this->getListType() == "search") {
             return $this->getDynUrlParams();
@@ -256,7 +257,7 @@ class ArticleDetails extends \OxidEsales\Eshop\Application\Component\Widget\Widg
      *
      * @param object $oProduct Product to process.
      */
-    protected function _processProduct($oProduct)
+    protected function _processProduct($oProduct) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $oProduct->setLinkType($this->getLinkType());
         if ($sAddParams = $this->_getAddUrlParams()) {
@@ -697,7 +698,7 @@ class ArticleDetails extends \OxidEsales\Eshop\Application\Component\Widget\Widg
      *
      * @return object
      */
-    protected function _getSubject($iLang)
+    protected function _getSubject($iLang) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         return $this->getProduct();
     }
@@ -898,7 +899,7 @@ class ArticleDetails extends \OxidEsales\Eshop\Application\Component\Widget\Widg
     /**
      * Set item sorting for widget based of retrieved parameters.
      */
-    protected function _setSortingParameters()
+    protected function _setSortingParameters() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $sSortingParameters = $this->getViewParameter('sorting');
         if ($sSortingParameters) {
@@ -968,7 +969,7 @@ class ArticleDetails extends \OxidEsales\Eshop\Application\Component\Widget\Widg
      * @param Utils  $myUtils  General utils.
      * @param Config $myConfig Main shop configuration.
      */
-    protected function _additionalChecksForArticle($myUtils, $myConfig)
+    protected function _additionalChecksForArticle($myUtils, $myConfig) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $blContinue = true;
         if (!$this->_oProduct->isVisible()) {

--- a/source/Application/Component/Widget/BetaNote.php
+++ b/source/Application/Component/Widget/BetaNote.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Application/Component/Widget/CategoryTree.php
+++ b/source/Application/Component/Widget/CategoryTree.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Application/Component/Widget/CookieNote.php
+++ b/source/Application/Component/Widget/CookieNote.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Application/Component/Widget/CurrencyList.php
+++ b/source/Application/Component/Widget/CurrencyList.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Application/Component/Widget/Information.php
+++ b/source/Application/Component/Widget/Information.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
@@ -54,7 +55,7 @@ class Information extends \OxidEsales\Eshop\Application\Component\Widget\WidgetC
      *
      * @return object|oxContentList
      */
-    protected function _getContentList()
+    protected function _getContentList() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         if (!$this->_oContentList) {
             $this->_oContentList = oxNew(\OxidEsales\Eshop\Application\Model\ContentList::class);

--- a/source/Application/Component/Widget/LanguageList.php
+++ b/source/Application/Component/Widget/LanguageList.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Application/Component/Widget/ManufacturerList.php
+++ b/source/Application/Component/Widget/ManufacturerList.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Application/Component/Widget/MiniBasket.php
+++ b/source/Application/Component/Widget/MiniBasket.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Application/Component/Widget/Rating.php
+++ b/source/Application/Component/Widget/Rating.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Application/Component/Widget/Recommendation.php
+++ b/source/Application/Component/Widget/Recommendation.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Application/Component/Widget/Review.php
+++ b/source/Application/Component/Widget/Review.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Application/Component/Widget/ServiceList.php
+++ b/source/Application/Component/Widget/ServiceList.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Application/Component/Widget/ServiceMenu.php
+++ b/source/Application/Component/Widget/ServiceMenu.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Application/Component/Widget/VendorList.php
+++ b/source/Application/Component/Widget/VendorList.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Application/Component/Widget/WidgetController.php
+++ b/source/Application/Component/Widget/WidgetController.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
@@ -59,7 +60,7 @@ class WidgetController extends \OxidEsales\Eshop\Application\Controller\Frontend
      * In widgets we do not need to parse seo and do any work related to that
      * Shop main control is responsible for that, and that has to be done once
      */
-    protected function _processRequest()
+    protected function _processRequest() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
     }
 }

--- a/source/Application/Controller/AccountController.php
+++ b/source/Application/Controller/AccountController.php
@@ -1,8 +1,10 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
 namespace OxidEsales\EshopCommunity\Application\Controller;
 
 use OxidEsales\Eshop\Core\Registry;
@@ -123,7 +125,8 @@ class AccountController extends \OxidEsales\Eshop\Application\Controller\Fronten
         // is logged in ?
         $user = $this->getUser();
         $passwordField = 'oxuser__oxpassword';
-        if (!$user || ($user && !$user->$passwordField->value) ||
+        if (
+            !$user || ($user && !$user->$passwordField->value) ||
             ($this->isEnabledPrivateSales() && $user && (!$user->isTermsAccepted() || $this->confirmTerms()))
         ) {
             $this->_sThisTemplate = $this->_getLoginTemplate();
@@ -139,7 +142,7 @@ class AccountController extends \OxidEsales\Eshop\Application\Controller\Fronten
      *
      * @return string
      */
-    protected function _getLoginTemplate()
+    protected function _getLoginTemplate() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         return $this->isEnabledPrivateSales() ? $this->_sThisAltLoginTemplate : $this->_sThisLoginTemplate;
     }
@@ -199,7 +202,8 @@ class AccountController extends \OxidEsales\Eshop\Application\Controller\Fronten
     public function redirectAfterLogin()
     {
         // in case source class is provided - redirecting back to it with all default parameters
-        if (($sourceClass = Registry::getConfig()->getRequestParameter("sourcecl")) &&
+        if (
+            ($sourceClass = Registry::getConfig()->getRequestParameter("sourcecl")) &&
             $this->_oaComponents['oxcmp_user']->getLoginStatus() === USER_LOGIN_SUCCESS
         ) {
             $redirectUrl = $this->getConfig()->getShopUrl() . 'index.php?cl=' . rawurlencode($sourceClass);

--- a/source/Application/Controller/AccountDownloadsController.php
+++ b/source/Application/Controller/AccountDownloadsController.php
@@ -1,8 +1,10 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
 namespace OxidEsales\EshopCommunity\Application\Controller;
 
 use oxArticleList;
@@ -85,7 +87,7 @@ class AccountDownloadsController extends \OxidEsales\Eshop\Application\Controlle
      *
      * @return array
      */
-    protected function _prepareForTemplate($oOrderFileList)
+    protected function _prepareForTemplate($oOrderFileList) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $oOrderArticles = [];
 

--- a/source/Application/Controller/AccountNewsletterController.php
+++ b/source/Application/Controller/AccountNewsletterController.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Application/Controller/AccountNoticeListController.php
+++ b/source/Application/Controller/AccountNoticeListController.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Application/Controller/AccountOrderController.php
+++ b/source/Application/Controller/AccountOrderController.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Application/Controller/AccountPasswordController.php
+++ b/source/Application/Controller/AccountPasswordController.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Application/Controller/AccountRecommlistController.php
+++ b/source/Application/Controller/AccountRecommlistController.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
@@ -182,7 +183,8 @@ class AccountRecommlistController extends \OxidEsales\Eshop\Application\Controll
         if ($this->_oActRecommList === null) {
             $this->_oActRecommList = false;
 
-            if (($oUser = $this->getUser()) &&
+            if (
+                ($oUser = $this->getUser()) &&
                 ($sRecommId = Registry::getConfig()->getRequestParameter('recommid'))
             ) {
                 $oRecommList = oxNew(\OxidEsales\Eshop\Application\Model\RecommendationList::class);
@@ -230,9 +232,9 @@ class AccountRecommlistController extends \OxidEsales\Eshop\Application\Controll
                 $this->_sThisTemplate = 'page/account/recommendationedit.tpl';
             }
 
-            $sTitle = trim(( string ) Registry::getConfig()->getRequestParameter('recomm_title', true));
-            $sAuthor = trim(( string ) Registry::getConfig()->getRequestParameter('recomm_author', true));
-            $sText = trim(( string ) Registry::getConfig()->getRequestParameter('recomm_desc', true));
+            $sTitle = trim((string) Registry::getConfig()->getRequestParameter('recomm_title', true));
+            $sAuthor = trim((string) Registry::getConfig()->getRequestParameter('recomm_author', true));
+            $sText = trim((string) Registry::getConfig()->getRequestParameter('recomm_desc', true));
 
             $oRecommList->oxrecommlists__oxtitle = new Field($sTitle);
             $oRecommList->oxrecommlists__oxauthor = new Field($sAuthor);
@@ -275,7 +277,8 @@ class AccountRecommlistController extends \OxidEsales\Eshop\Application\Controll
         }
 
         // deleting on demand
-        if (($sAction = Registry::getConfig()->getRequestParameter('deleteList')) &&
+        if (
+            ($sAction = Registry::getConfig()->getRequestParameter('deleteList')) &&
             ($oRecommList = $this->getActiveRecommList())
         ) {
             $oRecommList->delete();
@@ -300,7 +303,8 @@ class AccountRecommlistController extends \OxidEsales\Eshop\Application\Controll
             return;
         }
 
-        if (($sArtId = Registry::getConfig()->getRequestParameter('aid')) &&
+        if (
+            ($sArtId = Registry::getConfig()->getRequestParameter('aid')) &&
             ($oRecommList = $this->getActiveRecommList())
         ) {
             $oRecommList->removeArticle($sArtId);

--- a/source/Application/Controller/AccountReviewController.php
+++ b/source/Application/Controller/AccountReviewController.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Application/Controller/AccountUserController.php
+++ b/source/Application/Controller/AccountUserController.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Application/Controller/AccountWishlistController.php
+++ b/source/Application/Controller/AccountWishlistController.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
@@ -134,7 +135,7 @@ class AccountWishlistController extends \OxidEsales\Eshop\Application\Controller
     public function showSuggest()
     {
         if ($this->_blShowSuggest === null) {
-            $this->_blShowSuggest = ( bool ) Registry::getConfig()->getRequestParameter('blshowsuggest');
+            $this->_blShowSuggest = (bool) Registry::getConfig()->getRequestParameter('blshowsuggest');
         }
 
         return $this->_blShowSuggest;
@@ -210,10 +211,11 @@ class AccountWishlistController extends \OxidEsales\Eshop\Application\Controller
         $aParams = Registry::getConfig()->getRequestParameter('editval', true);
         if (is_array($aParams)) {
             $oUtilsView = Registry::getUtilsView();
-            $oParams = ( object ) $aParams;
-            $this->setEnteredData(( object ) Registry::getConfig()->getRequestParameter('editval'));
+            $oParams = (object) $aParams;
+            $this->setEnteredData((object) Registry::getConfig()->getRequestParameter('editval'));
 
-            if (!isset($aParams['rec_name']) || !isset($aParams['rec_email']) ||
+            if (
+                !isset($aParams['rec_name']) || !isset($aParams['rec_email']) ||
                 !$aParams['rec_name'] || !$aParams['rec_email']
             ) {
                 return $oUtilsView->addErrorToDisplay('ERROR_MESSAGE_COMPLETE_FIELDS_CORRECTLY', false, true);

--- a/source/Application/Controller/Admin/ActionsArticleAjax.php
+++ b/source/Application/Controller/Admin/ActionsArticleAjax.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
@@ -43,7 +44,7 @@ class ActionsArticleAjax extends \OxidEsales\Eshop\Application\Controller\Admin\
      *
      * @return string
      */
-    protected function _getQuery()
+    protected function _getQuery() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $myConfig = $this->getConfig();
         $oDb = \OxidEsales\Eshop\Core\DatabaseProvider::getDb();
@@ -85,7 +86,7 @@ class ActionsArticleAjax extends \OxidEsales\Eshop\Application\Controller\Admin\
      *
      * @return string
      */
-    protected function _addFilter($sQ)
+    protected function _addFilter($sQ) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $sArtTable = $this->_getViewName('oxarticles');
         $sQ = parent::_addFilter($sQ);

--- a/source/Application/Controller/Admin/ActionsController.php
+++ b/source/Application/Controller/Admin/ActionsController.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Application/Controller/Admin/ActionsGroupsAjax.php
+++ b/source/Application/Controller/Admin/ActionsGroupsAjax.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
@@ -39,7 +40,7 @@ class ActionsGroupsAjax extends \OxidEsales\Eshop\Application\Controller\Admin\L
      *
      * @return string
      */
-    protected function _getQuery()
+    protected function _getQuery() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         // active AJAX component
         $sGroupTable = $this->_getViewName('oxgroups');

--- a/source/Application/Controller/Admin/ActionsList.php
+++ b/source/Application/Controller/Admin/ActionsList.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
@@ -60,7 +61,7 @@ class ActionsList extends \OxidEsales\Eshop\Application\Controller\Admin\AdminLi
      *
      * @return $sQ
      */
-    protected function _prepareWhereQuery($aWhere, $sqlFull)
+    protected function _prepareWhereQuery($aWhere, $sqlFull) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $sQ = parent::_prepareWhereQuery($aWhere, $sqlFull);
         $sDisplayType = (int) \OxidEsales\Eshop\Core\Registry::getConfig()->getRequestParameter('displaytype');

--- a/source/Application/Controller/Admin/ActionsMain.php
+++ b/source/Application/Controller/Admin/ActionsMain.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
@@ -7,9 +8,9 @@
 namespace OxidEsales\EshopCommunity\Application\Controller\Admin;
 
 use stdClass;
-use \OxidEsales\Eshop\Application\Model\Actions;
-use \OxidEsales\Eshop\Core\Registry;
-use \OxidEsales\Eshop\Core\Request;
+use OxidEsales\Eshop\Application\Model\Actions;
+use OxidEsales\Eshop\Core\Registry;
+use OxidEsales\Eshop\Core\Request;
 
 /**
  * Admin article main actions manager.

--- a/source/Application/Controller/Admin/ActionsMainAjax.php
+++ b/source/Application/Controller/Admin/ActionsMainAjax.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
@@ -54,7 +55,7 @@ class ActionsMainAjax extends \OxidEsales\Eshop\Application\Controller\Admin\Lis
      *
      * @return string
      */
-    protected function _getQuery()
+    protected function _getQuery() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $myConfig = $this->getConfig();
         $oDb = \OxidEsales\Eshop\Core\DatabaseProvider::getDb();
@@ -103,7 +104,7 @@ class ActionsMainAjax extends \OxidEsales\Eshop\Application\Controller\Admin\Lis
      *
      * @return string
      */
-    protected function _addFilter($sQ)
+    protected function _addFilter($sQ) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $sQ = parent::_addFilter($sQ);
 
@@ -125,7 +126,7 @@ class ActionsMainAjax extends \OxidEsales\Eshop\Application\Controller\Admin\Lis
      *
      * @return string
      */
-    protected function _getSorting()
+    protected function _getSorting() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $sOxIdParameter = \OxidEsales\Eshop\Core\Registry::getConfig()->getRequestParameter('oxid');
         $sSynchOxidParameter = \OxidEsales\Eshop\Core\Registry::getConfig()->getRequestParameter('synchoxid');
@@ -273,7 +274,7 @@ class ActionsMainAjax extends \OxidEsales\Eshop\Application\Controller\Admin\Lis
      *
      * @return \OxidEsales\Eshop\Application\Model\RssFeed The rss feed handler.
      */
-    protected function _getOxRssFeed()
+    protected function _getOxRssFeed() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         return oxNew(\OxidEsales\Eshop\Application\Model\RssFeed::class);
     }

--- a/source/Application/Controller/Admin/ActionsOrderAjax.php
+++ b/source/Application/Controller/Admin/ActionsOrderAjax.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
@@ -33,7 +34,7 @@ class ActionsOrderAjax extends \OxidEsales\Eshop\Application\Controller\Admin\Li
      *
      * @return string
      */
-    protected function _getQuery()
+    protected function _getQuery() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $sSelTable = $this->_getViewName('oxselectlist');
         $sArtId = \OxidEsales\Eshop\Core\Registry::getConfig()->getRequestParameter('oxid');
@@ -47,7 +48,7 @@ class ActionsOrderAjax extends \OxidEsales\Eshop\Application\Controller\Admin\Li
      *
      * @return string
      */
-    protected function _getSorting()
+    protected function _getSorting() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         return 'order by oxobject2selectlist.oxsort ';
     }

--- a/source/Application/Controller/Admin/AdminContent.php
+++ b/source/Application/Controller/Admin/AdminContent.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Application/Controller/Admin/AdminController.php
+++ b/source/Application/Controller/Admin/AdminController.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
@@ -133,7 +134,7 @@ class AdminController extends \OxidEsales\Eshop\Core\Controller\BaseController
      *
      * @return oxshop
      */
-    protected function _getEditShop($sShopId)
+    protected function _getEditShop($sShopId) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         if (!$this->_oEditShop) {
             $this->_oEditShop = $this->getConfig()->getActiveShop();
@@ -216,7 +217,7 @@ class AdminController extends \OxidEsales\Eshop\Core\Controller\BaseController
      *
      * @return string
      */
-    protected function _getServiceProtocol()
+    protected function _getServiceProtocol() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         return $this->getConfig()->isSsl() ? 'https' : 'http';
     }
@@ -262,7 +263,7 @@ class AdminController extends \OxidEsales\Eshop\Core\Controller\BaseController
      *
      * @return string
      */
-    protected function _getShopVersionNr()
+    protected function _getShopVersionNr() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         return oxNew(ShopVersion::class)->getVersion();
     }
@@ -272,7 +273,7 @@ class AdminController extends \OxidEsales\Eshop\Core\Controller\BaseController
      *
      * @param string $sNode active view id
      */
-    protected function _setupNavigation($sNode)
+    protected function _setupNavigation($sNode) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         // navigation according to class
         if ($sNode) {
@@ -300,7 +301,7 @@ class AdminController extends \OxidEsales\Eshop\Core\Controller\BaseController
      *
      * @param string $sNode active view id
      */
-    protected function _addNavigationHistory($sNode)
+    protected function _addNavigationHistory($sNode) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $myUtilsServer = \OxidEsales\Eshop\Core\Registry::getUtilsServer();
 
@@ -373,7 +374,7 @@ class AdminController extends \OxidEsales\Eshop\Core\Controller\BaseController
      *
      * @return array
      */
-    protected function _getMaxUploadFileInfo($iMaxFileSize, $blFormatted = false)
+    protected function _getMaxUploadFileInfo($iMaxFileSize, $blFormatted = false) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $iMaxFileSize = $iMaxFileSize ? $iMaxFileSize : '2M';
 
@@ -460,7 +461,7 @@ class AdminController extends \OxidEsales\Eshop\Core\Controller\BaseController
     /**
      * Resets cache.
      */
-    protected function _resetContentCache()
+    protected function _resetContentCache() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
     }
 
@@ -472,7 +473,7 @@ class AdminController extends \OxidEsales\Eshop\Core\Controller\BaseController
      *
      * @return bool
      */
-    protected function _allowAdminEdit($sUserId)
+    protected function _allowAdminEdit($sUserId) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         return true;
     }
@@ -484,7 +485,7 @@ class AdminController extends \OxidEsales\Eshop\Core\Controller\BaseController
      *
      * @return boolean
      */
-    protected function _getCountryByCode($sCountryCode)
+    protected function _getCountryByCode($sCountryCode) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         //default country
         $sCountry = 'international';
@@ -521,9 +522,9 @@ class AdminController extends \OxidEsales\Eshop\Core\Controller\BaseController
      *
      * @return boolean
      */
-    protected function _authorize()
+    protected function _authorize() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
-        return ( bool ) (
+        return (bool) (
             $this->getSession()->checkSessionChallenge()
             && count(\OxidEsales\Eshop\Core\Registry::getUtilsServer()->getOxCookie())
             && \OxidEsales\Eshop\Core\Registry::getUtils()->checkAccessRights()

--- a/source/Application/Controller/Admin/AdminDetailsController.php
+++ b/source/Application/Controller/Admin/AdminDetailsController.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
@@ -68,7 +69,7 @@ class AdminDetailsController extends \OxidEsales\Eshop\Application\Controller\Ad
      *
      * @return string
      */
-    protected function _getEditValue($oObject, $sField)
+    protected function _getEditValue($oObject, $sField) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $sEditObjectValue = '';
         if ($oObject && $sField && isset($oObject->$sField)) {
@@ -92,7 +93,7 @@ class AdminDetailsController extends \OxidEsales\Eshop\Application\Controller\Ad
      *
      * @return string
      */
-    protected function _processEditValue($sValue)
+    protected function _processEditValue($sValue) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         // A. replace ONLY if long description is not processed by smarty, or users will not be able to
         // store smarty tags ([{$shop->currenthomedir}]/[{$oViewConf->getCurrentHomeDir()}]) in long
@@ -117,7 +118,7 @@ class AdminDetailsController extends \OxidEsales\Eshop\Application\Controller\Ad
      *
      * @return string
      */
-    protected function _getPlainEditor($width, $height, $object, $field)
+    protected function _getPlainEditor($width, $height, $object, $field) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $objectValue = $this->_getEditValue($object, $field);
 
@@ -139,7 +140,7 @@ class AdminDetailsController extends \OxidEsales\Eshop\Application\Controller\Ad
      *
      * @return string Editor output
      */
-    protected function _generateTextEditor($width, $height, $object, $field, $stylesheet = null)
+    protected function _generateTextEditor($width, $height, $object, $field, $stylesheet = null) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         return $this->generateTextEditor($width, $height, $object, $field, $stylesheet);
     }
@@ -202,7 +203,7 @@ class AdminDetailsController extends \OxidEsales\Eshop\Application\Controller\Ad
      *
      * @return string
      */
-    protected function _createCategoryTree($sTplVarName, $sEditCatId = '', $blForceNonCache = false, $iTreeShopId = null)
+    protected function _createCategoryTree($sTplVarName, $sEditCatId = '', $blForceNonCache = false, $iTreeShopId = null) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         // caching category tree, to load it once, not many times
         if (!isset($this->oCatTree) || $blForceNonCache) {
@@ -247,7 +248,7 @@ class AdminDetailsController extends \OxidEsales\Eshop\Application\Controller\Ad
      *
      * @return string
      */
-    protected function _getCategoryTree(
+    protected function _getCategoryTree( // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
         $sTplVarName,
         $sSelectedCatId,
         $sEditCatId = '',
@@ -304,7 +305,7 @@ class AdminDetailsController extends \OxidEsales\Eshop\Application\Controller\Ad
      *
      * @param string $sNode active view id
      */
-    protected function _setupNavigation($sNode)
+    protected function _setupNavigation($sNode) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         // navigation according to class
         if ($sNode) {
@@ -323,7 +324,7 @@ class AdminDetailsController extends \OxidEsales\Eshop\Application\Controller\Ad
      *
      * @param array $aIds to reset type => id
      */
-    protected function _resetCounts($aIds)
+    protected function _resetCounts($aIds) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         foreach ($aIds as $sType => $aResetInfo) {
             foreach ($aResetInfo as $sResetId => $iPos) {

--- a/source/Application/Controller/Admin/AdminLinks.php
+++ b/source/Application/Controller/Admin/AdminLinks.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Application/Controller/Admin/AdminListController.php
+++ b/source/Application/Controller/Admin/AdminListController.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
@@ -154,7 +155,7 @@ class AdminListController extends \OxidEsales\Eshop\Application\Controller\Admin
      *
      * @return int
      */
-    protected function _getViewListSize()
+    protected function _getViewListSize() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         if (!$this->_iViewListSize) {
             $config = $this->getConfig();
@@ -189,7 +190,7 @@ class AdminListController extends \OxidEsales\Eshop\Application\Controller\Admin
      *
      * @return int
      */
-    protected function _getUserDefListSize()
+    protected function _getUserDefListSize() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         if (!$this->_iViewListSize) {
             if (!($viewListSize = (int)\OxidEsales\Eshop\Core\Registry::getConfig()->getRequestParameter('viewListSize'))) {
@@ -250,7 +251,7 @@ class AdminListController extends \OxidEsales\Eshop\Application\Controller\Admin
      *
      * @param string $sql SQL query used co select list items
      */
-    protected function _calcListItemsCount($sql)
+    protected function _calcListItemsCount($sql) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $stringModifier = getStr();
 
@@ -273,7 +274,7 @@ class AdminListController extends \OxidEsales\Eshop\Application\Controller\Admin
      *
      * @param string $page jump page string
      */
-    protected function _setCurrentListPosition($page = null)
+    protected function _setCurrentListPosition($page = null) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $adminListSize = $this->_getViewListSize();
 
@@ -297,7 +298,7 @@ class AdminListController extends \OxidEsales\Eshop\Application\Controller\Admin
      *
      * @return string
      */
-    protected function _prepareOrderByQuery($query = null)
+    protected function _prepareOrderByQuery($query = null) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         // sorting
         $sortFields = $this->getListSorting();
@@ -341,7 +342,7 @@ class AdminListController extends \OxidEsales\Eshop\Application\Controller\Admin
      *
      * @return string
      */
-    protected function _buildSelectString($listObject = null)
+    protected function _buildSelectString($listObject = null) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         return $listObject !== null ? $listObject->buildSelectString(null) : "";
     }
@@ -356,7 +357,7 @@ class AdminListController extends \OxidEsales\Eshop\Application\Controller\Admin
      *
      * @return string
      */
-    protected function _processFilter($fieldValue)
+    protected function _processFilter($fieldValue) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $stringModifier = getStr();
 
@@ -374,7 +375,7 @@ class AdminListController extends \OxidEsales\Eshop\Application\Controller\Admin
      *
      * @return string
      */
-    protected function _buildFilter($value, $isSearchValue)
+    protected function _buildFilter($value, $isSearchValue) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         if ($isSearchValue) {
             //is search string, using LIKE
@@ -394,7 +395,7 @@ class AdminListController extends \OxidEsales\Eshop\Application\Controller\Admin
      *
      * @return bool
      */
-    protected function _isSearchValue($fieldValue)
+    protected function _isSearchValue($fieldValue) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         return (getStr()->preg_match('/^%/', $fieldValue) && getStr()->preg_match('/%$/', $fieldValue));
     }
@@ -409,7 +410,7 @@ class AdminListController extends \OxidEsales\Eshop\Application\Controller\Admin
      *
      * @return string
      */
-    protected function _prepareWhereQuery($whereQuery, $fullQuery)
+    protected function _prepareWhereQuery($whereQuery, $fullQuery) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         if (is_array($whereQuery) && count($whereQuery)) {
             $myUtilsString = \OxidEsales\Eshop\Core\Registry::getUtilsString();
@@ -468,7 +469,7 @@ class AdminListController extends \OxidEsales\Eshop\Application\Controller\Admin
      *
      * @return string
      */
-    protected function _changeselect($query)
+    protected function _changeselect($query) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         return $query;
     }
@@ -490,7 +491,7 @@ class AdminListController extends \OxidEsales\Eshop\Application\Controller\Admin
 
                 foreach ($filter as $table => $filterData) {
                     foreach ($filterData as $name => $value) {
-                        if ($value || '0' === ( string )$value) {
+                        if ($value || '0' === (string)$value) {
                             $field = "{$table}__{$name}";
 
                             // if no table name attached to field name, add it
@@ -522,7 +523,7 @@ class AdminListController extends \OxidEsales\Eshop\Application\Controller\Admin
      *
      * @return string
      */
-    protected function _convertToDBDate($value, $fieldType)
+    protected function _convertToDBDate($value, $fieldType) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $convertedObject = new \OxidEsales\Eshop\Core\Field();
         $convertedObject->setValue($value);
@@ -554,7 +555,7 @@ class AdminListController extends \OxidEsales\Eshop\Application\Controller\Admin
      *
      * @return string
      */
-    protected function _convertDate($date)
+    protected function _convertDate($date) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         // regexps to validate input
         $datePatterns = [
@@ -592,7 +593,7 @@ class AdminListController extends \OxidEsales\Eshop\Application\Controller\Admin
      *
      * @return string
      */
-    protected function _convertTime($fullDate)
+    protected function _convertTime($fullDate) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $date = substr($fullDate, 0, 10);
         $convertedObject = new \OxidEsales\Eshop\Core\Field();
@@ -630,7 +631,7 @@ class AdminListController extends \OxidEsales\Eshop\Application\Controller\Admin
     /**
      * Set parameters needed for list navigation
      */
-    protected function _setListNavigationParams()
+    protected function _setListNavigationParams() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         // list navigation
         $showNavigation = false;
@@ -715,7 +716,7 @@ class AdminListController extends \OxidEsales\Eshop\Application\Controller\Admin
      *
      * @param string $node active view id
      */
-    protected function _setupNavigation($node)
+    protected function _setupNavigation($node) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         // navigation according to class
         if ($node) {

--- a/source/Application/Controller/Admin/AdminNews.php
+++ b/source/Application/Controller/Admin/AdminNews.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Application/Controller/Admin/AdminNewsletter.php
+++ b/source/Application/Controller/Admin/AdminNewsletter.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Application/Controller/Admin/AdminOrder.php
+++ b/source/Application/Controller/Admin/AdminOrder.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Application/Controller/Admin/AdminPayment.php
+++ b/source/Application/Controller/Admin/AdminPayment.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Application/Controller/Admin/AdminPriceAlarm.php
+++ b/source/Application/Controller/Admin/AdminPriceAlarm.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Application/Controller/Admin/AdminStart.php
+++ b/source/Application/Controller/Admin/AdminStart.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Application/Controller/Admin/AdminUser.php
+++ b/source/Application/Controller/Admin/AdminUser.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Application/Controller/Admin/AdminWrapping.php
+++ b/source/Application/Controller/Admin/AdminWrapping.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Application/Controller/Admin/AdminlinksList.php
+++ b/source/Application/Controller/Admin/AdminlinksList.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Application/Controller/Admin/AdminlinksMain.php
+++ b/source/Application/Controller/Admin/AdminlinksMain.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Application/Controller/Admin/ArticleAccessoriesAjax.php
+++ b/source/Application/Controller/Admin/ArticleAccessoriesAjax.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
@@ -63,7 +64,7 @@ class ArticleAccessoriesAjax extends \OxidEsales\Eshop\Application\Controller\Ad
      * @return string
      * @throws DatabaseConnectionException
      */
-    protected function _getQuery()
+    protected function _getQuery() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $myConfig = Registry::getConfig();
         $oxidId = Registry::getConfig()->getRequestEscapedParameter('oxid');
@@ -117,7 +118,7 @@ class ArticleAccessoriesAjax extends \OxidEsales\Eshop\Application\Controller\Ad
      *
      * @return string
      */
-    protected function _getSorting()
+    protected function _getSorting() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         if ($this->containerId == 'container2') {
             return ' order by _2,_0';

--- a/source/Application/Controller/Admin/ArticleAttribute.php
+++ b/source/Application/Controller/Admin/ArticleAttribute.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Application/Controller/Admin/ArticleAttributeAjax.php
+++ b/source/Application/Controller/Admin/ArticleAttributeAjax.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
@@ -37,7 +38,7 @@ class ArticleAttributeAjax extends \OxidEsales\Eshop\Application\Controller\Admi
      *
      * @return string
      */
-    protected function _getQuery()
+    protected function _getQuery() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $oDb = \OxidEsales\Eshop\Core\DatabaseProvider::getDb();
         $sArtId = \OxidEsales\Eshop\Core\Registry::getConfig()->getRequestParameter('oxid');

--- a/source/Application/Controller/Admin/ArticleBundleAjax.php
+++ b/source/Application/Controller/Admin/ArticleBundleAjax.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
@@ -42,7 +43,7 @@ class ArticleBundleAjax extends \OxidEsales\Eshop\Application\Controller\Admin\L
      *
      * @return string
      */
-    protected function _getQuery()
+    protected function _getQuery() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $myConfig = $this->getConfig();
         $oDb = \OxidEsales\Eshop\Core\DatabaseProvider::getDb();
@@ -85,7 +86,7 @@ class ArticleBundleAjax extends \OxidEsales\Eshop\Application\Controller\Admin\L
      *
      * @return string
      */
-    protected function _addFilter($sQ)
+    protected function _addFilter($sQ) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $sArtTable = $this->_getViewName('oxarticles');
         $sQ = parent::_addFilter($sQ);

--- a/source/Application/Controller/Admin/ArticleController.php
+++ b/source/Application/Controller/Admin/ArticleController.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Application/Controller/Admin/ArticleCrossselling.php
+++ b/source/Application/Controller/Admin/ArticleCrossselling.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Application/Controller/Admin/ArticleCrosssellingAjax.php
+++ b/source/Application/Controller/Admin/ArticleCrosssellingAjax.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
@@ -52,7 +53,7 @@ class ArticleCrosssellingAjax extends \OxidEsales\Eshop\Application\Controller\A
      *
      * @return string
      */
-    protected function _getQuery()
+    protected function _getQuery() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $myConfig = $this->getConfig();
         $sArticleTable = $this->_getViewName('oxarticles');

--- a/source/Application/Controller/Admin/ArticleExtend.php
+++ b/source/Application/Controller/Admin/ArticleExtend.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Application/Controller/Admin/ArticleExtendAjax.php
+++ b/source/Application/Controller/Admin/ArticleExtendAjax.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
@@ -42,7 +43,7 @@ class ArticleExtendAjax extends \OxidEsales\Eshop\Application\Controller\Admin\L
      *
      * @return string
      */
-    protected function _getQuery()
+    protected function _getQuery() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $categoriesTable = $this->_getViewName('oxcategories');
         $objectToCategoryView = $this->_getViewName('oxobject2category');
@@ -74,7 +75,7 @@ class ArticleExtendAjax extends \OxidEsales\Eshop\Application\Controller\Admin\L
      *
      * @return array
      */
-    protected function _getDataFields($sQ)
+    protected function _getDataFields($sQ) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $dataFields = parent::_getDataFields($sQ);
         if (\OxidEsales\Eshop\Core\Registry::getConfig()->getRequestParameter('oxid') && is_array($dataFields) && count($dataFields)) {
@@ -196,7 +197,7 @@ class ArticleExtendAjax extends \OxidEsales\Eshop\Application\Controller\Admin\L
      *
      * @param string $oxId product id
      */
-    protected function _updateOxTime($oxId)
+    protected function _updateOxTime($oxId) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $database = \OxidEsales\Eshop\Core\DatabaseProvider::getDb();
         $objectToCategoryView = $this->_getViewName('oxobject2category');

--- a/source/Application/Controller/Admin/ArticleFiles.php
+++ b/source/Application/Controller/Admin/ArticleFiles.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
@@ -203,7 +204,7 @@ class ArticleFiles extends \OxidEsales\Eshop\Application\Controller\Admin\AdminD
      *
      * @return array
      */
-    protected function _processOptions($aParams)
+    protected function _processOptions($aParams) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         if (!is_array($aParams)) {
             $aParams = [];

--- a/source/Application/Controller/Admin/ArticleList.php
+++ b/source/Application/Controller/Admin/ArticleList.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
@@ -55,10 +56,12 @@ class ArticleList extends \OxidEsales\Eshop\Application\Controller\Admin\AdminLi
         if (!is_bool($sDateTime) && isset($oArticle->oxarticles__oxactive) && $oArticle->oxarticles__oxactive->value === '1') {
             return true;
         } else {
-            if (!is_bool($sDateTime) && isset($oArticle->oxarticles__oxactivefrom) &&
+            if (
+                !is_bool($sDateTime) && isset($oArticle->oxarticles__oxactivefrom) &&
                 isset($oArticle->oxarticles__oxactiveto) && $blUseTimeCheck &&
                 $oArticle->oxarticles__oxactivefrom->value <= $sDateTime &&
-                $oArticle->oxarticles__oxactiveto->value >= $sDateTime) {
+                $oArticle->oxarticles__oxactiveto->value >= $sDateTime
+            ) {
                 return true;
             }
         }
@@ -238,7 +241,7 @@ class ArticleList extends \OxidEsales\Eshop\Application\Controller\Admin\AdminLi
      *
      * @return string
      */
-    protected function _buildSelectString($oListObject = null)
+    protected function _buildSelectString($oListObject = null) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $sQ = parent::_buildSelectString($oListObject);
         if ($sQ) {

--- a/source/Application/Controller/Admin/ArticleMain.php
+++ b/source/Application/Controller/Admin/ArticleMain.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
@@ -111,7 +112,7 @@ class ArticleMain extends \OxidEsales\Eshop\Application\Controller\Admin\AdminDe
      *
      * @return string
      */
-    protected function _getEditValue($oObject, $sField)
+    protected function _getEditValue($oObject, $sField) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $sEditObjectValue = '';
         if ($oObject) {
@@ -169,7 +170,8 @@ class ArticleMain extends \OxidEsales\Eshop\Application\Controller\Admin\AdminDe
         }
 
         //article number handling, warns for artnum duplicates
-        if (isset($aParams['oxarticles__oxartnum']) && strlen($aParams['oxarticles__oxartnum']) > 0 &&
+        if (
+            isset($aParams['oxarticles__oxartnum']) && strlen($aParams['oxarticles__oxartnum']) > 0 &&
             $oConfig->getConfigParam('blWarnOnSameArtNums') &&
             $oArticle->oxarticles__oxartnum->value != $aParams['oxarticles__oxartnum']
         ) {
@@ -213,7 +215,7 @@ class ArticleMain extends \OxidEsales\Eshop\Application\Controller\Admin\AdminDe
      *
      * @return string
      */
-    protected function _processLongDesc($sValue)
+    protected function _processLongDesc($sValue) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         // TODO: the code below is redundant, optimize it, assignments should go smooth without conversions
         // hack, if editor screws up text, htmledit tends to do so
@@ -232,7 +234,7 @@ class ArticleMain extends \OxidEsales\Eshop\Application\Controller\Admin\AdminDe
      *
      * @param string $sArticleId Article id
      */
-    protected function _resetCategoriesCounter($sArticleId)
+    protected function _resetCategoriesCounter($sArticleId) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $oDb = DatabaseProvider::getDb();
         $sQ = "select oxcatnid from oxobject2category where oxobjectid = :oxobjectid";
@@ -353,7 +355,8 @@ class ArticleMain extends \OxidEsales\Eshop\Application\Controller\Admin\AdminDe
                 //article number handling, warns for artnum duplicates
                 $sFncParameter = \OxidEsales\Eshop\Core\Registry::getConfig()->getRequestParameter('fnc');
                 $sArtNumField = 'oxarticles__oxartnum';
-                if ($myConfig->getConfigParam('blWarnOnSameArtNums') &&
+                if (
+                    $myConfig->getConfigParam('blWarnOnSameArtNums') &&
                     $oArticle->$sArtNumField->value && $sFncParameter == 'copyArticle'
                 ) {
                     $sSelect = "select oxid from " . $oArticle->getCoreTableName() .
@@ -374,7 +377,7 @@ class ArticleMain extends \OxidEsales\Eshop\Application\Controller\Admin\AdminDe
      * @param string $sOldId       Id from old article
      * @param string $newArticleId Id from new article
      */
-    protected function _copyCategories($sOldId, $newArticleId)
+    protected function _copyCategories($sOldId, $newArticleId) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $myUtilsObject = \OxidEsales\Eshop\Core\Registry::getUtilsObject();
         $oDb = DatabaseProvider::getDb();
@@ -402,7 +405,7 @@ class ArticleMain extends \OxidEsales\Eshop\Application\Controller\Admin\AdminDe
      * @param string $sOldId Id from old article
      * @param string $sNewId Id from new article
      */
-    protected function _copyAttributes($sOldId, $sNewId)
+    protected function _copyAttributes($sOldId, $sNewId) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $myUtilsObject = \OxidEsales\Eshop\Core\Registry::getUtilsObject();
         $oDb = DatabaseProvider::getDb();
@@ -431,7 +434,7 @@ class ArticleMain extends \OxidEsales\Eshop\Application\Controller\Admin\AdminDe
      * @param string $sOldId Id from old article
      * @param string $sNewId Id from new article
      */
-    protected function _copyFiles($sOldId, $sNewId)
+    protected function _copyFiles($sOldId, $sNewId) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $myUtilsObject = \OxidEsales\Eshop\Core\Registry::getUtilsObject();
         $oDb = DatabaseProvider::getDb(DatabaseProvider::FETCH_MODE_ASSOC);
@@ -461,7 +464,7 @@ class ArticleMain extends \OxidEsales\Eshop\Application\Controller\Admin\AdminDe
      * @param string $sOldId Id from old article
      * @param string $sNewId Id from new article
      */
-    protected function _copySelectlists($sOldId, $sNewId)
+    protected function _copySelectlists($sOldId, $sNewId) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $myUtilsObject = \OxidEsales\Eshop\Core\Registry::getUtilsObject();
         $oDb = DatabaseProvider::getDb();
@@ -492,7 +495,7 @@ class ArticleMain extends \OxidEsales\Eshop\Application\Controller\Admin\AdminDe
      * @param string $sOldId Id from old article
      * @param string $sNewId Id from new article
      */
-    protected function _copyCrossseling($sOldId, $sNewId)
+    protected function _copyCrossseling($sOldId, $sNewId) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $myUtilsObject = \OxidEsales\Eshop\Core\Registry::getUtilsObject();
         $oDb = DatabaseProvider::getDb();
@@ -523,7 +526,7 @@ class ArticleMain extends \OxidEsales\Eshop\Application\Controller\Admin\AdminDe
      * @param string $sOldId Id from old article
      * @param string $sNewId Id from new article
      */
-    protected function _copyAccessoires($sOldId, $sNewId)
+    protected function _copyAccessoires($sOldId, $sNewId) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $myUtilsObject = \OxidEsales\Eshop\Core\Registry::getUtilsObject();
         $oDb = DatabaseProvider::getDb();
@@ -554,7 +557,7 @@ class ArticleMain extends \OxidEsales\Eshop\Application\Controller\Admin\AdminDe
      * @param string $sOldId Id from old article
      * @param string $sNewId Id from new article
      */
-    protected function _copyStaffelpreis($sOldId, $sNewId)
+    protected function _copyStaffelpreis($sOldId, $sNewId) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $sShopId = $this->getConfig()->getShopId();
         $oPriceList = oxNew(\OxidEsales\Eshop\Core\Model\ListModel::class);
@@ -580,7 +583,7 @@ class ArticleMain extends \OxidEsales\Eshop\Application\Controller\Admin\AdminDe
      * @param string $sOldId Id from old article
      * @param string $sNewId Id from new article
      */
-    protected function _copyArtExtends($sOldId, $sNewId)
+    protected function _copyArtExtends($sOldId, $sNewId) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $oExt = oxNew(\OxidEsales\Eshop\Core\Model\BaseModel::class);
         $oExt->init("oxartextends");
@@ -616,7 +619,7 @@ class ArticleMain extends \OxidEsales\Eshop\Application\Controller\Admin\AdminDe
      * @param object $oArticle       article object
      * @param object $oParentArticle article parent object
      */
-    protected function _formJumpList($oArticle, $oParentArticle)
+    protected function _formJumpList($oArticle, $oParentArticle) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $aJumpList = [];
         //fetching parent article variants
@@ -660,7 +663,7 @@ class ArticleMain extends \OxidEsales\Eshop\Application\Controller\Admin\AdminDe
      *
      * @return string
      */
-    protected function _getTitle($oObj)
+    protected function _getTitle($oObj) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $sTitle = $oObj->oxarticles__oxtitle->value;
         if (!strlen($sTitle)) {

--- a/source/Application/Controller/Admin/ArticleOverview.php
+++ b/source/Application/Controller/Admin/ArticleOverview.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Application/Controller/Admin/ArticlePictures.php
+++ b/source/Application/Controller/Admin/ArticlePictures.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
@@ -136,7 +137,7 @@ class ArticlePictures extends \OxidEsales\Eshop\Application\Controller\Admin\Adm
      * @param int                                         $iIndex         master picture index
      * @param bool                                        $blDeleteMaster if TRUE - deletes and unsets master image file
      */
-    protected function _resetMasterPicture($oArticle, $iIndex, $blDeleteMaster = false)
+    protected function _resetMasterPicture($oArticle, $iIndex, $blDeleteMaster = false) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         if ($this->canResetMasterPicture($oArticle, $iIndex)) {
             if (!$oArticle->isDerived()) {
@@ -165,7 +166,7 @@ class ArticlePictures extends \OxidEsales\Eshop\Application\Controller\Admin\Adm
      *
      * @param \OxidEsales\Eshop\Application\Model\Article $oArticle article object
      */
-    protected function _deleteMainIcon($oArticle)
+    protected function _deleteMainIcon($oArticle) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         if ($this->canDeleteMainIcon($oArticle)) {
             if (!$oArticle->isDerived()) {
@@ -183,7 +184,7 @@ class ArticlePictures extends \OxidEsales\Eshop\Application\Controller\Admin\Adm
      *
      * @param \OxidEsales\Eshop\Application\Model\Article $oArticle article object
      */
-    protected function _deleteThumbnail($oArticle)
+    protected function _deleteThumbnail($oArticle) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         if ($this->canDeleteThumbnail($oArticle)) {
             if (!$oArticle->isDerived()) {
@@ -202,7 +203,7 @@ class ArticlePictures extends \OxidEsales\Eshop\Application\Controller\Admin\Adm
      *
      * @param \OxidEsales\Eshop\Application\Model\Article $oArticle article object
      */
-    protected function _cleanupCustomFields($oArticle)
+    protected function _cleanupCustomFields($oArticle) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $sIcon = $oArticle->oxarticles__oxicon->value;
         $sThumb = $oArticle->oxarticles__oxthumb->value;

--- a/source/Application/Controller/Admin/ArticleReview.php
+++ b/source/Application/Controller/Admin/ArticleReview.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
@@ -76,7 +77,7 @@ class ArticleReview extends \OxidEsales\Eshop\Application\Controller\Admin\Admin
      *
      * @return oxList
      */
-    protected function _getReviewList($article)
+    protected function _getReviewList($article) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $database = \OxidEsales\Eshop\Core\DatabaseProvider::getDb();
         $query = "select oxreviews.* from oxreviews

--- a/source/Application/Controller/Admin/ArticleSelectionAjax.php
+++ b/source/Application/Controller/Admin/ArticleSelectionAjax.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
@@ -40,7 +41,7 @@ class ArticleSelectionAjax extends \OxidEsales\Eshop\Application\Controller\Admi
      *
      * @return string
      */
-    protected function _getQuery()
+    protected function _getQuery() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $sSLViewName = $this->_getViewName('oxselectlist');
         $sArtViewName = $this->_getViewName('oxarticles');
@@ -126,7 +127,7 @@ class ArticleSelectionAjax extends \OxidEsales\Eshop\Application\Controller\Admi
 
                 $sSql = "select max(oxsort) + 1 from oxobject2selectlist where oxobjectid = :oxobjectid";
 
-                $oNew->$sOxSortField = new \OxidEsales\Eshop\Core\Field(( int ) $database->getOne($sSql, [
+                $oNew->$sOxSortField = new \OxidEsales\Eshop\Core\Field((int) $database->getOne($sSql, [
                     ':oxobjectid' => $soxId
                 ]));
                 $oNew->save();

--- a/source/Application/Controller/Admin/ArticleSeo.php
+++ b/source/Application/Controller/Admin/ArticleSeo.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
@@ -137,7 +138,7 @@ class ArticleSeo extends \OxidEsales\Eshop\Application\Controller\Admin\ObjectSe
      *
      * @return array
      */
-    protected function _getCategoryList($oArticle)
+    protected function _getCategoryList($oArticle) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $sMainCatId = false;
         if ($oMainCat = $oArticle->getCategory()) {
@@ -183,7 +184,7 @@ class ArticleSeo extends \OxidEsales\Eshop\Application\Controller\Admin\ObjectSe
      *
      * @return array
      */
-    protected function _getVendorList($oArticle)
+    protected function _getVendorList($oArticle) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         if ($oArticle->oxarticles__oxvendorid->value) {
             $oVendor = oxNew(\OxidEsales\Eshop\Application\Model\Vendor::class);
@@ -200,7 +201,7 @@ class ArticleSeo extends \OxidEsales\Eshop\Application\Controller\Admin\ObjectSe
      *
      * @return array
      */
-    protected function _getManufacturerList($oArticle)
+    protected function _getManufacturerList($oArticle) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         if ($oArticle->oxarticles__oxmanufacturerid->value) {
             $oManufacturer = oxNew(\OxidEsales\Eshop\Application\Model\Manufacturer::class);
@@ -277,7 +278,7 @@ class ArticleSeo extends \OxidEsales\Eshop\Application\Controller\Admin\ObjectSe
      *
      * @return null
      */
-    protected function _getAltSeoEntryId()
+    protected function _getAltSeoEntryId() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         return $this->getEditObjectId();
     }
@@ -287,7 +288,7 @@ class ArticleSeo extends \OxidEsales\Eshop\Application\Controller\Admin\ObjectSe
      *
      * @return string
      */
-    protected function _getType()
+    protected function _getType() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         return 'oxarticle';
     }
@@ -309,7 +310,7 @@ class ArticleSeo extends \OxidEsales\Eshop\Application\Controller\Admin\ObjectSe
      *
      * @return oxSeoEncoderCategory
      */
-    protected function _getEncoder()
+    protected function _getEncoder() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         return \OxidEsales\Eshop\Core\Registry::get(\OxidEsales\Eshop\Application\Model\SeoEncoderArticle::class);
     }
@@ -358,7 +359,7 @@ class ArticleSeo extends \OxidEsales\Eshop\Application\Controller\Admin\ObjectSe
      *
      * @return string
      */
-    protected function _getSaveObjectId()
+    protected function _getSaveObjectId() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         return $this->getEditObjectId();
     }

--- a/source/Application/Controller/Admin/ArticleStock.php
+++ b/source/Application/Controller/Admin/ArticleStock.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
@@ -162,8 +163,8 @@ class ArticleStock extends \OxidEsales\Eshop\Application\Controller\Admin\AdminD
         }
 
         if (!$myConfig->getConfigParam('blAllowUnevenAmounts')) {
-            $aParams['oxprice2article__oxamount'] = round(( string ) $aParams['oxprice2article__oxamount']);
-            $aParams['oxprice2article__oxamountto'] = round(( string ) $aParams['oxprice2article__oxamountto']);
+            $aParams['oxprice2article__oxamount'] = round((string) $aParams['oxprice2article__oxamount']);
+            $aParams['oxprice2article__oxamountto'] = round((string) $aParams['oxprice2article__oxamountto']);
         }
 
         $dPrice = $aParams['price'];
@@ -176,7 +177,8 @@ class ArticleStock extends \OxidEsales\Eshop\Application\Controller\Admin\AdminD
         $oArticlePrice->$sType = new \OxidEsales\Eshop\Core\Field($dPrice);
 
         //validating
-        if ($oArticlePrice->$sType->value &&
+        if (
+            $oArticlePrice->$sType->value &&
             $oArticlePrice->oxprice2article__oxamount->value &&
             $oArticlePrice->oxprice2article__oxamountto->value &&
             is_numeric($oArticlePrice->$sType->value) &&
@@ -191,8 +193,10 @@ class ArticleStock extends \OxidEsales\Eshop\Application\Controller\Admin\AdminD
         $oArticle = oxNew(\OxidEsales\Eshop\Application\Model\Article::class);
         $oArticle->loadInLang($this->_iEditLang, $sOxArtId);
         $sPriceField = 'oxarticles__oxprice';
-        if (($aParams['price'] >= $oArticle->$sPriceField->value) &&
-            ($aParams['pricetype'] == 'oxprice2article__oxaddabs')) {
+        if (
+            ($aParams['price'] >= $oArticle->$sPriceField->value) &&
+            ($aParams['pricetype'] == 'oxprice2article__oxaddabs')
+        ) {
             if (is_null($sOXID)) {
                 $sOXID = $oArticlePrice->getId();
             }

--- a/source/Application/Controller/Admin/ArticleUserdef.php
+++ b/source/Application/Controller/Admin/ArticleUserdef.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Application/Controller/Admin/ArticleVariant.php
+++ b/source/Application/Controller/Admin/ArticleVariant.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
@@ -164,7 +165,7 @@ class ArticleVariant extends \OxidEsales\Eshop\Application\Controller\Admin\Admi
      *
      * @return bool
      */
-    protected function _isAnythingChanged($oProduct, $aData)
+    protected function _isAnythingChanged($oProduct, $aData) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         if (!is_array($aData)) {
             return true;
@@ -185,9 +186,10 @@ class ArticleVariant extends \OxidEsales\Eshop\Application\Controller\Admin\Admi
      *
      * @return \OxidEsales\Eshop\Application\Model\Article
      */
-    protected function _getProductParent($sParentId)
+    protected function _getProductParent($sParentId) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
-        if ($this->_oProductParent === null ||
+        if (
+            $this->_oProductParent === null ||
             ($this->_oProductParent !== false && $this->_oProductParent->getId() != $sParentId)
         ) {
             $this->_oProductParent = false;

--- a/source/Application/Controller/Admin/AttributeCategory.php
+++ b/source/Application/Controller/Admin/AttributeCategory.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Application/Controller/Admin/AttributeCategoryAjax.php
+++ b/source/Application/Controller/Admin/AttributeCategoryAjax.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
@@ -46,7 +47,7 @@ class AttributeCategoryAjax extends \OxidEsales\Eshop\Application\Controller\Adm
      *
      * @return string
      */
-    protected function _getQuery()
+    protected function _getQuery() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $myConfig = $this->getConfig();
         $oDb = \OxidEsales\Eshop\Core\DatabaseProvider::getDb();
@@ -130,7 +131,7 @@ class AttributeCategoryAjax extends \OxidEsales\Eshop\Application\Controller\Adm
 
                 $sSql = "select max(oxsort) + 1 from oxcategory2attribute where oxobjectid = :oxobjectid";
 
-                $oNewGroup->$sOxSortField = new \OxidEsales\Eshop\Core\Field(( int ) $database->getOne($sSql, [
+                $oNewGroup->$sOxSortField = new \OxidEsales\Eshop\Core\Field((int) $database->getOne($sSql, [
                     ':oxobjectid' => $sAdd
                 ]));
                 $oNewGroup->save();

--- a/source/Application/Controller/Admin/AttributeController.php
+++ b/source/Application/Controller/Admin/AttributeController.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Application/Controller/Admin/AttributeList.php
+++ b/source/Application/Controller/Admin/AttributeList.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Application/Controller/Admin/AttributeMain.php
+++ b/source/Application/Controller/Admin/AttributeMain.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Application/Controller/Admin/AttributeMainAjax.php
+++ b/source/Application/Controller/Admin/AttributeMainAjax.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
@@ -52,7 +53,7 @@ class AttributeMainAjax extends \OxidEsales\Eshop\Application\Controller\Admin\L
      *
      * @return string
      */
-    protected function _getQuery()
+    protected function _getQuery() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $myConfig = $this->getConfig();
         $oDb = \OxidEsales\Eshop\Core\DatabaseProvider::getDb();
@@ -100,7 +101,7 @@ class AttributeMainAjax extends \OxidEsales\Eshop\Application\Controller\Admin\L
      *
      * @return string
      */
-    protected function _addFilter($sQ)
+    protected function _addFilter($sQ) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $sQ = parent::_addFilter($sQ);
 

--- a/source/Application/Controller/Admin/AttributeOrderAjax.php
+++ b/source/Application/Controller/Admin/AttributeOrderAjax.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
@@ -31,7 +32,7 @@ class AttributeOrderAjax extends \OxidEsales\Eshop\Application\Controller\Admin\
      *
      * @return string
      */
-    protected function _getQuery()
+    protected function _getQuery() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $sSelTable = $this->_getViewName('oxattribute');
         $sArtId = \OxidEsales\Eshop\Core\Registry::getConfig()->getRequestParameter('oxid');
@@ -45,7 +46,7 @@ class AttributeOrderAjax extends \OxidEsales\Eshop\Application\Controller\Admin\
      *
      * @return string
      */
-    protected function _getSorting()
+    protected function _getSorting() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         return 'order by oxcategory2attribute.oxsort ';
     }

--- a/source/Application/Controller/Admin/CategoryController.php
+++ b/source/Application/Controller/Admin/CategoryController.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Application/Controller/Admin/CategoryList.php
+++ b/source/Application/Controller/Admin/CategoryList.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Application/Controller/Admin/CategoryMain.php
+++ b/source/Application/Controller/Admin/CategoryMain.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
@@ -174,7 +175,7 @@ class CategoryMain extends \OxidEsales\Eshop\Application\Controller\Admin\AdminD
      *
      * @return string
      */
-    protected function _processLongDesc($sValue)
+    protected function _processLongDesc($sValue) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         // workaround for firefox showing &lang= as &9001;= entity, mantis#0001272
         return str_replace('&lang=', '&amp;lang=', $sValue);
@@ -230,7 +231,7 @@ class CategoryMain extends \OxidEsales\Eshop\Application\Controller\Admin\AdminD
      *
      * @return null
      */
-    protected function _deleteCatPicture($item, $field)
+    protected function _deleteCatPicture($item, $field) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         if ($item->isDerived()) {
             return;
@@ -277,7 +278,7 @@ class CategoryMain extends \OxidEsales\Eshop\Application\Controller\Admin\AdminD
      *
      * @return array
      */
-    protected function _parseRequestParametersForSave($aReqParams)
+    protected function _parseRequestParametersForSave($aReqParams) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         // checkbox handling
         if (!isset($aReqParams['oxcategories__oxactive'])) {

--- a/source/Application/Controller/Admin/CategoryMainAjax.php
+++ b/source/Application/Controller/Admin/CategoryMainAjax.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
@@ -51,7 +52,7 @@ class CategoryMainAjax extends \OxidEsales\Eshop\Application\Controller\Admin\Li
      *
      * @return string
      */
-    protected function _getQuery()
+    protected function _getQuery() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $myConfig = $this->getConfig();
 
@@ -93,7 +94,7 @@ class CategoryMainAjax extends \OxidEsales\Eshop\Application\Controller\Admin\Li
      *
      * @return string
      */
-    protected function _addFilter($sQ)
+    protected function _addFilter($sQ) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $sArtTable = $this->_getViewName('oxarticles');
         $sQ = parent::_addFilter($sQ);
@@ -176,7 +177,7 @@ class CategoryMainAjax extends \OxidEsales\Eshop\Application\Controller\Admin\Li
      *
      * @param string $sProdIds product ids: "id1", "id2", "id3"
      */
-    protected function _updateOxTime($sProdIds)
+    protected function _updateOxTime($sProdIds) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         if ($sProdIds) {
             $sO2CView = $this->_getViewName('oxobject2category');

--- a/source/Application/Controller/Admin/CategoryOrder.php
+++ b/source/Application/Controller/Admin/CategoryOrder.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Application/Controller/Admin/CategoryOrderAjax.php
+++ b/source/Application/Controller/Admin/CategoryOrderAjax.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
@@ -46,7 +47,7 @@ class CategoryOrderAjax extends \OxidEsales\Eshop\Application\Controller\Admin\L
      *
      * @return string
      */
-    protected function _getQuery()
+    protected function _getQuery() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         // looking for table/view
         $sArtTable = $this->_getViewName('oxarticles');
@@ -77,7 +78,7 @@ class CategoryOrderAjax extends \OxidEsales\Eshop\Application\Controller\Admin\L
      *
      * @return string
      */
-    protected function _getSorting()
+    protected function _getSorting() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $sOrder = '';
         if (\OxidEsales\Eshop\Core\Registry::getConfig()->getRequestParameter('synchoxid')) {

--- a/source/Application/Controller/Admin/CategoryPictures.php
+++ b/source/Application/Controller/Admin/CategoryPictures.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Application/Controller/Admin/CategorySeo.php
+++ b/source/Application/Controller/Admin/CategorySeo.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
@@ -40,7 +41,7 @@ class CategorySeo extends \OxidEsales\Eshop\Application\Controller\Admin\ObjectS
      *
      * @return oxSeoEncoderCategory
      */
-    protected function _getEncoder()
+    protected function _getEncoder() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         return \OxidEsales\Eshop\Core\Registry::get(\OxidEsales\Eshop\Application\Model\SeoEncoderCategory::class);
     }
@@ -60,7 +61,7 @@ class CategorySeo extends \OxidEsales\Eshop\Application\Controller\Admin\ObjectS
      *
      * @return string
      */
-    protected function _getType()
+    protected function _getType() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         return 'oxcategory';
     }

--- a/source/Application/Controller/Admin/CategoryText.php
+++ b/source/Application/Controller/Admin/CategoryText.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Application/Controller/Admin/CategoryUpdate.php
+++ b/source/Application/Controller/Admin/CategoryUpdate.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
@@ -30,7 +31,7 @@ class CategoryUpdate extends \OxidEsales\Eshop\Application\Controller\Admin\Admi
      *
      * @return oxCategoryList
      */
-    protected function _getCategoryList()
+    protected function _getCategoryList() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         if ($this->_oCatList == null) {
             $this->_oCatList = oxNew(\OxidEsales\Eshop\Application\Model\CategoryList::class);

--- a/source/Application/Controller/Admin/ContentList.php
+++ b/source/Application/Controller/Admin/ContentList.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
@@ -65,7 +66,7 @@ class ContentList extends \OxidEsales\Eshop\Application\Controller\Admin\AdminLi
      *
      * @return string
      */
-    protected function _prepareWhereQuery($aWhere, $sqlFull)
+    protected function _prepareWhereQuery($aWhere, $sqlFull) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $sQ = parent::_prepareWhereQuery($aWhere, $sqlFull);
         $sFolder = \OxidEsales\Eshop\Core\Registry::getConfig()->getRequestParameter('folder');

--- a/source/Application/Controller/Admin/ContentMain.php
+++ b/source/Application/Controller/Admin/ContentMain.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
@@ -196,7 +197,7 @@ class ContentMain extends \OxidEsales\Eshop\Application\Controller\Admin\AdminDe
      *
      * @return string
      */
-    protected function _prepareIdent($sIdent)
+    protected function _prepareIdent($sIdent) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         if ($sIdent) {
             return getStr()->preg_replace("/[^a-zA-Z0-9_]*/", "", $sIdent);
@@ -211,7 +212,7 @@ class ContentMain extends \OxidEsales\Eshop\Application\Controller\Admin\AdminDe
      *
      * @return null
      */
-    protected function _checkIdent($sIdent, $sOxId)
+    protected function _checkIdent($sIdent, $sOxId) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         // We force reading from master to prevent issues with slow replications or open transactions (see ESDEV-3804).
         $masterDb = \OxidEsales\Eshop\Core\DatabaseProvider::getMaster();
@@ -222,11 +223,13 @@ class ContentMain extends \OxidEsales\Eshop\Application\Controller\Admin\AdminDe
         if (!strlen($sIdent)) {
             $blAllow = true;
         // We force reading from master to prevent issues with slow replications or open transactions (see ESDEV-3804).
-        } elseif ($masterDb->getOne("select oxid from oxcontents where oxloadid = :oxloadid and oxid != :oxid and oxshopid = :oxshopid", [
+        } elseif (
+            $masterDb->getOne("select oxid from oxcontents where oxloadid = :oxloadid and oxid != :oxid and oxshopid = :oxshopid", [
             ':oxloadid' => $sIdent,
             ':oxid' => $sOxId,
             ':oxshopid' => $this->getConfig()->getShopId()
-        ])) {
+            ])
+        ) {
             $blAllow = true;
         }
 

--- a/source/Application/Controller/Admin/ContentSeo.php
+++ b/source/Application/Controller/Admin/ContentSeo.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
@@ -18,7 +19,7 @@ class ContentSeo extends \OxidEsales\Eshop\Application\Controller\Admin\ObjectSe
      *
      * @return string
      */
-    protected function _getType()
+    protected function _getType() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         return 'oxcontent';
     }
@@ -28,7 +29,7 @@ class ContentSeo extends \OxidEsales\Eshop\Application\Controller\Admin\ObjectSe
      *
      * @return oxSeoEncoderContent
      */
-    protected function _getEncoder()
+    protected function _getEncoder() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         return \OxidEsales\Eshop\Core\Registry::get(\OxidEsales\Eshop\Application\Model\SeoEncoderContent::class);
     }

--- a/source/Application/Controller/Admin/CountryController.php
+++ b/source/Application/Controller/Admin/CountryController.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Application/Controller/Admin/CountryList.php
+++ b/source/Application/Controller/Admin/CountryList.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
@@ -74,7 +75,7 @@ class CountryList extends \OxidEsales\Eshop\Application\Controller\Admin\AdminLi
      *
      * @return string The name of the field we want to be the second order by argument.
      */
-    protected function _getSecondSortFieldName()
+    protected function _getSecondSortFieldName() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         return $this->sSecondDefSortField;
     }

--- a/source/Application/Controller/Admin/CountryMain.php
+++ b/source/Application/Controller/Admin/CountryMain.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Application/Controller/Admin/DeliveryArticles.php
+++ b/source/Application/Controller/Admin/DeliveryArticles.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Application/Controller/Admin/DeliveryArticlesAjax.php
+++ b/source/Application/Controller/Admin/DeliveryArticlesAjax.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
@@ -51,7 +52,7 @@ class DeliveryArticlesAjax extends \OxidEsales\Eshop\Application\Controller\Admi
      *
      * @return string
      */
-    protected function _getQuery()
+    protected function _getQuery() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $myConfig = $this->getConfig();
         $oDb = \OxidEsales\Eshop\Core\DatabaseProvider::getDb();
@@ -96,7 +97,7 @@ class DeliveryArticlesAjax extends \OxidEsales\Eshop\Application\Controller\Admi
      *
      * @return string
      */
-    /*protected function _addFilter( $sQ )
+    /*protected function _addFilter( $sQ ) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $sArtTable = $this->_getViewName('oxarticles');
         $sQ = parent::_addFilter( $sQ );

--- a/source/Application/Controller/Admin/DeliveryCategoriesAjax.php
+++ b/source/Application/Controller/Admin/DeliveryCategoriesAjax.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
@@ -39,7 +40,7 @@ class DeliveryCategoriesAjax extends \OxidEsales\Eshop\Application\Controller\Ad
      *
      * @return string
      */
-    protected function _getQuery()
+    protected function _getQuery() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         // looking for table/view
         $sCatTable = $this->_getViewName('oxcategories');

--- a/source/Application/Controller/Admin/DeliveryController.php
+++ b/source/Application/Controller/Admin/DeliveryController.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Application/Controller/Admin/DeliveryGroupsAjax.php
+++ b/source/Application/Controller/Admin/DeliveryGroupsAjax.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
@@ -36,7 +37,7 @@ class DeliveryGroupsAjax extends \OxidEsales\Eshop\Application\Controller\Admin\
      *
      * @return string
      */
-    protected function _getQuery()
+    protected function _getQuery() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $myConfig = $this->getConfig();
         $oDb = \OxidEsales\Eshop\Core\DatabaseProvider::getDb();

--- a/source/Application/Controller/Admin/DeliveryList.php
+++ b/source/Application/Controller/Admin/DeliveryList.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Application/Controller/Admin/DeliveryMain.php
+++ b/source/Application/Controller/Admin/DeliveryMain.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Application/Controller/Admin/DeliveryMainAjax.php
+++ b/source/Application/Controller/Admin/DeliveryMainAjax.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
@@ -40,7 +41,7 @@ class DeliveryMainAjax extends \OxidEsales\Eshop\Application\Controller\Admin\Li
      *
      * @return string
      */
-    protected function _getQuery()
+    protected function _getQuery() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $sCountryTable = $this->_getViewName('oxcountry');
         $oDb = \OxidEsales\Eshop\Core\DatabaseProvider::getDb();

--- a/source/Application/Controller/Admin/DeliverySetController.php
+++ b/source/Application/Controller/Admin/DeliverySetController.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Application/Controller/Admin/DeliverySetCountryAjax.php
+++ b/source/Application/Controller/Admin/DeliverySetCountryAjax.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
@@ -40,7 +41,7 @@ class DeliverySetCountryAjax extends \OxidEsales\Eshop\Application\Controller\Ad
      *
      * @return string
      */
-    protected function _getQuery()
+    protected function _getQuery() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $oDb = \OxidEsales\Eshop\Core\DatabaseProvider::getDb();
         $sId = $this->getConfig()->getRequestParameter('oxid');

--- a/source/Application/Controller/Admin/DeliverySetGroupsAjax.php
+++ b/source/Application/Controller/Admin/DeliverySetGroupsAjax.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
@@ -36,7 +37,7 @@ class DeliverySetGroupsAjax extends \OxidEsales\Eshop\Application\Controller\Adm
      *
      * @return string
      */
-    protected function _getQuery()
+    protected function _getQuery() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $oDb = \OxidEsales\Eshop\Core\DatabaseProvider::getDb();
         $sId = $this->getConfig()->getRequestParameter('oxid');

--- a/source/Application/Controller/Admin/DeliverySetList.php
+++ b/source/Application/Controller/Admin/DeliverySetList.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Application/Controller/Admin/DeliverySetMain.php
+++ b/source/Application/Controller/Admin/DeliverySetMain.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Application/Controller/Admin/DeliverySetMainAjax.php
+++ b/source/Application/Controller/Admin/DeliverySetMainAjax.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
@@ -40,7 +41,7 @@ class DeliverySetMainAjax extends \OxidEsales\Eshop\Application\Controller\Admin
      *
      * @return string
      */
-    protected function _getQuery()
+    protected function _getQuery() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $sId = $this->getConfig()->getRequestParameter('oxid');
         $sSynchId = $this->getConfig()->getRequestParameter('synchoxid');

--- a/source/Application/Controller/Admin/DeliverySetPayment.php
+++ b/source/Application/Controller/Admin/DeliverySetPayment.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Application/Controller/Admin/DeliverySetPaymentAjax.php
+++ b/source/Application/Controller/Admin/DeliverySetPaymentAjax.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
@@ -39,7 +40,7 @@ class DeliverySetPaymentAjax extends \OxidEsales\Eshop\Application\Controller\Ad
      *
      * @return string
      */
-    protected function _getQuery()
+    protected function _getQuery() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $oDb = \OxidEsales\Eshop\Core\DatabaseProvider::getDb();
         $sId = $this->getConfig()->getRequestParameter('oxid');

--- a/source/Application/Controller/Admin/DeliverySetRdfa.php
+++ b/source/Application/Controller/Admin/DeliverySetRdfa.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Application/Controller/Admin/DeliverySetUsers.php
+++ b/source/Application/Controller/Admin/DeliverySetUsers.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Application/Controller/Admin/DeliverySetUsersAjax.php
+++ b/source/Application/Controller/Admin/DeliverySetUsersAjax.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
@@ -52,7 +53,7 @@ class DeliverySetUsersAjax extends \OxidEsales\Eshop\Application\Controller\Admi
      *
      * @return string
      */
-    protected function _getQuery()
+    protected function _getQuery() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $myConfig = $this->getConfig();
         $oDb = \OxidEsales\Eshop\Core\DatabaseProvider::getDb();

--- a/source/Application/Controller/Admin/DeliveryUsers.php
+++ b/source/Application/Controller/Admin/DeliveryUsers.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Application/Controller/Admin/DeliveryUsersAjax.php
+++ b/source/Application/Controller/Admin/DeliveryUsersAjax.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
@@ -50,7 +51,7 @@ class DeliveryUsersAjax extends \OxidEsales\Eshop\Application\Controller\Admin\L
      *
      * @return string
      */
-    protected function _getQuery()
+    protected function _getQuery() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $myConfig = $this->getConfig();
 

--- a/source/Application/Controller/Admin/DiagnosticsController.php
+++ b/source/Application/Controller/Admin/DiagnosticsController.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Application/Controller/Admin/DiagnosticsList.php
+++ b/source/Application/Controller/Admin/DiagnosticsList.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Application/Controller/Admin/DiagnosticsMain.php
+++ b/source/Application/Controller/Admin/DiagnosticsMain.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
@@ -64,7 +65,7 @@ class DiagnosticsMain extends \OxidEsales\Eshop\Application\Controller\Admin\Adm
      *
      * @return string
      */
-    protected function _hasError()
+    protected function _hasError() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         return $this->_blError;
     }
@@ -74,7 +75,7 @@ class DiagnosticsMain extends \OxidEsales\Eshop\Application\Controller\Admin\Adm
      *
      * @return string
      */
-    protected function _getErrorMessage()
+    protected function _getErrorMessage() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         return $this->_sErrorMessage;
     }
@@ -116,7 +117,7 @@ class DiagnosticsMain extends \OxidEsales\Eshop\Application\Controller\Admin\Adm
      *
      * @return array list of shop files to be checked
      */
-    protected function _getFilesToCheck()
+    protected function _getFilesToCheck() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $oDiagnostics = oxNew(\OxidEsales\Eshop\Application\Model\Diagnostics::class);
         $aFilePathList = $oDiagnostics->getFileCheckerPathList();
@@ -145,7 +146,7 @@ class DiagnosticsMain extends \OxidEsales\Eshop\Application\Controller\Admin\Adm
      *
      * @return null|oxFileCheckerResult
      */
-    protected function _checkOxidFiles($aFileList)
+    protected function _checkOxidFiles($aFileList) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $oFileChecker = oxNew(\OxidEsales\Eshop\Application\Model\FileChecker::class);
         $oFileChecker->setBaseDirectory($this->_sShopDir);
@@ -182,7 +183,7 @@ class DiagnosticsMain extends \OxidEsales\Eshop\Application\Controller\Admin\Adm
      *
      * @return string body of report
      */
-    protected function _getFileCheckReport($oFileCheckerResult)
+    protected function _getFileCheckReport($oFileCheckerResult) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $aViewData = [
             "sVersion"       => $this->getConfig()->getVersion(),
@@ -233,7 +234,7 @@ class DiagnosticsMain extends \OxidEsales\Eshop\Application\Controller\Admin\Adm
      *
      * @return array
      */
-    protected function _runBasicDiagnostics()
+    protected function _runBasicDiagnostics() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $aViewData = [];
         $oDiagnostics = oxNew(\OxidEsales\Eshop\Application\Model\Diagnostics::class);

--- a/source/Application/Controller/Admin/DiscountArticles.php
+++ b/source/Application/Controller/Admin/DiscountArticles.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Application/Controller/Admin/DiscountArticlesAjax.php
+++ b/source/Application/Controller/Admin/DiscountArticlesAjax.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
@@ -56,7 +57,7 @@ class DiscountArticlesAjax extends \OxidEsales\Eshop\Application\Controller\Admi
      *
      * @return string
      */
-    protected function _getQuery()
+    protected function _getQuery() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $oConfig = $this->getConfig();
 

--- a/source/Application/Controller/Admin/DiscountCategoriesAjax.php
+++ b/source/Application/Controller/Admin/DiscountCategoriesAjax.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
@@ -44,7 +45,7 @@ class DiscountCategoriesAjax extends \OxidEsales\Eshop\Application\Controller\Ad
      *
      * @return string
      */
-    protected function _getQuery()
+    protected function _getQuery() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $oDb = \OxidEsales\Eshop\Core\DatabaseProvider::getDb();
         $oConfig = $this->getConfig();

--- a/source/Application/Controller/Admin/DiscountController.php
+++ b/source/Application/Controller/Admin/DiscountController.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Application/Controller/Admin/DiscountGroupsAjax.php
+++ b/source/Application/Controller/Admin/DiscountGroupsAjax.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
@@ -41,7 +42,7 @@ class DiscountGroupsAjax extends \OxidEsales\Eshop\Application\Controller\Admin\
      *
      * @return string
      */
-    protected function _getQuery()
+    protected function _getQuery() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $oConfig = $this->getConfig();
         // active AJAX component

--- a/source/Application/Controller/Admin/DiscountItemAjax.php
+++ b/source/Application/Controller/Admin/DiscountItemAjax.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
@@ -46,7 +47,7 @@ class DiscountItemAjax extends \OxidEsales\Eshop\Application\Controller\Admin\Li
      *
      * @return string
      */
-    protected function _getQuery()
+    protected function _getQuery() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $oConfig = $this->getConfig();
 
@@ -137,7 +138,7 @@ class DiscountItemAjax extends \OxidEsales\Eshop\Application\Controller\Admin\Li
      *
      * @return string
      */
-    protected function _getQueryCols()
+    protected function _getQueryCols() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $oConfig = $this->getConfig();
         $sLangTag = \OxidEsales\Eshop\Core\Registry::getLang()->getLanguageTag();

--- a/source/Application/Controller/Admin/DiscountList.php
+++ b/source/Application/Controller/Admin/DiscountList.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Application/Controller/Admin/DiscountMain.php
+++ b/source/Application/Controller/Admin/DiscountMain.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Application/Controller/Admin/DiscountMainAjax.php
+++ b/source/Application/Controller/Admin/DiscountMainAjax.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
@@ -40,7 +41,7 @@ class DiscountMainAjax extends \OxidEsales\Eshop\Application\Controller\Admin\Li
      *
      * @return string
      */
-    protected function _getQuery()
+    protected function _getQuery() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $oConfig = $this->getConfig();
         $sCountryTable = $this->_getViewName('oxcountry');

--- a/source/Application/Controller/Admin/DiscountUsers.php
+++ b/source/Application/Controller/Admin/DiscountUsers.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Application/Controller/Admin/DiscountUsersAjax.php
+++ b/source/Application/Controller/Admin/DiscountUsersAjax.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
@@ -50,7 +51,7 @@ class DiscountUsersAjax extends \OxidEsales\Eshop\Application\Controller\Admin\L
      *
      * @return string
      */
-    protected function _getQuery()
+    protected function _getQuery() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $oConfig = $this->getConfig();
 

--- a/source/Application/Controller/Admin/DynEconda.php
+++ b/source/Application/Controller/Admin/DynEconda.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Application/Controller/Admin/DynamicExportBaseController.php
+++ b/source/Application/Controller/Admin/DynamicExportBaseController.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
@@ -545,7 +546,7 @@ class DynamicExportBaseController extends \OxidEsales\Eshop\Application\Controll
      *
      * @return string
      */
-    protected function _unHtmlEntities($sInput)
+    protected function _unHtmlEntities($sInput) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $aTransTbl = array_flip(get_html_translation_table(HTML_ENTITIES));
 
@@ -557,7 +558,7 @@ class DynamicExportBaseController extends \OxidEsales\Eshop\Application\Controll
      *
      * @return string
      */
-    protected function _getHeapTableName()
+    protected function _getHeapTableName() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         // table name must not start with any digit
         return "tmp_" . str_replace("0", "", md5($this->getSession()->getId()));
@@ -570,7 +571,7 @@ class DynamicExportBaseController extends \OxidEsales\Eshop\Application\Controll
      *
      * @return string
      */
-    protected function _generateTableCharSet($sMysqlVersion)
+    protected function _generateTableCharSet($sMysqlVersion) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $sTableCharset = "";
 
@@ -597,7 +598,7 @@ class DynamicExportBaseController extends \OxidEsales\Eshop\Application\Controll
      *
      * @return bool
      */
-    protected function _createHeapTable($sHeapTable, $sTableCharset)
+    protected function _createHeapTable($sHeapTable, $sTableCharset) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $blDone = false;
         $oDB = \OxidEsales\Eshop\Core\DatabaseProvider::getDb();
@@ -617,7 +618,7 @@ class DynamicExportBaseController extends \OxidEsales\Eshop\Application\Controll
      *
      * @return string
      */
-    protected function _getCatAdd($aChosenCat)
+    protected function _getCatAdd($aChosenCat) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $sCatAdd = null;
         if (is_array($aChosenCat) && count($aChosenCat)) {
@@ -645,7 +646,7 @@ class DynamicExportBaseController extends \OxidEsales\Eshop\Application\Controll
      *
      * @return bool
      */
-    protected function _insertArticles($sHeapTable, $sCatAdd)
+    protected function _insertArticles($sHeapTable, $sCatAdd) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $oDB = \OxidEsales\Eshop\Core\DatabaseProvider::getDb();
 
@@ -696,7 +697,7 @@ class DynamicExportBaseController extends \OxidEsales\Eshop\Application\Controll
      *
      * @param string $sHeapTable table name
      */
-    protected function _removeParentArticles($sHeapTable)
+    protected function _removeParentArticles($sHeapTable) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         if (!(\OxidEsales\Eshop\Core\Registry::getConfig()->getRequestParameter("blExportMainVars"))) {
             $oDB = \OxidEsales\Eshop\Core\DatabaseProvider::getDb();
@@ -727,7 +728,7 @@ class DynamicExportBaseController extends \OxidEsales\Eshop\Application\Controll
     /**
      * stores some info in session
      */
-    protected function _setSessionParams()
+    protected function _setSessionParams() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         // reset it from session
         \OxidEsales\Eshop\Core\Registry::getSession()->deleteVariable("sExportDelCost");
@@ -775,7 +776,7 @@ class DynamicExportBaseController extends \OxidEsales\Eshop\Application\Controll
      *
      * @return null
      */
-    protected function _loadRootCats()
+    protected function _loadRootCats() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         if ($this->_aCatLvlCache === null) {
             $this->_aCatLvlCache = [];
@@ -826,7 +827,7 @@ class DynamicExportBaseController extends \OxidEsales\Eshop\Application\Controll
      *
      * @return string
      */
-    protected function _findDeepestCatPath($oArticle)
+    protected function _findDeepestCatPath($oArticle) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $sRet = "";
 
@@ -867,7 +868,7 @@ class DynamicExportBaseController extends \OxidEsales\Eshop\Application\Controll
      *
      * @return object
      */
-    protected function _initArticle($sHeapTable, $iCnt, &$blContinue)
+    protected function _initArticle($sHeapTable, $iCnt, &$blContinue) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $oRs = $this->getDb()->selectLimit("select oxid from $sHeapTable", 1, $iCnt);
         if ($oRs != false && $oRs->count() > 0) {
@@ -901,7 +902,7 @@ class DynamicExportBaseController extends \OxidEsales\Eshop\Application\Controll
      *
      * @return \OxidEsales\Eshop\Application\Model\Article
      */
-    protected function _setCampaignDetailLink($oArticle)
+    protected function _setCampaignDetailLink($oArticle) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         // #827
         if ($sCampaign = \OxidEsales\Eshop\Core\Registry::getConfig()->getRequestParameter("sExportCampaign")) {
@@ -909,7 +910,8 @@ class DynamicExportBaseController extends \OxidEsales\Eshop\Application\Controll
             //#1166R - pangora - campaign
             $oArticle->appendLink("campaign={$sCampaign}");
 
-            if (\OxidEsales\Eshop\Core\Registry::getConfig()->getRequestParameter("blAppendCatToCampaign") &&
+            if (
+                \OxidEsales\Eshop\Core\Registry::getConfig()->getRequestParameter("blAppendCatToCampaign") &&
                 ($sCat = $this->getCategoryString($oArticle))
             ) {
                 $oArticle->appendLink("/$sCat");

--- a/source/Application/Controller/Admin/DynamicInterface.php
+++ b/source/Application/Controller/Admin/DynamicInterface.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Application/Controller/Admin/DynamicScreenController.php
+++ b/source/Application/Controller/Admin/DynamicScreenController.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
@@ -32,7 +33,7 @@ class DynamicScreenController extends \OxidEsales\Eshop\Application\Controller\A
      *
      * @param string $sNode None name
      */
-    protected function _setupNavigation($sNode)
+    protected function _setupNavigation($sNode) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $myAdminNavig = $this->getNavigation();
         $sNode = \OxidEsales\Eshop\Core\Registry::getConfig()->getRequestParameter("menu");

--- a/source/Application/Controller/Admin/DynamicScreenList.php
+++ b/source/Application/Controller/Admin/DynamicScreenList.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Application/Controller/Admin/DynamicScreenLocal.php
+++ b/source/Application/Controller/Admin/DynamicScreenLocal.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Application/Controller/Admin/GenericExport.php
+++ b/source/Application/Controller/Admin/GenericExport.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Application/Controller/Admin/GenericExportDo.php
+++ b/source/Application/Controller/Admin/GenericExportDo.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Application/Controller/Admin/GenericExportMain.php
+++ b/source/Application/Controller/Admin/GenericExportMain.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Application/Controller/Admin/GenericImport.php
+++ b/source/Application/Controller/Admin/GenericImport.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Application/Controller/Admin/GenericImportMain.php
+++ b/source/Application/Controller/Admin/GenericImportMain.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
@@ -165,7 +166,7 @@ class GenericImportMain extends \OxidEsales\Eshop\Application\Controller\Admin\A
     /**
      * Deletes uploaded csv file from temp directory
      */
-    protected function _deleteCsvFile()
+    protected function _deleteCsvFile() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $sPath = $this->_getUploadedCsvFilePath();
         if (is_file($sPath)) {
@@ -179,7 +180,7 @@ class GenericImportMain extends \OxidEsales\Eshop\Application\Controller\Admin\A
      *
      * @return array
      */
-    protected function _getCsvFieldsNames()
+    protected function _getCsvFieldsNames() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $blCsvContainsHeader = $this->getConfig()->getRequestParameter('blContainsHeader');
         \OxidEsales\Eshop\Core\Registry::getSession()->setVariable('blCsvContainsHeader', $blCsvContainsHeader);
@@ -208,7 +209,7 @@ class GenericImportMain extends \OxidEsales\Eshop\Application\Controller\Admin\A
      *
      * @return array
      */
-    protected function _getCsvFirstRow()
+    protected function _getCsvFirstRow() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $sPath = $this->_getUploadedCsvFilePath();
         $iMaxLineLength = 8192;
@@ -225,7 +226,7 @@ class GenericImportMain extends \OxidEsales\Eshop\Application\Controller\Admin\A
     /**
      * Resets CSV parameters stored in session
      */
-    protected function _resetUploadedCsvData()
+    protected function _resetUploadedCsvData() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $this->_sCsvFilePath = null;
         \OxidEsales\Eshop\Core\Registry::getSession()->setVariable('sCsvFilePath', null);
@@ -240,7 +241,7 @@ class GenericImportMain extends \OxidEsales\Eshop\Application\Controller\Admin\A
      *
      * @return int
      */
-    protected function _checkErrors($iNavStep)
+    protected function _checkErrors($iNavStep) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         if ($iNavStep == 2) {
             if (!$this->_getUploadedCsvFilePath()) {
@@ -280,7 +281,7 @@ class GenericImportMain extends \OxidEsales\Eshop\Application\Controller\Admin\A
      *
      * @return string
      */
-    protected function _getUploadedCsvFilePath()
+    protected function _getUploadedCsvFilePath() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         //try to get uploaded csv file path
         if ($this->_sCsvFilePath !== null) {
@@ -305,7 +306,7 @@ class GenericImportMain extends \OxidEsales\Eshop\Application\Controller\Admin\A
      *
      * @param object $oErpImport Import object
      */
-    protected function _checkImportErrors($oErpImport)
+    protected function _checkImportErrors($oErpImport) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         foreach ($oErpImport->getStatistics() as $aValue) {
             if (!$aValue ['r']) {
@@ -321,7 +322,7 @@ class GenericImportMain extends \OxidEsales\Eshop\Application\Controller\Admin\A
      *
      * @return string
      */
-    protected function _getCsvFieldsTerminator()
+    protected function _getCsvFieldsTerminator() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         if ($this->_sStringTerminator === null) {
             $this->_sStringTerminator = $this->_sDefaultStringTerminator;
@@ -338,7 +339,7 @@ class GenericImportMain extends \OxidEsales\Eshop\Application\Controller\Admin\A
      *
      * @return string
      */
-    protected function _getCsvFieldsEncolser()
+    protected function _getCsvFieldsEncolser() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         if ($this->_sStringEncloser === null) {
             $this->_sStringEncloser = $this->_sDefaultStringEncloser;

--- a/source/Application/Controller/Admin/LanguageController.php
+++ b/source/Application/Controller/Admin/LanguageController.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Application/Controller/Admin/LanguageList.php
+++ b/source/Application/Controller/Admin/LanguageList.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
@@ -92,7 +93,7 @@ class LanguageList extends \OxidEsales\Eshop\Application\Controller\Admin\AdminL
      *
      * @return array
      */
-    protected function _getLanguagesList()
+    protected function _getLanguagesList() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $aLangParams = $this->getConfig()->getConfigParam('aLanguageParams');
         $aLanguages = \OxidEsales\Eshop\Core\Registry::getLang()->getLanguageArray();
@@ -138,7 +139,7 @@ class LanguageList extends \OxidEsales\Eshop\Application\Controller\Admin\AdminL
      *
      * @return bool
      */
-    protected function _sortLanguagesCallback($oLang1, $oLang2)
+    protected function _sortLanguagesCallback($oLang1, $oLang2) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $sSortParam = $this->_sDefSortField;
         $sVal1 = is_string($oLang1->$sSortParam) ? strtolower($oLang1->$sSortParam) : $oLang1->$sSortParam;
@@ -157,7 +158,7 @@ class LanguageList extends \OxidEsales\Eshop\Application\Controller\Admin\AdminL
      *
      * @param string $iLangId language ID
      */
-    protected function _resetMultiLangDbFields($iLangId)
+    protected function _resetMultiLangDbFields($iLangId) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $iLangId = (int) $iLangId;
 

--- a/source/Application/Controller/Admin/LanguageMain.php
+++ b/source/Application/Controller/Admin/LanguageMain.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
@@ -183,7 +184,7 @@ class LanguageMain extends \OxidEsales\Eshop\Application\Controller\Admin\AdminD
      *
      * @return array
      */
-    protected function _getLanguageInfo($sOxId)
+    protected function _getLanguageInfo($sOxId) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $sDefaultLang = $this->getConfig()->getConfigParam('sDefaultLang');
 
@@ -202,7 +203,7 @@ class LanguageMain extends \OxidEsales\Eshop\Application\Controller\Admin\AdminD
      *
      * @param array $aLangData languages parameters array
      */
-    protected function _setLanguages($aLangData)
+    protected function _setLanguages($aLangData) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $this->_aLangData = $aLangData;
     }
@@ -214,7 +215,7 @@ class LanguageMain extends \OxidEsales\Eshop\Application\Controller\Admin\AdminD
      *
      * @return array
      */
-    protected function _getLanguages()
+    protected function _getLanguages() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $aLangData['params'] = $this->getConfig()->getConfigParam('aLanguageParams');
         $aLangData['lang'] = $this->getConfig()->getConfigParam('aLanguages');
@@ -235,7 +236,7 @@ class LanguageMain extends \OxidEsales\Eshop\Application\Controller\Admin\AdminD
      * @param string $sOldId old ID
      * @param string $sNewId new ID
      */
-    protected function _updateAbbervation($sOldId, $sNewId)
+    protected function _updateAbbervation($sOldId, $sNewId) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         foreach (array_keys($this->_aLangData) as $sTypeKey) {
             if (is_array($this->_aLangData[$sTypeKey]) && count($this->_aLangData[$sTypeKey]) > 0) {
@@ -258,7 +259,7 @@ class LanguageMain extends \OxidEsales\Eshop\Application\Controller\Admin\AdminD
      * Sort languages, languages parameters, urls, ssl urls arrays according
      * base land ID
      */
-    protected function _sortLangArraysByBaseId()
+    protected function _sortLangArraysByBaseId() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $aUrls = [];
         $aSslUrls = [];
@@ -285,7 +286,7 @@ class LanguageMain extends \OxidEsales\Eshop\Application\Controller\Admin\AdminD
      *
      * @return array
      */
-    protected function _assignDefaultLangParams($aLanguages)
+    protected function _assignDefaultLangParams($aLanguages) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $aParams = [];
         $iBaseId = 0;
@@ -306,7 +307,7 @@ class LanguageMain extends \OxidEsales\Eshop\Application\Controller\Admin\AdminD
      *
      * @param string $sOxId language abbervation
      */
-    protected function _setDefaultLang($sOxId)
+    protected function _setDefaultLang($sOxId) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $sDefaultId = $this->_aLangData['params'][$sOxId]['baseId'];
         $this->getConfig()->saveShopConfVar('str', 'sDefaultLang', $sDefaultId);
@@ -317,7 +318,7 @@ class LanguageMain extends \OxidEsales\Eshop\Application\Controller\Admin\AdminD
      *
      * @return int
      */
-    protected function _getAvailableLangBaseId()
+    protected function _getAvailableLangBaseId() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $aBaseId = [];
         foreach ($this->_aLangData['params'] as $aLang) {
@@ -345,7 +346,7 @@ class LanguageMain extends \OxidEsales\Eshop\Application\Controller\Admin\AdminD
      *
      * @param string $sOxId language abbervation
      */
-    protected function _checkLangTranslations($sOxId)
+    protected function _checkLangTranslations($sOxId) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $myConfig = $this->getConfig();
 
@@ -365,7 +366,7 @@ class LanguageMain extends \OxidEsales\Eshop\Application\Controller\Admin\AdminD
      *
      * @return bool
      */
-    protected function _checkMultilangFieldsExistsInDb($sOxId)
+    protected function _checkMultilangFieldsExistsInDb($sOxId) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $iBaseId = $this->_aLangData['params'][$sOxId]['baseId'];
         $sTable = getLangTableName('oxarticles', $iBaseId);
@@ -382,7 +383,7 @@ class LanguageMain extends \OxidEsales\Eshop\Application\Controller\Admin\AdminD
      *
      * @return null
      */
-    protected function _addNewMultilangFieldsToDb()
+    protected function _addNewMultilangFieldsToDb() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         //creating new multilingual fields with new id over whole DB
         $oDbMeta = oxNew(\OxidEsales\Eshop\Core\DbMetaDataHandler::class);
@@ -411,7 +412,7 @@ class LanguageMain extends \OxidEsales\Eshop\Application\Controller\Admin\AdminD
      *
      * @return bool
      */
-    protected function _checkLangExists($sAbbr)
+    protected function _checkLangExists($sAbbr) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $aAbbrs = array_keys($this->_aLangData['lang']);
 
@@ -427,7 +428,7 @@ class LanguageMain extends \OxidEsales\Eshop\Application\Controller\Admin\AdminD
      *
      * @return bool
      */
-    protected function _sortLangParamsByBaseIdCallback($oLang1, $oLang2)
+    protected function _sortLangParamsByBaseIdCallback($oLang1, $oLang2) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         return ($oLang1['baseId'] < $oLang2['baseId']) ? -1 : 1;
     }
@@ -437,7 +438,7 @@ class LanguageMain extends \OxidEsales\Eshop\Application\Controller\Admin\AdminD
      *
      * @return bool
      */
-    protected function _validateInput()
+    protected function _validateInput() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $result = true;
 

--- a/source/Application/Controller/Admin/ListComponentAjax.php
+++ b/source/Application/Controller/Admin/ListComponentAjax.php
@@ -141,7 +141,7 @@ class ListComponentAjax extends \OxidEsales\Eshop\Core\Base
     {
         if ($function) {
             $this->$function();
-            $this->dispatchEvent(new AfterAdminAjaxRequestProcessedEvent);
+            $this->dispatchEvent(new AfterAdminAjaxRequestProcessedEvent());
         } else {
             $sQAdd = $this->_getQuery();
 

--- a/source/Application/Controller/Admin/ListComponentAjax.php
+++ b/source/Application/Controller/Admin/ListComponentAjax.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
@@ -78,7 +79,7 @@ class ListComponentAjax extends \OxidEsales\Eshop\Core\Base
      *
      * @return array
      */
-    protected function _getActionIds($sId)
+    protected function _getActionIds($sId) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $aColumns = $this->_getColNames();
         foreach ($aColumns as $iPos => $aCol) {
@@ -103,7 +104,7 @@ class ListComponentAjax extends \OxidEsales\Eshop\Core\Base
      *
      * @return string
      */
-    protected function _getQuery()
+    protected function _getQuery() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         return '';
     }
@@ -115,7 +116,7 @@ class ListComponentAjax extends \OxidEsales\Eshop\Core\Base
      *
      * @return string
      */
-    protected function _getDataQuery($sQ)
+    protected function _getDataQuery($sQ) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         return 'select ' . $this->_getQueryCols() . $sQ;
     }
@@ -127,7 +128,7 @@ class ListComponentAjax extends \OxidEsales\Eshop\Core\Base
      *
      * @return string
      */
-    protected function _getCountQuery($sQ)
+    protected function _getCountQuery($sQ) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         return 'select count( * ) ' . $sQ;
     }
@@ -158,11 +159,11 @@ class ListComponentAjax extends \OxidEsales\Eshop\Core\Base
      *
      * @return int
      */
-    protected function _getSortCol()
+    protected function _getSortCol() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $aVisibleNames = $this->_getVisibleColNames();
         $iCol = \OxidEsales\Eshop\Core\Registry::getConfig()->getRequestParameter('sort');
-        $iCol = $iCol ? (( int ) str_replace('_', '', $iCol)) : 0;
+        $iCol = $iCol ? ((int) str_replace('_', '', $iCol)) : 0;
         $iCol = (!isset($aVisibleNames[$iCol])) ? 0 : $iCol;
 
         return $iCol;
@@ -177,7 +178,7 @@ class ListComponentAjax extends \OxidEsales\Eshop\Core\Base
      *
      * @return array
      */
-    protected function _getColNames($sId = null)
+    protected function _getColNames($sId = null) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         if ($sId === null) {
             $sId = \OxidEsales\Eshop\Core\Registry::getConfig()->getRequestParameter('cmpid');
@@ -196,7 +197,7 @@ class ListComponentAjax extends \OxidEsales\Eshop\Core\Base
      *
      * @return array
      */
-    protected function _getIdentColNames()
+    protected function _getIdentColNames() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $aColNames = $this->_getColNames();
         $aCols = [];
@@ -215,7 +216,7 @@ class ListComponentAjax extends \OxidEsales\Eshop\Core\Base
      *
      * @return array
      */
-    protected function _getVisibleColNames()
+    protected function _getVisibleColNames() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $aColNames = $this->_getColNames();
         $aUserCols = \OxidEsales\Eshop\Core\Registry::getConfig()->getRequestParameter('aCols');
@@ -224,7 +225,7 @@ class ListComponentAjax extends \OxidEsales\Eshop\Core\Base
         // user defined some cols to load ?
         if (is_array($aUserCols)) {
             foreach ($aUserCols as $iKey => $sCol) {
-                $iCol = ( int ) str_replace('_', '', $sCol);
+                $iCol = (int) str_replace('_', '', $sCol);
                 if (isset($aColNames[$iCol]) && !$aColNames[$iCol][4]) {
                     $aVisibleCols[$iCol] = $aColNames[$iCol];
                 }
@@ -250,7 +251,7 @@ class ListComponentAjax extends \OxidEsales\Eshop\Core\Base
      *
      * @return string
      */
-    protected function _getQueryCols()
+    protected function _getQueryCols() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $sQ = $this->_buildColsQuery($this->_getVisibleColNames(), false) . ", ";
         $sQ .= $this->_buildColsQuery($this->_getIdentColNames());
@@ -266,7 +267,7 @@ class ListComponentAjax extends \OxidEsales\Eshop\Core\Base
      *
      * @return string
      */
-    protected function _buildColsQuery($aIdentCols, $blIdentCols = true)
+    protected function _buildColsQuery($aIdentCols, $blIdentCols = true) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $sQ = '';
         foreach ($aIdentCols as $iCnt => $aCol) {
@@ -293,7 +294,7 @@ class ListComponentAjax extends \OxidEsales\Eshop\Core\Base
      *
      * @return bool
      */
-    protected function _isExtendedColumn($sColumn)
+    protected function _isExtendedColumn($sColumn) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $blVariantsSelectionParameter = \OxidEsales\Eshop\Core\Registry::getConfig()->getConfigParam('blVariantsSelection');
 
@@ -310,7 +311,7 @@ class ListComponentAjax extends \OxidEsales\Eshop\Core\Base
      *
      * @return string
      */
-    protected function _getExtendedColQuery($sViewTable, $sColumn, $iCnt)
+    protected function _getExtendedColQuery($sViewTable, $sColumn, $iCnt) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         // multilanguage
         $sVarSelect = "$sViewTable.oxvarselect";
@@ -325,7 +326,7 @@ class ListComponentAjax extends \OxidEsales\Eshop\Core\Base
      *
      * @return string
      */
-    protected function _getSorting()
+    protected function _getSorting() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         return ' order by _' . $this->_getSortCol() . ' ' . $this->_getSortDir() . ' ';
     }
@@ -337,7 +338,7 @@ class ListComponentAjax extends \OxidEsales\Eshop\Core\Base
      *
      * @return string
      */
-    protected function _getLimit($iStart)
+    protected function _getLimit($iStart) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $iLimit = (int) \OxidEsales\Eshop\Core\Registry::getConfig()->getRequestParameter("results");
         $iLimit = $iLimit ? $iLimit : $this->_iSqlLimit;
@@ -350,7 +351,7 @@ class ListComponentAjax extends \OxidEsales\Eshop\Core\Base
      *
      * @return string
      */
-    protected function _getFilter()
+    protected function _getFilter() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $sQ = '';
         $oConfig = $this->getConfig();
@@ -394,7 +395,7 @@ class ListComponentAjax extends \OxidEsales\Eshop\Core\Base
      *
      * @return string
      */
-    protected function _addFilter($sQ)
+    protected function _addFilter($sQ) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         if ($sQ && ($sFilter = $this->_getFilter())) {
             $sQ .= ((stristr($sQ, 'where') === false) ? 'where' : ' and ') . $sFilter;
@@ -410,7 +411,7 @@ class ListComponentAjax extends \OxidEsales\Eshop\Core\Base
      *
      * @return array
      */
-    protected function _getAll($sQ)
+    protected function _getAll($sQ) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $aReturn = [];
         $rs = \OxidEsales\Eshop\Core\DatabaseProvider::getDb()->select($sQ);
@@ -429,7 +430,7 @@ class ListComponentAjax extends \OxidEsales\Eshop\Core\Base
      *
      * @return string
      */
-    protected function _getSortDir()
+    protected function _getSortDir() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $sDir = \OxidEsales\Eshop\Core\Registry::getConfig()->getRequestParameter('dir');
         if (!in_array($sDir, $this->_aPosDir)) {
@@ -444,7 +445,7 @@ class ListComponentAjax extends \OxidEsales\Eshop\Core\Base
      *
      * @return int
      */
-    protected function _getStartIndex()
+    protected function _getStartIndex() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         return (int) \OxidEsales\Eshop\Core\Registry::getConfig()->getRequestParameter('startIndex');
     }
@@ -456,7 +457,7 @@ class ListComponentAjax extends \OxidEsales\Eshop\Core\Base
      *
      * @return int
      */
-    protected function _getTotalCount($sQ)
+    protected function _getTotalCount($sQ) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         // TODO: implement caching here
 
@@ -475,7 +476,7 @@ class ListComponentAjax extends \OxidEsales\Eshop\Core\Base
      *
      * @return array
      */
-    protected function _getDataFields($sQ)
+    protected function _getDataFields($sQ) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         // We force reading from master to prevent issues with slow replications or open transactions (see ESDEV-3804).
         return \OxidEsales\Eshop\Core\DatabaseProvider::getMaster(\OxidEsales\Eshop\Core\DatabaseProvider::FETCH_MODE_ASSOC)->getAll($sQ, false);
@@ -486,7 +487,7 @@ class ListComponentAjax extends \OxidEsales\Eshop\Core\Base
      *
      * @param array $aData data to output
      */
-    protected function _outputResponse($aData)
+    protected function _outputResponse($aData) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $this->_output(json_encode($aData));
     }
@@ -496,7 +497,7 @@ class ListComponentAjax extends \OxidEsales\Eshop\Core\Base
      *
      * @param string $sOut string to echo
      */
-    protected function _output($sOut)
+    protected function _output($sOut) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         echo $sOut;
     }
@@ -508,7 +509,7 @@ class ListComponentAjax extends \OxidEsales\Eshop\Core\Base
      *
      * @return string
      */
-    protected function _getViewName($sTable)
+    protected function _getViewName($sTable) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         return getViewName($sTable, \OxidEsales\Eshop\Core\Registry::getConfig()->getRequestParameter('editlanguage'));
     }
@@ -521,7 +522,7 @@ class ListComponentAjax extends \OxidEsales\Eshop\Core\Base
      *
      * @return array
      */
-    protected function _getData($sCountQ, $sQ)
+    protected function _getData($sCountQ, $sQ) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $sQ = $this->_addFilter($sQ);
         $sCountQ = $this->_addFilter($sCountQ);
@@ -628,14 +629,14 @@ class ListComponentAjax extends \OxidEsales\Eshop\Core\Base
     /**
      * Resets content cache.
      */
-    protected function _resetContentCache()
+    protected function _resetContentCache() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
     }
 
     /**
      * Resets output caches
      */
-    protected function _resetCaches()
+    protected function _resetCaches() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
     }
 }

--- a/source/Application/Controller/Admin/ListReview.php
+++ b/source/Application/Controller/Admin/ListReview.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
@@ -32,7 +33,7 @@ class ListReview extends \OxidEsales\Eshop\Application\Controller\Admin\ArticleL
      *
      * @return int
      */
-    protected function _getViewListSize()
+    protected function _getViewListSize() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         return $this->_getUserDefListSize();
     }
@@ -60,7 +61,7 @@ class ListReview extends \OxidEsales\Eshop\Application\Controller\Admin\ArticleL
      *
      * @return string
      */
-    protected function _buildSelectString($oObject = null)
+    protected function _buildSelectString($oObject = null) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $sArtTable = getViewName('oxarticles', $this->_iEditLang);
 
@@ -86,7 +87,7 @@ class ListReview extends \OxidEsales\Eshop\Application\Controller\Admin\ArticleL
      *
      * @return string
      */
-    protected function _prepareWhereQuery($aWhere, $sSql)
+    protected function _prepareWhereQuery($aWhere, $sSql) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $sSql = parent::_prepareWhereQuery($aWhere, $sSql);
 

--- a/source/Application/Controller/Admin/ListUser.php
+++ b/source/Application/Controller/Admin/ListUser.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
@@ -18,7 +19,7 @@ class ListUser extends \OxidEsales\Eshop\Application\Controller\Admin\UserList
      *
      * @return int
      */
-    protected function _getViewListSize()
+    protected function _getViewListSize() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         return $this->_getUserDefListSize();
     }

--- a/source/Application/Controller/Admin/LoginController.php
+++ b/source/Application/Controller/Admin/LoginController.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
@@ -177,7 +178,7 @@ class LoginController extends \OxidEsales\Eshop\Application\Controller\Admin\Adm
      *
      * @return boolean
      */
-    protected function _authorize()
+    protected function _authorize() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         return true;
     }
@@ -197,7 +198,7 @@ class LoginController extends \OxidEsales\Eshop\Application\Controller\Admin\Adm
      *
      * @return array
      */
-    protected function _getAvailableLanguages()
+    protected function _getAvailableLanguages() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $sDefLang = \OxidEsales\Eshop\Core\Registry::getUtilsServer()->getOxCookie('oxidadminlanguage');
         $sDefLang = $sDefLang ? $sDefLang : $this->_getBrowserLanguage();
@@ -215,7 +216,7 @@ class LoginController extends \OxidEsales\Eshop\Application\Controller\Admin\Adm
      *
      * @return string
      */
-    protected function _getBrowserLanguage()
+    protected function _getBrowserLanguage() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         return strtolower(substr($_SERVER['HTTP_ACCEPT_LANGUAGE'], 0, 2));
     }

--- a/source/Application/Controller/Admin/ManufacturerController.php
+++ b/source/Application/Controller/Admin/ManufacturerController.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Application/Controller/Admin/ManufacturerList.php
+++ b/source/Application/Controller/Admin/ManufacturerList.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Application/Controller/Admin/ManufacturerMain.php
+++ b/source/Application/Controller/Admin/ManufacturerMain.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Application/Controller/Admin/ManufacturerMainAjax.php
+++ b/source/Application/Controller/Admin/ManufacturerMainAjax.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
@@ -52,7 +53,7 @@ class ManufacturerMainAjax extends \OxidEsales\Eshop\Application\Controller\Admi
      *
      * @return string
      */
-    protected function _getQuery()
+    protected function _getQuery() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $config = $this->getConfig();
 
@@ -90,7 +91,7 @@ class ManufacturerMainAjax extends \OxidEsales\Eshop\Application\Controller\Admi
      *
      * @return string
      */
-    protected function _addFilter($query)
+    protected function _addFilter($query) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $config = $this->getConfig();
         $articleViewName = $this->_getViewName('oxarticles');

--- a/source/Application/Controller/Admin/ManufacturerSeo.php
+++ b/source/Application/Controller/Admin/ManufacturerSeo.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
@@ -38,7 +39,7 @@ class ManufacturerSeo extends \OxidEsales\Eshop\Application\Controller\Admin\Obj
      *
      * @return oxSeoEncoderManufacturer
      */
-    protected function _getEncoder()
+    protected function _getEncoder() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         return \OxidEsales\Eshop\Core\Registry::get(\OxidEsales\Eshop\Application\Model\SeoEncoderManufacturer::class);
     }
@@ -58,7 +59,7 @@ class ManufacturerSeo extends \OxidEsales\Eshop\Application\Controller\Admin\Obj
      *
      * @return string
      */
-    protected function _getType()
+    protected function _getType() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         return 'oxmanufacturer';
     }

--- a/source/Application/Controller/Admin/ModuleConfiguration.php
+++ b/source/Application/Controller/Admin/ModuleConfiguration.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
@@ -76,7 +77,7 @@ class ModuleConfiguration extends \OxidEsales\Eshop\Application\Controller\Admin
      *
      * @return string
      */
-    protected function _getModuleForConfigVars()
+    protected function _getModuleForConfigVars() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         return \OxidEsales\Eshop\Core\Config::OXMODULE_MODULE_PREFIX . $this->_sModuleId;
     }
@@ -94,7 +95,7 @@ class ModuleConfiguration extends \OxidEsales\Eshop\Application\Controller\Admin
      *
      * @return array
      */
-    public function _loadMetadataConfVars($aModuleSettings)
+    public function _loadMetadataConfVars($aModuleSettings) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $oConfig = $this->getConfig();
 
@@ -331,7 +332,7 @@ class ModuleConfiguration extends \OxidEsales\Eshop\Application\Controller\Admin
      *
      * @return string
      */
-    private function _getDbConfigTypeName($type)
+    private function _getDbConfigTypeName($type) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         return $type === 'password' ? 'str' : $type;
     }

--- a/source/Application/Controller/Admin/ModuleController.php
+++ b/source/Application/Controller/Admin/ModuleController.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Application/Controller/Admin/ModuleList.php
+++ b/source/Application/Controller/Admin/ModuleList.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Application/Controller/Admin/ModuleMain.php
+++ b/source/Application/Controller/Admin/ModuleMain.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Application/Controller/Admin/ModuleSortList.php
+++ b/source/Application/Controller/Admin/ModuleSortList.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Application/Controller/Admin/NavigationController.php
+++ b/source/Application/Controller/Admin/NavigationController.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
@@ -151,7 +152,7 @@ class NavigationController extends \OxidEsales\Eshop\Application\Controller\Admi
      *
      * @return array
      */
-    protected function _doStartUpChecks()
+    protected function _doStartUpChecks() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $messages = [];
 
@@ -202,7 +203,7 @@ class NavigationController extends \OxidEsales\Eshop\Application\Controller\Admi
      *
      * @return string
      */
-    protected function _checkVersion()
+    protected function _checkVersion() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $edition = $this->getConfig()->getEdition();
         $query = 'http://admin.oxid-esales.com/' . $edition . '/onlinecheck.php?getlatestversion';

--- a/source/Application/Controller/Admin/NavigationTree.php
+++ b/source/Application/Controller/Admin/NavigationTree.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
@@ -51,7 +52,7 @@ class NavigationTree extends \OxidEsales\Eshop\Core\Base
      * @param string $parentXPath parent xpath
      * @param string $childXPath  child xpath from parent
      */
-    protected function _cleanEmptyParents($dom, $parentXPath, $childXPath)
+    protected function _cleanEmptyParents($dom, $parentXPath, $childXPath) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $xPath = new DomXPath($dom);
         $nodeList = $xPath->query($parentXPath);
@@ -70,7 +71,7 @@ class NavigationTree extends \OxidEsales\Eshop\Core\Base
      *
      * @param DomDocument $dom where to add links
      */
-    protected function _addLinks($dom)
+    protected function _addLinks($dom) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $url = 'index.php?'; // session parameters will be included later (after cache processor)
         $xPath = new DomXPath($dom);
@@ -97,7 +98,7 @@ class NavigationTree extends \OxidEsales\Eshop\Core\Base
      * @param string      $menuFile which file to load
      * @param DomDocument $dom      where to load
      */
-    protected function _loadFromFile($menuFile, $dom)
+    protected function _loadFromFile($menuFile, $dom) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $merge = false;
         $domFile = new DomDocument();
@@ -134,7 +135,7 @@ class NavigationTree extends \OxidEsales\Eshop\Core\Base
      *
      * @param object $dom dom element to add links
      */
-    protected function _addDynLinks($dom)
+    protected function _addDynLinks($dom) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $myUtilsFile = \OxidEsales\Eshop\Core\Registry::getUtilsFile();
 
@@ -203,7 +204,7 @@ class NavigationTree extends \OxidEsales\Eshop\Core\Base
      *
      * @param object $dom dom element to add links
      */
-    protected function _sessionizeLocalUrls($dom)
+    protected function _sessionizeLocalUrls($dom) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $url = $this->_getAdminUrl();
         $xPath = new DomXPath($dom);
@@ -224,7 +225,7 @@ class NavigationTree extends \OxidEsales\Eshop\Core\Base
      *
      * @param object $dom DOMDocument
      */
-    protected function _checkRights($dom)
+    protected function _checkRights($dom) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $xPath = new DomXPath($dom);
         $nodeList = $xPath->query('//*[@rights or @norights]');
@@ -255,7 +256,7 @@ class NavigationTree extends \OxidEsales\Eshop\Core\Base
      *
      * @param DOMDocument $dom document to check group
      */
-    protected function _checkGroups($dom)
+    protected function _checkGroups($dom) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $xPath = new DomXPath($dom);
         $nodeList = $xPath->query("//*[@nogroup or @group]");
@@ -288,7 +289,7 @@ class NavigationTree extends \OxidEsales\Eshop\Core\Base
      *
      * @return null
      */
-    protected function _checkDemoShopDenials($dom)
+    protected function _checkDemoShopDenials($dom) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         if (!$this->getConfig()->isDemoShop()) {
             // nothing to check for non demo shop
@@ -326,7 +327,7 @@ class NavigationTree extends \OxidEsales\Eshop\Core\Base
      * @param object $domElemTo   DOMElement
      * @param object $domElemFrom DOMElement
      */
-    protected function _copyAttributes($domElemTo, $domElemFrom)
+    protected function _copyAttributes($domElemTo, $domElemFrom) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         foreach ($domElemFrom->attributes as $attr) {
             $domElemTo->setAttribute($attr->nodeName, $attr->nodeValue);
@@ -342,7 +343,7 @@ class NavigationTree extends \OxidEsales\Eshop\Core\Base
      * @param object $domDocTo    node to append child
      * @param string $queryStart  node query
      */
-    protected function _mergeNodes($domElemTo, $domElemFrom, $xPathTo, $domDocTo, $queryStart)
+    protected function _mergeNodes($domElemTo, $domElemFrom, $xPathTo, $domDocTo, $queryStart) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         foreach ($domElemFrom->childNodes as $fromNode) {
             if ($fromNode->nodeType === XML_ELEMENT_NODE) {
@@ -376,7 +377,7 @@ class NavigationTree extends \OxidEsales\Eshop\Core\Base
      * @param DomDocument $domNew what to merge
      * @param DomDocument $dom    where to merge
      */
-    protected function _merge($domNew, $dom)
+    protected function _merge($domNew, $dom) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $xPath = new DOMXPath($dom);
         $this->_mergeNodes($dom->documentElement, $domNew->documentElement, $xPath, $dom, '/OX');
@@ -456,7 +457,7 @@ class NavigationTree extends \OxidEsales\Eshop\Core\Base
      *
      * @return array
      */
-    protected function _getMenuFiles()
+    protected function _getMenuFiles() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $adminNavigationFileLocator = $this->getContainer()->get('oxid_esales.templating.admin.navigation.file.locator');
         $filesToLoad = $adminNavigationFileLocator->locate();
@@ -491,7 +492,7 @@ class NavigationTree extends \OxidEsales\Eshop\Core\Base
      *
      * @return bool
      */
-    protected function _checkDynFile($dynFilePath)
+    protected function _checkDynFile($dynFilePath) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $dynFile = null;
         if (file_exists($dynFilePath)) {
@@ -522,7 +523,7 @@ class NavigationTree extends \OxidEsales\Eshop\Core\Base
      *
      * @return string
      */
-    protected function _processCachedFile($cacheContents)
+    protected function _processCachedFile($cacheContents) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         return $cacheContents;
     }
@@ -532,7 +533,7 @@ class NavigationTree extends \OxidEsales\Eshop\Core\Base
      *
      * @return DOMDocument
      */
-    protected function _getInitialDom()
+    protected function _getInitialDom() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         if ($this->_oInitialDom === null) {
             $myOxUtlis = \OxidEsales\Eshop\Core\Registry::getUtils();
@@ -709,7 +710,7 @@ class NavigationTree extends \OxidEsales\Eshop\Core\Base
      *
      * @return string
      */
-    protected function _getAdminUrl()
+    protected function _getAdminUrl() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $myConfig = $this->getConfig();
 
@@ -729,7 +730,7 @@ class NavigationTree extends \OxidEsales\Eshop\Core\Base
      *
      * @return bool
      */
-    protected function _hasRights($rights)
+    protected function _hasRights($rights) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         return $this->getUser()->oxuser__oxrights->value == $rights;
     }
@@ -741,7 +742,7 @@ class NavigationTree extends \OxidEsales\Eshop\Core\Base
      *
      * @return bool
      */
-    protected function _hasGroup($groupId)
+    protected function _hasGroup($groupId) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         return $this->getUser()->inGroup($groupId);
     }
@@ -773,7 +774,7 @@ class NavigationTree extends \OxidEsales\Eshop\Core\Base
      *
      * @return string
      */
-    protected function _getDynMenuUrl($lang, $loadDynContents)
+    protected function _getDynMenuUrl($lang, $loadDynContents) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         if (!$loadDynContents) {
             // getting dyn info from oxid server is off, so getting local menu path
@@ -794,7 +795,7 @@ class NavigationTree extends \OxidEsales\Eshop\Core\Base
      *
      * @return string
      */
-    protected function _getDynMenuLang()
+    protected function _getDynMenuLang() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $myConfig = $this->getConfig();
         $lang = \OxidEsales\Eshop\Core\Registry::getLang();

--- a/source/Application/Controller/Admin/NewsList.php
+++ b/source/Application/Controller/Admin/NewsList.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Application/Controller/Admin/NewsMain.php
+++ b/source/Application/Controller/Admin/NewsMain.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Application/Controller/Admin/NewsMainAjax.php
+++ b/source/Application/Controller/Admin/NewsMainAjax.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
@@ -41,7 +42,7 @@ class NewsMainAjax extends \OxidEsales\Eshop\Application\Controller\Admin\ListCo
      *
      * @return string
      */
-    protected function _getQuery()
+    protected function _getQuery() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         // active AJAX component
         $sGroupTable = $this->_getViewName('oxgroups');

--- a/source/Application/Controller/Admin/NewsText.php
+++ b/source/Application/Controller/Admin/NewsText.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Application/Controller/Admin/NewsletterList.php
+++ b/source/Application/Controller/Admin/NewsletterList.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Application/Controller/Admin/NewsletterMain.php
+++ b/source/Application/Controller/Admin/NewsletterMain.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Application/Controller/Admin/NewsletterPlain.php
+++ b/source/Application/Controller/Admin/NewsletterPlain.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Application/Controller/Admin/NewsletterPreview.php
+++ b/source/Application/Controller/Admin/NewsletterPreview.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Application/Controller/Admin/NewsletterSelection.php
+++ b/source/Application/Controller/Admin/NewsletterSelection.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Application/Controller/Admin/NewsletterSelectionAjax.php
+++ b/source/Application/Controller/Admin/NewsletterSelectionAjax.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
@@ -36,7 +37,7 @@ class NewsletterSelectionAjax extends \OxidEsales\Eshop\Application\Controller\A
      *
      * @return string
      */
-    protected function _getQuery()
+    protected function _getQuery() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         // active AJAX component
         $sGroupTable = $this->_getViewName('oxgroups');

--- a/source/Application/Controller/Admin/NewsletterSend.php
+++ b/source/Application/Controller/Admin/NewsletterSend.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
@@ -182,7 +183,7 @@ class NewsletterSend extends \OxidEsales\Eshop\Application\Controller\Admin\News
      *
      * @param string $sNode referred id
      */
-    protected function _setupNavigation($sNode)
+    protected function _setupNavigation($sNode) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $sNode = 'newsletter_list';
 

--- a/source/Application/Controller/Admin/ObjectSeo.php
+++ b/source/Application/Controller/Admin/ObjectSeo.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
@@ -100,7 +101,7 @@ class ObjectSeo extends \OxidEsales\Eshop\Application\Controller\Admin\AdminDeta
      *
      * @return null|string
      */
-    protected function _getAdditionalParams($aSeoData)
+    protected function _getAdditionalParams($aSeoData) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $sParams = null;
         if (isset($aSeoData['oxparams'])) {
@@ -117,7 +118,7 @@ class ObjectSeo extends \OxidEsales\Eshop\Application\Controller\Admin\AdminDeta
      *
      * @return string
      */
-    protected function _getSaveObjectId()
+    protected function _getSaveObjectId() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         return $this->getEditObjectId();
     }
@@ -159,7 +160,7 @@ class ObjectSeo extends \OxidEsales\Eshop\Application\Controller\Admin\AdminDeta
     /**
      * Returns url type
      */
-    protected function _getType()
+    protected function _getType() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
     }
 
@@ -170,7 +171,7 @@ class ObjectSeo extends \OxidEsales\Eshop\Application\Controller\Admin\AdminDeta
      *
      * @return string
      */
-    protected function _getStdUrl($sOxid)
+    protected function _getStdUrl($sOxid) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         if ($sType = $this->_getType()) {
             $oObject = oxNew($sType);
@@ -193,7 +194,7 @@ class ObjectSeo extends \OxidEsales\Eshop\Application\Controller\Admin\AdminDeta
     /**
      * Returns alternative seo entry id
      */
-    protected function _getAltSeoEntryId()
+    protected function _getAltSeoEntryId() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
     }
 
@@ -202,7 +203,7 @@ class ObjectSeo extends \OxidEsales\Eshop\Application\Controller\Admin\AdminDeta
      *
      * @return string
      */
-    protected function _getSeoEntryType()
+    protected function _getSeoEntryType() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         return $this->_getType();
     }
@@ -222,7 +223,7 @@ class ObjectSeo extends \OxidEsales\Eshop\Application\Controller\Admin\AdminDeta
     /**
      * Returns current object type seo encoder object
      */
-    protected function _getEncoder()
+    protected function _getEncoder() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
     }
 

--- a/source/Application/Controller/Admin/OrderAddress.php
+++ b/source/Application/Controller/Admin/OrderAddress.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
@@ -53,7 +54,7 @@ class OrderAddress extends \OxidEsales\Eshop\Application\Controller\Admin\AdminD
      *
      * @return null
      */
-    protected function _processAddress($aData, $sTypeToProcess, $aIgnore)
+    protected function _processAddress($aData, $sTypeToProcess, $aIgnore) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         // empty address fields?
         $blEmpty = true;

--- a/source/Application/Controller/Admin/OrderArticle.php
+++ b/source/Application/Controller/Admin/OrderArticle.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Application/Controller/Admin/OrderDownloads.php
+++ b/source/Application/Controller/Admin/OrderDownloads.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Application/Controller/Admin/OrderList.php
+++ b/source/Application/Controller/Admin/OrderList.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
@@ -117,7 +118,7 @@ class OrderList extends \OxidEsales\Eshop\Application\Controller\Admin\AdminList
      *
      * @return string
      */
-    protected function _prepareWhereQuery($whereQuery, $fullQuery)
+    protected function _prepareWhereQuery($whereQuery, $fullQuery) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $database = \OxidEsales\Eshop\Core\DatabaseProvider::getDb();
         $query = parent::_prepareWhereQuery($whereQuery, $fullQuery);
@@ -142,7 +143,7 @@ class OrderList extends \OxidEsales\Eshop\Application\Controller\Admin\AdminList
      *
      * @return string
      */
-    protected function _buildSelectString($listObject = null)
+    protected function _buildSelectString($listObject = null) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $query = parent::_buildSelectString($listObject);
         $database = \OxidEsales\Eshop\Core\DatabaseProvider::getDb();

--- a/source/Application/Controller/Admin/OrderMain.php
+++ b/source/Application/Controller/Admin/OrderMain.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Application/Controller/Admin/OrderOverview.php
+++ b/source/Application/Controller/Admin/OrderOverview.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
@@ -75,7 +76,7 @@ class OrderOverview extends \OxidEsales\Eshop\Application\Controller\Admin\Admin
      *
      * @return oxUserPayment
      */
-    protected function _getPaymentType($oOrder)
+    protected function _getPaymentType($oOrder) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         if (!($oUserPayment = $oOrder->getPaymentType()) && $oOrder->oxorder__oxpaymenttype->value) {
             $oPayment = oxNew(\OxidEsales\Eshop\Application\Model\Payment::class);

--- a/source/Application/Controller/Admin/OrderRemark.php
+++ b/source/Application/Controller/Admin/OrderRemark.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Application/Controller/Admin/PaymentCountry.php
+++ b/source/Application/Controller/Admin/PaymentCountry.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Application/Controller/Admin/PaymentCountryAjax.php
+++ b/source/Application/Controller/Admin/PaymentCountryAjax.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
@@ -40,7 +41,7 @@ class PaymentCountryAjax extends \OxidEsales\Eshop\Application\Controller\Admin\
      *
      * @return string
      */
-    protected function _getQuery()
+    protected function _getQuery() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         // looking for table/view
         $sCountryTable = $this->_getViewName('oxcountry');

--- a/source/Application/Controller/Admin/PaymentList.php
+++ b/source/Application/Controller/Admin/PaymentList.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Application/Controller/Admin/PaymentMain.php
+++ b/source/Application/Controller/Admin/PaymentMain.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Application/Controller/Admin/PaymentMainAjax.php
+++ b/source/Application/Controller/Admin/PaymentMainAjax.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
@@ -38,7 +39,7 @@ class PaymentMainAjax extends \OxidEsales\Eshop\Application\Controller\Admin\Lis
      *
      * @return string
      */
-    protected function _getQuery()
+    protected function _getQuery() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         // looking for table/view
         $sGroupTable = $this->_getViewName('oxgroups');

--- a/source/Application/Controller/Admin/PaymentRdfa.php
+++ b/source/Application/Controller/Admin/PaymentRdfa.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Application/Controller/Admin/PriceAlarmList.php
+++ b/source/Application/Controller/Admin/PriceAlarmList.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
@@ -41,7 +42,7 @@ class PriceAlarmList extends \OxidEsales\Eshop\Application\Controller\Admin\Admi
      *
      * @return string
      */
-    protected function _buildSelectString($oListObject = null)
+    protected function _buildSelectString($oListObject = null) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $sViewName = getViewName("oxarticles", (int) $this->getConfig()->getConfigParam("sDefaultLang"));
         $sSql = "select oxpricealarm.*, {$sViewName}.oxtitle AS articletitle, ";

--- a/source/Application/Controller/Admin/PriceAlarmMail.php
+++ b/source/Application/Controller/Admin/PriceAlarmMail.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Application/Controller/Admin/PriceAlarmMain.php
+++ b/source/Application/Controller/Admin/PriceAlarmMain.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Application/Controller/Admin/PriceAlarmSend.php
+++ b/source/Application/Controller/Admin/PriceAlarmSend.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
@@ -68,7 +69,7 @@ class PriceAlarmSend extends \OxidEsales\Eshop\Application\Controller\Admin\Admi
      *
      * @param string $sId Class name
      */
-    protected function _setupNavigation($sId)
+    protected function _setupNavigation($sId) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         parent::_setupNavigation('pricealarm_list');
     }

--- a/source/Application/Controller/Admin/SelectListController.php
+++ b/source/Application/Controller/Admin/SelectListController.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Application/Controller/Admin/SelectListList.php
+++ b/source/Application/Controller/Admin/SelectListList.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Application/Controller/Admin/SelectListMain.php
+++ b/source/Application/Controller/Admin/SelectListMain.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
@@ -319,7 +320,7 @@ class SelectListMain extends \OxidEsales\Eshop\Application\Controller\Admin\Admi
      *
      * @return bool - true if failed.
      */
-    protected function _rearrangeFields($oField, $iPos)
+    protected function _rearrangeFields($oField, $iPos) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         if (!isset($this->aFieldArray) || !is_array($this->aFieldArray)) {
             return true;

--- a/source/Application/Controller/Admin/SelectListMainAjax.php
+++ b/source/Application/Controller/Admin/SelectListMainAjax.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
@@ -61,7 +62,7 @@ class SelectListMainAjax extends \OxidEsales\Eshop\Application\Controller\Admin\
      *
      * @return string
      */
-    protected function _getQuery()
+    protected function _getQuery() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $myConfig = $this->getConfig();
 
@@ -137,7 +138,7 @@ class SelectListMainAjax extends \OxidEsales\Eshop\Application\Controller\Admin\
                 $oNewGroup->init("oxobject2selectlist");
                 $oNewGroup->oxobject2selectlist__oxobjectid = new \OxidEsales\Eshop\Core\Field($sAdd);
                 $oNewGroup->oxobject2selectlist__oxselnid = new \OxidEsales\Eshop\Core\Field($soxId);
-                $oNewGroup->oxobject2selectlist__oxsort = new \OxidEsales\Eshop\Core\Field(( int ) $database->getOne("select max(oxsort) + 1 from oxobject2selectlist where oxobjectid = :oxobjectid", [':oxobjectid' => $sAdd]));
+                $oNewGroup->oxobject2selectlist__oxsort = new \OxidEsales\Eshop\Core\Field((int) $database->getOne("select max(oxsort) + 1 from oxobject2selectlist where oxobjectid = :oxobjectid", [':oxobjectid' => $sAdd]));
                 $oNewGroup->save();
 
                 $this->onArticleAddToSelectionList($sAdd);

--- a/source/Application/Controller/Admin/SelectListOrderAjax.php
+++ b/source/Application/Controller/Admin/SelectListOrderAjax.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
@@ -33,7 +34,7 @@ class SelectListOrderAjax extends \OxidEsales\Eshop\Application\Controller\Admin
      *
      * @return string
      */
-    protected function _getQuery()
+    protected function _getQuery() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $sSelTable = $this->_getViewName('oxselectlist');
         $sArtId = \OxidEsales\Eshop\Core\Registry::getConfig()->getRequestParameter('oxid');
@@ -47,7 +48,7 @@ class SelectListOrderAjax extends \OxidEsales\Eshop\Application\Controller\Admin
      *
      * @return string
      */
-    protected function _getSorting()
+    protected function _getSorting() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         return 'order by oxobject2selectlist.oxsort ';
     }

--- a/source/Application/Controller/Admin/ShopConfiguration.php
+++ b/source/Application/Controller/Admin/ShopConfiguration.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
@@ -122,7 +123,7 @@ class ShopConfiguration extends \OxidEsales\Eshop\Application\Controller\Admin\A
      *
      * @return string
      */
-    protected function _getModuleForConfigVars()
+    protected function _getModuleForConfigVars() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         return '';
     }
@@ -266,7 +267,7 @@ class ShopConfiguration extends \OxidEsales\Eshop\Application\Controller\Admin\A
      *
      * @return mixed
      */
-    protected function _parseConstraint($type, $constraint)
+    protected function _parseConstraint($type, $constraint) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         switch ($type) {
             case "select":
@@ -284,7 +285,7 @@ class ShopConfiguration extends \OxidEsales\Eshop\Application\Controller\Admin\A
      *
      * @return string
      */
-    protected function _serializeConstraint($type, $constraint)
+    protected function _serializeConstraint($type, $constraint) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         switch ($type) {
             case "select":
@@ -303,7 +304,7 @@ class ShopConfiguration extends \OxidEsales\Eshop\Application\Controller\Admin\A
      *
      * @return mixed
      */
-    public function _unserializeConfVar($type, $name, $value)
+    public function _unserializeConfVar($type, $name, $value) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $str = getStr();
         $data = null;
@@ -353,7 +354,7 @@ class ShopConfiguration extends \OxidEsales\Eshop\Application\Controller\Admin\A
      *
      * @return string
      */
-    public function _serializeConfVar($type, $name, $value)
+    public function _serializeConfVar($type, $name, $value) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $data = $value;
 
@@ -390,7 +391,7 @@ class ShopConfiguration extends \OxidEsales\Eshop\Application\Controller\Admin\A
      *
      * @return string
      */
-    protected function _arrayToMultiline($input)
+    protected function _arrayToMultiline($input) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         return implode("\n", (array) $input);
     }
@@ -402,7 +403,7 @@ class ShopConfiguration extends \OxidEsales\Eshop\Application\Controller\Admin\A
      *
      * @return array
      */
-    protected function _multilineToArray($multiline)
+    protected function _multilineToArray($multiline) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $array = explode("\n", $multiline);
         if (is_array($array)) {
@@ -424,7 +425,7 @@ class ShopConfiguration extends \OxidEsales\Eshop\Application\Controller\Admin\A
      *
      * @return string
      */
-    protected function _aarrayToMultiline($input)
+    protected function _aarrayToMultiline($input) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         if (is_array($input)) {
             $multiline = '';
@@ -446,7 +447,7 @@ class ShopConfiguration extends \OxidEsales\Eshop\Application\Controller\Admin\A
      *
      * @return array
      */
-    protected function _multilineToAarray($multiline)
+    protected function _multilineToAarray($multiline) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $string = getStr();
         $array = [];

--- a/source/Application/Controller/Admin/ShopController.php
+++ b/source/Application/Controller/Admin/ShopController.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Application/Controller/Admin/ShopCountries.php
+++ b/source/Application/Controller/Admin/ShopCountries.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Application/Controller/Admin/ShopDefaultCategoryAjax.php
+++ b/source/Application/Controller/Admin/ShopDefaultCategoryAjax.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
@@ -32,7 +33,7 @@ class ShopDefaultCategoryAjax extends \OxidEsales\Eshop\Application\Controller\A
      *
      * @return string
      */
-    protected function _getQuery()
+    protected function _getQuery() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $oCat = oxNew(\OxidEsales\Eshop\Application\Model\Category::class);
         $oCat->setLanguage(\OxidEsales\Eshop\Core\Registry::getConfig()->getRequestParameter('editlanguage'));

--- a/source/Application/Controller/Admin/ShopLicense.php
+++ b/source/Application/Controller/Admin/ShopLicense.php
@@ -67,7 +67,7 @@ class ShopLicense extends \OxidEsales\Eshop\Application\Controller\Admin\ShopCon
      *
      * @return bool
      */
-    protected function _canUpdate()
+    protected function _canUpdate() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $myConfig = $this->getConfig();
 
@@ -87,7 +87,7 @@ class ShopLicense extends \OxidEsales\Eshop\Application\Controller\Admin\ShopCon
      * @param string $sUrl current version info fetching url by edition
      * @return string
      */
-    protected function _fetchCurVersionInfo($sUrl)
+    protected function _fetchCurVersionInfo($sUrl) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         try {
             $response = $this->requestVersionInfo($sUrl);

--- a/source/Application/Controller/Admin/ShopList.php
+++ b/source/Application/Controller/Admin/ShopList.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Application/Controller/Admin/ShopMain.php
+++ b/source/Application/Controller/Admin/ShopMain.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
@@ -145,7 +146,7 @@ class ShopMain extends \OxidEsales\Eshop\Application\Controller\Admin\AdminDetai
      *
      * @return array
      */
-    protected function _getNonCopyConfigVars()
+    protected function _getNonCopyConfigVars() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $nonCopyVars = [
             'aSerials',
@@ -180,7 +181,7 @@ class ShopMain extends \OxidEsales\Eshop\Application\Controller\Admin\AdminDetai
      *
      * @param \OxidEsales\Eshop\Application\Model\Shop $shop new shop object
      */
-    protected function _copyConfigVars($shop)
+    protected function _copyConfigVars($shop) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $config = $this->getConfig();
         $utilsObject = \OxidEsales\Eshop\Core\Registry::getUtilsObject();

--- a/source/Application/Controller/Admin/ShopPerformance.php
+++ b/source/Application/Controller/Admin/ShopPerformance.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Application/Controller/Admin/ShopRdfa.php
+++ b/source/Application/Controller/Admin/ShopRdfa.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Application/Controller/Admin/ShopSeo.php
+++ b/source/Application/Controller/Admin/ShopSeo.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
@@ -60,7 +61,7 @@ class ShopSeo extends \OxidEsales\Eshop\Application\Controller\Admin\ShopConfigu
      *
      * @param int $iShopId active shop id
      */
-    protected function _loadActiveUrl($iShopId)
+    protected function _loadActiveUrl($iShopId) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $sActObject = null;
         if ($this->_sActSeoObject) {
@@ -118,7 +119,7 @@ class ShopSeo extends \OxidEsales\Eshop\Application\Controller\Admin\ShopConfigu
      *
      * @return array
      */
-    protected function _processUrls($aUrls)
+    protected function _processUrls($aUrls) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         if (isset($aUrls['oxseo__oxstdurl']) && $aUrls['oxseo__oxstdurl']) {
             $aUrls['oxseo__oxstdurl'] = $this->_cleanupUrl($aUrls['oxseo__oxstdurl']);
@@ -140,7 +141,7 @@ class ShopSeo extends \OxidEsales\Eshop\Application\Controller\Admin\ShopConfigu
      *
      * @return string
      */
-    protected function _cleanupUrl($sUrl)
+    protected function _cleanupUrl($sUrl) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         // replacing &amp; to & or removing double &&
         while ((stripos($sUrl, '&amp;') !== false) || (stripos($sUrl, '&&') !== false)) {

--- a/source/Application/Controller/Admin/ShopSystem.php
+++ b/source/Application/Controller/Admin/ShopSystem.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Application/Controller/Admin/SystemInfoController.php
+++ b/source/Application/Controller/Admin/SystemInfoController.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Application/Controller/Admin/SystemRequirements.php
+++ b/source/Application/Controller/Admin/SystemRequirements.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Application/Controller/Admin/SystemRequirementsList.php
+++ b/source/Application/Controller/Admin/SystemRequirementsList.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Application/Controller/Admin/SystemRequirementsMain.php
+++ b/source/Application/Controller/Admin/SystemRequirementsMain.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Application/Controller/Admin/ThemeConfiguration.php
+++ b/source/Application/Controller/Admin/ThemeConfiguration.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
@@ -65,7 +66,7 @@ class ThemeConfiguration extends \OxidEsales\Eshop\Application\Controller\Admin\
      *
      * @return string
      */
-    protected function _getModuleForConfigVars()
+    protected function _getModuleForConfigVars() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         if ($this->_sTheme === null) {
             $this->_sTheme = $this->getEditObjectId();

--- a/source/Application/Controller/Admin/ThemeController.php
+++ b/source/Application/Controller/Admin/ThemeController.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Application/Controller/Admin/ThemeList.php
+++ b/source/Application/Controller/Admin/ThemeList.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Application/Controller/Admin/ThemeMain.php
+++ b/source/Application/Controller/Admin/ThemeMain.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Application/Controller/Admin/ToolsController.php
+++ b/source/Application/Controller/Admin/ToolsController.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Application/Controller/Admin/ToolsList.php
+++ b/source/Application/Controller/Admin/ToolsList.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
@@ -122,7 +123,7 @@ class ToolsList extends \OxidEsales\Eshop\Application\Controller\Admin\AdminList
      *
      * @return mixed
      */
-    protected function _processFiles()
+    protected function _processFiles() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         if (isset($_FILES['myfile']['name'])) {
             // process all files
@@ -166,7 +167,7 @@ class ToolsList extends \OxidEsales\Eshop\Application\Controller\Admin\AdminList
      *
      * @return mixed
      */
-    protected function _prepareSQL($sSQL, $iSQLlen)
+    protected function _prepareSQL($sSQL, $iSQLlen) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $sStrStart = "";
         $blString = false;

--- a/source/Application/Controller/Admin/ToolsMain.php
+++ b/source/Application/Controller/Admin/ToolsMain.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Application/Controller/Admin/UserAddress.php
+++ b/source/Application/Controller/Admin/UserAddress.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Application/Controller/Admin/UserArticle.php
+++ b/source/Application/Controller/Admin/UserArticle.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Application/Controller/Admin/UserExtend.php
+++ b/source/Application/Controller/Admin/UserExtend.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Application/Controller/Admin/UserGroupController.php
+++ b/source/Application/Controller/Admin/UserGroupController.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Application/Controller/Admin/UserGroupList.php
+++ b/source/Application/Controller/Admin/UserGroupList.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Application/Controller/Admin/UserGroupMain.php
+++ b/source/Application/Controller/Admin/UserGroupMain.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Application/Controller/Admin/UserGroupMainAjax.php
+++ b/source/Application/Controller/Admin/UserGroupMainAjax.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
@@ -51,7 +52,7 @@ class UserGroupMainAjax extends \OxidEsales\Eshop\Application\Controller\Admin\L
      *
      * @return string
      */
-    protected function _getQuery()
+    protected function _getQuery() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $myConfig = $this->getConfig();
 

--- a/source/Application/Controller/Admin/UserList.php
+++ b/source/Application/Controller/Admin/UserList.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
@@ -89,7 +90,7 @@ class UserList extends \OxidEsales\Eshop\Application\Controller\Admin\AdminListC
      *
      * @return string
      */
-    public function _prepareWhereQuery($whereQuery, $fullQuery)
+    public function _prepareWhereQuery($whereQuery, $fullQuery) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $nameWhere = null;
         if (isset($whereQuery['oxuser.oxlname']) && ($name = $whereQuery['oxuser.oxlname'])) {

--- a/source/Application/Controller/Admin/UserMain.php
+++ b/source/Application/Controller/Admin/UserMain.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Application/Controller/Admin/UserMainAjax.php
+++ b/source/Application/Controller/Admin/UserMainAjax.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
@@ -37,7 +38,7 @@ class UserMainAjax extends \OxidEsales\Eshop\Application\Controller\Admin\ListCo
      *
      * @return string
      */
-    protected function _getQuery()
+    protected function _getQuery() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         // looking for table/view
         $sGroupTable = $this->_getViewName('oxgroups');

--- a/source/Application/Controller/Admin/UserOverview.php
+++ b/source/Application/Controller/Admin/UserOverview.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Application/Controller/Admin/UserPayment.php
+++ b/source/Application/Controller/Admin/UserPayment.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
@@ -118,7 +119,7 @@ class UserPayment extends \OxidEsales\Eshop\Application\Controller\Admin\AdminDe
             if ($aParams['oxuserpayments__oxid'] != "-1") {
                 $oAdress = oxNew(\OxidEsales\Eshop\Application\Model\UserPayment::class);
                 if ($oAdress->load($aParams['oxuserpayments__oxid'])) {
-                    $this->_blDelete = ( bool ) $oAdress->delete();
+                    $this->_blDelete = (bool) $oAdress->delete();
                 }
             }
         }

--- a/source/Application/Controller/Admin/UserRemark.php
+++ b/source/Application/Controller/Admin/UserRemark.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Application/Controller/Admin/VendorController.php
+++ b/source/Application/Controller/Admin/VendorController.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Application/Controller/Admin/VendorList.php
+++ b/source/Application/Controller/Admin/VendorList.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Application/Controller/Admin/VendorMain.php
+++ b/source/Application/Controller/Admin/VendorMain.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Application/Controller/Admin/VendorMainAjax.php
+++ b/source/Application/Controller/Admin/VendorMainAjax.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
@@ -51,7 +52,7 @@ class VendorMainAjax extends \OxidEsales\Eshop\Application\Controller\Admin\List
      *
      * @return string
      */
-    protected function _getQuery()
+    protected function _getQuery() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         // looking for table/view
         $sArtTable = $this->_getViewName('oxarticles');
@@ -88,7 +89,7 @@ class VendorMainAjax extends \OxidEsales\Eshop\Application\Controller\Admin\List
      *
      * @return string
      */
-    protected function _addFilter($sQ)
+    protected function _addFilter($sQ) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $sArtTable = $this->_getViewName('oxarticles');
         $sQ = parent::_addFilter($sQ);

--- a/source/Application/Controller/Admin/VendorSeo.php
+++ b/source/Application/Controller/Admin/VendorSeo.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
@@ -38,7 +39,7 @@ class VendorSeo extends \OxidEsales\Eshop\Application\Controller\Admin\ObjectSeo
      *
      * @return oxSeoEncoderVendor
      */
-    protected function _getEncoder()
+    protected function _getEncoder() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         return \OxidEsales\Eshop\Core\Registry::get(\OxidEsales\Eshop\Application\Model\SeoEncoderVendor::class);
     }
@@ -71,7 +72,7 @@ class VendorSeo extends \OxidEsales\Eshop\Application\Controller\Admin\ObjectSeo
      *
      * @return string
      */
-    protected function _getType()
+    protected function _getType() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         return 'oxvendor';
     }

--- a/source/Application/Controller/Admin/VoucherSerieController.php
+++ b/source/Application/Controller/Admin/VoucherSerieController.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Application/Controller/Admin/VoucherSerieExport.php
+++ b/source/Application/Controller/Admin/VoucherSerieExport.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
@@ -81,7 +82,7 @@ class VoucherSerieExport extends \OxidEsales\Eshop\Application\Controller\Admin\
      *
      * @return string
      */
-    protected function _getExportFileName()
+    protected function _getExportFileName() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $sSessionFileName = \OxidEsales\Eshop\Core\Registry::getSession()->getVariable("sExportFileName");
         if (!$sSessionFileName) {
@@ -97,7 +98,7 @@ class VoucherSerieExport extends \OxidEsales\Eshop\Application\Controller\Admin\
      *
      * @return string
      */
-    protected function _getExportFilePath()
+    protected function _getExportFilePath() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         return $this->getConfig()->getConfigParam('sShopDir') . "/export/" . $this->_getExportFileName();
     }

--- a/source/Application/Controller/Admin/VoucherSerieGenerate.php
+++ b/source/Application/Controller/Admin/VoucherSerieGenerate.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
@@ -83,7 +84,7 @@ class VoucherSerieGenerate extends \OxidEsales\Eshop\Application\Controller\Admi
                 $this->_iGenerated = $iCnt;
             }
 
-            $blRandomNr = ( bool ) \OxidEsales\Eshop\Core\Registry::getSession()->getVariable("randomVoucherNr");
+            $blRandomNr = (bool) \OxidEsales\Eshop\Core\Registry::getSession()->getVariable("randomVoucherNr");
             $sVoucherNr = $blRandomNr ? \OxidEsales\Eshop\Core\Registry::getUtilsObject()->generateUID() : \OxidEsales\Eshop\Core\Registry::getSession()->getVariable("voucherNr");
 
             $oNewVoucher = oxNew(\OxidEsales\Eshop\Application\Model\Voucher::class);

--- a/source/Application/Controller/Admin/VoucherSerieGroups.php
+++ b/source/Application/Controller/Admin/VoucherSerieGroups.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Application/Controller/Admin/VoucherSerieGroupsAjax.php
+++ b/source/Application/Controller/Admin/VoucherSerieGroupsAjax.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
@@ -37,7 +38,7 @@ class VoucherSerieGroupsAjax extends \OxidEsales\Eshop\Application\Controller\Ad
      *
      * @return string
      */
-    protected function _getQuery()
+    protected function _getQuery() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         // looking for table/view
         $sGroupTable = $this->_getViewName('oxgroups');

--- a/source/Application/Controller/Admin/VoucherSerieList.php
+++ b/source/Application/Controller/Admin/VoucherSerieList.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Application/Controller/Admin/VoucherSerieMain.php
+++ b/source/Application/Controller/Admin/VoucherSerieMain.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
@@ -132,7 +133,7 @@ class VoucherSerieMain extends \OxidEsales\Eshop\Application\Controller\Admin\Dy
      *
      * @return oxvoucherserie
      */
-    protected function _getVoucherSerie()
+    protected function _getVoucherSerie() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         if ($this->_oVoucherSerie == null) {
             $oVoucherSerie = oxNew(\OxidEsales\Eshop\Application\Model\VoucherSerie::class);

--- a/source/Application/Controller/Admin/WrappingList.php
+++ b/source/Application/Controller/Admin/WrappingList.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Application/Controller/Admin/WrappingMain.php
+++ b/source/Application/Controller/Admin/WrappingMain.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Application/Controller/ArticleDetailsController.php
+++ b/source/Application/Controller/ArticleDetailsController.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
@@ -172,7 +173,7 @@ class ArticleDetailsController extends \OxidEsales\Eshop\Application\Controller\
      *
      * @return \OxidEsales\Eshop\Application\Model\Article
      */
-    protected function _getParentProduct($parentId)
+    protected function _getParentProduct($parentId) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         if ($parentId && $this->_oParentProd === null) {
             $this->_oParentProd = false;
@@ -191,7 +192,7 @@ class ArticleDetailsController extends \OxidEsales\Eshop\Application\Controller\
      *
      * @return string | null
      */
-    protected function _getAddUrlParams()
+    protected function _getAddUrlParams() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         if ($this->getListType() == "search") {
             return $this->getDynUrlParams();
@@ -237,7 +238,7 @@ class ArticleDetailsController extends \OxidEsales\Eshop\Application\Controller\
      *
      * @param \OxidEsales\Eshop\Application\Model\Article $article Product to process
      */
-    protected function _processProduct($article)
+    protected function _processProduct($article) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $article->setLinkType($this->getLinkType());
         if ($dynamicParameters = $this->_getAddUrlParams()) {
@@ -322,7 +323,7 @@ class ArticleDetailsController extends \OxidEsales\Eshop\Application\Controller\
      *
      * @return string
      */
-    protected function _prepareMetaDescription($meta, $length = 200, $descriptionTag = false)
+    protected function _prepareMetaDescription($meta, $length = 200, $descriptionTag = false) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         if (!$meta) {
             $article = $this->getProduct();
@@ -351,7 +352,7 @@ class ArticleDetailsController extends \OxidEsales\Eshop\Application\Controller\
      *
      * @return string
      */
-    protected function _prepareMetaKeyword($keywords, $removeDuplicatedWords = true)
+    protected function _prepareMetaKeyword($keywords, $removeDuplicatedWords = true) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         if (!$keywords) {
             $article = $this->getProduct();
@@ -385,7 +386,8 @@ class ArticleDetailsController extends \OxidEsales\Eshop\Application\Controller\
             return;
         }
 
-        if ($this->canAcceptFormData() &&
+        if (
+            $this->canAcceptFormData() &&
             ($user = $this->getUser()) && ($article = $this->getProduct())
         ) {
             $articleRating = $this->getConfig()->getRequestParameter('artrating');
@@ -406,7 +408,7 @@ class ArticleDetailsController extends \OxidEsales\Eshop\Application\Controller\
                 }
             }
 
-            if (($reviewText = trim(( string ) $this->getConfig()->getRequestParameter('rvw_txt', true)))) {
+            if (($reviewText = trim((string) $this->getConfig()->getRequestParameter('rvw_txt', true)))) {
                 $review = oxNew(\OxidEsales\Eshop\Application\Model\Review::class);
                 $review->oxreviews__oxobjectid = new Field($article->getId());
                 $review->oxreviews__oxtype = new Field('oxarticle');
@@ -436,7 +438,7 @@ class ArticleDetailsController extends \OxidEsales\Eshop\Application\Controller\
             return;
         }
 
-        $recommendationText = trim(( string ) $this->getConfig()->getRequestParameter('recomm_txt'));
+        $recommendationText = trim((string) $this->getConfig()->getRequestParameter('recomm_txt'));
         $recommendationListId = $this->getConfig()->getRequestParameter('recomm');
         $articleId = $this->getProduct()->getId();
 
@@ -452,7 +454,7 @@ class ArticleDetailsController extends \OxidEsales\Eshop\Application\Controller\
      *
      * @return string
      */
-    protected function _getSeoObjectId()
+    protected function _getSeoObjectId() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         if ($article = $this->getProduct()) {
             return $article->getId();
@@ -502,7 +504,7 @@ class ArticleDetailsController extends \OxidEsales\Eshop\Application\Controller\
     /**
      * Runs additional checks for article.
      */
-    protected function _additionalChecksForArticle()
+    protected function _additionalChecksForArticle() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $config = $this->getConfig();
         $utils = Registry::getUtils();
@@ -764,7 +766,7 @@ class ArticleDetailsController extends \OxidEsales\Eshop\Application\Controller\
      *
      * @return \OxidEsales\Eshop\Application\Model\Article
      */
-    protected function _getSubject($languageId)
+    protected function _getSubject($languageId) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         return $this->getProduct();
     }
@@ -1251,7 +1253,7 @@ class ArticleDetailsController extends \OxidEsales\Eshop\Application\Controller\
      *
      * @return array
      */
-    protected function _getVendorBreadCrumb()
+    protected function _getVendorBreadCrumb() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $paths = [];
         $vendorPath = [];
@@ -1280,7 +1282,7 @@ class ArticleDetailsController extends \OxidEsales\Eshop\Application\Controller\
      *
      * @return array
      */
-    protected function _getRecommendationListBredCrumb()
+    protected function _getRecommendationListBredCrumb() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $paths = [];
         $recommListPath = [];
@@ -1296,7 +1298,7 @@ class ArticleDetailsController extends \OxidEsales\Eshop\Application\Controller\
      *
      * @return array
      */
-    protected function _getSearchBreadCrumb()
+    protected function _getSearchBreadCrumb() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $paths = [];
         $searchPath = [];
@@ -1307,7 +1309,7 @@ class ArticleDetailsController extends \OxidEsales\Eshop\Application\Controller\
         $sessionToken = Registry::getSession()->getVariable('sess_stoken');
 
         $searchPath['title'] = sprintf($translatedString, $this->getSearchParamForHtml());
-        $searchPath['link'] = $selfLink . 'stoken=' . $sessionToken . "&amp;cl=search&amp;".
+        $searchPath['link'] = $selfLink . 'stoken=' . $sessionToken . "&amp;cl=search&amp;" .
                             "searchparam=" . $this->getSearchParamForHtml();
 
         $paths[] = $searchPath;
@@ -1320,7 +1322,7 @@ class ArticleDetailsController extends \OxidEsales\Eshop\Application\Controller\
      *
      * @return array
      */
-    protected function _getCategoryBreadCrumb()
+    protected function _getCategoryBreadCrumb() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $paths = [];
 

--- a/source/Application/Controller/ArticleListController.php
+++ b/source/Application/Controller/ArticleListController.php
@@ -1,8 +1,10 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
 namespace OxidEsales\EshopCommunity\Application\Controller;
 
 use oxArticleList;
@@ -236,7 +238,7 @@ class ArticleListController extends \OxidEsales\Eshop\Application\Controller\Fro
      * or
      * - displays 404 error if category has no products
      */
-    protected function _checkRequestedPage()
+    protected function _checkRequestedPage() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $pageCount = $this->getPageCount();
         $currentPageNumber = $this->getActPage();
@@ -255,7 +257,7 @@ class ArticleListController extends \OxidEsales\Eshop\Application\Controller\Fro
      * Iterates through list articles and performs list view specific tasks:
      *  - sets type of link which needs to be generated (Manufacturer link)
      */
-    protected function _processListArticles()
+    protected function _processListArticles() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         if ($articleList = $this->getArticleList()) {
             $linkType = $this->_getProductLinkType();
@@ -312,7 +314,7 @@ class ArticleListController extends \OxidEsales\Eshop\Application\Controller\Fro
      *
      * @return int
      */
-    protected function _getProductLinkType()
+    protected function _getProductLinkType() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $categoryType = OXARTICLE_LINKTYPE_CATEGORY;
         if (($category = $this->getActiveCategory()) && $category->isPriceCategory()) {
@@ -364,7 +366,7 @@ class ArticleListController extends \OxidEsales\Eshop\Application\Controller\Fro
      *
      * @return oxArticleList
      */
-    protected function _loadArticles($category)
+    protected function _loadArticles($category) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $config = $this->getConfig();
 
@@ -416,7 +418,7 @@ class ArticleListController extends \OxidEsales\Eshop\Application\Controller\Fro
      *
      * @return int
      */
-    protected function _getRequestPageNr()
+    protected function _getRequestPageNr() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         return parent::getActPage();
     }
@@ -426,7 +428,7 @@ class ArticleListController extends \OxidEsales\Eshop\Application\Controller\Fro
      *
      * @return null|string
      */
-    protected function _getListDisplayType()
+    protected function _getListDisplayType() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $listDisplayType = Registry::getSession()->getVariable('ldtype');
 
@@ -442,7 +444,7 @@ class ArticleListController extends \OxidEsales\Eshop\Application\Controller\Fro
      *
      * @return string
      */
-    protected function _getSeoObjectId()
+    protected function _getSeoObjectId() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         if (($category = $this->getActiveCategory())) {
             return $category->getId();
@@ -454,7 +456,7 @@ class ArticleListController extends \OxidEsales\Eshop\Application\Controller\Fro
      *
      * @return string
      */
-    protected function _getCatPathString()
+    protected function _getCatPathString() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         if ($this->_sCatPathString === null) {
             // marking as already set
@@ -485,7 +487,7 @@ class ArticleListController extends \OxidEsales\Eshop\Application\Controller\Fro
      *
      * @return  string
      */
-    protected function _prepareMetaDescription($meta, $length = 1024, $descriptionTag = false)
+    protected function _prepareMetaDescription($meta, $length = 1024, $descriptionTag = false) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $description = '';
         // appending parent title
@@ -544,7 +546,7 @@ class ArticleListController extends \OxidEsales\Eshop\Application\Controller\Fro
      *
      * @return  string
      */
-    protected function _collectMetaDescription($meta, $length = 1024, $descriptionTag = false)
+    protected function _collectMetaDescription($meta, $length = 1024, $descriptionTag = false) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         //formatting description tag
         $category = $this->getActiveCategory();
@@ -582,7 +584,7 @@ class ArticleListController extends \OxidEsales\Eshop\Application\Controller\Fro
      *
      * @return string
      */
-    protected function _prepareMetaKeyword($keywords, $removeDuplicatedWords = true)
+    protected function _prepareMetaKeyword($keywords, $removeDuplicatedWords = true) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $keywords = '';
         if (($activeCategory = $this->getActiveCategory())) {
@@ -619,7 +621,7 @@ class ArticleListController extends \OxidEsales\Eshop\Application\Controller\Fro
      *
      * @return string
      */
-    protected function _collectMetaKeyword($keywords)
+    protected function _collectMetaKeyword($keywords) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $maxTextLength = 60;
         $text = '';
@@ -689,7 +691,7 @@ class ArticleListController extends \OxidEsales\Eshop\Application\Controller\Fro
      *
      * @return string
      */
-    protected function _addPageNrParam($url, $currentPage, $languageId = null)
+    protected function _addPageNrParam($url, $currentPage, $languageId = null) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         if (Registry::getUtils()->seoIsActive() && ($category = $this->getActiveCategory())) {
             if ($currentPage) {
@@ -708,7 +710,7 @@ class ArticleListController extends \OxidEsales\Eshop\Application\Controller\Fro
      *
      * @return bool
      */
-    protected function _isActCategory()
+    protected function _isActCategory() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         return $this->_blIsCat;
     }
@@ -782,7 +784,7 @@ class ArticleListController extends \OxidEsales\Eshop\Application\Controller\Fro
      *
      * @return object
      */
-    protected function _getSubject($languageId)
+    protected function _getSubject($languageId) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         return $this->getActiveCategory();
     }

--- a/source/Application/Controller/BasketController.php
+++ b/source/Application/Controller/BasketController.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
@@ -401,7 +402,7 @@ class BasketController extends \OxidEsales\Eshop\Application\Controller\Frontend
      * @param \OxidEsales\Eshop\Application\Model\Basket $oBasket
      * @param array                                      $aWrapping
      */
-    protected function _setWrappingInfo($oBasket, $aWrapping)
+    protected function _setWrappingInfo($oBasket, $aWrapping) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         if (is_array($aWrapping) && count($aWrapping)) {
             foreach ($oBasket->getContents() as $sKey => $oBasketItem) {

--- a/source/Application/Controller/ClearCookiesController.php
+++ b/source/Application/Controller/ClearCookiesController.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
@@ -7,7 +8,7 @@
 namespace OxidEsales\EshopCommunity\Application\Controller;
 
 use OxidEsales\Eshop\Core\Registry;
-use \OxidEsales\EshopCommunity\Internal\Transition\ShopEvents\AllCookiesRemovedEvent;
+use OxidEsales\EshopCommunity\Internal\Transition\ShopEvents\AllCookiesRemovedEvent;
 
 /**
  * CMS - loads pages and displays it
@@ -40,7 +41,7 @@ class ClearCookiesController extends \OxidEsales\Eshop\Application\Controller\Fr
     /**
      * Clears all cookies
      */
-    protected function _removeCookies()
+    protected function _removeCookies() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $oUtilsServer = Registry::getUtilsServer();
         if (isset($_SERVER['HTTP_COOKIE'])) {

--- a/source/Application/Controller/CompareController.php
+++ b/source/Application/Controller/CompareController.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
@@ -243,7 +244,7 @@ class CompareController extends \OxidEsales\Eshop\Application\Controller\Fronten
      *
      * @param int $iNumber article count in compare page
      */
-    protected function _setArticlesPerPage($iNumber)
+    protected function _setArticlesPerPage($iNumber) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $this->_iArticlesPerPage = $iNumber;
     }
@@ -351,7 +352,7 @@ class CompareController extends \OxidEsales\Eshop\Application\Controller\Fronten
      *
      * @return array $aNewItems
      */
-    protected function _removeArticlesFromPage($aItems, $oList)
+    protected function _removeArticlesFromPage($aItems, $oList) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         //#1106S $aItems changed to $oList.
         //2006-08-10 Alfonsas, compare arrows fixed, array position is very important here, preserve it.
@@ -379,7 +380,7 @@ class CompareController extends \OxidEsales\Eshop\Application\Controller\Fronten
      *
      * @return array $oNewList
      */
-    protected function _changeArtListOrder($aItems, $oList)
+    protected function _changeArtListOrder($aItems, $oList) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         // #777C changing order of list elements, according to $aItems
         $oNewList = [];

--- a/source/Application/Controller/ContactController.php
+++ b/source/Application/Controller/ContactController.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Application/Controller/ContentController.php
+++ b/source/Application/Controller/ContentController.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
@@ -165,7 +166,7 @@ class ContentController extends \OxidEsales\Eshop\Application\Controller\Fronten
      *
      * @return bool
      */
-    protected function _canShowContent($sContentIdent)
+    protected function _canShowContent($sContentIdent) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         return !(
             $this->isEnabledPrivateSales() &&
@@ -183,7 +184,7 @@ class ContentController extends \OxidEsales\Eshop\Application\Controller\Fronten
      *
      * @return string
      */
-    protected function _prepareMetaDescription($sMeta, $iLength = 200, $blDescTag = false)
+    protected function _prepareMetaDescription($sMeta, $iLength = 200, $blDescTag = false) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         if (!$sMeta) {
             $sMeta = $this->getContent()->oxcontents__oxtitle->value;
@@ -201,7 +202,7 @@ class ContentController extends \OxidEsales\Eshop\Application\Controller\Fronten
      *
      * @return string
      */
-    protected function _prepareMetaKeyword($sKeywords, $blRemoveDuplicatedWords = true)
+    protected function _prepareMetaKeyword($sKeywords, $blRemoveDuplicatedWords = true) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         if (!$sKeywords) {
             $sKeywords = $this->getContent()->oxcontents__oxtitle->value;
@@ -239,7 +240,8 @@ class ContentController extends \OxidEsales\Eshop\Application\Controller\Fronten
         $blPlain = (bool) Registry::getConfig()->getRequestParameter('plain');
         if ($blPlain === false) {
             $oUser = $this->getUser();
-            if ($this->isEnabledPrivateSales() &&
+            if (
+                $this->isEnabledPrivateSales() &&
                 (!$oUser || ($oUser && !$oUser->isTermsAccepted()))
             ) {
                 $blPlain = true;
@@ -254,7 +256,7 @@ class ContentController extends \OxidEsales\Eshop\Application\Controller\Fronten
      *
      * @return string
      */
-    protected function _getSeoObjectId()
+    protected function _getSeoObjectId() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         return Registry::getConfig()->getRequestParameter('oxcid');
     }
@@ -317,7 +319,7 @@ class ContentController extends \OxidEsales\Eshop\Application\Controller\Fronten
      *
      * @return object
      */
-    protected function _getSubject($iLang)
+    protected function _getSubject($iLang) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         return $this->getContent();
     }
@@ -327,7 +329,7 @@ class ContentController extends \OxidEsales\Eshop\Application\Controller\Fronten
      *
      * @return string
      */
-    protected function _getTplName()
+    protected function _getTplName() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         // assign template name
         $sTplName = Registry::getConfig()->getRequestParameter('tpl');

--- a/source/Application/Controller/CreditsController.php
+++ b/source/Application/Controller/CreditsController.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
@@ -23,7 +24,7 @@ class CreditsController extends \OxidEsales\Eshop\Application\Controller\Content
      *
      * @return string
      */
-    protected function _getSeoObjectId()
+    protected function _getSeoObjectId() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         return $this->getContentId();
     }

--- a/source/Application/Controller/DownloadController.php
+++ b/source/Application/Controller/DownloadController.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Application/Controller/ExceptionErrorController.php
+++ b/source/Application/Controller/ExceptionErrorController.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
@@ -46,7 +47,7 @@ class ExceptionErrorController extends \OxidEsales\Eshop\Application\Controller\
      *
      * @return array
      */
-    protected function _getErrors()
+    protected function _getErrors() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $aErrors = \OxidEsales\Eshop\Core\Registry::getSession()->getVariable('Errors');
 

--- a/source/Application/Controller/ForgotPasswordController.php
+++ b/source/Application/Controller/ForgotPasswordController.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Application/Controller/FrontendController.php
+++ b/source/Application/Controller/FrontendController.php
@@ -1,8 +1,10 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
 namespace OxidEsales\EshopCommunity\Application\Controller;
 
 use oxActionList;
@@ -458,7 +460,7 @@ class FrontendController extends \OxidEsales\Eshop\Core\Controller\BaseControlle
      *
      * @return array
      */
-    protected function _getComponentNames()
+    protected function _getComponentNames() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         if (self::$_aCollectedComponentNames === null) {
             self::$_aCollectedComponentNames = array_merge($this->_aComponentNames, $this->_aUserComponentNames);
@@ -484,7 +486,7 @@ class FrontendController extends \OxidEsales\Eshop\Core\Controller\BaseControlle
      * redirects to it. If no alternative path was found - 404 header is emitted
      * and page is rendered
      */
-    protected function _processRequest()
+    protected function _processRequest() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $utils = Registry::getUtils();
 
@@ -735,7 +737,7 @@ class FrontendController extends \OxidEsales\Eshop\Core\Controller\BaseControlle
                 $this->_sListDisplayType = $this->getConfig()->getConfigParam('sDefaultListDisplayType');
             }
 
-            $this->_sListDisplayType = in_array(( string ) $this->_sListDisplayType, $this->_aListDisplayTypes) ?
+            $this->_sListDisplayType = in_array((string) $this->_sListDisplayType, $this->_aListDisplayTypes) ?
                 $this->_sListDisplayType : 'infogrid';
 
             // writing to session
@@ -1024,13 +1026,14 @@ class FrontendController extends \OxidEsales\Eshop\Core\Controller\BaseControlle
      *
      * @return string
      */
-    protected function _getMetaFromSeo($dataType)
+    protected function _getMetaFromSeo($dataType) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $seoObjectId = $this->_getSeoObjectId();
         $baseLanguageId = Registry::getLang()->getBaseLanguage();
         $shopId = $this->getConfig()->getShopId();
 
-        if ($seoObjectId && Registry::getUtils()->seoIsActive() &&
+        if (
+            $seoObjectId && Registry::getUtils()->seoIsActive() &&
             ($keywords = Registry::getSeoEncoder()->getMetaData($seoObjectId, $dataType, $shopId, $baseLanguageId))
         ) {
             return $keywords;
@@ -1044,11 +1047,12 @@ class FrontendController extends \OxidEsales\Eshop\Core\Controller\BaseControlle
      *
      * @return string
      */
-    protected function _getMetaFromContent($metaIdent)
+    protected function _getMetaFromContent($metaIdent) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         if ($metaIdent) {
             $content = oxNew(\OxidEsales\Eshop\Application\Model\Content::class);
-            if ($content->loadByIdent($metaIdent) &&
+            if (
+                $content->loadByIdent($metaIdent) &&
                 $content->oxcontents__oxactive->value
             ) {
                 return getStr()->strip_tags($content->oxcontents__oxcontent->value);
@@ -1140,7 +1144,7 @@ class FrontendController extends \OxidEsales\Eshop\Core\Controller\BaseControlle
     /**
      * Forces output no index meta data for current view
      */
-    protected function _forceNoIndex()
+    protected function _forceNoIndex() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $this->_blForceNoIndex = true;
     }
@@ -1194,7 +1198,7 @@ class FrontendController extends \OxidEsales\Eshop\Core\Controller\BaseControlle
     /**
      * Sets number of articles per page to config value
      */
-    protected function _setNrOfArtPerPage()
+    protected function _setNrOfArtPerPage() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $config = $this->getConfig();
 
@@ -1249,7 +1253,7 @@ class FrontendController extends \OxidEsales\Eshop\Core\Controller\BaseControlle
     /**
      * Override this function to return object it which is used to identify its seo meta info
      */
-    protected function _getSeoObjectId()
+    protected function _getSeoObjectId() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
     }
 
@@ -1262,7 +1266,7 @@ class FrontendController extends \OxidEsales\Eshop\Core\Controller\BaseControlle
      *
      * @return  string  $string    converted string
      */
-    protected function _prepareMetaDescription($meta, $length = 1024, $removeDuplicatedWords = false)
+    protected function _prepareMetaDescription($meta, $length = 1024, $removeDuplicatedWords = false) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         if ($meta) {
             $stringModifier = getStr();
@@ -1308,7 +1312,7 @@ class FrontendController extends \OxidEsales\Eshop\Core\Controller\BaseControlle
      *
      * @return string of keywords separated by comma
      */
-    protected function _prepareMetaKeyword($keywords, $removeDuplicatedWords = true)
+    protected function _prepareMetaKeyword($keywords, $removeDuplicatedWords = true) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $string = $this->_prepareMetaDescription($keywords, -1, false);
 
@@ -1327,7 +1331,7 @@ class FrontendController extends \OxidEsales\Eshop\Core\Controller\BaseControlle
      *
      * @return string of words separated by comma
      */
-    protected function _removeDuplicatedWords($input, $skipTags = [])
+    protected function _removeDuplicatedWords($input, $skipTags = []) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $stringModifier = getStr();
         if (is_array($input)) {
@@ -1506,7 +1510,7 @@ class FrontendController extends \OxidEsales\Eshop\Core\Controller\BaseControlle
      *
      * @return object
      */
-    protected function _getSubject($languageId)
+    protected function _getSubject($languageId) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         return null;
     }
@@ -1628,7 +1632,7 @@ class FrontendController extends \OxidEsales\Eshop\Core\Controller\BaseControlle
      *
      * @return string
      */
-    protected function _getRequestParams($addPageNumber = true)
+    protected function _getRequestParams($addPageNumber = true) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $class = $this->getClassName();
         $function = $this->getFncName();
@@ -1717,7 +1721,7 @@ class FrontendController extends \OxidEsales\Eshop\Core\Controller\BaseControlle
      *
      * @return string
      */
-    protected function _getSeoRequestParams()
+    protected function _getSeoRequestParams() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $class = $this->getClassName();
         $function = $this->getFncName();
@@ -1986,7 +1990,7 @@ class FrontendController extends \OxidEsales\Eshop\Core\Controller\BaseControlle
      *
      * @return string
      */
-    protected function _addPageNrParam($url, $page, $languageId = null)
+    protected function _addPageNrParam($url, $page, $languageId = null) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         if ($page) {
             if ((strpos($url, 'pgNr='))) {
@@ -2166,7 +2170,7 @@ class FrontendController extends \OxidEsales\Eshop\Core\Controller\BaseControlle
     public function getActPage()
     {
         if ($this->_iActPage === null) {
-            $this->_iActPage = ( int ) $this->getConfig()->getRequestParameter('pgNr');
+            $this->_iActPage = (int) $this->getConfig()->getRequestParameter('pgNr');
             $this->_iActPage = ($this->_iActPage < 0) ? 0 : $this->_iActPage;
         }
 
@@ -2406,7 +2410,7 @@ class FrontendController extends \OxidEsales\Eshop\Core\Controller\BaseControlle
      *
      * @return bool
      */
-    protected function _canRedirect()
+    protected function _canRedirect() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         foreach ($this->_aBlockRedirectParams as $param) {
             if ($this->getConfig()->getRequestParameter($param) !== null) {
@@ -2957,7 +2961,8 @@ class FrontendController extends \OxidEsales\Eshop\Core\Controller\BaseControlle
         $activeCountry = $user->getActiveCountry();
         if ($activeCountry !== '') {
             $country = oxNew(\OxidEsales\Eshop\Application\Model\Country::class);
-            if ($country->load($activeCountry) &&
+            if (
+                $country->load($activeCountry) &&
                 $country->oxcountry__oxvatstatus->value !== null &&
                 $country->oxcountry__oxvatstatus->value == 0
             ) {
@@ -3028,7 +3033,7 @@ class FrontendController extends \OxidEsales\Eshop\Core\Controller\BaseControlle
      */
     private function isAllowedSortingOrder($sortOrder)
     {
-        $allowedSortOrders = array_merge((new SortingValidator)->getSortingOrders(), ['']);
+        $allowedSortOrders = array_merge((new SortingValidator())->getSortingOrders(), ['']);
         return in_array(strtolower($sortOrder), $allowedSortOrders);
     }
 }

--- a/source/Application/Controller/InviteController.php
+++ b/source/Application/Controller/InviteController.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Application/Controller/LinksController.php
+++ b/source/Application/Controller/LinksController.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Application/Controller/ManufacturerListController.php
+++ b/source/Application/Controller/ManufacturerListController.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
@@ -122,7 +123,7 @@ class ManufacturerListController extends \OxidEsales\Eshop\Application\Controlle
      *
      * @return int
      */
-    protected function _getProductLinkType()
+    protected function _getProductLinkType() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         return OXARTICLE_LINKTYPE_MANUFACTURER;
     }
@@ -134,7 +135,7 @@ class ManufacturerListController extends \OxidEsales\Eshop\Application\Controlle
      *
      * @return array
      */
-    protected function _loadArticles($oManufacturer)
+    protected function _loadArticles($oManufacturer) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $sManufacturerId = $oManufacturer->getId();
 
@@ -160,7 +161,7 @@ class ManufacturerListController extends \OxidEsales\Eshop\Application\Controlle
      *
      * @return string
      */
-    protected function _getSeoObjectId()
+    protected function _getSeoObjectId() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         if (($oManufacturer = $this->getActManufacturer())) {
             return $oManufacturer->getId();
@@ -177,7 +178,7 @@ class ManufacturerListController extends \OxidEsales\Eshop\Application\Controlle
      *
      * @return string
      */
-    protected function _addPageNrParam($sUrl, $iPage, $iLang = null)
+    protected function _addPageNrParam($sUrl, $iPage, $iLang = null) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         if (Registry::getUtils()->seoIsActive() && ($oManufacturer = $this->getActManufacturer())) {
             if ($iPage) {
@@ -349,7 +350,7 @@ class ManufacturerListController extends \OxidEsales\Eshop\Application\Controlle
      *
      * @return string
      */
-    protected function _prepareMetaKeyword($aCatPath, $blRemoveDuplicatedWords = true)
+    protected function _prepareMetaKeyword($aCatPath, $blRemoveDuplicatedWords = true) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         return parent::_collectMetaKeyword($aCatPath);
     }
@@ -366,7 +367,7 @@ class ManufacturerListController extends \OxidEsales\Eshop\Application\Controlle
      *
      * @return  string  $sString    converted string
      */
-    protected function _prepareMetaDescription($aCatPath, $iLength = 1024, $blDescTag = false)
+    protected function _prepareMetaDescription($aCatPath, $iLength = 1024, $blDescTag = false) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         return parent::_collectMetaDescription($aCatPath, $iLength, $blDescTag);
     }
@@ -379,7 +380,7 @@ class ManufacturerListController extends \OxidEsales\Eshop\Application\Controlle
      *
      * @return object
      */
-    protected function _getSubject($iLang)
+    protected function _getSubject($iLang) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         return $this->getActManufacturer();
     }

--- a/source/Application/Controller/MoreDetailsController.php
+++ b/source/Application/Controller/MoreDetailsController.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Application/Controller/NewsController.php
+++ b/source/Application/Controller/NewsController.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Application/Controller/NewsletterController.php
+++ b/source/Application/Controller/NewsletterController.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Application/Controller/OrderController.php
+++ b/source/Application/Controller/OrderController.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
@@ -250,7 +251,8 @@ class OrderController extends \OxidEsales\Eshop\Application\Controller\FrontendC
             $sPaymentid = $oBasket->getPaymentId();
             $oPayment = oxNew(\OxidEsales\Eshop\Application\Model\Payment::class);
 
-            if ($sPaymentid && $oPayment->load($sPaymentid) &&
+            if (
+                $sPaymentid && $oPayment->load($sPaymentid) &&
                 $oPayment->isValidPayment(
                     Registry::getSession()->getVariable('dynvalue'),
                     $this->getConfig()->getShopId(),
@@ -495,7 +497,7 @@ class OrderController extends \OxidEsales\Eshop\Application\Controller\FrontendC
      *
      * @return  string  $sNextStep  partial parameter url for next step
      */
-    protected function _getNextStep($iSuccess)
+    protected function _getNextStep($iSuccess) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $sNextStep = 'thankyou';
 
@@ -539,7 +541,7 @@ class OrderController extends \OxidEsales\Eshop\Application\Controller\FrontendC
      *
      * @return bool
      */
-    protected function _validateTermsAndConditions()
+    protected function _validateTermsAndConditions() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $blValid = true;
         $oConfig = $this->getConfig();

--- a/source/Application/Controller/OxidStartController.php
+++ b/source/Application/Controller/OxidStartController.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
@@ -105,7 +106,7 @@ class OxidStartController extends \OxidEsales\Eshop\Application\Controller\Front
      *
      * @return SystemEventHandler
      */
-    protected function _getSystemEventHandler()
+    protected function _getSystemEventHandler() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         return oxNew(\OxidEsales\Eshop\Core\SystemEventHandler::class);
     }

--- a/source/Application/Controller/PaymentController.php
+++ b/source/Application/Controller/PaymentController.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
@@ -169,7 +170,7 @@ class PaymentController extends \OxidEsales\Eshop\Application\Controller\Fronten
             $oBasket = $this->getSession()->getBasket();
             $blPsBasketReservationEnabled = $myConfig->getConfigParam('blPsBasketReservationEnabled');
             if ($blPsBasketReservationEnabled && (!$oBasket || ($oBasket && !$oBasket->getProductsCount()))) {
-                Registry::getUtils()->redirect($myConfig->getShopHomeUrl() .'cl=basket', true, 302);
+                Registry::getUtils()->redirect($myConfig->getShopHomeUrl() . 'cl=basket', true, 302);
             }
 
             $oUser = $this->getUser();
@@ -186,9 +187,9 @@ class PaymentController extends \OxidEsales\Eshop\Application\Controller\Fronten
             $sPayErrorTextParameter = Registry::getConfig()->getRequestParameter('payerrortext');
             $shopSecureHomeURL = $myConfig->getShopSecureHomeURL();
 
-            $sPayError = $sPayErrorParameter ?'payerror='.$sPayErrorParameter:'';
-            $sPayErrorText = $sPayErrorTextParameter ?'payerrortext='.$sPayErrorTextParameter:'';
-            $sRedirectURL = $shopSecureHomeURL .'sslredirect=forced&cl=payment&'.$sPayError."&".$sPayErrorText;
+            $sPayError = $sPayErrorParameter ? 'payerror=' . $sPayErrorParameter : '';
+            $sPayErrorText = $sPayErrorTextParameter ? 'payerrortext=' . $sPayErrorTextParameter : '';
+            $sRedirectURL = $shopSecureHomeURL . 'sslredirect=forced&cl=payment&' . $sPayError . "&" . $sPayErrorText;
             Registry::getUtils()->redirect($sRedirectURL, true, 302);
         }
 
@@ -208,7 +209,7 @@ class PaymentController extends \OxidEsales\Eshop\Application\Controller\Fronten
      * tries to set 'oxempty' payment to aViewData['oxemptypayment'].
      * On error sets aViewData['payerror'] to -2
      */
-    protected function _setDefaultEmptyPayment()
+    protected function _setDefaultEmptyPayment() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         // no shipping method there !!
         if ($this->getConfig()->getConfigParam('blOtherCountryOrder')) {
@@ -227,7 +228,7 @@ class PaymentController extends \OxidEsales\Eshop\Application\Controller\Fronten
     /**
      * Unsets payment errors from session
      */
-    protected function _unsetPaymentErrors()
+    protected function _unsetPaymentErrors() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $iPayError = Registry::getConfig()->getRequestParameter('payerror');
         $sPayErrorText = Registry::getConfig()->getRequestParameter('payerrortext');
@@ -418,7 +419,7 @@ class PaymentController extends \OxidEsales\Eshop\Application\Controller\Fronten
      * @param array                                      $aPaymentList payments array
      * @param \OxidEsales\Eshop\Application\Model\Basket $oBasket      basket object
      */
-    protected function _setValues(&$aPaymentList, $oBasket = null)
+    protected function _setValues(&$aPaymentList, $oBasket = null) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         if (is_array($aPaymentList)) {
             foreach ($aPaymentList as $oPayment) {
@@ -515,7 +516,7 @@ class PaymentController extends \OxidEsales\Eshop\Application\Controller\Fronten
      * Assign debit note payment values to view data. Loads user debit note payment
      * if available and assigns payment data to $this->_aDynValue
      */
-    protected function _assignDebitNoteParams()
+    protected function _assignDebitNoteParams() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         // #701A
         $oUserPayment = oxNew(\OxidEsales\Eshop\Application\Model\UserPayment::class);
@@ -526,7 +527,8 @@ class PaymentController extends \OxidEsales\Eshop\Application\Controller\Fronten
 
             //checking if some of values is allready set in session - leave it
             foreach ($aAddPaymentData as $oData) {
-                if (!isset($this->_aDynValue[$oData->name]) ||
+                if (
+                    !isset($this->_aDynValue[$oData->name]) ||
                     (isset($this->_aDynValue[$oData->name]) && !$this->_aDynValue[$oData->name])
                 ) {
                     $this->_aDynValue[$oData->name] = $oData->value;
@@ -622,7 +624,7 @@ class PaymentController extends \OxidEsales\Eshop\Application\Controller\Fronten
      *
      * @return bool
      */
-    protected function _checkArrValuesEmpty($aData, $aKeys)
+    protected function _checkArrValuesEmpty($aData, $aKeys) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         if (!is_array($aKeys) || count($aKeys) < 1) {
             return false;
@@ -650,7 +652,7 @@ class PaymentController extends \OxidEsales\Eshop\Application\Controller\Fronten
      *
      * @return null
      */
-    protected function _filterDynData()
+    protected function _filterDynData() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         //in case we actually ARE allowed to store the data
         if (Registry::getConfig()->getConfigParam("blStoreCreditCardInfo")) {
@@ -677,7 +679,8 @@ class PaymentController extends \OxidEsales\Eshop\Application\Controller\Fronten
             Registry::getSession()->setVariable("dynvalue", $aDynData);
         }
 
-        if (!$this->_checkArrValuesEmpty($_REQUEST["dynvalue"], $aFields) ||
+        if (
+            !$this->_checkArrValuesEmpty($_REQUEST["dynvalue"], $aFields) ||
             !$this->_checkArrValuesEmpty($_POST["dynvalue"], $aFields) ||
             !$this->_checkArrValuesEmpty($_GET["dynvalue"], $aFields)
         ) {

--- a/source/Application/Controller/PriceAlarmController.php
+++ b/source/Application/Controller/PriceAlarmController.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
@@ -134,7 +135,7 @@ class PriceAlarmController extends \OxidEsales\Eshop\Application\Controller\Fron
      *
      * @return array
      */
-    private function _getParams()
+    private function _getParams() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         return Registry::getConfig()->getRequestParameter('pa');
     }

--- a/source/Application/Controller/RecommListController.php
+++ b/source/Application/Controller/RecommListController.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
@@ -153,7 +154,7 @@ class RecommListController extends \OxidEsales\Eshop\Application\Controller\Arti
      *
      * @return int
      */
-    protected function _getProductLinkType()
+    protected function _getProductLinkType() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         return OXARTICLE_LINKTYPE_RECOMM;
     }
@@ -201,7 +202,8 @@ class RecommListController extends \OxidEsales\Eshop\Application\Controller\Arti
             return;
         }
 
-        if ($this->canAcceptFormData() &&
+        if (
+            $this->canAcceptFormData() &&
             ($oRecommList = $this->getActiveRecommList()) && ($oUser = $this->getUser())
         ) {
             //save rating
@@ -222,7 +224,7 @@ class RecommListController extends \OxidEsales\Eshop\Application\Controller\Arti
                 }
             }
 
-            if (($sReviewText = trim(( string ) Registry::getConfig()->getRequestParameter('rvw_txt', true)))) {
+            if (($sReviewText = trim((string) Registry::getConfig()->getRequestParameter('rvw_txt', true)))) {
                 $oReview = oxNew(\OxidEsales\Eshop\Application\Model\Review::class);
                 $oReview->oxreviews__oxobjectid = new Field($oRecommList->getId());
                 $oReview->oxreviews__oxtype = new Field('oxrecommlist');
@@ -485,7 +487,7 @@ class RecommListController extends \OxidEsales\Eshop\Application\Controller\Arti
      *
      * @return string
      */
-    protected function _addPageNrParam($sUrl, $iPage, $iLang = null)
+    protected function _addPageNrParam($sUrl, $iPage, $iLang = null) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         if (Registry::getUtils()->seoIsActive() && ($oRecomm = $this->getActiveRecommList())) {
             if ($iPage) {

--- a/source/Application/Controller/RecommendationAddController.php
+++ b/source/Application/Controller/RecommendationAddController.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Application/Controller/RegisterController.php
+++ b/source/Application/Controller/RegisterController.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Application/Controller/ReviewController.php
+++ b/source/Application/Controller/ReviewController.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
@@ -222,7 +223,7 @@ class ReviewController extends \OxidEsales\Eshop\Application\Controller\ArticleD
                     }
                 }
 
-                if (($sReviewText = trim(( string ) Registry::getConfig()->getRequestParameter('rvw_txt', true)))) {
+                if (($sReviewText = trim((string) Registry::getConfig()->getRequestParameter('rvw_txt', true)))) {
                     $oReview = oxNew(\OxidEsales\Eshop\Application\Model\Review::class);
                     $oReview->oxreviews__oxobjectid = new Field($oActObject->getId());
                     $oReview->oxreviews__oxtype = new Field($sType);
@@ -278,7 +279,7 @@ class ReviewController extends \OxidEsales\Eshop\Application\Controller\ArticleD
      *
      * @return object
      */
-    protected function _getActiveObject()
+    protected function _getActiveObject() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         if ($this->_oActObject === null) {
             $this->_oActObject = false;
@@ -300,7 +301,7 @@ class ReviewController extends \OxidEsales\Eshop\Application\Controller\ArticleD
      *
      * @return string
      */
-    protected function _getActiveType()
+    protected function _getActiveType() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         if ($this->getProduct()) {
             return 'oxarticle';

--- a/source/Application/Controller/RssController.php
+++ b/source/Application/Controller/RssController.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
@@ -48,7 +49,7 @@ class RssController extends \OxidEsales\Eshop\Application\Controller\FrontendCon
      *
      * @return RssFeed
      */
-    protected function _getRssFeed()
+    protected function _getRssFeed() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         if (!$this->_oRss) {
             $this->_oRss = oxNew(RssFeed::class);
@@ -105,7 +106,7 @@ class RssController extends \OxidEsales\Eshop\Application\Controller\FrontendCon
      *
      * @return string
      */
-    protected function _processOutput($sInput)
+    protected function _processOutput($sInput) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         return getStr()->recodeEntities($sInput);
     }

--- a/source/Application/Controller/SearchController.php
+++ b/source/Application/Controller/SearchController.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
@@ -236,7 +237,7 @@ class SearchController extends \OxidEsales\Eshop\Application\Controller\Frontend
      * Iterates through list articles and performs list view specific tasks:
      *  - sets type of link which needs to be generated (Manufacturer link)
      */
-    protected function _processListArticles()
+    protected function _processListArticles() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $sAddDynParams = $this->getAddUrlParams();
         if ($sAddDynParams && ($aArtList = $this->getArticleList())) {
@@ -287,7 +288,7 @@ class SearchController extends \OxidEsales\Eshop\Application\Controller\Frontend
      *
      * @return object
      */
-    protected function _isSearchClass()
+    protected function _isSearchClass() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         if ($this->_blSearchClass === null) {
             $this->_blSearchClass = false;
@@ -487,7 +488,7 @@ class SearchController extends \OxidEsales\Eshop\Application\Controller\Frontend
      *
      * @return bool
      */
-    protected function _canRedirect()
+    protected function _canRedirect() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         return false;
     }

--- a/source/Application/Controller/StartController.php
+++ b/source/Application/Controller/StartController.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
@@ -141,9 +142,10 @@ class StartController extends \OxidEsales\Eshop\Application\Controller\FrontendC
      *
      * @return string
      */
-    protected function _prepareMetaDescription($sMeta, $iLength = 1024, $blDescTag = false)
+    protected function _prepareMetaDescription($sMeta, $iLength = 1024, $blDescTag = false) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
-        if (!$sMeta &&
+        if (
+            !$sMeta &&
             $this->getConfig()->getConfigParam('bl_perfLoadAktion') &&
             $oArt = $this->getFirstArticle()
         ) {
@@ -164,9 +166,10 @@ class StartController extends \OxidEsales\Eshop\Application\Controller\FrontendC
      *
      * @return string
      */
-    protected function _prepareMetaKeyword($sKeywords, $blRemoveDuplicatedWords = true)
+    protected function _prepareMetaKeyword($sKeywords, $blRemoveDuplicatedWords = true) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
-        if (!$sKeywords &&
+        if (
+            !$sKeywords &&
             $this->getConfig()->getConfigParam('bl_perfLoadAktion') &&
             $oArt = $this->getFirstArticle()
         ) {
@@ -182,7 +185,7 @@ class StartController extends \OxidEsales\Eshop\Application\Controller\FrontendC
      *
      * @return string
      */
-    protected function _getLoadActionsParam()
+    protected function _getLoadActionsParam() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         if ($this->_blLoadActions === null) {
             $this->_blLoadActions = false;

--- a/source/Application/Controller/SuggestController.php
+++ b/source/Application/Controller/SuggestController.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
@@ -104,7 +105,8 @@ class SuggestController extends \OxidEsales\Eshop\Application\Controller\Fronten
             }
         }
 
-        if (!oxNew(MailValidator::class)->isValidEmail($aParams["rec_email"])
+        if (
+            !oxNew(MailValidator::class)->isValidEmail($aParams["rec_email"])
             || !oxNew(MailValidator::class)->isValidEmail($aParams["send_email"])
         ) {
             $oUtilsView->addErrorToDisplay('SUGGEST_INVALIDMAIL');

--- a/source/Application/Controller/TemplateController.php
+++ b/source/Application/Controller/TemplateController.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Application/Controller/TextEditorHandler.php
+++ b/source/Application/Controller/TextEditorHandler.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Application/Controller/ThankYouController.php
+++ b/source/Application/Controller/ThankYouController.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Application/Controller/UserController.php
+++ b/source/Application/Controller/UserController.php
@@ -1,8 +1,10 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
 namespace OxidEsales\EshopCommunity\Application\Controller;
 
 use OxidEsales\Eshop\Core\Registry;
@@ -89,8 +91,10 @@ class UserController extends \OxidEsales\Eshop\Application\Controller\FrontendCo
 
             $basket = $this->getSession()->getBasket();
             $isPsBasketReservationsEnabled = $config->getConfigParam('blPsBasketReservationEnabled');
-            if ($this->_blIsOrderStep && $isPsBasketReservationsEnabled &&
-                (!$basket || ($basket && !$basket->getProductsCount()))) {
+            if (
+                $this->_blIsOrderStep && $isPsBasketReservationsEnabled &&
+                (!$basket || ($basket && !$basket->getProductsCount()))
+            ) {
                 Registry::getUtils()->redirect($config->getShopHomeUrl() . 'cl=basket', true, 302);
             }
         }

--- a/source/Application/Controller/VendorListController.php
+++ b/source/Application/Controller/VendorListController.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
@@ -119,7 +120,7 @@ class VendorListController extends \OxidEsales\Eshop\Application\Controller\Arti
      *
      * @return int
      */
-    protected function _getProductLinkType()
+    protected function _getProductLinkType() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         return OXARTICLE_LINKTYPE_VENDOR;
     }
@@ -131,7 +132,7 @@ class VendorListController extends \OxidEsales\Eshop\Application\Controller\Arti
      *
      * @return array
      */
-    protected function _loadArticles($oVendor)
+    protected function _loadArticles($oVendor) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $sVendorId = $oVendor->getId();
 
@@ -157,7 +158,7 @@ class VendorListController extends \OxidEsales\Eshop\Application\Controller\Arti
      *
      * @return string
      */
-    protected function _getSeoObjectId()
+    protected function _getSeoObjectId() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         if (($oVendor = $this->getActVendor())) {
             return $oVendor->getId();
@@ -174,7 +175,7 @@ class VendorListController extends \OxidEsales\Eshop\Application\Controller\Arti
      *
      * @return string
      */
-    protected function _addPageNrParam($sUrl, $iPage, $iLang = null)
+    protected function _addPageNrParam($sUrl, $iPage, $iLang = null) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         if (\OxidEsales\Eshop\Core\Registry::getUtils()->seoIsActive() && ($oVendor = $this->getActVendor())) {
             if ($iPage) {
@@ -295,7 +296,7 @@ class VendorListController extends \OxidEsales\Eshop\Application\Controller\Arti
      *
      * @return string
      */
-    protected function _getVendorId()
+    protected function _getVendorId() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         return \OxidEsales\Eshop\Core\Registry::getConfig()->getRequestParameter('cnid');
     }
@@ -357,7 +358,7 @@ class VendorListController extends \OxidEsales\Eshop\Application\Controller\Arti
      *
      * @return string
      */
-    protected function _prepareMetaKeyword($sKeywords, $blRemoveDuplicatedWords = true)
+    protected function _prepareMetaKeyword($sKeywords, $blRemoveDuplicatedWords = true) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         return parent::_collectMetaKeyword($sKeywords);
     }
@@ -372,7 +373,7 @@ class VendorListController extends \OxidEsales\Eshop\Application\Controller\Arti
      *
      * @return string
      */
-    protected function _prepareMetaDescription($sMeta, $iLength = 1024, $blDescTag = false)
+    protected function _prepareMetaDescription($sMeta, $iLength = 1024, $blDescTag = false) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         return parent::_collectMetaDescription($sMeta, $iLength, $blDescTag);
     }
@@ -385,7 +386,7 @@ class VendorListController extends \OxidEsales\Eshop\Application\Controller\Arti
      *
      * @return object
      */
-    protected function _getSubject($iLang)
+    protected function _getSubject($iLang) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         return $this->getActVendor();
     }

--- a/source/Application/Controller/WishListController.php
+++ b/source/Application/Controller/WishListController.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Application/Controller/WrappingController.php
+++ b/source/Application/Controller/WrappingController.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Application/Model/ActionList.php
+++ b/source/Application/Model/ActionList.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
@@ -111,7 +112,7 @@ class ActionList extends \OxidEsales\Eshop\Core\Model\ListModel
      *
      * @return string
      */
-    protected function _getUserGroupFilter($oUser = null)
+    protected function _getUserGroupFilter($oUser = null) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $oUser = ($oUser == null) ? $this->getUser() : $oUser;
         $sTable = getViewName('oxactions');

--- a/source/Application/Model/Actions.php
+++ b/source/Application/Model/Actions.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
@@ -168,11 +169,12 @@ class Actions extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel
      */
     public function isRunning()
     {
-        if (!(
+        if (
+            !(
             $this->oxactions__oxactive->value
               && $this->oxactions__oxtype->value == 2
               && $this->oxactions__oxactivefrom->value != '0000-00-00 00:00:00'
-        )
+            )
         ) {
             return false;
         }

--- a/source/Application/Model/Address.php
+++ b/source/Application/Model/Address.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
@@ -35,7 +36,7 @@ class Address extends \OxidEsales\Eshop\Core\Model\BaseModel
      *
      * @return oxState
      */
-    protected function _getStateObject()
+    protected function _getStateObject() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         if (is_null($this->_oStateObject)) {
             $this->_oStateObject = oxNew(\OxidEsales\Eshop\Application\Model\State::class);
@@ -148,7 +149,7 @@ class Address extends \OxidEsales\Eshop\Core\Model\BaseModel
      *
      * @return string
      */
-    protected function _getMergedAddressFields()
+    protected function _getMergedAddressFields() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $sDelAddress = '';
         $sDelAddress .= $this->oxaddress__oxcompany;

--- a/source/Application/Model/AmountPriceList.php
+++ b/source/Application/Model/AmountPriceList.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
@@ -76,7 +77,7 @@ class AmountPriceList extends \OxidEsales\Eshop\Core\Model\ListModel
      *
      * @return array
      */
-    protected function _loadFromDb()
+    protected function _loadFromDb() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $sArticleId = $this->getArticle()->getId();
         $db = \OxidEsales\Eshop\Core\DatabaseProvider::getDb(\OxidEsales\Eshop\Core\DatabaseProvider::FETCH_MODE_ASSOC);

--- a/source/Application/Model/Article.php
+++ b/source/Application/Model/Article.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
@@ -712,7 +713,7 @@ class Article extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
      *
      * @return string
      */
-    protected function _createSqlActiveSnippet($forceCoreTable)
+    protected function _createSqlActiveSnippet($forceCoreTable) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         // check if article is still active
         $sQ = $this->getActiveCheckQuery($forceCoreTable);
@@ -971,7 +972,7 @@ class Article extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
      *
      * @return double
      */
-    protected function _calculateVarMinPrice()
+    protected function _calculateVarMinPrice() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $dPrice = $this->_getVarMinPrice();
 
@@ -1009,7 +1010,7 @@ class Article extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
      *
      * @return double
      */
-    protected function _prepareModifiedPrice($dPrice)
+    protected function _prepareModifiedPrice($dPrice) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $dPrice = $this->_preparePrice($dPrice, $this->getArticleVat());
 
@@ -1069,7 +1070,8 @@ class Article extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
 
         // active ?
         $sNow = date('Y-m-d H:i:s');
-        if (!$this->oxarticles__oxactive->value &&
+        if (
+            !$this->oxarticles__oxactive->value &&
             (
                 $this->oxarticles__oxactivefrom->value > $sNow ||
              $this->oxarticles__oxactiveto->value < $sNow
@@ -1136,7 +1138,7 @@ class Article extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
     /**
      * @param \OxidEsales\Eshop\Application\Model\Article $article
      */
-    protected function _setShopValues($article)
+    protected function _setShopValues($article) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
     }
 
@@ -1179,7 +1181,7 @@ class Article extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
      *
      * @return array
      */
-    protected function _loadData($articleId)
+    protected function _loadData($articleId) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         return $this->_loadFromDb($articleId);
     }
@@ -1818,7 +1820,7 @@ class Article extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
     /**
      * @return oxi18n
      */
-    protected function _createMultilanguageVendorObject()
+    protected function _createMultilanguageVendorObject() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $oVendor = oxNew(\OxidEsales\Eshop\Core\Model\MultiLanguageModel::class);
         $oVendor->init('oxvendor');
@@ -1864,7 +1866,8 @@ class Article extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
     public function getManufacturer($blShopCheck = true)
     {
         $oManufacturer = oxNew(\OxidEsales\Eshop\Application\Model\Manufacturer::class);
-        if (!($sManufacturerId = $this->getManufacturerId()) &&
+        if (
+            !($sManufacturerId = $this->getManufacturerId()) &&
             !$blShopCheck && $this->oxarticles__oxmanufacturerid->value
         ) {
             $this->updateManufacturerBeforeLoading($oManufacturer);
@@ -2059,7 +2062,7 @@ class Article extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
      *
      * @return double
      */
-    protected function _getModifiedAmountPrice($amount)
+    protected function _getModifiedAmountPrice($amount) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         return $this->_getAmountPrice($amount);
     }
@@ -2356,7 +2359,8 @@ class Article extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
         for ($i = 1; $i <= $iPicCount; $i++) {
             $sPicVal = $this->getPictureUrl($i);
             $sIcoVal = $this->getIconUrl($i);
-            if (!$oStr->strstr($sIcoVal, 'nopic_ico.jpg') && !$oStr->strstr($sIcoVal, 'nopic.jpg') &&
+            if (
+                !$oStr->strstr($sIcoVal, 'nopic_ico.jpg') && !$oStr->strstr($sIcoVal, 'nopic.jpg') &&
                 !$oStr->strstr($sPicVal, 'nopic_ico.jpg') && !$oStr->strstr($sPicVal, 'nopic.jpg') &&
                 $sPicVal !== null
             ) {
@@ -2526,7 +2530,8 @@ class Article extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
             //negative stock values we would allow to reserve more items than are initially available
             //by keeping the stock level not lower than zero. When discarding reservations
             //stock level might differ from original value.
-            if (!$myConfig->getConfigParam('blPsBasketReservationEnabled')
+            if (
+                !$myConfig->getConfigParam('blPsBasketReservationEnabled')
                  || ($myConfig->getConfigParam('blPsBasketReservationEnabled')
                      && $myConfig->getConfigParam('blAllowNegativeStock'))
             ) {
@@ -3025,7 +3030,8 @@ class Article extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
      */
     public function resetRemindStatus()
     {
-        if ($this->oxarticles__oxremindactive->value == 2 &&
+        if (
+            $this->oxarticles__oxremindactive->value == 2 &&
             $this->oxarticles__oxremindamount->value <= $this->oxarticles__oxstock->value
         ) {
             $this->oxarticles__oxremindactive->value = 1;
@@ -3554,7 +3560,7 @@ class Article extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
      *
      * @return array | oxsimplevariantlist | oxarticlelist
      */
-    protected function _loadVariantList($loadSimpleVariants, $blRemoveNotOrderables = true, $forceCoreTableUsage = null)
+    protected function _loadVariantList($loadSimpleVariants, $blRemoveNotOrderables = true, $forceCoreTableUsage = null) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $variants = [];
         if (($articleId = $this->getId())) {
@@ -3563,7 +3569,8 @@ class Article extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
 
             $config = $this->getConfig();
 
-            if (!$this->_blLoadVariants ||
+            if (
+                !$this->_blLoadVariants ||
                 (!$this->isAdmin() && !$config->getConfigParam('blLoadVariants')) ||
                 (!$this->isAdmin() && !$this->oxarticles__oxvarcount->value)
             ) {
@@ -3636,7 +3643,7 @@ class Article extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
      *
      * @return array
      */
-    protected function _selectCategoryIds($query, $field)
+    protected function _selectCategoryIds($query, $field) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $oDb = \OxidEsales\Eshop\Core\DatabaseProvider::getDb(\OxidEsales\Eshop\Core\DatabaseProvider::FETCH_MODE_ASSOC);
         $aResult = $oDb->getAll($query);
@@ -3658,7 +3665,7 @@ class Article extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
      *
      * @return string
      */
-    protected function _getCategoryIdsSelect($blActCats = false)
+    protected function _getCategoryIdsSelect($blActCats = false) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $sO2CView = $this->_getObjectViewName('oxobject2category');
         $sCatView = $this->_getObjectViewName('oxcategories');
@@ -3684,7 +3691,7 @@ class Article extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
      *
      * @return string
      */
-    protected function _getActiveCategorySelectSnippet()
+    protected function _getActiveCategorySelectSnippet() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $sCatView = $this->_getObjectViewName('oxcategories');
 
@@ -3699,7 +3706,7 @@ class Article extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
      *
      * @return \OxidEsales\Eshop\Core\Price
      */
-    protected function _calculatePrice($oPrice, $dVat = null)
+    protected function _calculatePrice($oPrice, $dVat = null) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         // apply VAT only if configuration requires it
         if (isset($dVat) || !$this->getConfig()->getConfigParam('bl_perfCalcVatOnlyForBasketOrder')) {
@@ -3730,7 +3737,7 @@ class Article extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
      *
      * @return bool
      */
-    protected function _hasAnyVariant($blForceCoreTable = null)
+    protected function _hasAnyVariant($blForceCoreTable = null) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         if (($sId = $this->getId())) {
             if ($this->oxarticles__oxshopid->value == $this->getConfig()->getShopId()) {
@@ -3752,7 +3759,7 @@ class Article extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
      *
      * @return bool
      */
-    protected function _isStockStatusChanged()
+    protected function _isStockStatusChanged() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         return $this->_iStockStatus != $this->_iStockStatusOnLoad;
     }
@@ -3762,7 +3769,7 @@ class Article extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
      *
      * @return bool
      */
-    protected function _isVisibilityChanged()
+    protected function _isVisibilityChanged() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         return $this->_isStockStatusChanged() && ($this->_iStockStatus == -1 || $this->_iStockStatusOnLoad == -1);
     }
@@ -3772,7 +3779,7 @@ class Article extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
      *
      * @return null
      */
-    protected function _saveArtLongDesc()
+    protected function _saveArtLongDesc() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         if (in_array("oxlongdesc", $this->_aSkipSaveFields)) {
             return;
@@ -3824,7 +3831,7 @@ class Article extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
     /**
      * Removes object data fields (oxarticles__oxtimestamp, oxarticles__oxparentid, oxarticles__oxinsert).
      */
-    protected function _skipSaveFields()
+    protected function _skipSaveFields() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $this->_aSkipSaveFields = [];
 
@@ -3847,7 +3854,7 @@ class Article extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
      *
      * @return array $aDiscounts
      */
-    protected function _mergeDiscounts($aDiscounts, $aItemDiscounts)
+    protected function _mergeDiscounts($aDiscounts, $aItemDiscounts) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         foreach ($aItemDiscounts as $sKey => $oDiscount) {
             // add prices of the same discounts
@@ -3866,7 +3873,7 @@ class Article extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
      *
      * @return double
      */
-    protected function _getGroupPrice()
+    protected function _getGroupPrice() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $sPriceSufix = $this->_getUserPriceSufix();
         $sVarName = "oxarticles__oxprice{$sPriceSufix}";
@@ -3888,14 +3895,15 @@ class Article extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
      *
      * @return double
      */
-    protected function _getAmountPrice($amount = 1)
+    protected function _getAmountPrice($amount = 1) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         startProfile("_getAmountPrice");
 
         $dPrice = $this->_getGroupPrice();
         $oAmtPrices = $this->_getAmountPriceList();
         foreach ($oAmtPrices as $oAmPrice) {
-            if ($oAmPrice->oxprice2article__oxamount->value <= $amount
+            if (
+                $oAmPrice->oxprice2article__oxamount->value <= $amount
                 && $amount <= $oAmPrice->oxprice2article__oxamountto->value
                 && $dPrice > $oAmPrice->oxprice2article__oxaddabs->value
             ) {
@@ -3916,7 +3924,7 @@ class Article extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
      *
      * @return double
      */
-    protected function _modifySelectListPrice($dPrice, $aChosenList = null)
+    protected function _modifySelectListPrice($dPrice, $aChosenList = null) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $myConfig = $this->getConfig();
         // #690
@@ -3945,7 +3953,7 @@ class Article extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
      *
      * @return array
      */
-    protected function _fillAmountPriceList($aAmPriceList)
+    protected function _fillAmountPriceList($aAmPriceList) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $oLang = \OxidEsales\Eshop\Core\Registry::getLang();
 
@@ -4033,7 +4041,7 @@ class Article extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
      * @param \OxidEsales\Eshop\Core\Price $oPrice Price object
      * @param double                       $dVat   VAT percent
      */
-    protected function _applyVAT(\OxidEsales\Eshop\Core\Price $oPrice, $dVat)
+    protected function _applyVAT(\OxidEsales\Eshop\Core\Price $oPrice, $dVat) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         startProfile(__FUNCTION__);
         $oPrice->setVAT($dVat);
@@ -4051,7 +4059,7 @@ class Article extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
      * @param \OxidEsales\Eshop\Core\Price $oPrice Price object
      * @param object                       $oCur   Currency object
      */
-    protected function _applyCurrency(\OxidEsales\Eshop\Core\Price $oPrice, $oCur = null)
+    protected function _applyCurrency(\OxidEsales\Eshop\Core\Price $oPrice, $oCur = null) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         if (!$oCur) {
             $oCur = $this->getConfig()->getActShopCurrencyObject();
@@ -4066,7 +4074,7 @@ class Article extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
      * @param string $sAttributeSql Attribute selection snippet
      * @param int    $iCnt          The number of selected attributes
      */
-    protected function _getAttribsString(&$sAttributeSql, &$iCnt)
+    protected function _getAttribsString(&$sAttributeSql, &$iCnt) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         // we do not use lists here as we don't need this overhead right now
         $oDb = \OxidEsales\Eshop\Core\DatabaseProvider::getDb();
@@ -4095,7 +4103,7 @@ class Article extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
      *
      * @return array
      */
-    protected function _getSimList($sAttributeSql, $iCnt)
+    protected function _getSimList($sAttributeSql, $iCnt) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         // #523A
         $iAttrPercent = $this->getConfig()->getConfigParam('iAttributesPercent') / 100;
@@ -4131,7 +4139,7 @@ class Article extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
      *
      * @return string
      */
-    protected function _generateSimListSearchStr($sArticleTable, $aList)
+    protected function _generateSimListSearchStr($sArticleTable, $aList) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $sFieldList = $this->getSelectFields();
         $aList = array_slice($aList, 0, $this->getConfig()->getConfigParam('iNrofSimilarArticles'));
@@ -4154,7 +4162,7 @@ class Article extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
      *
      * @return string
      */
-    protected function _generateSearchStr($sOXID, $blSearchPriceCat = false)
+    protected function _generateSearchStr($sOXID, $blSearchPriceCat = false) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $sCatView = getViewName('oxcategories', $this->getLanguage());
         $sO2CView = getViewName('oxobject2category');
@@ -4175,7 +4183,7 @@ class Article extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
      *
      * @return string
      */
-    protected function _generateSearchStrForCustomerBought()
+    protected function _generateSearchStrForCustomerBought() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $sArtTable = $this->getViewName();
         $sOrderArtTable = getViewName('oxorderarticles');
@@ -4238,7 +4246,7 @@ class Article extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
      *
      * @return string
      */
-    protected function _generateSelectCatStr($sOXID, $sCatId, $dPriceFromTo = false)
+    protected function _generateSelectCatStr($sOXID, $sCatId, $dPriceFromTo = false) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $sCategoryView = getViewName('oxcategories');
         $sO2CView = getViewName('oxobject2category');
@@ -4269,7 +4277,7 @@ class Article extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
      *
      * @return \OxidEsales\Eshop\Application\Model\AmountPriceList
      */
-    protected function _getAmountPriceList()
+    protected function _getAmountPriceList() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         return $this->buildAmountPriceList();
     }
@@ -4315,7 +4323,7 @@ class Article extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
      *
      * @return bool
      */
-    protected function _isFieldEmpty($sFieldName)
+    protected function _isFieldEmpty($sFieldName) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $mValue = $this->$sFieldName->value;
 
@@ -4341,19 +4349,21 @@ class Article extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
 
         $sFieldName = strtolower($sFieldName);
 
-        if ($sFieldName == 'oxarticles__oxicon' && (strpos($mValue, "nopic_ico.jpg") !== false || strpos(
-            $mValue,
-            "nopic.jpg"
-        ) !== false)
+        if (
+            $sFieldName == 'oxarticles__oxicon' && (strpos($mValue, "nopic_ico.jpg") !== false || strpos(
+                $mValue,
+                "nopic.jpg"
+            ) !== false)
         ) {
             return true;
         }
 
-        if (strpos($mValue, "nopic.jpg") !== false && ($sFieldName == 'oxarticles__oxthumb' || substr(
-            $sFieldName,
-            0,
-            17
-        ) == 'oxarticles__oxpic' || substr($sFieldName, 0, 18) == 'oxarticles__oxzoom')
+        if (
+            strpos($mValue, "nopic.jpg") !== false && ($sFieldName == 'oxarticles__oxthumb' || substr(
+                $sFieldName,
+                0,
+                17
+            ) == 'oxarticles__oxpic' || substr($sFieldName, 0, 18) == 'oxarticles__oxzoom')
         ) {
             return true;
         }
@@ -4368,7 +4378,7 @@ class Article extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
      *
      * @return null;
      */
-    protected function _assignParentFieldValue($sFieldName)
+    protected function _assignParentFieldValue($sFieldName) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         if (!($oParentArticle = $this->getParentArticle())) {
             return;
@@ -4407,7 +4417,7 @@ class Article extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
      *
      * @return bool.
      */
-    protected function _isImageField($sFieldName)
+    protected function _isImageField($sFieldName) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         return (stristr($sFieldName, '_oxthumb') || stristr($sFieldName, '_oxicon') || stristr(
             $sFieldName,
@@ -4418,7 +4428,7 @@ class Article extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
     /**
      * Assigns parent field values to article
      */
-    protected function _assignParentFieldValues()
+    protected function _assignParentFieldValues() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         startProfile('articleAssignParentInternal');
         if ($this->oxarticles__oxparentid->value) {
@@ -4435,9 +4445,10 @@ class Article extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
     /**
      * if we have variants then depending on config option the parent may be non buyable
      */
-    protected function _assignNotBuyableParent()
+    protected function _assignNotBuyableParent() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
-        if (!$this->getConfig()->getConfigParam('blVariantParentBuyable') &&
+        if (
+            !$this->getConfig()->getConfigParam('blVariantParentBuyable') &&
             ($this->_blHasVariants || $this->oxarticles__oxvarstock->value || $this->oxarticles__oxvarcount->value)
         ) {
             $this->_blNotBuyableParent = true;
@@ -4447,7 +4458,7 @@ class Article extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
     /**
      * Assigns stock status to article
      */
-    protected function _assignStock()
+    protected function _assignStock() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $myConfig = $this->getConfig();
         // -----------------------------------
@@ -4462,7 +4473,8 @@ class Article extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
         $this->_iStockStatus = 0;
 
         // if we have flag /*1 or*/ 4 - we show always green light
-        if ($myConfig->getConfigParam('blUseStock') && /*$this->oxarticles__oxstockflag->value != 1 && */
+        if (
+            $myConfig->getConfigParam('blUseStock') && /*$this->oxarticles__oxstockflag->value != 1 && */
             $this->oxarticles__oxstockflag->value != 4
         ) {
             //ORANGE light
@@ -4519,7 +4531,7 @@ class Article extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
      *
      * @deprecated on b-dev (2015-11-30); Not used anymore. Setting pers params to session was removed since 2.7.
      */
-    protected function _assignPersistentParam()
+    protected function _assignPersistentParam() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         // Persistent Parameter Handling
         $aPersParam = \OxidEsales\Eshop\Core\Registry::getSession()->getVariable('persparam');
@@ -4531,7 +4543,7 @@ class Article extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
     /**
      * assigns dynimagedir to article
      */
-    protected function _assignDynImageDir()
+    protected function _assignDynImageDir() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $myConfig = $this->getConfig();
 
@@ -4546,7 +4558,7 @@ class Article extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
     /**
      * Adds a flag if article is on comparisonlist.
      */
-    protected function _assignComparisonListFlag()
+    protected function _assignComparisonListFlag() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         // #657 add a flag if article is on comparisonlist
 
@@ -4563,7 +4575,7 @@ class Article extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
      *
      * @return bool
      */
-    protected function _insert()
+    protected function _insert() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         // set oxinsert
         $sNow = date('Y-m-d H:i:s', \OxidEsales\Eshop\Core\Registry::getUtilsDate()->getTime());
@@ -4580,7 +4592,7 @@ class Article extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
      *
      * @return bool
      */
-    protected function _update()
+    protected function _update() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $this->setUpdateSeo(true);
         $this->_setUpdateSeoOnFieldChange('oxtitle');
@@ -4597,7 +4609,7 @@ class Article extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
      *
      * @return int
      */
-    protected function _deleteRecords($articleId)
+    protected function _deleteRecords($articleId) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $oDb = \OxidEsales\Eshop\Core\DatabaseProvider::getDb();
 
@@ -4677,12 +4689,12 @@ class Article extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
      *
      * @param string $sOXID Article ID
      */
-    protected function _deleteVariantRecords($sOXID)
+    protected function _deleteVariantRecords($sOXID) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         if ($sOXID) {
             $database = \OxidEsales\Eshop\Core\DatabaseProvider::getDb();
             //collect variants to remove recursively
-            $query= 'select oxid from ' . $this->getViewName() . ' where oxparentid = :oxparentid';
+            $query = 'select oxid from ' . $this->getViewName() . ' where oxparentid = :oxparentid';
             $rs = $database->select($query, [
                 ':oxparentid' => $sOXID
             ]);
@@ -4700,7 +4712,7 @@ class Article extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
     /**
      * Delete pics
      */
-    protected function _deletePics()
+    protected function _deletePics() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $myConfig = $this->getConfig();
         $oPictureHandler = \OxidEsales\Eshop\Core\Registry::getPictureHandler();
@@ -4725,7 +4737,7 @@ class Article extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
      * @param string $sVendorId       Vendor ID
      * @param string $sManufacturerId Manufacturer ID
      */
-    protected function _onChangeResetCounts($sOxid, $sVendorId = null, $sManufacturerId = null)
+    protected function _onChangeResetCounts($sOxid, $sVendorId = null, $sManufacturerId = null) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $myUtilsCount = \OxidEsales\Eshop\Core\Registry::getUtilsCount();
 
@@ -4749,7 +4761,7 @@ class Article extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
      *
      * @param string $parentId product parent id
      */
-    protected function _onChangeUpdateStock($parentId)
+    protected function _onChangeUpdateStock($parentId) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         if ($parentId) {
             $database = \OxidEsales\Eshop\Core\DatabaseProvider::getDb();
@@ -4796,11 +4808,12 @@ class Article extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
      *
      * @param string $sOxid product id
      */
-    protected function _onChangeStockResetCount($sOxid)
+    protected function _onChangeStockResetCount($sOxid) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $myConfig = $this->getConfig();
 
-        if ($myConfig->getConfigParam('blUseStock') && $this->oxarticles__oxstockflag->value == 2 &&
+        if (
+            $myConfig->getConfigParam('blUseStock') && $this->oxarticles__oxstockflag->value == 2 &&
             ($this->oxarticles__oxstock->value + $this->oxarticles__oxvarstock->value) <= 0
         ) {
             $this->_onChangeResetCounts(
@@ -4816,7 +4829,7 @@ class Article extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
      *
      * @param string $parentId Parent ID
      */
-    protected function _onChangeUpdateVarCount($parentId)
+    protected function _onChangeUpdateVarCount($parentId) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         if ($parentId) {
             $database = \OxidEsales\Eshop\Core\DatabaseProvider::getDb();
@@ -4839,7 +4852,7 @@ class Article extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
      *
      * @param string $sParentId Parent ID
      */
-    protected function _setVarMinMaxPrice($sParentId)
+    protected function _setVarMinMaxPrice($sParentId) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         if ($sParentId) {
             $database = \OxidEsales\Eshop\Core\DatabaseProvider::getDb(\OxidEsales\Eshop\Core\DatabaseProvider::FETCH_MODE_ASSOC);
@@ -4888,14 +4901,15 @@ class Article extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
      *
      * @return bool
      */
-    protected function _hasMasterImage($iIndex)
+    protected function _hasMasterImage($iIndex) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $sPicName = basename($this->{"oxarticles__oxpic" . $iIndex}->value);
 
         if ($sPicName == "nopic.jpg" || $sPicName == "") {
             return false;
         }
-        if ($this->isVariant() &&
+        if (
+            $this->isVariant() &&
             $this->getParentArticle() &&
             $this->getParentArticle()->{"oxarticles__oxpic" . $iIndex}->value == $this->{"oxarticles__oxpic" . $iIndex}->value
         ) {
@@ -4917,7 +4931,7 @@ class Article extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
      *
      * @return bool
      */
-    protected function _isPriceViewModeNetto()
+    protected function _isPriceViewModeNetto() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $blResult = (bool) $this->getConfig()->getConfigParam('blShowNetPrice');
         $oUser = $this->getArticleUser();
@@ -4936,7 +4950,7 @@ class Article extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
      *
      * @return oxPice
      */
-    protected function _getPriceObject($blCalculationModeNetto = null)
+    protected function _getPriceObject($blCalculationModeNetto = null) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         /** @var \OxidEsales\Eshop\Core\Price $oPrice */
         $oPrice = oxNew(\OxidEsales\Eshop\Core\Price::class);
@@ -4961,7 +4975,7 @@ class Article extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
      *
      * @return double
      */
-    protected function _getPriceForView($oPrice)
+    protected function _getPriceForView($oPrice) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         if ($this->_isPriceViewModeNetto()) {
             $dPrice = $oPrice->getNettoPrice();
@@ -4982,7 +4996,7 @@ class Article extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
      *
      * @return double
      */
-    protected function _preparePrice($dPrice, $dVat, $blCalculationModeNetto = null)
+    protected function _preparePrice($dPrice, $dVat, $blCalculationModeNetto = null) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         if ($blCalculationModeNetto === null) {
             $blCalculationModeNetto = $this->_isPriceViewModeNetto();
@@ -5006,7 +5020,7 @@ class Article extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
      *
      * @return null
      */
-    protected function _getUserPriceSufix()
+    protected function _getUserPriceSufix() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $sPriceSuffix = '';
         $oUser = $this->getArticleUser();
@@ -5029,7 +5043,7 @@ class Article extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
      *
      * @return null
      */
-    protected function _getPrice()
+    protected function _getPrice() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $sPriceSuffix = $this->_getUserPriceSufix();
         if ($sPriceSuffix === '') {
@@ -5050,7 +5064,7 @@ class Article extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
      *
      * @return null
      */
-    protected function _getVarMinPrice()
+    protected function _getVarMinPrice() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         if ($this->_dVarMinPrice === null) {
             $dPrice = $this->_getShopVarMinPrice();
@@ -5088,7 +5102,7 @@ class Article extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
      *
      * @return null
      */
-    protected function _getVarMaxPrice()
+    protected function _getVarMaxPrice() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         if ($this->_dVarMaxPrice === null) {
             $dPrice = $this->_getShopVarMaxPrice();
@@ -5127,7 +5141,7 @@ class Article extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
      *
      * @return double|null
      */
-    protected function _getShopVarMinPrice()
+    protected function _getShopVarMinPrice() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         return null;
     }
@@ -5138,7 +5152,7 @@ class Article extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
      *
      * @return double|null
      */
-    protected function _getShopVarMaxPrice()
+    protected function _getShopVarMaxPrice() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         return null;
     }
@@ -5150,7 +5164,7 @@ class Article extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
      *
      * @return array
      */
-    protected function _loadFromDb($articleId)
+    protected function _loadFromDb($articleId) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $sSelect = $this->buildSelectString([$this->getViewName() . ".oxid" => $articleId]);
 
@@ -5173,7 +5187,7 @@ class Article extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
      *
      * @return bool
      */
-    protected function _updateParentDependFields()
+    protected function _updateParentDependFields() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $oDb = \OxidEsales\Eshop\Core\DatabaseProvider::getDb();
 
@@ -5194,7 +5208,7 @@ class Article extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
      *
      * @return array
      */
-    protected function _getCopyParentFields()
+    protected function _getCopyParentFields() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         return $this->_aCopyParentField;
     }
@@ -5202,7 +5216,7 @@ class Article extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
     /**
      * Set parent field value to child - variants
      */
-    protected function _assignParentDependFields()
+    protected function _assignParentDependFields() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $sParent = $this->getParentArticle();
         if ($sParent) {
@@ -5215,7 +5229,7 @@ class Article extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
     /**
      * Saves values of sorting fields on article load.
      */
-    protected function _saveSortingFieldValuesOnLoad()
+    protected function _saveSortingFieldValuesOnLoad() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $aSortingFields = \OxidEsales\Eshop\Core\Registry::getConfig()->getConfigParam('aSortCols');
         $aSortingFields = !empty($aSortingFields) ? (array) $aSortingFields : [];

--- a/source/Application/Model/ArticleList.php
+++ b/source/Application/Model/ArticleList.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
@@ -154,7 +155,7 @@ class ArticleList extends \OxidEsales\Eshop\Core\Model\ListModel
      *
      * @return int
      */
-    protected function _sortByOrderMapCallback($key1, $key2)
+    protected function _sortByOrderMapCallback($key1, $key2) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         if (isset($this->_aOrderMap[$key1])) {
             if (isset($this->_aOrderMap[$key2])) {
@@ -479,7 +480,7 @@ class ArticleList extends \OxidEsales\Eshop\Core\Model\ListModel
      *
      * @return string
      */
-    protected function _getArticleSelect($sRecommId, $sArticlesFilter = null)
+    protected function _getArticleSelect($sRecommId, $sArticlesFilter = null) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $sRecommId = \OxidEsales\Eshop\Core\DatabaseProvider::getDb()->quote($sRecommId);
 
@@ -701,7 +702,8 @@ class ArticleList extends \OxidEsales\Eshop\Core\Model\ListModel
         // not active or not available products must not have button "tobasket"
         $sNow = date('Y-m-d H:i:s');
         foreach ($this as $oArticle) {
-            if (!$oArticle->oxarticles__oxactive->value &&
+            if (
+                !$oArticle->oxarticles__oxactive->value &&
                 (
                     $oArticle->oxarticles__oxactivefrom->value > $sNow ||
                  $oArticle->oxarticles__oxactiveto->value < $sNow
@@ -831,7 +833,7 @@ class ArticleList extends \OxidEsales\Eshop\Core\Model\ListModel
      *
      * @param string $sSql SQL select
      */
-    protected function _createIdListFromSql($sSql)
+    protected function _createIdListFromSql($sSql) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $rs = \OxidEsales\Eshop\Core\DatabaseProvider::getDb(\OxidEsales\Eshop\Core\DatabaseProvider::FETCH_MODE_ASSOC)->select($sSql);
         if ($rs != false && $rs->count() > 0) {
@@ -851,7 +853,7 @@ class ArticleList extends \OxidEsales\Eshop\Core\Model\ListModel
      *
      * @return string
      */
-    protected function _getFilterIdsSql($sCatId, $aFilter)
+    protected function _getFilterIdsSql($sCatId, $aFilter) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $sO2CView = getViewName('oxobject2category');
         $sO2AView = getViewName('oxobject2attribute');
@@ -891,7 +893,7 @@ class ArticleList extends \OxidEsales\Eshop\Core\Model\ListModel
      *
      * @return string
      */
-    protected function _getFilterSql($sCatId, $aFilter)
+    protected function _getFilterSql($sCatId, $aFilter) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $sArticleTable = getViewName('oxarticles');
         $aIds = \OxidEsales\Eshop\Core\DatabaseProvider::getDb(\OxidEsales\Eshop\Core\DatabaseProvider::FETCH_MODE_ASSOC)->getAll($this->_getFilterIdsSql($sCatId, $aFilter));
@@ -925,7 +927,7 @@ class ArticleList extends \OxidEsales\Eshop\Core\Model\ListModel
      *
      * @return string SQL
      */
-    protected function _getCategorySelect($sFields, $sCatId, $aSessionFilter)
+    protected function _getCategorySelect($sFields, $sCatId, $aSessionFilter) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $sArticleTable = getViewName('oxarticles');
         $sO2CView = getViewName('oxobject2category');
@@ -963,7 +965,7 @@ class ArticleList extends \OxidEsales\Eshop\Core\Model\ListModel
      *
      * @return string SQL
      */
-    protected function _getCategoryCountSelect($sCatId, $aSessionFilter)
+    protected function _getCategoryCountSelect($sCatId, $aSessionFilter) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $sArticleTable = getViewName('oxarticles');
         $sO2CView = getViewName('oxobject2category');
@@ -994,7 +996,7 @@ class ArticleList extends \OxidEsales\Eshop\Core\Model\ListModel
      *
      * @return string
      */
-    protected function _getSearchSelect($sSearchString)
+    protected function _getSearchSelect($sSearchString) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         // check if it has string at all
         if (!$sSearchString || !str_replace(' ', '', $sSearchString)) {
@@ -1061,7 +1063,7 @@ class ArticleList extends \OxidEsales\Eshop\Core\Model\ListModel
      *
      * @return string
      */
-    protected function _getPriceSelect($dPriceFrom, $dPriceTo)
+    protected function _getPriceSelect($dPriceFrom, $dPriceTo) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $oBaseObject = $this->getBaseObject();
         $sArticleTable = $oBaseObject->getViewName();
@@ -1089,7 +1091,7 @@ class ArticleList extends \OxidEsales\Eshop\Core\Model\ListModel
      *
      * @return string
      */
-    protected function _getVendorSelect($sVendorId)
+    protected function _getVendorSelect($sVendorId) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $sArticleTable = getViewName('oxarticles');
         $oBaseObject = $this->getBaseObject();
@@ -1112,7 +1114,7 @@ class ArticleList extends \OxidEsales\Eshop\Core\Model\ListModel
      *
      * @return string
      */
-    protected function _getManufacturerSelect($sManufacturerId)
+    protected function _getManufacturerSelect($sManufacturerId) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $sArticleTable = getViewName('oxarticles');
         $oBaseObject = $this->getBaseObject();
@@ -1133,7 +1135,7 @@ class ArticleList extends \OxidEsales\Eshop\Core\Model\ListModel
      *
      * @return bool
      */
-    protected function _canUpdatePrices()
+    protected function _canUpdatePrices() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $oConfig = $this->getConfig();
         $blCan = false;

--- a/source/Application/Model/Attribute.php
+++ b/source/Application/Model/Attribute.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
@@ -136,7 +137,7 @@ class Attribute extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel
      *
      * @return mixed attribute id or false
      */
-    protected function _getAttrId($sSelTitle)
+    protected function _getAttrId($sSelTitle) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $oDb = \OxidEsales\Eshop\Core\DatabaseProvider::getDB();
         $sAttViewName = getViewName('oxattribute');
@@ -153,7 +154,7 @@ class Attribute extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel
      *
      * @return string attribute id
      */
-    protected function _createAttribute($aSelTitle)
+    protected function _createAttribute($aSelTitle) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $myLang = \OxidEsales\Eshop\Core\Registry::getLang();
         $aConfLanguages = $myLang->getLanguageIds();

--- a/source/Application/Model/AttributeList.php
+++ b/source/Application/Model/AttributeList.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
@@ -57,7 +58,7 @@ class AttributeList extends \OxidEsales\Eshop\Core\Model\ListModel
      *
      * @return array $aAttributes
      */
-    protected function _createAttributeListFromSql($sSelect)
+    protected function _createAttributeListFromSql($sSelect) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $aAttributes = [];
         $rs = \OxidEsales\Eshop\Core\DatabaseProvider::getDb()->select($sSelect);
@@ -218,7 +219,7 @@ class AttributeList extends \OxidEsales\Eshop\Core\Model\ListModel
      *
      * @return array $aAttributes
      */
-    protected function _mergeAttributes($aAttributes, $aParentAttributes)
+    protected function _mergeAttributes($aAttributes, $aParentAttributes) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         if (count($aParentAttributes)) {
             $aAttrIds = [];

--- a/source/Application/Model/Basket.php
+++ b/source/Application/Model/Basket.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
@@ -396,7 +397,7 @@ class Basket extends \OxidEsales\Eshop\Core\Base
      * @param string $sNewKey new key to place in old one's place
      * @param mixed  $value   (optional)
      */
-    protected function _changeBasketItemKey($sOldKey, $sNewKey, $value = null)
+    protected function _changeBasketItemKey($sOldKey, $sNewKey, $value = null) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         reset($this->_aBasketContents);
         $iOldKeyPlace = 0;
@@ -589,7 +590,7 @@ class Basket extends \OxidEsales\Eshop\Core\Base
     {
         $aSel = ($aSel != null) ? $aSel : [0 => '0'];
 
-        $sItemKey = md5($sProductId . '|' . serialize($aSel) . '|' . serialize($aPersParam) . '|' . ( int ) $blBundle . '|' . serialize($sAdditionalParam));
+        $sItemKey = md5($sProductId . '|' . serialize($aSel) . '|' . serialize($aPersParam) . '|' . (int) $blBundle . '|' . serialize($sAdditionalParam));
 
         return $sItemKey;
     }
@@ -623,7 +624,7 @@ class Basket extends \OxidEsales\Eshop\Core\Base
     /**
      * Unsets bundled basket items from basket contents array
      */
-    protected function _clearBundles()
+    protected function _clearBundles() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         reset($this->_aBasketContents);
         foreach ($this->_aBasketContents as $sItemKey => $oBasketItem) {
@@ -640,7 +641,7 @@ class Basket extends \OxidEsales\Eshop\Core\Base
      *
      * @return array
      */
-    protected function _getArticleBundles($oBasketItem)
+    protected function _getArticleBundles($oBasketItem) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $aBundles = [];
 
@@ -664,7 +665,7 @@ class Basket extends \OxidEsales\Eshop\Core\Base
      *
      * @return array
      */
-    protected function _getItemBundles($oBasketItem, $aBundles = [])
+    protected function _getItemBundles($oBasketItem, $aBundles = []) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         if ($oBasketItem->isBundle()) {
             return [];
@@ -701,7 +702,7 @@ class Basket extends \OxidEsales\Eshop\Core\Base
      *
      * @return array
      */
-    protected function _getBasketBundles($aBundles = [])
+    protected function _getBasketBundles($aBundles = []) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $aDiscounts = \OxidEsales\Eshop\Core\Registry::get(\OxidEsales\Eshop\Application\Model\DiscountList::class)->getBasketBundleDiscounts($this, $this->getBasketUser());
 
@@ -730,7 +731,7 @@ class Basket extends \OxidEsales\Eshop\Core\Base
      * Iterates through basket contents and adds bundles to items + adds
      * global basket bundles
      */
-    protected function _addBundles()
+    protected function _addBundles() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $aBundles = [];
         // iterating through articles and binding bundles
@@ -770,7 +771,7 @@ class Basket extends \OxidEsales\Eshop\Core\Base
      *
      * @param array $aBundles added bundle articles
      */
-    protected function _addBundlesToBasket($aBundles)
+    protected function _addBundlesToBasket($aBundles) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         foreach ($aBundles as $sBundleId => $dAmount) {
             if ($dAmount) {
@@ -792,7 +793,7 @@ class Basket extends \OxidEsales\Eshop\Core\Base
     /**
      * Iterates through basket items and calculates its prices and discounts
      */
-    protected function _calcItemsPrice()
+    protected function _calcItemsPrice() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         // resetting
         $this->setSkipDiscounts(false);
@@ -878,7 +879,7 @@ class Basket extends \OxidEsales\Eshop\Core\Base
      *
      * @return array $aDiscounts
      */
-    protected function _mergeDiscounts($aDiscounts, $aItemDiscounts)
+    protected function _mergeDiscounts($aDiscounts, $aItemDiscounts) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         foreach ($aItemDiscounts as $sKey => $oDiscount) {
             // add prices of the same discounts
@@ -897,7 +898,7 @@ class Basket extends \OxidEsales\Eshop\Core\Base
      *
      * @return \OxidEsales\Eshop\Core\Price
      */
-    protected function _calcDeliveryCost()
+    protected function _calcDeliveryCost() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         if ($this->_oDeliveryPrice !== null) {
             return $this->_oDeliveryPrice;
@@ -1015,7 +1016,7 @@ class Basket extends \OxidEsales\Eshop\Core\Base
     /**
      * Performs final sum calculation and rounding.
      */
-    protected function _calcTotalPrice()
+    protected function _calcTotalPrice() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         // 1. add products price
         $dPrice = $this->_dBruttoSum;
@@ -1073,7 +1074,7 @@ class Basket extends \OxidEsales\Eshop\Core\Base
     /**
      * Calculates voucher discount
      */
-    protected function _calcVoucherDiscount()
+    protected function _calcVoucherDiscount() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         if ($this->getConfig()->getConfigParam('bl_showVouchers') && ($this->_oVoucherDiscount === null || ($this->_blUpdateNeeded && !$this->isAdmin()))) {
             $this->_oVoucherDiscount = $this->_getPriceObject();
@@ -1137,7 +1138,7 @@ class Basket extends \OxidEsales\Eshop\Core\Base
     /**
      * Performs netto price and VATs calculations including discounts and vouchers.
      */
-    protected function _applyDiscounts()
+    protected function _applyDiscounts() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         //apply discounts for brutto price
         $dDiscountedSum = $this->_getDiscountedProductsSum();
@@ -1182,7 +1183,7 @@ class Basket extends \OxidEsales\Eshop\Core\Base
      *
      * @return \OxidEsales\Eshop\Core\Price
      */
-    protected function _getPriceObject()
+    protected function _getPriceObject() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $oPrice = oxNew(\OxidEsales\Eshop\Core\Price::class);
 
@@ -1198,7 +1199,7 @@ class Basket extends \OxidEsales\Eshop\Core\Base
     /**
      * Loads basket discounts and calculates discount values.
      */
-    protected function _calcBasketDiscount()
+    protected function _calcBasketDiscount() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         // resetting
         $this->_aDiscounts = [];
@@ -1261,7 +1262,7 @@ class Basket extends \OxidEsales\Eshop\Core\Base
     /**
      * Calculates total basket discount value.
      */
-    protected function _calcBasketTotalDiscount()
+    protected function _calcBasketTotalDiscount() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         if ($this->_oTotalDiscount === null || (!$this->isAdmin())) {
             $this->_oTotalDiscount = $this->_getPriceObject();
@@ -1288,7 +1289,7 @@ class Basket extends \OxidEsales\Eshop\Core\Base
      *
      * @return \OxidEsales\Eshop\Core\Price
      */
-    protected function _calcBasketWrapping()
+    protected function _calcBasketWrapping() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $oWrappingPrices = oxNew(\OxidEsales\Eshop\Core\PriceList::class);
 
@@ -1314,7 +1315,7 @@ class Basket extends \OxidEsales\Eshop\Core\Base
      *
      * @return \OxidEsales\Eshop\Core\Price
      */
-    protected function _calcBasketGiftCard()
+    protected function _calcBasketGiftCard() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $oGiftCardPrice = oxNew(\OxidEsales\Eshop\Core\Price::class);
 
@@ -1344,7 +1345,7 @@ class Basket extends \OxidEsales\Eshop\Core\Base
      *
      * @return \OxidEsales\Eshop\Core\Price
      */
-    protected function _calcPaymentCost()
+    protected function _calcPaymentCost() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         // resetting values
         $oPaymentPrice = oxNew(\OxidEsales\Eshop\Core\Price::class);
@@ -1658,7 +1659,7 @@ class Basket extends \OxidEsales\Eshop\Core\Base
      *
      * @return bool
      */
-    protected function _canSaveBasket()
+    protected function _canSaveBasket() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         return $this->isSaveToDataBaseEnabled();
     }
@@ -1693,7 +1694,7 @@ class Basket extends \OxidEsales\Eshop\Core\Base
     /**
      * Saves existing basket to database
      */
-    protected function _save()
+    protected function _save() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         if ($this->isSaveToDataBaseEnabled()) {
             if ($oUser = $this->getBasketUser()) {
@@ -1719,7 +1720,7 @@ class Basket extends \OxidEsales\Eshop\Core\Base
      * \OxidEsales\Eshop\Application\Model\Basket::deleteBasket() method which cleans up basket data when
      * user completes order.
      */
-    protected function _deleteSavedBasket()
+    protected function _deleteSavedBasket() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         // deleting basket if session user available
         if ($oUser = $this->getBasketUser()) {
@@ -1737,7 +1738,7 @@ class Basket extends \OxidEsales\Eshop\Core\Base
      *
      * @return string
      */
-    protected function _findDelivCountry()
+    protected function _findDelivCountry() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $myConfig = $this->getConfig();
         $oUser = $this->getBasketUser();
@@ -2700,7 +2701,7 @@ class Basket extends \OxidEsales\Eshop\Core\Base
      *
      * @return double
      */
-    public function _getDiscountedProductsSum()
+    public function _getDiscountedProductsSum()  // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         if ($oProductsPrice = $this->getDiscountProductsPrice()) {
             $dPrice = $oProductsPrice->getSum($this->isCalculationModeNetto());
@@ -2771,7 +2772,7 @@ class Basket extends \OxidEsales\Eshop\Core\Base
         $blIsBelowMinOrderPrice = false;
         $sConfValue = $this->getConfig()->getConfigParam('iMinOrderPrice');
         if (is_numeric($sConfValue) && $this->getProductsCount()) {
-            $dMinOrderPrice = \OxidEsales\Eshop\Core\Price::getPriceInActCurrency(( double ) $sConfValue);
+            $dMinOrderPrice = \OxidEsales\Eshop\Core\Price::getPriceInActCurrency((double) $sConfValue);
             $dNotDiscountedProductPrice = 0;
             if ($oPrice = $this->getNotDiscountProductsPrice()) {
                 $dNotDiscountedProductPrice = $oPrice->getBruttoSum();
@@ -2860,7 +2861,7 @@ class Basket extends \OxidEsales\Eshop\Core\Base
      *
      * @return bool
      */
-    protected function _isProductInRootCategory($sProductId, $sRootCatId)
+    protected function _isProductInRootCategory($sProductId, $sRootCatId) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $sO2CTable = getViewName('oxobject2category');
         $sCatTable = getViewName('oxcategories');
@@ -2945,7 +2946,7 @@ class Basket extends \OxidEsales\Eshop\Core\Base
      *
      * @deprecated since v.6.0.0 (2017-08-24); Use addedNewItem() instead.
      */
-    protected function _addedNewItem($sProductID, $dAmount, $aSel, $aPersParam, $blOverride, $blBundle, $sOldBasketItemId)
+    protected function _addedNewItem($sProductID, $dAmount, $aSel, $aPersParam, $blOverride, $blBundle, $sOldBasketItemId) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $this->addedNewItem($blOverride);
     }

--- a/source/Application/Model/BasketContentMarkGenerator.php
+++ b/source/Application/Model/BasketContentMarkGenerator.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
@@ -63,7 +64,7 @@ class BasketContentMarkGenerator
      *
      * @return \OxidEsales\Eshop\Application\Model\Basket
      */
-    private function _getBasket()
+    private function _getBasket() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         return $this->_oBasket;
     }
@@ -75,7 +76,7 @@ class BasketContentMarkGenerator
      *
      * @return array
      */
-    private function _formMarks($sCurrentMark)
+    private function _formMarks($sCurrentMark) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $oBasket = $this->_getBasket();
         $aMarks = [];

--- a/source/Application/Model/BasketItem.php
+++ b/source/Application/Model/BasketItem.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
@@ -715,7 +716,7 @@ class BasketItem extends \OxidEsales\Eshop\Core\Base
      *
      * @throws oxNoArticleException exception
      */
-    protected function _setArticle($sProductId)
+    protected function _setArticle($sProductId) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $oConfig = $this->getConfig();
         $oArticle = $this->getArticle(true, $sProductId);
@@ -753,7 +754,7 @@ class BasketItem extends \OxidEsales\Eshop\Core\Base
      *
      * @param \OxidEsales\Eshop\Application\Model\OrderArticle $oOrderArticle order article
      */
-    protected function _setFromOrderArticle($oOrderArticle)
+    protected function _setFromOrderArticle($oOrderArticle) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         // overriding whole article
         $this->_oArticle = $oOrderArticle;
@@ -774,7 +775,7 @@ class BasketItem extends \OxidEsales\Eshop\Core\Base
      *
      * @param array $aSelList item select lists
      */
-    protected function _setSelectList($aSelList)
+    protected function _setSelectList($aSelList) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         // checking for default select list
         $aSelectLists = $this->getArticle()->getSelectLists();

--- a/source/Application/Model/BasketReservation.php
+++ b/source/Application/Model/BasketReservation.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
@@ -39,7 +40,7 @@ class BasketReservation extends \OxidEsales\Eshop\Core\Base
      *
      * @return string
      */
-    protected function _getReservationsId()
+    protected function _getReservationsId() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $sId = \OxidEsales\Eshop\Core\Registry::getSession()->getVariable('basketReservationToken');
         if (!$sId) {
@@ -58,7 +59,7 @@ class BasketReservation extends \OxidEsales\Eshop\Core\Base
      *
      * @return \OxidEsales\EshopCommunity\Application\Model\UserBasket
      */
-    protected function _loadReservations($sBasketId)
+    protected function _loadReservations($sBasketId) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $oReservations = oxNew(\OxidEsales\Eshop\Application\Model\UserBasket::class);
         $aWhere = ['oxuserbaskets.oxuserid' => $sBasketId, 'oxuserbaskets.oxtitle' => 'reservations'];
@@ -99,7 +100,7 @@ class BasketReservation extends \OxidEsales\Eshop\Core\Base
      *
      * @return array
      */
-    protected function _getReservedItems()
+    protected function _getReservedItems() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         if (isset($this->_aCurrentlyReserved)) {
             return $this->_aCurrentlyReserved;
@@ -145,7 +146,7 @@ class BasketReservation extends \OxidEsales\Eshop\Core\Base
      *
      * @return array
      */
-    protected function _basketDifference(\OxidEsales\Eshop\Application\Model\Basket $oBasket)
+    protected function _basketDifference(\OxidEsales\Eshop\Application\Model\Basket $oBasket) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $aDiff = $this->_getReservedItems();
         // refreshing history
@@ -168,7 +169,7 @@ class BasketReservation extends \OxidEsales\Eshop\Core\Base
      *
      * @see oxBasketReservation::_basketDifference
      */
-    protected function _reserveArticles($aBasketDiff)
+    protected function _reserveArticles($aBasketDiff) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $blAllowNegativeStock = $this->getConfig()->getConfigParam('blAllowNegativeStock');
 

--- a/source/Application/Model/Category.php
+++ b/source/Application/Model/Category.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
@@ -211,7 +212,7 @@ class Category extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implement
      *
      * @return array
      */
-    protected function _loadFromDb($sOXID)
+    protected function _loadFromDb($sOXID) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $sSelect = $this->buildSelectString(["`{$this->getViewName()}`.`oxid`" => $sOXID]);
         $aData = \OxidEsales\Eshop\Core\DatabaseProvider::getDb(\OxidEsales\Eshop\Core\DatabaseProvider::FETCH_MODE_ASSOC)->getRow($sSelect);
@@ -443,7 +444,8 @@ class Category extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implement
     {
         $myConfig = $this->getConfig();
 
-        if (!isset($this->_iNrOfArticles)
+        if (
+            !isset($this->_iNrOfArticles)
             && !$this->isAdmin()
             && (
                 $myConfig->getConfigParam('bl_perfShowActionCatArticleCnt')
@@ -542,7 +544,8 @@ class Category extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implement
      */
     public function getLink($iLang = null)
     {
-        if (!\OxidEsales\Eshop\Core\Registry::getUtils()->seoIsActive() ||
+        if (
+            !\OxidEsales\Eshop\Core\Registry::getUtils()->seoIsActive() ||
             (isset($this->oxcategories__oxextlink) && $this->oxcategories__oxextlink->value)
         ) {
             return $this->getStdLink($iLang);
@@ -833,7 +836,7 @@ class Category extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implement
      *
      * @return bool
      */
-    protected function _insert()
+    protected function _insert() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         if ($this->oxcategories__oxparentid->value != "oxrootid") {
             // load parent
@@ -895,7 +898,7 @@ class Category extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implement
      *
      * @return bool
      */
-    protected function _update()
+    protected function _update() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $this->setUpdateSeo(true);
         $this->_setUpdateSeoOnFieldChange('oxtitle');
@@ -1020,7 +1023,7 @@ class Category extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implement
      *
      * @return null
      */
-    protected function _setFieldData($fieldName, $value, $dataType = \OxidEsales\Eshop\Core\Field::T_TEXT)
+    protected function _setFieldData($fieldName, $value, $dataType = \OxidEsales\Eshop\Core\Field::T_TEXT) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         //preliminary quick check saves 3% of execution time in category lists by avoiding redundant strtolower() call
         $fieldNameIndex2 = $fieldName[2];

--- a/source/Application/Model/CategoryList.php
+++ b/source/Application/Model/CategoryList.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
@@ -130,7 +131,7 @@ class CategoryList extends \OxidEsales\Eshop\Core\Model\ListModel
      *
      * @return string return
      */
-    protected function _getSqlSelectFieldsForTree($sTable, $aColumns = null)
+    protected function _getSqlSelectFieldsForTree($sTable, $aColumns = null) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         if ($aColumns && count($aColumns)) {
             foreach ($aColumns as $key => $val) {
@@ -176,7 +177,7 @@ class CategoryList extends \OxidEsales\Eshop\Core\Model\ListModel
      *
      * @return string
      */
-    protected function _getSelectString($blReverse = false, $aColumns = null, $sOrder = null)
+    protected function _getSelectString($blReverse = false, $aColumns = null, $sOrder = null) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $sViewName = $this->getBaseObject()->getViewName();
         $sFieldList = $this->_getSqlSelectFieldsForTree($sViewName, $aColumns);
@@ -212,7 +213,7 @@ class CategoryList extends \OxidEsales\Eshop\Core\Model\ListModel
      *
      * @return string
      */
-    protected function _getDepthSqlSnippet($oCat)
+    protected function _getDepthSqlSnippet($oCat) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $sViewName = $this->getBaseObject()->getViewName();
         $sDepthSnippet = ' ( 0';
@@ -248,7 +249,7 @@ class CategoryList extends \OxidEsales\Eshop\Core\Model\ListModel
      *
      * @return string
      */
-    protected function _getDepthSqlUnion($oCat, $aColumns = null)
+    protected function _getDepthSqlUnion($oCat, $aColumns = null) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         if (!$oCat) {
             return '';
@@ -269,7 +270,7 @@ class CategoryList extends \OxidEsales\Eshop\Core\Model\ListModel
      *
      * @return array
      */
-    protected function _loadFromDb()
+    protected function _loadFromDb() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $sSql = $this->_getSelectString(false, null, 'oxparentid, oxsort, oxtitle');
         $aData = \OxidEsales\Eshop\Core\DatabaseProvider::getDb(\OxidEsales\Eshop\Core\DatabaseProvider::FETCH_MODE_ASSOC)->getAll($sSql);
@@ -326,7 +327,7 @@ class CategoryList extends \OxidEsales\Eshop\Core\Model\ListModel
      *
      * @param string $sId category id
      */
-    protected function _ppLoadFullCategory($sId)
+    protected function _ppLoadFullCategory($sId) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         if (isset($this->_aArray[$sId])) {
             $oNewCat = oxNew(\OxidEsales\Eshop\Application\Model\Category::class);
@@ -405,7 +406,7 @@ class CategoryList extends \OxidEsales\Eshop\Core\Model\ListModel
     /**
      * Category list postprocessing routine, responsible for removal of inactive of forbidden categories, and subcategories.
      */
-    protected function _ppRemoveInactiveCategories()
+    protected function _ppRemoveInactiveCategories() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         // Collect all items which must be remove
         $aRemoveList = [];
@@ -423,11 +424,13 @@ class CategoryList extends \OxidEsales\Eshop\Core\Model\ListModel
 
         // Remove collected item's children from the list too (in the ranges).
         foreach ($this->_aArray as $sId => $oCat) {
-            if (isset($aRemoveList[$oCat->oxcategories__oxrootid->value]) &&
+            if (
+                isset($aRemoveList[$oCat->oxcategories__oxrootid->value]) &&
                 is_array($aRemoveList[$oCat->oxcategories__oxrootid->value])
             ) {
                 foreach ($aRemoveList[$oCat->oxcategories__oxrootid->value] as $iLeft => $iRight) {
-                    if (($iLeft <= $oCat->oxcategories__oxleft->value)
+                    if (
+                        ($iLeft <= $oCat->oxcategories__oxleft->value)
                         && ($iRight >= $oCat->oxcategories__oxleft->value)
                     ) {
                         // this is a child in an inactive range (parent already gone)
@@ -444,7 +447,7 @@ class CategoryList extends \OxidEsales\Eshop\Core\Model\ListModel
      *
      * @return null
      */
-    protected function _ppAddPathInfo()
+    protected function _ppAddPathInfo() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         if (is_null($this->_sActCat)) {
             return;
@@ -466,7 +469,7 @@ class CategoryList extends \OxidEsales\Eshop\Core\Model\ListModel
     /**
      * Category list postprocessing routine, responsible adding of content categories
      */
-    protected function _ppAddContentCategories()
+    protected function _ppAddContentCategories() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         // load content pages for adding them into menu tree
         $oContentList = oxNew(\OxidEsales\Eshop\Application\Model\ContentList::class);
@@ -482,7 +485,7 @@ class CategoryList extends \OxidEsales\Eshop\Core\Model\ListModel
     /**
      * Category list postprocessing routine, responsible building an sorting of hierarchical category tree
      */
-    protected function _ppBuildTree()
+    protected function _ppBuildTree() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $aTree = [];
         foreach ($this->_aArray as $oCat) {
@@ -503,7 +506,7 @@ class CategoryList extends \OxidEsales\Eshop\Core\Model\ListModel
      * Category list postprocessing routine, responsible for making flat category tree and adding depth information.
      * Requires reversed category list!
      */
-    protected function _ppAddDepthInformation()
+    protected function _ppAddDepthInformation() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $aTree = [];
         foreach ($this->_aArray as $oCat) {
@@ -527,7 +530,7 @@ class CategoryList extends \OxidEsales\Eshop\Core\Model\ListModel
      *
      * @return array $aTree
      */
-    protected function _addDepthInfo($aTree, $oCat, $sDepth = "")
+    protected function _addDepthInfo($aTree, $oCat, $sDepth = "") // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $sDepth .= "-";
         $oCat->oxcategories__oxtitle->setValue($sDepth . ' ' . $oCat->oxcategories__oxtitle->value);
@@ -619,7 +622,7 @@ class CategoryList extends \OxidEsales\Eshop\Core\Model\ListModel
      * @param bool   $isRoot   is the current node root?
      * @param string $thisRoot the id of the root
      */
-    protected function _updateNodes($oxRootId, $isRoot, $thisRoot)
+    protected function _updateNodes($oxRootId, $isRoot, $thisRoot) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         // Called from inside a transaction so master is picked automatically (see ESDEV-3804 and ESDEV-3822).
         $database = \OxidEsales\Eshop\Core\DatabaseProvider::getDb();

--- a/source/Application/Model/CompanyVatIn.php
+++ b/source/Application/Model/CompanyVatIn.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
@@ -57,7 +58,7 @@ class CompanyVatIn
      *
      * @return string
      */
-    protected function _cleanUp($sValue)
+    protected function _cleanUp($sValue) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         return (string) \OxidEsales\Eshop\Core\Str::getStr()->preg_replace("/\s|-/", '', $sValue);
     }

--- a/source/Application/Model/Content.php
+++ b/source/Application/Model/Content.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
@@ -126,7 +127,7 @@ class Content extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
      *
      * @return array
      */
-    protected function _loadFromDb($sLoadId)
+    protected function _loadFromDb($sLoadId) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $sTable = $this->getViewName();
         $sShopId = $this->getShopId();
@@ -351,7 +352,7 @@ class Content extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
      *
      * @return null
      */
-    protected function _setFieldData($sFieldName, $sValue, $iDataType = \OxidEsales\Eshop\Core\Field::T_TEXT)
+    protected function _setFieldData($sFieldName, $sValue, $iDataType = \OxidEsales\Eshop\Core\Field::T_TEXT) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $sLoweredFieldName = strtolower($sFieldName);
         if ('oxcontent' === $sLoweredFieldName || 'oxcontents__oxcontent' === $sLoweredFieldName) {
@@ -368,7 +369,7 @@ class Content extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
      *
      * @return mixed
      */
-    protected function _getFieldData($sFieldName)
+    protected function _getFieldData($sFieldName) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         return $this->{$sFieldName}->value;
     }

--- a/source/Application/Model/ContentList.php
+++ b/source/Application/Model/ContentList.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
@@ -115,7 +116,7 @@ class ContentList extends \OxidEsales\Eshop\Core\Model\ListModel
      *
      * @return array
      */
-    protected function _loadFromDb($iType)
+    protected function _loadFromDb($iType) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $sSql = $this->_getSQLByType($iType);
         $aData = \OxidEsales\Eshop\Core\DatabaseProvider::getDb(\OxidEsales\Eshop\Core\DatabaseProvider::FETCH_MODE_ASSOC)->getAll($sSql);
@@ -128,7 +129,7 @@ class ContentList extends \OxidEsales\Eshop\Core\Model\ListModel
      *
      * @param integer $type - type of content
      */
-    protected function _load($type)
+    protected function _load($type) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $data = $this->_loadFromDb($type);
         $this->assignArray($data);
@@ -146,7 +147,7 @@ class ContentList extends \OxidEsales\Eshop\Core\Model\ListModel
     /**
      * Extract oxContentList object to associative array with oxloadid as keys.
      */
-    protected function _extractListToArray()
+    protected function _extractListToArray() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $aExtractedContents = [];
         foreach ($this as $oContent) {
@@ -163,7 +164,7 @@ class ContentList extends \OxidEsales\Eshop\Core\Model\ListModel
      *
      * @return string
      */
-    protected function _getSQLByType($iType)
+    protected function _getSQLByType($iType) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $sSQLAdd = '';
         $oDb = \OxidEsales\Eshop\Core\DatabaseProvider::getDb();

--- a/source/Application/Model/Contract/ArticleInterface.php
+++ b/source/Application/Model/Contract/ArticleInterface.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Application/Model/Contract/CacheConnectorInterface.php
+++ b/source/Application/Model/Contract/CacheConnectorInterface.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Application/Model/Country.php
+++ b/source/Application/Model/Country.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Application/Model/CountryList.php
+++ b/source/Application/Model/CountryList.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Application/Model/Delivery.php
+++ b/source/Application/Model/Delivery.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
@@ -186,7 +187,7 @@ class Delivery extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel
      */
     public function hasArticles()
     {
-        return ( bool ) count($this->getArticles());
+        return (bool) count($this->getArticles());
     }
 
     /**
@@ -196,7 +197,7 @@ class Delivery extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel
      */
     public function hasCategories()
     {
-        return ( bool ) count($this->getCategories());
+        return (bool) count($this->getCategories());
     }
 
     /**
@@ -426,7 +427,7 @@ class Delivery extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel
      *
      * @return bool
      */
-    protected function _isForArticle($content, $artAmount)
+    protected function _isForArticle($content, $artAmount) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         return $this->isDeliveryRuleFitByArticle($artAmount);
     }
@@ -456,7 +457,7 @@ class Delivery extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel
      *
      * @return boolean
      */
-    protected function _checkDeliveryAmount($iAmount)
+    protected function _checkDeliveryAmount($iAmount) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $blResult = false;
 
@@ -585,7 +586,7 @@ class Delivery extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel
      *
      * @return float|int
      */
-    protected function _getMultiplier()
+    protected function _getMultiplier() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $dAmount = 0;
 
@@ -605,7 +606,7 @@ class Delivery extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel
      *
      * @return float
      */
-    protected function _getCostSum()
+    protected function _getCostSum() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         if ($this->getAddSumType() == 'abs') {
             $oCur = $this->getConfig()->getActShopCurrencyObject();

--- a/source/Application/Model/DeliveryList.php
+++ b/source/Application/Model/DeliveryList.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
@@ -98,7 +99,7 @@ class DeliveryList extends \OxidEsales\Eshop\Core\Model\ListModel
      *
      * @return array
      */
-    protected function _getList($oUser = null, $sCountryId = null, $sDelSet = null)
+    protected function _getList($oUser = null, $sCountryId = null, $sDelSet = null) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         // checking for current session user which gives additional restrictions for user itself, users group and country
         if ($oUser === null) {
@@ -138,7 +139,7 @@ class DeliveryList extends \OxidEsales\Eshop\Core\Model\ListModel
      *
      * @return string
      */
-    protected function _getFilterSelect($oUser, $sCountryId, $sDelSet)
+    protected function _getFilterSelect($oUser, $sCountryId, $sDelSet) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $oDb = \OxidEsales\Eshop\Core\DatabaseProvider::getDb();
 

--- a/source/Application/Model/DeliverySet.php
+++ b/source/Application/Model/DeliverySet.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Application/Model/DeliverySetList.php
+++ b/source/Application/Model/DeliverySetList.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
@@ -79,7 +80,7 @@ class DeliverySetList extends \OxidEsales\Eshop\Core\Model\ListModel
      *
      * @return array
      */
-    protected function _getList($oUser = null, $sCountryId = null)
+    protected function _getList($oUser = null, $sCountryId = null) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         // checking for current session user which gives additional restrictions for user itself, users group and country
         if ($oUser === null) {
@@ -120,7 +121,7 @@ class DeliverySetList extends \OxidEsales\Eshop\Core\Model\ListModel
      *
      * @return string
      */
-    protected function _getFilterSelect($oUser, $sCountryId)
+    protected function _getFilterSelect($oUser, $sCountryId) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $sTable = getViewName('oxdeliveryset');
         $sQ = "select $sTable.* from $sTable ";

--- a/source/Application/Model/Diagnostics.php
+++ b/source/Application/Model/Diagnostics.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
@@ -249,7 +250,7 @@ class Diagnostics
      *
      * @return integer
      */
-    protected function _countRows($sTable, $blMode)
+    protected function _countRows($sTable, $blMode) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $oDb = \OxidEsales\Eshop\Core\DatabaseProvider::getDb();
         $sRequest = 'SELECT COUNT(*) FROM ' . $sTable;
@@ -365,7 +366,7 @@ class Diagnostics
      *
      * @return string
      */
-    protected function _getApacheVersion()
+    protected function _getApacheVersion() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         if (function_exists('apache_get_version')) {
             $sReturn = apache_get_version();
@@ -381,7 +382,7 @@ class Diagnostics
      *
      * @return string
      */
-    protected function _getVirtualizationSystem()
+    protected function _getVirtualizationSystem() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $sSystemType = '';
 
@@ -421,7 +422,7 @@ class Diagnostics
      *
      * @return string
      */
-    protected function _getDeviceList($sSystemType)
+    protected function _getDeviceList($sSystemType) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         return exec('lspci | grep -i ' . $sSystemType);
     }
@@ -431,7 +432,7 @@ class Diagnostics
      *
      * @return string
      */
-    protected function _getCpuAmount()
+    protected function _getCpuAmount() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         // cat /proc/cpuinfo | grep "processor" | sort -u | cut -d: -f2');
         return exec('cat /proc/cpuinfo | grep "physical id" | sort | uniq | wc -l');
@@ -442,7 +443,7 @@ class Diagnostics
      *
      * @return float
      */
-    protected function _getCpuMhz()
+    protected function _getCpuMhz() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         return round(exec('cat /proc/cpuinfo | grep "MHz" | sort -u | cut -d: -f2'), 0);
     }
@@ -452,7 +453,7 @@ class Diagnostics
      *
      * @return string
      */
-    protected function _getBogoMips()
+    protected function _getBogoMips() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         return exec('cat /proc/cpuinfo | grep "bogomips" | sort -u | cut -d: -f2');
     }
@@ -462,7 +463,7 @@ class Diagnostics
      *
      * @return string
      */
-    protected function _getMemoryTotal()
+    protected function _getMemoryTotal() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         return exec('cat /proc/meminfo | grep "MemTotal" | sort -u | cut -d: -f2');
     }
@@ -472,7 +473,7 @@ class Diagnostics
      *
      * @return string
      */
-    protected function _getMemoryFree()
+    protected function _getMemoryFree() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         return exec('cat /proc/meminfo | grep "MemFree" | sort -u | cut -d: -f2');
     }
@@ -482,7 +483,7 @@ class Diagnostics
      *
      * @return string
      */
-    protected function _getCpuModel()
+    protected function _getCpuModel() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         return exec('cat /proc/cpuinfo | grep "model name" | sort -u | cut -d: -f2');
     }
@@ -492,7 +493,7 @@ class Diagnostics
      *
      * @return string
      */
-    protected function _getDiskTotalSpace()
+    protected function _getDiskTotalSpace() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         return round(disk_total_space('/') / 1024 / 1024, 0) . ' GiB';
     }
@@ -502,7 +503,7 @@ class Diagnostics
      *
      * @return string
      */
-    protected function _getDiskFreeSpace()
+    protected function _getDiskFreeSpace() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         return round(disk_free_space('/') / 1024 / 1024, 0) . ' GiB';
     }
@@ -512,7 +513,7 @@ class Diagnostics
      *
      * @return string
      */
-    protected function _getPhpVersion()
+    protected function _getPhpVersion() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         return phpversion();
     }
@@ -522,7 +523,7 @@ class Diagnostics
      *
      * @return string
      */
-    protected function _getMySqlServerInfo()
+    protected function _getMySqlServerInfo() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $aResult = \OxidEsales\Eshop\Core\DatabaseProvider::getDb(\OxidEsales\Eshop\Core\DatabaseProvider::FETCH_MODE_ASSOC)->getRow("SHOW VARIABLES LIKE 'version'");
 

--- a/source/Application/Model/DiagnosticsOutput.php
+++ b/source/Application/Model/DiagnosticsOutput.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Application/Model/Discount.php
+++ b/source/Application/Model/Discount.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
@@ -219,7 +220,7 @@ class Discount extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel
             ':oxtype' => 'oxarticles'
         ];
 
-        if (!($blOk = ( bool )$oDb->getOne($sQ, $params))) {
+        if (!($blOk = (bool)$oDb->getOne($sQ, $params))) {
             // checking article category
             $blOk = $this->_checkForArticleCategories($oArticle);
         }
@@ -273,11 +274,13 @@ class Discount extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel
     {
         $blIs = true;
 
-        if ($this->oxdiscount__oxprice->value &&
+        if (
+            $this->oxdiscount__oxprice->value &&
             ($dAmount < $this->oxdiscount__oxprice->value || $dAmount > $this->oxdiscount__oxpriceto->value)
         ) {
             $blIs = false;
-        } elseif ($this->oxdiscount__oxamount->value &&
+        } elseif (
+            $this->oxdiscount__oxamount->value &&
                   ($dAmount < $this->oxdiscount__oxamount->value || $dAmount > $this->oxdiscount__oxamountto->value)
         ) {
             $blIs = false;
@@ -521,7 +524,7 @@ class Discount extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel
      *
      * @return bool
      */
-    protected function _checkForArticleCategories($oArticle)
+    protected function _checkForArticleCategories($oArticle) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         // check if article is in some assigned category
         $aCatIds = $oArticle->getCategoryIds();
@@ -553,7 +556,7 @@ class Discount extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel
      *
      * @return string
      */
-    protected function _getProductCheckQuery($oProduct)
+    protected function _getProductCheckQuery($oProduct) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $oDb = \OxidEsales\Eshop\Core\DatabaseProvider::getDb();
         // check if this article is assigned
@@ -573,7 +576,7 @@ class Discount extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel
      *
      * @return bool
      */
-    protected function _isArticleAssigned($oArticle)
+    protected function _isArticleAssigned($oArticle) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $oDb = \OxidEsales\Eshop\Core\DatabaseProvider::getDb();
 
@@ -597,7 +600,7 @@ class Discount extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel
      *
      * @return bool
      */
-    protected function _isCategoriesAssigned($aCategoryIds)
+    protected function _isCategoriesAssigned($aCategoryIds) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         if (empty($aCategoryIds)) {
             return false;

--- a/source/Application/Model/DiscountList.php
+++ b/source/Application/Model/DiscountList.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
@@ -54,7 +55,7 @@ class DiscountList extends \OxidEsales\Eshop\Core\Model\ListModel
      *
      * @return array
      */
-    protected function _getList($oUser = null)
+    protected function _getList($oUser = null) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $sUserId = $oUser ? $oUser->getId() : '';
 
@@ -105,7 +106,7 @@ class DiscountList extends \OxidEsales\Eshop\Core\Model\ListModel
      *
      * @return string
      */
-    protected function _getFilterSelect($oUser)
+    protected function _getFilterSelect($oUser) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $oBaseObject = $this->getBaseObject();
 

--- a/source/Application/Model/File.php
+++ b/source/Application/Model/File.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
@@ -112,7 +113,7 @@ class File extends \OxidEsales\Eshop\Core\Model\BaseModel
      *
      * @throws oxException Throws exception if file wasn't uploaded successfully.
      */
-    protected function _checkArticleFile($aFileInfo)
+    protected function _checkArticleFile($aFileInfo) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         //checking params
         if (!isset($aFileInfo['name']) || !isset($aFileInfo['tmp_name'])) {
@@ -130,7 +131,7 @@ class File extends \OxidEsales\Eshop\Core\Model\BaseModel
      *
      * @return string
      */
-    protected function _getBaseDownloadDirPath()
+    protected function _getBaseDownloadDirPath() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $sConfigValue = \OxidEsales\Eshop\Core\Registry::getConfig()->getConfigParam('sDownloadsDir');
 
@@ -191,7 +192,7 @@ class File extends \OxidEsales\Eshop\Core\Model\BaseModel
      *
      * @return string
      */
-    protected function _getFileLocation()
+    protected function _getFileLocation() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $this->_sRelativeFilePath = '';
         $sFileHash = $this->oxfiles__oxstorehash->value;
@@ -221,7 +222,7 @@ class File extends \OxidEsales\Eshop\Core\Model\BaseModel
      *
      * @return string
      */
-    protected function _getHashedFileDir($sFileHash)
+    protected function _getHashedFileDir($sFileHash) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $sDir = substr($sFileHash, 0, 2);
         $sAbsDir = $this->_getBaseDownloadDirPath() . DIRECTORY_SEPARATOR . $sDir;
@@ -241,7 +242,7 @@ class File extends \OxidEsales\Eshop\Core\Model\BaseModel
      *
      * @return string
      */
-    protected function _getFileHash($sFileName)
+    protected function _getFileHash($sFileName) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         return md5_file($sFileName);
     }
@@ -255,7 +256,7 @@ class File extends \OxidEsales\Eshop\Core\Model\BaseModel
      *
      * @return bool
      */
-    protected function _uploadFile($sSource, $sTarget)
+    protected function _uploadFile($sSource, $sTarget) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $blDone = move_uploaded_file($sSource, $sTarget);
 
@@ -310,7 +311,7 @@ class File extends \OxidEsales\Eshop\Core\Model\BaseModel
      *
      * @return null|false
      */
-    protected function _deleteFile()
+    protected function _deleteFile() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         if (!$this->isUploaded()) {
             return false;
@@ -334,7 +335,7 @@ class File extends \OxidEsales\Eshop\Core\Model\BaseModel
      *
      * @return string
      */
-    protected function _getFilenameForUrl()
+    protected function _getFilenameForUrl() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         return rawurlencode($this->oxfiles__oxfilename->value);
     }

--- a/source/Application/Model/FileChecker.php
+++ b/source/Application/Model/FileChecker.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
@@ -249,7 +250,7 @@ class FileChecker
      *
      * @return string error
      */
-    protected function _isWebServiceOnline()
+    protected function _isWebServiceOnline() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $oXML = null;
         $aParams = [
@@ -288,7 +289,7 @@ class FileChecker
      *
      * @return boolean
      */
-    protected function _isShopVersionIsKnown()
+    protected function _isShopVersionIsKnown() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $aParams = [
             'job' => 'existsversion',
@@ -401,7 +402,7 @@ class FileChecker
      *
      * @return \SimpleXMLElement
      */
-    protected function _getFileVersion($sMD5, $sFile)
+    protected function _getFileVersion($sMD5, $sFile) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $aParams = [
             'job' => 'md5check',

--- a/source/Application/Model/FileCheckerResult.php
+++ b/source/Application/Model/FileCheckerResult.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Application/Model/FileCollector.php
+++ b/source/Application/Model/FileCollector.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
@@ -120,7 +121,8 @@ class FileCollector
                 } else {
                     $sExt = substr(strrchr($sFile, '.'), 1);
 
-                    if ((!empty($aExtensions) && is_array($aExtensions) && in_array($sExt, $aExtensions)) ||
+                    if (
+                        (!empty($aExtensions) && is_array($aExtensions) && in_array($sExt, $aExtensions)) ||
                         (empty($aExtensions))
                     ) {
                         $this->addFile($sFolder . $sFile);

--- a/source/Application/Model/Groups.php
+++ b/source/Application/Model/Groups.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Application/Model/Links.php
+++ b/source/Application/Model/Links.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
@@ -41,7 +42,7 @@ class Links extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel
      *
      * @return null
      */
-    protected function _setFieldData($sFieldName, $sValue, $iDataType = \OxidEsales\Eshop\Core\Field::T_TEXT)
+    protected function _setFieldData($sFieldName, $sValue, $iDataType = \OxidEsales\Eshop\Core\Field::T_TEXT) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         if ('oxurldesc' === strtolower($sFieldName) || 'oxlinks__oxurldesc' === strtolower($sFieldName)) {
             $iDataType = \OxidEsales\Eshop\Core\Field::T_RAW;

--- a/source/Application/Model/ListObject.php
+++ b/source/Application/Model/ListObject.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Application/Model/Maintenance.php
+++ b/source/Application/Model/Maintenance.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Application/Model/Manufacturer.php
+++ b/source/Application/Model/Manufacturer.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
@@ -155,7 +156,7 @@ class Manufacturer extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel imple
      *
      * @return bool
      */
-    protected function _setRootObjectData()
+    protected function _setRootObjectData() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $this->setId('root');
         $this->oxmanufacturers__oxicon = new \OxidEsales\Eshop\Core\Field('', \OxidEsales\Eshop\Core\Field::T_RAW);

--- a/source/Application/Model/ManufacturerList.php
+++ b/source/Application/Model/ManufacturerList.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
@@ -146,7 +147,7 @@ class ManufacturerList extends \OxidEsales\Eshop\Core\Model\ListModel
      *
      * @param object $oManufacturer manufacturer object
      */
-    protected function _addCategoryFields($oManufacturer)
+    protected function _addCategoryFields($oManufacturer) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $oManufacturer->oxcategories__oxid = new \OxidEsales\Eshop\Core\Field($oManufacturer->oxmanufacturers__oxid->value);
         $oManufacturer->oxcategories__oxicon = $oManufacturer->oxmanufacturers__oxicon;
@@ -180,7 +181,7 @@ class ManufacturerList extends \OxidEsales\Eshop\Core\Model\ListModel
     /**
      * Processes manufacturer category URLs
      */
-    protected function _seoSetManufacturerData()
+    protected function _seoSetManufacturerData() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         // only when SEO id on and in front end
         if (\OxidEsales\Eshop\Core\Registry::getUtils()->seoIsActive() && !$this->isAdmin()) {

--- a/source/Application/Model/MdVariant.php
+++ b/source/Application/Model/MdVariant.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
@@ -361,7 +362,7 @@ class MdVariant extends \OxidEsales\Eshop\Core\Base
      *
      * @param \OxidEsales\Eshop\Application\Model\MdVariant $oSubvariant Subvariant
      */
-    protected function _addMdSubvariant($oSubvariant)
+    protected function _addMdSubvariant($oSubvariant) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $this->_aSubvariants[$oSubvariant->getId()] = $oSubvariant;
     }
@@ -371,7 +372,7 @@ class MdVariant extends \OxidEsales\Eshop\Core\Base
      *
      * @return bool
      */
-    protected function _isFixedPrice()
+    protected function _isFixedPrice() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $dPrice = $this->getDPrice();
         $aVariants = $this->getMdSubvariants();

--- a/source/Application/Model/MediaUrl.php
+++ b/source/Application/Model/MediaUrl.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
@@ -117,7 +118,7 @@ class MediaUrl extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel
      *
      * @return string
      */
-    protected function _getYoutubeHtml()
+    protected function _getYoutubeHtml() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $sUrl = $this->oxmediaurls__oxurl->value;
         $sDesc = $this->oxmediaurls__oxdesc->value;

--- a/source/Application/Model/News.php
+++ b/source/Application/Model/News.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
@@ -131,7 +132,7 @@ class News extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel
     /**
      * Updates object information in DB.
      */
-    protected function _update()
+    protected function _update() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $this->oxnews__oxdate->setValue(\OxidEsales\Eshop\Core\Registry::getUtilsDate()->formatDBDate($this->oxnews__oxdate->value, true));
 
@@ -143,7 +144,7 @@ class News extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel
      *
      * @return bool
      */
-    protected function _insert()
+    protected function _insert() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         if (!$this->oxnews__oxdate || \OxidEsales\Eshop\Core\Registry::getUtilsDate()->isEmptyDate($this->oxnews__oxdate->value)) {
             // if date field is empty, assigning current date
@@ -164,7 +165,7 @@ class News extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel
      *
      * @return null
      */
-    protected function _setFieldData($sFieldName, $sValue, $iDataType = \OxidEsales\Eshop\Core\Field::T_TEXT)
+    protected function _setFieldData($sFieldName, $sValue, $iDataType = \OxidEsales\Eshop\Core\Field::T_TEXT) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         switch (strtolower($sFieldName)) {
             case 'oxlongdesc':

--- a/source/Application/Model/NewsList.php
+++ b/source/Application/Model/NewsList.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Application/Model/NewsSubscribed.php
+++ b/source/Application/Model/NewsSubscribed.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
@@ -127,7 +128,7 @@ class NewsSubscribed extends \OxidEsales\Eshop\Core\Model\BaseModel
      *
      * @return mixed oxid on success or false on failure
      */
-    protected function _insert()
+    protected function _insert() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         // set subscription date
         $this->oxnewssubscribed__oxsubscribed = new \OxidEsales\Eshop\Core\Field(date('Y-m-d H:i:s'), \OxidEsales\Eshop\Core\Field::T_RAW);
@@ -140,7 +141,7 @@ class NewsSubscribed extends \OxidEsales\Eshop\Core\Model\BaseModel
      *
      * @return mixed oxid on success or false on failure
      */
-    protected function _update()
+    protected function _update() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         if (($this->_blWasSubscribed || $this->_blWasPreSubscribed) && !$this->oxnewssubscribed__oxdboptin->value) {
             // set unsubscription date

--- a/source/Application/Model/Newsletter.php
+++ b/source/Application/Model/Newsletter.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
@@ -182,7 +183,7 @@ class Newsletter extends \OxidEsales\Eshop\Core\Model\BaseModel
      *
      * @param bool $blPerfLoadAktion perform option load actions
      */
-    protected function _setParams($blPerfLoadAktion = false)
+    protected function _setParams($blPerfLoadAktion = false) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $myConfig = $this->getConfig();
 
@@ -214,7 +215,7 @@ class Newsletter extends \OxidEsales\Eshop\Core\Model\BaseModel
      *
      * @param string $sUserid User ID or OBJECT
      */
-    protected function _setUser($sUserid)
+    protected function _setUser($sUserid) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         if (is_string($sUserid)) {
             $oUser = oxNew(\OxidEsales\Eshop\Application\Model\User::class);
@@ -233,7 +234,7 @@ class Newsletter extends \OxidEsales\Eshop\Core\Model\BaseModel
      * @param \OxidEsales\Eshop\Core\Controller\BaseController $oView            view object to store view data
      * @param bool                                             $blPerfLoadAktion perform option load actions
      */
-    protected function _assignProducts($oView, $blPerfLoadAktion = false)
+    protected function _assignProducts($oView, $blPerfLoadAktion = false) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         if ($blPerfLoadAktion) {
             $oArtList = oxNew(\OxidEsales\Eshop\Application\Model\ArticleList::class);
@@ -274,7 +275,7 @@ class Newsletter extends \OxidEsales\Eshop\Core\Model\BaseModel
      *
      * @return null
      */
-    protected function _setFieldData($sFieldName, $sValue, $iDataType = \OxidEsales\Eshop\Core\Field::T_TEXT)
+    protected function _setFieldData($sFieldName, $sValue, $iDataType = \OxidEsales\Eshop\Core\Field::T_TEXT) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         if ('oxtemplate' === $sFieldName || 'oxplaintemplate' === $sFieldName) {
             $iDataType = \OxidEsales\Eshop\Core\Field::T_RAW;

--- a/source/Application/Model/Object2Category.php
+++ b/source/Application/Model/Object2Category.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Application/Model/Object2Group.php
+++ b/source/Application/Model/Object2Group.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Application/Model/Order.php
+++ b/source/Application/Model/Order.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
@@ -73,7 +74,7 @@ class Order extends \OxidEsales\Eshop\Core\Model\BaseModel
      *
      * @var int
      */
-    const ORDER_STATE_INVALIDDElADDRESSCHANGED = 7;
+    const ORDER_STATE_INVALIDDElADDRESSCHANGED = 7; // phpcs:ignore
 
     /**
      * Protection parameters used for some data in order are invalid
@@ -298,7 +299,7 @@ class Order extends \OxidEsales\Eshop\Core\Model\BaseModel
      *
      * @return string
      */
-    protected function _getCountryTitle($sCountryId)
+    protected function _getCountryTitle($sCountryId) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $sTitle = null;
         if ($sCountryId && $sCountryId != '-1') {
@@ -317,7 +318,7 @@ class Order extends \OxidEsales\Eshop\Core\Model\BaseModel
      *
      * @return \oxlist
      */
-    protected function _getArticles($blExcludeCanceled = false)
+    protected function _getArticles($blExcludeCanceled = false) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $sSelect = "SELECT `oxorderarticles`.* FROM `oxorderarticles`
                         WHERE `oxorderarticles`.`oxorderid` = :oxorderid" .
@@ -583,7 +584,7 @@ class Order extends \OxidEsales\Eshop\Core\Model\BaseModel
      *
      * @param string $sStatus order transaction status
      */
-    protected function _setOrderStatus($sStatus)
+    protected function _setOrderStatus($sStatus) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $oDb = \OxidEsales\Eshop\Core\DatabaseProvider::getDb();
         $sQ = 'update oxorder set oxtransstatus = :oxtransstatus where oxid = :oxid';
@@ -603,7 +604,7 @@ class Order extends \OxidEsales\Eshop\Core\Model\BaseModel
      *
      * @return float
      */
-    protected function _convertVat($sVat)
+    protected function _convertVat($sVat) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         if (strpos($sVat, '.') < strpos($sVat, ',')) {
             $sVat = str_replace(['.', ','], ['', '.'], $sVat);
@@ -617,7 +618,7 @@ class Order extends \OxidEsales\Eshop\Core\Model\BaseModel
     /**
      * Reset Vat info
      */
-    protected function _resetVats()
+    protected function _resetVats() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $this->oxorder__oxartvat1 = new \OxidEsales\Eshop\Core\Field(null);
         $this->oxorder__oxartvatprice1 = new \OxidEsales\Eshop\Core\Field(null);
@@ -633,7 +634,7 @@ class Order extends \OxidEsales\Eshop\Core\Model\BaseModel
      *
      * @param \OxidEsales\Eshop\Application\Model\Basket $oBasket Shopping basket object
      */
-    protected function _loadFromBasket(\OxidEsales\Eshop\Application\Model\Basket $oBasket)
+    protected function _loadFromBasket(\OxidEsales\Eshop\Application\Model\Basket $oBasket) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $myConfig = $this->getConfig();
 
@@ -738,7 +739,7 @@ class Order extends \OxidEsales\Eshop\Core\Model\BaseModel
      *
      * @param object $oUser user object
      */
-    protected function _setUser($oUser)
+    protected function _setUser($oUser) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $this->oxorder__oxuserid = new \OxidEsales\Eshop\Core\Field($oUser->getId());
 
@@ -784,7 +785,7 @@ class Order extends \OxidEsales\Eshop\Core\Model\BaseModel
      *
      * @param \OxidEsales\Eshop\Application\Model\Basket $oBasket basket object
      */
-    protected function _setWrapping(\OxidEsales\Eshop\Application\Model\Basket $oBasket)
+    protected function _setWrapping(\OxidEsales\Eshop\Application\Model\Basket $oBasket) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         // wrapping price
         if (($oWrappingCost = $oBasket->getCosts('oxwrapping'))) {
@@ -811,7 +812,7 @@ class Order extends \OxidEsales\Eshop\Core\Model\BaseModel
      *
      * @param array $aArticleList article list
      */
-    protected function _setOrderArticles($aArticleList)
+    protected function _setOrderArticles($aArticleList) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         // reset articles list
         $this->_oArticles = oxNew(\OxidEsales\Eshop\Core\Model\ListModel::class);
@@ -914,7 +915,7 @@ class Order extends \OxidEsales\Eshop\Core\Model\BaseModel
      *
      * @return  integer 2 or an error code
      */
-    protected function _executePayment(\OxidEsales\Eshop\Application\Model\Basket $oBasket, $oUserpayment)
+    protected function _executePayment(\OxidEsales\Eshop\Application\Model\Basket $oBasket, $oUserpayment) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $oPayTransaction = $this->_getGateway();
         $oPayTransaction->setPaymentParams($oUserpayment);
@@ -948,7 +949,7 @@ class Order extends \OxidEsales\Eshop\Core\Model\BaseModel
      *
      * @return object $oPayTransaction payment gateway object
      */
-    protected function _getGateway()
+    protected function _getGateway() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         return oxNew(\OxidEsales\Eshop\Application\Model\PaymentGateway::class);
     }
@@ -960,7 +961,7 @@ class Order extends \OxidEsales\Eshop\Core\Model\BaseModel
      *
      * @return \OxidEsales\Eshop\Application\Model\UserPayment
      */
-    protected function _setPayment($sPaymentid)
+    protected function _setPayment($sPaymentid) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $oPayment = oxNew(\OxidEsales\Eshop\Application\Model\Payment::class);
 
@@ -1010,7 +1011,7 @@ class Order extends \OxidEsales\Eshop\Core\Model\BaseModel
     /**
      * Assigns oxfolder as new
      */
-    protected function _setFolder()
+    protected function _setFolder() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $myConfig = $this->getConfig();
         $this->oxorder__oxfolder = new \OxidEsales\Eshop\Core\Field(key($myConfig->getShopConfVar('aOrderfolder', $myConfig->getShopId())), \OxidEsales\Eshop\Core\Field::T_RAW);
@@ -1023,7 +1024,7 @@ class Order extends \OxidEsales\Eshop\Core\Model\BaseModel
      * @param array  $aArticleList basket products
      * @param object $oUser        user object
      */
-    protected function _updateWishlist($aArticleList, $oUser)
+    protected function _updateWishlist($aArticleList, $oUser) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         foreach ($aArticleList as $oContent) {
             if (($sWishId = $oContent->getWishId())) {
@@ -1061,7 +1062,7 @@ class Order extends \OxidEsales\Eshop\Core\Model\BaseModel
      *
      * @return null
      */
-    protected function _updateNoticeList($aArticleList, $oUser)
+    protected function _updateNoticeList($aArticleList, $oUser) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         /*
          * #6141
@@ -1095,7 +1096,7 @@ class Order extends \OxidEsales\Eshop\Core\Model\BaseModel
     /**
      * Updates order date to current date
      */
-    protected function _updateOrderDate()
+    protected function _updateOrderDate() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $oDb = \OxidEsales\Eshop\Core\DatabaseProvider::getDb();
         $sDate = date('Y-m-d H:i:s', \OxidEsales\Eshop\Core\Registry::getUtilsDate()->getTime());
@@ -1114,7 +1115,7 @@ class Order extends \OxidEsales\Eshop\Core\Model\BaseModel
      * @param \OxidEsales\Eshop\Application\Model\Basket $oBasket basket object
      * @param \OxidEsales\Eshop\Application\Model\User   $oUser   user object
      */
-    protected function _markVouchers($oBasket, $oUser)
+    protected function _markVouchers($oBasket, $oUser) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $this->_aVoucherList = $oBasket->getVouchers();
 
@@ -1224,7 +1225,7 @@ class Order extends \OxidEsales\Eshop\Core\Model\BaseModel
      *
      * @return bool
      */
-    protected function _insert()
+    protected function _insert() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $myConfig = $this->getConfig();
         $oUtilsDate = \OxidEsales\Eshop\Core\Registry::getUtilsDate();
@@ -1259,7 +1260,7 @@ class Order extends \OxidEsales\Eshop\Core\Model\BaseModel
      *
      * @return String
      */
-    protected function _getCounterIdent()
+    protected function _getCounterIdent() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $sCounterIdent = ($this->_blSeparateNumbering) ? 'oxOrder_' . $this->getConfig()->getShopId() : 'oxOrder';
 
@@ -1272,13 +1273,13 @@ class Order extends \OxidEsales\Eshop\Core\Model\BaseModel
      *
      * @return bool
      */
-    protected function _setNumber()
+    protected function _setNumber() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $oDb = \OxidEsales\Eshop\Core\DatabaseProvider::getDb();
 
         $iCnt = oxNew(\OxidEsales\Eshop\Core\Counter::class)->getNext($this->_getCounterIdent());
         $sQ = "update oxorder set oxordernr = :oxordernr where oxid = :oxid";
-        $blUpdate = ( bool ) $oDb->execute($sQ, [
+        $blUpdate = (bool) $oDb->execute($sQ, [
             ':oxordernr' => $iCnt,
             ':oxid' => $this->getId()
         ]);
@@ -1295,7 +1296,7 @@ class Order extends \OxidEsales\Eshop\Core\Model\BaseModel
      *
      * @return null
      */
-    protected function _update()
+    protected function _update() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $this->_aSkipSaveFields = ['oxtimestamp', 'oxorderdate'];
         $this->oxorder__oxsenddate = new \OxidEsales\Eshop\Core\Field(\OxidEsales\Eshop\Core\Registry::getUtilsDate()->formatDBDate($this->oxorder__oxsenddate->value, true));
@@ -1388,7 +1389,7 @@ class Order extends \OxidEsales\Eshop\Core\Model\BaseModel
      *
      * @return \OxidEsales\Eshop\Application\Model\Basket
      */
-    protected function _getOrderBasket($blStockCheck = true)
+    protected function _getOrderBasket($blStockCheck = true) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $this->_oOrderBasket = oxNew(\OxidEsales\Eshop\Application\Model\Basket::class);
         $this->_oOrderBasket->enableSaveToDataBase(false);
@@ -1553,7 +1554,7 @@ class Order extends \OxidEsales\Eshop\Core\Model\BaseModel
             ':oxshopid' => $this->getConfig()->getShopId()
         ];
 
-        return (( int ) \OxidEsales\Eshop\Core\DatabaseProvider::getDb()->getOne($sQ, $params) + 1);
+        return ((int) \OxidEsales\Eshop\Core\DatabaseProvider::getDb()->getOne($sQ, $params) + 1);
     }
 
     /**
@@ -1569,7 +1570,7 @@ class Order extends \OxidEsales\Eshop\Core\Model\BaseModel
             ':oxshopid' => $this->getConfig()->getShopId()
         ];
 
-        return (( int ) \OxidEsales\Eshop\Core\DatabaseProvider::getDb()->getOne($sQ, $params) + 1);
+        return ((int) \OxidEsales\Eshop\Core\DatabaseProvider::getDb()->getOne($sQ, $params) + 1);
     }
 
     /**
@@ -1652,7 +1653,7 @@ class Order extends \OxidEsales\Eshop\Core\Model\BaseModel
         ];
 
         // We force reading from master to prevent issues with slow replications or open transactions (see ESDEV-3804).
-        return ( double ) \OxidEsales\Eshop\Core\DatabaseProvider::getMaster()->getOne($sSelect, $params);
+        return (double) \OxidEsales\Eshop\Core\DatabaseProvider::getMaster()->getOne($sSelect, $params);
     }
 
     /**
@@ -1676,7 +1677,7 @@ class Order extends \OxidEsales\Eshop\Core\Model\BaseModel
         ];
 
         // We force reading from master to prevent issues with slow replications or open transactions (see ESDEV-3804).
-        return ( int ) \OxidEsales\Eshop\Core\DatabaseProvider::getMaster()->getOne($sSelect, $params);
+        return (int) \OxidEsales\Eshop\Core\DatabaseProvider::getMaster()->getOne($sSelect, $params);
     }
 
 
@@ -1687,7 +1688,7 @@ class Order extends \OxidEsales\Eshop\Core\Model\BaseModel
      *
      * @return bool
      */
-    protected function _checkOrderExist($sOxId = null)
+    protected function _checkOrderExist($sOxId = null) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         if (!$sOxId) {
             return false;
@@ -1714,7 +1715,7 @@ class Order extends \OxidEsales\Eshop\Core\Model\BaseModel
      *
      * @return bool
      */
-    protected function _sendOrderByEmail($oUser = null, $oBasket = null, $oPayment = null)
+    protected function _sendOrderByEmail($oUser = null, $oBasket = null, $oPayment = null) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $iRet = self::ORDER_STATE_MAILINGERROR;
 
@@ -1856,7 +1857,7 @@ class Order extends \OxidEsales\Eshop\Core\Model\BaseModel
      * @param \OxidEsales\Eshop\Application\Model\Basket $oBasket        basket object
      * @param array                                      $aOrderArticles order articles
      */
-    protected function _addOrderArticlesToBasket($oBasket, $aOrderArticles)
+    protected function _addOrderArticlesToBasket($oBasket, $aOrderArticles) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         // if no order articles, return empty basket
         if (count($aOrderArticles) > 0) {
@@ -1873,7 +1874,7 @@ class Order extends \OxidEsales\Eshop\Core\Model\BaseModel
      * @param \OxidEsales\Eshop\Application\Model\Basket $oBasket   basket to add articles
      * @param array                                      $aArticles article array
      */
-    protected function _addArticlesToBasket($oBasket, $aArticles)
+    protected function _addArticlesToBasket($oBasket, $aArticles) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         // if no order articles
         if (count($aArticles) > 0) {

--- a/source/Application/Model/OrderArticle.php
+++ b/source/Application/Model/OrderArticle.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
@@ -163,7 +164,7 @@ class OrderArticle extends \OxidEsales\Eshop\Core\Model\BaseModel implements Art
      *
      * @return double
      */
-    protected function _getArtStock($dAddAmount = 0, $blAllowNegativeStock = false)
+    protected function _getArtStock($dAddAmount = 0, $blAllowNegativeStock = false) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         // We force reading from master to prevent issues with slow replications or open transactions (see ESDEV-3804).
         $masterDb = \OxidEsales\Eshop\Core\DatabaseProvider::getMaster();
@@ -171,7 +172,7 @@ class OrderArticle extends \OxidEsales\Eshop\Core\Model\BaseModel implements Art
         // #1592A. must take real value
         $sQ = 'select oxstock from oxarticles 
             where oxid = :oxid';
-        $iStockCount = ( float ) $masterDb->getOne($sQ, [
+        $iStockCount = (float) $masterDb->getOne($sQ, [
             ':oxid' => $this->oxorderarticles__oxartid->value
         ]);
 
@@ -225,7 +226,7 @@ class OrderArticle extends \OxidEsales\Eshop\Core\Model\BaseModel implements Art
      *
      * @return null
      */
-    protected function _setFieldData($sFieldName, $sValue, $iDataType = \OxidEsales\Eshop\Core\Field::T_TEXT)
+    protected function _setFieldData($sFieldName, $sValue, $iDataType = \OxidEsales\Eshop\Core\Field::T_TEXT) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $sFieldName = strtolower($sFieldName);
         switch ($sFieldName) {
@@ -291,7 +292,7 @@ class OrderArticle extends \OxidEsales\Eshop\Core\Model\BaseModel implements Art
     /**
      * Sets article parameters to current object, so this object can be used for basket calculation
      */
-    protected function _setArticleParams()
+    protected function _setArticleParams() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         // creating needed fields
         $this->oxarticles__oxstock = $this->oxorderarticles__oxamount;
@@ -349,7 +350,7 @@ class OrderArticle extends \OxidEsales\Eshop\Core\Model\BaseModel implements Art
      *
      * @return \OxidEsales\Eshop\Application\Model\Article | false
      */
-    protected function _getOrderArticle($sArticleId = null)
+    protected function _getOrderArticle($sArticleId = null) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         if ($this->_oOrderArticle === null) {
             $this->_oOrderArticle = false;
@@ -641,7 +642,8 @@ class OrderArticle extends \OxidEsales\Eshop\Core\Model\BaseModel implements Art
         // ordered articles
         if (($blSave = parent::save()) && $this->isNewOrderItem()) {
             $myConfig = $this->getConfig();
-            if ($myConfig->getConfigParam('blUseStock') &&
+            if (
+                $myConfig->getConfigParam('blUseStock') &&
                 $myConfig->getConfigParam('blPsBasketReservationEnabled')
             ) {
                 $this->getSession()
@@ -688,7 +690,7 @@ class OrderArticle extends \OxidEsales\Eshop\Core\Model\BaseModel implements Art
      */
     public function isBundle()
     {
-        return ( bool ) $this->oxorderarticles__oxisbundle->value;
+        return (bool) $this->oxorderarticles__oxisbundle->value;
     }
 
     /**
@@ -763,7 +765,7 @@ class OrderArticle extends \OxidEsales\Eshop\Core\Model\BaseModel implements Art
      *
      * @return bool
      */
-    protected function _insert()
+    protected function _insert() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $iInsertTime = time();
         $now = date('Y-m-d H:i:s', $iInsertTime);
@@ -803,7 +805,7 @@ class OrderArticle extends \OxidEsales\Eshop\Core\Model\BaseModel implements Art
     /**
      * Set order files
      */
-    public function _setOrderFiles()
+    public function _setOrderFiles() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $oArticle = $this->getArticle();
 

--- a/source/Application/Model/OrderArticleList.php
+++ b/source/Application/Model/OrderArticleList.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Application/Model/OrderFile.php
+++ b/source/Application/Model/OrderFile.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
@@ -132,7 +133,7 @@ class OrderFile extends \OxidEsales\Eshop\Core\Model\BaseModel
      *
      * @return string
      */
-    protected function _getFieldLongName($sFieldName)
+    protected function _getFieldLongName($sFieldName) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $aFieldNames = [
             'oxorderfiles__oxarticletitle',

--- a/source/Application/Model/OrderFileList.php
+++ b/source/Application/Model/OrderFileList.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Application/Model/Payment.php
+++ b/source/Application/Model/Payment.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
@@ -227,7 +228,8 @@ class Payment extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel
         }
 
         // discounts
-        if ((!$iRules || ($iRules & self::PAYMENT_ADDSUMRULE_DISCOUNTS)) &&
+        if (
+            (!$iRules || ($iRules & self::PAYMENT_ADDSUMRULE_DISCOUNTS)) &&
             ($oCosts = $oBasket->getTotalDiscount())
         ) {
             $dBasketPrice -= $oCosts->getPrice();
@@ -239,7 +241,8 @@ class Payment extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel
         }
 
         // delivery
-        if ((!$iRules || ($iRules & self::PAYMENT_ADDSUMRULE_SHIPCOSTS)) &&
+        if (
+            (!$iRules || ($iRules & self::PAYMENT_ADDSUMRULE_SHIPCOSTS)) &&
             ($oCosts = $oBasket->getCosts('oxdelivery'))
         ) {
             if ($oBasket->isCalculationModeNetto()) {
@@ -250,7 +253,8 @@ class Payment extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel
         }
 
         // wrapping
-        if (($iRules & self::PAYMENT_ADDSUMRULE_GIFTS) &&
+        if (
+            ($iRules & self::PAYMENT_ADDSUMRULE_GIFTS) &&
             ($oCosts = $oBasket->getCosts('oxwrapping'))
         ) {
             if ($oBasket->isCalculationModeNetto()) {
@@ -261,7 +265,8 @@ class Payment extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel
         }
 
         // gift card
-        if (($iRules & self::PAYMENT_ADDSUMRULE_GIFTS) &&
+        if (
+            ($iRules & self::PAYMENT_ADDSUMRULE_GIFTS) &&
             ($oCosts = $oBasket->getCosts('oxgiftcard'))
         ) {
             if ($oBasket->isCalculationModeNetto()) {
@@ -418,13 +423,14 @@ class Payment extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel
 
                 return false;
             }
-            if (count(
-                \OxidEsales\Eshop\Core\Registry::get(\OxidEsales\Eshop\Application\Model\DeliverySetList::class)
+            if (
+                count(
+                    \OxidEsales\Eshop\Core\Registry::get(\OxidEsales\Eshop\Application\Model\DeliverySetList::class)
                     ->getDeliverySetList(
                         $oUser,
                         $oUser->getActiveCountry()
                     )
-            )
+                )
             ) {
                 $this->_iPaymentError = -3;
 

--- a/source/Application/Model/PaymentGateway.php
+++ b/source/Application/Model/PaymentGateway.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
@@ -105,7 +106,7 @@ class PaymentGateway extends \OxidEsales\Eshop\Core\Base
      *
      * @return bool
      */
-    protected function _isActive()
+    protected function _isActive() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         return $this->_blActive;
     }

--- a/source/Application/Model/PaymentList.php
+++ b/source/Application/Model/PaymentList.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
@@ -53,7 +54,7 @@ class PaymentList extends \OxidEsales\Eshop\Core\Model\ListModel
      *
      * @return string
      */
-    protected function _getFilterSelect($sShipSetId, $dPrice, $oUser)
+    protected function _getFilterSelect($sShipSetId, $dPrice, $oUser) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $oDb = \OxidEsales\Eshop\Core\DatabaseProvider::getDb();
         $sBoni = ($oUser && $oUser->oxuser__oxboni->value) ? $oUser->oxuser__oxboni->value : 0;

--- a/source/Application/Model/PriceAlarm.php
+++ b/source/Application/Model/PriceAlarm.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
@@ -87,7 +88,7 @@ class PriceAlarm extends \OxidEsales\Eshop\Core\Model\BaseModel
      *
      * @return bool
      */
-    protected function _insert()
+    protected function _insert() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         // set oxinsert value
         $this->oxpricealarm__oxinsert = new \OxidEsales\Eshop\Core\Field(date('Y-m-d', \OxidEsales\Eshop\Core\Registry::getUtilsDate()->getTime()));

--- a/source/Application/Model/Rating.php
+++ b/source/Application/Model/Rating.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Application/Model/RecommendationList.php
+++ b/source/Application/Model/RecommendationList.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
@@ -106,7 +107,7 @@ class RecommendationList extends \OxidEsales\Eshop\Core\Model\BaseModel implemen
      *
      * @return string
      */
-    protected function _getArticleSelect()
+    protected function _getArticleSelect() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $sArtView = getViewName('oxarticles');
         $sSelect = "select count(distinct $sArtView.oxid) from oxobject2list ";
@@ -302,7 +303,7 @@ class RecommendationList extends \OxidEsales\Eshop\Core\Model\BaseModel implemen
      * @param \OxidEsales\Eshop\Core\Model\ListModel $oRecommList recommendation list
      * @param array                                  $aIds        article ids
      */
-    protected function _loadFirstArticles(\OxidEsales\Eshop\Core\Model\ListModel $oRecommList, $aIds)
+    protected function _loadFirstArticles(\OxidEsales\Eshop\Core\Model\ListModel $oRecommList, $aIds) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $aIds = \OxidEsales\Eshop\Core\DatabaseProvider::getDb()->quoteArray($aIds);
         $sIds = implode(", ", $aIds);
@@ -389,7 +390,7 @@ class RecommendationList extends \OxidEsales\Eshop\Core\Model\BaseModel implemen
      *
      * @return string
      */
-    protected function _getSearchSelect($sSearchStr)
+    protected function _getSearchSelect($sSearchStr) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $iShopId = $this->getConfig()->getShopId();
         $sSearchStrQuoted = \OxidEsales\Eshop\Core\DatabaseProvider::getDb()->quote("%$sSearchStr%");

--- a/source/Application/Model/Remark.php
+++ b/source/Application/Model/Remark.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
@@ -60,7 +61,7 @@ class Remark extends \OxidEsales\Eshop\Core\Model\BaseModel
      *
      * @return bool
      */
-    protected function _insert()
+    protected function _insert() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         // set oxcreate
         $sNow = date('Y-m-d H:i:s', \OxidEsales\Eshop\Core\Registry::getUtilsDate()->getTime());

--- a/source/Application/Model/RequiredAddressFields.php
+++ b/source/Application/Model/RequiredAddressFields.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
@@ -100,7 +101,7 @@ class RequiredAddressFields
      *
      * @return mixed
      */
-    private function _filterFields($aFields, $sPrefix)
+    private function _filterFields($aFields, $sPrefix) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $aAllowed = [];
         foreach ($aFields as $sKey => $sValue) {

--- a/source/Application/Model/RequiredFieldValidator.php
+++ b/source/Application/Model/RequiredFieldValidator.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
@@ -40,7 +41,7 @@ class RequiredFieldValidator
      *
      * @return bool
      */
-    private function _validateFieldValueArray($aFieldValues)
+    private function _validateFieldValueArray($aFieldValues) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $blValid = true;
         foreach ($aFieldValues as $sValue) {

--- a/source/Application/Model/RequiredFieldsValidator.php
+++ b/source/Application/Model/RequiredFieldsValidator.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
@@ -125,7 +126,7 @@ class RequiredFieldsValidator
      *
      * @param array $aFields Invalid field name.
      */
-    private function _setInvalidFields($aFields)
+    private function _setInvalidFields($aFields) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $this->_aInvalidFields = $aFields;
     }

--- a/source/Application/Model/Review.php
+++ b/source/Application/Model/Review.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
@@ -87,7 +88,7 @@ class Review extends \OxidEsales\Eshop\Core\Model\BaseModel
      *
      * @return bool
      */
-    protected function _insert()
+    protected function _insert() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         // set oxcreate
         $this->oxreviews__oxcreate = new \OxidEsales\Eshop\Core\Field(date('Y-m-d H:i:s', \OxidEsales\Eshop\Core\Registry::getUtilsDate()->getTime()));

--- a/source/Application/Model/RssFeed.php
+++ b/source/Application/Model/RssFeed.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
@@ -95,7 +96,7 @@ class RssFeed extends \OxidEsales\Eshop\Core\Base
      *
      * @access protected
      */
-    protected function _loadBaseChannel()
+    protected function _loadBaseChannel() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $oShop = $this->getConfig()->getActiveShop();
         $this->_aChannel['title'] = $oShop->oxshops__oxname->value;
@@ -131,7 +132,7 @@ class RssFeed extends \OxidEsales\Eshop\Core\Base
      * @access protected
      * @return string
      */
-    protected function _getCacheId($name)
+    protected function _getCacheId($name) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $oConfig = $this->getConfig();
 
@@ -146,7 +147,7 @@ class RssFeed extends \OxidEsales\Eshop\Core\Base
      * @access protected
      * @return array
      */
-    protected function _loadFromCache($name)
+    protected function _loadFromCache($name) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         if ($aRes = Registry::getUtils()->fromFileCache($this->_getCacheId($name))) {
             if ($aRes['timestamp'] > time() - self::CACHE_TTL) {
@@ -168,7 +169,7 @@ class RssFeed extends \OxidEsales\Eshop\Core\Base
      * @access protected
      * @return string
      */
-    protected function _getLastBuildDate($name, $aData)
+    protected function _getLastBuildDate($name, $aData) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         if ($aData2 = Registry::getUtils()->fromFileCache($this->_getCacheId($name))) {
             $sLastBuildDate = $aData2['content']['lastBuildDate'];
@@ -194,7 +195,7 @@ class RssFeed extends \OxidEsales\Eshop\Core\Base
      * @access protected
      * @return void
      */
-    protected function _saveToCache($name, $aContent)
+    protected function _saveToCache($name, $aContent) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $aData = ['timestamp' => time(), 'content' => $aContent];
 
@@ -210,7 +211,7 @@ class RssFeed extends \OxidEsales\Eshop\Core\Base
      * @access protected
      * @return array
      */
-    protected function _getArticleItems(\OxidEsales\Eshop\Application\Model\ArticleList $oList)
+    protected function _getArticleItems(\OxidEsales\Eshop\Application\Model\ArticleList $oList) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $myUtilsUrl = Registry::getUtilsUrl();
         $aItems = [];
@@ -280,7 +281,7 @@ class RssFeed extends \OxidEsales\Eshop\Core\Base
      *
      * @return string
      */
-    protected function _prepareUrl($sUri, $sTitle)
+    protected function _prepareUrl($sUri, $sTitle) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $iLang = Registry::getLang()->getBaseLanguage();
         $sUrl = $this->_getShopUrl();
@@ -303,7 +304,7 @@ class RssFeed extends \OxidEsales\Eshop\Core\Base
      *
      * @return string
      */
-    protected function _prepareFeedName($sTitle)
+    protected function _prepareFeedName($sTitle) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $oShop = $this->getConfig()->getActiveShop();
 
@@ -316,7 +317,7 @@ class RssFeed extends \OxidEsales\Eshop\Core\Base
      * @access protected
      * @return string
      */
-    protected function _getShopUrl()
+    protected function _getShopUrl() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $sUrl = $this->getConfig()->getShopUrl();
         $oStr = getStr();
@@ -343,7 +344,7 @@ class RssFeed extends \OxidEsales\Eshop\Core\Base
      *
      * @access protected
      */
-    protected function _loadData($sTag, $sTitle, $sDesc, $aItems, $sRssUrl, $sTargetUrl = null)
+    protected function _loadData($sTag, $sTitle, $sDesc, $aItems, $sRssUrl, $sTargetUrl = null) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $this->_loadBaseChannel();
 
@@ -498,7 +499,7 @@ class RssFeed extends \OxidEsales\Eshop\Core\Base
      *
      * @return string
      */
-    protected function _getCatPath($oCat)
+    protected function _getCatPath($oCat) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $sCatPathString = '';
         $sSep = '';
@@ -593,7 +594,7 @@ class RssFeed extends \OxidEsales\Eshop\Core\Base
      *
      * @return string
      */
-    protected function _getSearchParamsUrl($sSearch, $sCatId, $sVendorId, $sManufacturerId)
+    protected function _getSearchParamsUrl($sSearch, $sCatId, $sVendorId, $sManufacturerId) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $sParams = "searchparam=" . urlencode($sSearch);
         if ($sCatId) {
@@ -621,7 +622,7 @@ class RssFeed extends \OxidEsales\Eshop\Core\Base
      * @access protected
      * @return string
      */
-    protected function _getObjectField($sId, $sObject, $sField)
+    protected function _getObjectField($sId, $sObject, $sField) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         if (!$sId) {
             return '';
@@ -647,7 +648,7 @@ class RssFeed extends \OxidEsales\Eshop\Core\Base
      * @access protected
      * @return string
      */
-    protected function _getSearchParamsTranslation($sSearch, $sId, $sCatId, $sVendorId, $sManufacturerId)
+    protected function _getSearchParamsTranslation($sSearch, $sId, $sCatId, $sVendorId, $sManufacturerId) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $oLang = Registry::getLang();
         $sCatTitle = '';
@@ -777,7 +778,7 @@ class RssFeed extends \OxidEsales\Eshop\Core\Base
      *
      * @return array
      */
-    protected function _getRecommListItems($oList)
+    protected function _getRecommListItems($oList) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $myUtilsUrl = Registry::getUtilsUrl();
         $aItems = [];
@@ -964,7 +965,7 @@ class RssFeed extends \OxidEsales\Eshop\Core\Base
      *
      * @return bool Went everything well?
      */
-    protected function _deleteFile($sFilePath)
+    protected function _deleteFile($sFilePath) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         return @unlink($sFilePath);
     }

--- a/source/Application/Model/Search.php
+++ b/source/Application/Model/Search.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
@@ -112,7 +113,7 @@ class Search extends \OxidEsales\Eshop\Core\Base
      *
      * @return string
      */
-    protected function _getSearchSelect($sSearchParamForQuery = false, $sInitialSearchCat = false, $sInitialSearchVendor = false, $sInitialSearchManufacturer = false, $sSortBy = false)
+    protected function _getSearchSelect($sSearchParamForQuery = false, $sInitialSearchCat = false, $sInitialSearchVendor = false, $sInitialSearchManufacturer = false, $sSortBy = false) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         if (!$sSearchParamForQuery && !$sInitialSearchCat && !$sInitialSearchVendor && !$sInitialSearchManufacturer) {
             //no search string
@@ -239,7 +240,7 @@ class Search extends \OxidEsales\Eshop\Core\Base
      *
      * @return string
      */
-    protected function _getWhere($sSearchString)
+    protected function _getWhere($sSearchString) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $oDb = \OxidEsales\Eshop\Core\DatabaseProvider::getDb();
         $myConfig = $this->getConfig();

--- a/source/Application/Model/SelectList.php
+++ b/source/Application/Model/SelectList.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Application/Model/Selection.php
+++ b/source/Application/Model/Selection.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Application/Model/SeoEncoderArticle.php
+++ b/source/Application/Model/SeoEncoderArticle.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
@@ -30,7 +31,7 @@ class SeoEncoderArticle extends \OxidEsales\Eshop\Core\SeoEncoder
      *
      * @return string
      */
-    protected function _getUrlExtension()
+    protected function _getUrlExtension() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         return '.html';
     }
@@ -44,7 +45,7 @@ class SeoEncoderArticle extends \OxidEsales\Eshop\Core\SeoEncoder
      *
      * @return \OxidEsales\Eshop\Application\Model\Article
      */
-    protected function _getProductForLang($oArticle, $iLang)
+    protected function _getProductForLang($oArticle, $iLang) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         if (isset($iLang) && $iLang != $oArticle->getLanguage()) {
             $sId = $oArticle->getId();
@@ -111,7 +112,7 @@ class SeoEncoderArticle extends \OxidEsales\Eshop\Core\SeoEncoder
      *
      * @return \OxidEsales\Eshop\Application\Model\RecommendationList | null
      */
-    protected function _getRecomm($oArticle, $iLang)
+    protected function _getRecomm($oArticle, $iLang) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $oList = null;
         $oView = $this->getConfig()->getActiveView();
@@ -127,7 +128,7 @@ class SeoEncoderArticle extends \OxidEsales\Eshop\Core\SeoEncoder
      *
      * @return string
      */
-    protected function _getListType()
+    protected function _getListType() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         return $this->getConfig()->getActiveView()->getListType();
     }
@@ -141,7 +142,7 @@ class SeoEncoderArticle extends \OxidEsales\Eshop\Core\SeoEncoder
      *
      * @return string
      */
-    protected function _createArticleCategoryUri($oArticle, $oCategory, $iLang)
+    protected function _createArticleCategoryUri($oArticle, $oCategory, $iLang) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         startProfile(__FUNCTION__);
         $oArticle = $this->_getProductForLang($oArticle, $iLang);
@@ -224,7 +225,7 @@ class SeoEncoderArticle extends \OxidEsales\Eshop\Core\SeoEncoder
      *
      * @return \OxidEsales\Eshop\Application\Model\Category | null
      */
-    protected function _getCategory($oArticle, $iLang)
+    protected function _getCategory($oArticle, $iLang) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $oCat = null;
         $oView = $this->getConfig()->getActiveView();
@@ -244,7 +245,7 @@ class SeoEncoderArticle extends \OxidEsales\Eshop\Core\SeoEncoder
      *
      * @return string
      */
-    protected function _getMainCategory($oArticle)
+    protected function _getMainCategory($oArticle) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $oMainCat = null;
 
@@ -331,7 +332,7 @@ class SeoEncoderArticle extends \OxidEsales\Eshop\Core\SeoEncoder
      *
      * @return string
      */
-    protected function _prepareArticleTitle($oArticle)
+    protected function _prepareArticleTitle($oArticle) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         // create title part for uri
         if (!($sTitle = $oArticle->oxarticles__oxtitle->value)) {
@@ -416,7 +417,7 @@ class SeoEncoderArticle extends \OxidEsales\Eshop\Core\SeoEncoder
      *
      * @return \OxidEsales\Eshop\Application\Model\Vendor | null
      */
-    protected function _getVendor($oArticle, $iLang)
+    protected function _getVendor($oArticle, $iLang) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $oView = $this->getConfig()->getActiveView();
 
@@ -493,7 +494,7 @@ class SeoEncoderArticle extends \OxidEsales\Eshop\Core\SeoEncoder
      *
      * @return \OxidEsales\Eshop\Application\Model\Manufacturer | null
      */
-    protected function _getManufacturer($oArticle, $iLang)
+    protected function _getManufacturer($oArticle, $iLang) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $oManufacturer = null;
         if ($sActManufacturerId = $oArticle->oxarticles__oxmanufacturerid->value) {
@@ -602,7 +603,7 @@ class SeoEncoderArticle extends \OxidEsales\Eshop\Core\SeoEncoder
      *
      * @return string
      */
-    protected function _getAltUri($sObjectId, $iLang)
+    protected function _getAltUri($sObjectId, $iLang) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $sSeoUrl = null;
         $oArticle = oxNew(\OxidEsales\Eshop\Application\Model\Article::class);

--- a/source/Application/Model/SeoEncoderCategory.php
+++ b/source/Application/Model/SeoEncoderCategory.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
@@ -21,7 +22,7 @@ class SeoEncoderCategory extends \OxidEsales\Eshop\Core\SeoEncoder
      *
      * @return string
      */
-    protected function _getUrlExtension()
+    protected function _getUrlExtension() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         return '/';
     }
@@ -37,7 +38,7 @@ class SeoEncoderCategory extends \OxidEsales\Eshop\Core\SeoEncoder
      *
      * @return boolean
      */
-    protected function _categoryUrlLoader($oCat, $iLang)
+    protected function _categoryUrlLoader($oCat, $iLang) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $sCacheId = $this->_getCategoryCacheId($oCat, $iLang);
         if (isset($this->_aCatCache[$sCacheId])) {
@@ -60,7 +61,7 @@ class SeoEncoderCategory extends \OxidEsales\Eshop\Core\SeoEncoder
      *
      * @return string
      */
-    private function _getCategoryCacheId($oCat, $iLang)
+    private function _getCategoryCacheId($oCat, $iLang) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         return $oCat->getId() . '_' . ((int) $iLang);
     }
@@ -208,10 +209,10 @@ class SeoEncoderCategory extends \OxidEsales\Eshop\Core\SeoEncoder
 
         // update subarticles
         $sQ = "update oxseo as seo1, (select o2c.oxobjectid as id from oxcategories as cat left join oxobject2category "
-              ."as o2c on o2c.oxcatnid=cat.oxid where cat.oxrootid = :oxrootid and cat.oxleft >= :oxleft "
-              ."and cat.oxright <= :oxright) as seo2 "
-              ."set seo1.oxexpired = '1' where seo1.oxtype = 'oxarticle' and seo1.oxobjectid = seo2.id "
-              ."and seo1.oxfixed = 0";
+              . "as o2c on o2c.oxcatnid=cat.oxid where cat.oxrootid = :oxrootid and cat.oxleft >= :oxleft "
+              . "and cat.oxright <= :oxright) as seo2 "
+              . "set seo1.oxexpired = '1' where seo1.oxtype = 'oxarticle' and seo1.oxobjectid = seo2.id "
+              . "and seo1.oxfixed = 0";
         $oDb->execute($sQ, [
             ':oxrootid' => $aCatInfo[0][0],
             ':oxleft' => (int) $aCatInfo[0][1],
@@ -254,7 +255,7 @@ class SeoEncoderCategory extends \OxidEsales\Eshop\Core\SeoEncoder
      *
      * @return string
      */
-    protected function _getAltUri($sObjectId, $iLang)
+    protected function _getAltUri($sObjectId, $iLang) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $sSeoUrl = null;
         $oCat = oxNew(\OxidEsales\Eshop\Application\Model\Category::class);

--- a/source/Application/Model/SeoEncoderContent.php
+++ b/source/Application/Model/SeoEncoderContent.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
@@ -19,7 +20,7 @@ class SeoEncoderContent extends \OxidEsales\Eshop\Core\SeoEncoder
      *
      * @return string
      */
-    protected function _getUrlExtension()
+    protected function _getUrlExtension() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         return '/';
     }
@@ -114,7 +115,7 @@ class SeoEncoderContent extends \OxidEsales\Eshop\Core\SeoEncoder
      *
      * @return string
      */
-    protected function _getAltUri($sObjectId, $iLang)
+    protected function _getAltUri($sObjectId, $iLang) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $sSeoUrl = null;
         $oCont = oxNew(\OxidEsales\Eshop\Application\Model\Content::class);

--- a/source/Application/Model/SeoEncoderManufacturer.php
+++ b/source/Application/Model/SeoEncoderManufacturer.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
@@ -25,7 +26,7 @@ class SeoEncoderManufacturer extends \OxidEsales\Eshop\Core\SeoEncoder
      *
      * @return string
      */
-    protected function _getUrlExtension()
+    protected function _getUrlExtension() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         return '/';
     }
@@ -144,7 +145,7 @@ class SeoEncoderManufacturer extends \OxidEsales\Eshop\Core\SeoEncoder
      *
      * @return string
      */
-    protected function _getAltUri($sObjectId, $iLang)
+    protected function _getAltUri($sObjectId, $iLang) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $sSeoUrl = null;
         $oManufacturer = oxNew(\OxidEsales\Eshop\Application\Model\Manufacturer::class);

--- a/source/Application/Model/SeoEncoderRecomm.php
+++ b/source/Application/Model/SeoEncoderRecomm.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Application/Model/SeoEncoderVendor.php
+++ b/source/Application/Model/SeoEncoderVendor.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
@@ -26,7 +27,7 @@ class SeoEncoderVendor extends \OxidEsales\Eshop\Core\SeoEncoder
      *
      * @return string
      */
-    protected function _getUrlExtension()
+    protected function _getUrlExtension() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         return '/';
     }
@@ -146,7 +147,7 @@ class SeoEncoderVendor extends \OxidEsales\Eshop\Core\SeoEncoder
      *
      * @return string
      */
-    protected function _getAltUri($vendorId, $languageId)
+    protected function _getAltUri($vendorId, $languageId) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $seoUrl = null;
         $vendor = oxNew(\OxidEsales\Eshop\Application\Model\Vendor::class);

--- a/source/Application/Model/Shop.php
+++ b/source/Application/Model/Shop.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
@@ -192,7 +193,7 @@ class Shop extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel
      *
      * @return string
      */
-    protected function _getViewSelect($sTable, $iLang)
+    protected function _getViewSelect($sTable, $iLang) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $oMetaData = oxNew(\OxidEsales\Eshop\Core\DbMetaDataHandler::class);
         $aFields = $oMetaData->getSinglelangFields($sTable, $iLang);
@@ -212,7 +213,7 @@ class Shop extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel
      *
      * @return string
      */
-    protected function _getViewSelectMultilang($sTable)
+    protected function _getViewSelectMultilang($sTable) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $aFields = [];
 
@@ -237,7 +238,7 @@ class Shop extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel
      *
      * @return string $sSQL
      */
-    protected function _getViewJoinAll($sTable)
+    protected function _getViewJoinAll($sTable) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $sJoin = ' ';
         $oMetaData = oxNew(\OxidEsales\Eshop\Core\DbMetaDataHandler::class);
@@ -259,7 +260,7 @@ class Shop extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel
      *
      * @return string $sSQL
      */
-    protected function _getViewJoinLang($sTable, $iLang)
+    protected function _getViewJoinLang($sTable, $iLang) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $sJoin = ' ';
         $sLangTable = getLangTableName($sTable, $iLang);
@@ -273,7 +274,7 @@ class Shop extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel
     /**
      * Gets all invalid views and drops them from database
      */
-    protected function _cleanInvalidViews()
+    protected function _cleanInvalidViews() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $oDb = \OxidEsales\Eshop\Core\DatabaseProvider::getDb();
         $oLang = \OxidEsales\Eshop\Core\Registry::getLang();
@@ -303,7 +304,7 @@ class Shop extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel
     /**
      * Creates all view queries and adds them in query array
      */
-    protected function _prepareViewsQueries()
+    protected function _prepareViewsQueries() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $oLang = \OxidEsales\Eshop\Core\Registry::getLang();
         $aLanguages = $oLang->getLanguageIds($this->getId());
@@ -350,7 +351,7 @@ class Shop extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel
      *
      * @return bool
      */
-    protected function _runQueries()
+    protected function _runQueries() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $oDb = \OxidEsales\Eshop\Core\DatabaseProvider::getDb();
         $aQueries = $this->getQueries();

--- a/source/Application/Model/ShopList.php
+++ b/source/Application/Model/ShopList.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Application/Model/ShopViewValidator.php
+++ b/source/Application/Model/ShopViewValidator.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
@@ -138,7 +139,7 @@ class ShopViewValidator
      *
      * @return array
      */
-    protected function _getAllViews()
+    protected function _getAllViews() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         if (empty($this->_aAllViews)) {
             $this->_aAllViews = \OxidEsales\Eshop\Core\DatabaseProvider::getDb()->getCol("SHOW TABLES LIKE  'oxv\_%'");
@@ -154,14 +155,15 @@ class ShopViewValidator
      *
      * @return bool
      */
-    protected function _isCurrentShopView($sViewName)
+    protected function _isCurrentShopView($sViewName) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $blResult = false;
 
         $blEndsWithShopId = preg_match("/[_]([0-9]+)$/", $sViewName, $aMatchEndsWithShopId);
         $blContainsShopId = preg_match("/[_]([0-9]+)[_]/", $sViewName, $aMatchContainsShopId);
 
-        if ((!$blEndsWithShopId && !$blContainsShopId) ||
+        if (
+            (!$blEndsWithShopId && !$blContainsShopId) ||
             ($blEndsWithShopId && $aMatchEndsWithShopId[1] == $this->getShopId()) ||
             ($blContainsShopId && $aMatchContainsShopId[1] == $this->getShopId())
         ) {
@@ -177,7 +179,7 @@ class ShopViewValidator
      *
      * @return array
      */
-    protected function _getShopViews()
+    protected function _getShopViews() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         if (empty($this->_aShopViews)) {
             $this->_aShopViews = [];
@@ -198,7 +200,7 @@ class ShopViewValidator
      *
      * @return array
      */
-    protected function _getValidShopViews()
+    protected function _getValidShopViews() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         if (empty($this->_aValidShopViews)) {
             $aTables = $this->getShopTables();
@@ -247,7 +249,7 @@ class ShopViewValidator
      *
      * @return bool
      */
-    protected function _isViewValid($sViewName)
+    protected function _isViewValid($sViewName) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         return in_array($sViewName, $this->_getValidShopViews());
     }

--- a/source/Application/Model/SimpleVariant.php
+++ b/source/Application/Model/SimpleVariant.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
@@ -105,7 +106,7 @@ class SimpleVariant extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel impl
      *
      * @return double
      */
-    protected function _getGroupPrice()
+    protected function _getGroupPrice() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $dPrice = $this->oxarticles__oxprice->value;
         if ($oUser = $this->getArticleUser()) {
@@ -174,7 +175,7 @@ class SimpleVariant extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel impl
      * @param \OxidEsales\Eshop\Core\Price $oPrice Price object
      * @param object                       $oCur   Currency object
      */
-    protected function _applyCurrency(\OxidEsales\Eshop\Core\Price $oPrice, $oCur = null)
+    protected function _applyCurrency(\OxidEsales\Eshop\Core\Price $oPrice, $oCur = null) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         if (!$oCur) {
             $oCur = $this->getConfig()->getActShopCurrencyObject();
@@ -188,7 +189,7 @@ class SimpleVariant extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel impl
      *
      * @param \OxidEsales\Eshop\Core\Price $oPrice Price object
      */
-    protected function _applyParentDiscounts($oPrice)
+    protected function _applyParentDiscounts($oPrice) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         if (($oParent = $this->getParent())) {
             $oParent->applyDiscountsForVariant($oPrice);
@@ -200,7 +201,7 @@ class SimpleVariant extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel impl
      *
      * @param \OxidEsales\Eshop\Core\Price $oPrice price object
      */
-    protected function _applyParentVat($oPrice)
+    protected function _applyParentVat($oPrice) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         if (($oParent = $this->getParent()) && !$this->getConfig()->getConfigParam('bl_perfCalcVatOnlyForBasketOrder')) {
             $oParent->applyVats($oPrice);

--- a/source/Application/Model/SimpleVariantList.php
+++ b/source/Application/Model/SimpleVariantList.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
@@ -40,7 +41,7 @@ class SimpleVariantList extends \OxidEsales\Eshop\Core\Model\ListModel
      * @param oxSimleVariant $oListObject Simple variant
      * @param array          $aDbFields   Array of available
      */
-    protected function _assignElement($oListObject, $aDbFields)
+    protected function _assignElement($oListObject, $aDbFields) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $oListObject->setParent($this->_oParent);
         parent::_assignElement($oListObject, $aDbFields);

--- a/source/Application/Model/SmartyRenderer.php
+++ b/source/Application/Model/SmartyRenderer.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Application/Model/State.php
+++ b/source/Application/Model/State.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Application/Model/User.php
+++ b/source/Application/Model/User.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
@@ -181,7 +182,7 @@ class User extends \OxidEsales\Eshop\Core\Model\BaseModel
      *
      * @return oxState
      */
-    protected function _getStateObject()
+    protected function _getStateObject() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         if (is_null($this->_oStateObject)) {
             $this->_oStateObject = oxNew(\OxidEsales\Eshop\Application\Model\State::class);
@@ -423,7 +424,7 @@ class User extends \OxidEsales\Eshop\Core\Model\BaseModel
      *
      * @return $sWishId
      */
-    protected function _getWishListId()
+    protected function _getWishListId() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $this->_sWishId = null;
         // check if we have to set it here
@@ -518,7 +519,8 @@ class User extends \OxidEsales\Eshop\Core\Model\BaseModel
     public function save()
     {
         $blAddRemark = false;
-        if ($this->oxuser__oxpassword->value
+        if (
+            $this->oxuser__oxpassword->value
             && (!$this->oxuser__oxregister instanceof \OxidEsales\Eshop\Core\Field || $this->oxuser__oxregister->value < 1)
         ) {
             $blAddRemark = true;
@@ -1233,7 +1235,7 @@ class User extends \OxidEsales\Eshop\Core\Model\BaseModel
      *
      * @return string
      */
-    protected function _getMergedAddressFields()
+    protected function _getMergedAddressFields() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $sDelAddress = '';
         $sDelAddress .= $this->oxuser__oxcompany;
@@ -1260,7 +1262,7 @@ class User extends \OxidEsales\Eshop\Core\Model\BaseModel
      *
      * @param array $aDelAddress address data array
      */
-    protected function _assignAddress($aDelAddress)
+    protected function _assignAddress($aDelAddress) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         if (is_array($aDelAddress) && count($aDelAddress)) {
             $sAddressId = $this->getConfig()->getRequestParameter('oxaddressid');
@@ -1304,7 +1306,7 @@ class User extends \OxidEsales\Eshop\Core\Model\BaseModel
      *
      * @return string
      */
-    protected function _getLoginQueryHashedWithMD5($userName, $password, $shopId, $isAdmin)
+    protected function _getLoginQueryHashedWithMD5($userName, $password, $shopId, $isAdmin) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $database = \OxidEsales\Eshop\Core\DatabaseProvider::getDb();
 
@@ -1341,7 +1343,7 @@ class User extends \OxidEsales\Eshop\Core\Model\BaseModel
      *
      * @return string
      */
-    protected function _getLoginQuery($userName, $password, $shopId, $isAdmin)
+    protected function _getLoginQuery($userName, $password, $shopId, $isAdmin) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $database = DatabaseProvider::getDb();
         $userNameCondition = $this->formQueryPartForUserName($userName, $database);
@@ -1371,7 +1373,7 @@ class User extends \OxidEsales\Eshop\Core\Model\BaseModel
      *
      * @return string
      */
-    protected function _getShopSelect($myConfig, $sShopID, $blAdmin)
+    protected function _getShopSelect($myConfig, $sShopID, $blAdmin) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $sShopSelect = $this->formQueryPartForAdminView($sShopID, $blAdmin);
 
@@ -1598,7 +1600,7 @@ class User extends \OxidEsales\Eshop\Core\Model\BaseModel
      *
      * @return string
      */
-    protected function _getCookieUserId()
+    protected function _getCookieUserId() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $sUserID = null;
         $oConfig = $this->getConfig();
@@ -1643,7 +1645,7 @@ class User extends \OxidEsales\Eshop\Core\Model\BaseModel
      *
      * @throws $oEx if user is wrong
      */
-    protected function _ldapLogin($sUser, $sPassword, $sShopID, $sShopSelect)
+    protected function _ldapLogin($sUser, $sPassword, $sShopID, $sShopSelect) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $aLDAPParams = $this->getConfig()->getConfigParam('aLDAPParams');
         $oLDAP = oxNew(\OxidEsales\Eshop\Core\LDAP::class, $aLDAPParams['HOST'], $aLDAPParams['PORT']);
@@ -1710,7 +1712,7 @@ class User extends \OxidEsales\Eshop\Core\Model\BaseModel
      *
      * @return string
      */
-    protected function _getUserRights()
+    protected function _getUserRights() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         // previously user had no rights defined
         if (!$this->oxuser__oxrights instanceof \OxidEsales\Eshop\Core\Field || !$this->oxuser__oxrights->value) {
@@ -1762,7 +1764,7 @@ class User extends \OxidEsales\Eshop\Core\Model\BaseModel
      *
      * @return bool
      */
-    protected function _insert()
+    protected function _insert() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
 
         // set oxcreate date
@@ -1780,7 +1782,7 @@ class User extends \OxidEsales\Eshop\Core\Model\BaseModel
      *
      * @return bool
      */
-    protected function _update()
+    protected function _update() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         //V #M418: for not registered users, don't change boni during update
         if (!$this->oxuser__oxpassword->value && $this->oxuser__oxregister->value < 1) {
@@ -1929,7 +1931,7 @@ class User extends \OxidEsales\Eshop\Core\Model\BaseModel
      *
      * @param string $sCountryId users country id
      */
-    protected function _setAutoGroups($sCountryId)
+    protected function _setAutoGroups($sCountryId) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         // assigning automatically to specific groups
         $blForeigner = true;
@@ -2380,7 +2382,7 @@ class User extends \OxidEsales\Eshop\Core\Model\BaseModel
      *
      * @return void
      */
-    protected function _dbLogin(string $userName, $password, $shopID)
+    protected function _dbLogin(string $userName, $password, $shopID) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $database = \OxidEsales\Eshop\Core\DatabaseProvider::getDb();
         $userId = $database->getOne($this->_getLoginQuery($userName, $password, $shopID, $this->isAdmin()));
@@ -2428,7 +2430,7 @@ class User extends \OxidEsales\Eshop\Core\Model\BaseModel
      *
      * @return bool
      */
-    protected function _isDemoShop()
+    protected function _isDemoShop() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $blDemoMode = false;
 
@@ -2449,7 +2451,7 @@ class User extends \OxidEsales\Eshop\Core\Model\BaseModel
      *
      * @return string
      */
-    protected function _getDemoShopLoginQuery($sUser, $sPassword)
+    protected function _getDemoShopLoginQuery($sUser, $sPassword) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         if ($sPassword == "admin" && $sUser == "admin") {
             $sSelect = "SELECT `oxid` FROM `oxuser` WHERE `oxrights` = 'malladmin' ";

--- a/source/Application/Model/User/UserShippingAddressUpdatableFields.php
+++ b/source/Application/Model/User/UserShippingAddressUpdatableFields.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Application/Model/User/UserUpdatableFields.php
+++ b/source/Application/Model/User/UserUpdatableFields.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Application/Model/UserAddressList.php
+++ b/source/Application/Model/UserAddressList.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Application/Model/UserBasket.php
+++ b/source/Application/Model/UserBasket.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
@@ -62,7 +63,7 @@ class UserBasket extends \OxidEsales\Eshop\Core\Model\BaseModel
      *
      * @return mixed
      */
-    protected function _insert()
+    protected function _insert() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         // marking basket as not new any more
         $this->_blNewBasket = false;
@@ -185,7 +186,7 @@ class UserBasket extends \OxidEsales\Eshop\Core\Model\BaseModel
      *
      * @return oxUserBasketItem
      */
-    protected function _createItem($sProductId, $aSelList = null, $aPersParams = null)
+    protected function _createItem($sProductId, $aSelList = null, $aPersParams = null) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $oNewItem = oxNew(\OxidEsales\Eshop\Application\Model\UserBasketItem::class);
         $oNewItem->oxuserbasketitems__oxartid = new \OxidEsales\Eshop\Core\Field($sProductId, \OxidEsales\Eshop\Core\Field::T_RAW);
@@ -246,7 +247,7 @@ class UserBasket extends \OxidEsales\Eshop\Core\Model\BaseModel
      *
      * @return string
      */
-    protected function _getItemKey($sProductId, $aSel = null, $aPersParam = null)
+    protected function _getItemKey($sProductId, $aSel = null, $aPersParam = null) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $aSel = ($aSel != null) ? $aSel : [0 => '0'];
 

--- a/source/Application/Model/UserBasketItem.php
+++ b/source/Application/Model/UserBasketItem.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
@@ -195,9 +196,10 @@ class UserBasketItem extends \OxidEsales\Eshop\Core\Model\BaseModel
      *
      * @return null
      */
-    protected function _setFieldData($sFieldName, $sValue, $iDataType = \OxidEsales\Eshop\Core\Field::T_TEXT)
+    protected function _setFieldData($sFieldName, $sValue, $iDataType = \OxidEsales\Eshop\Core\Field::T_TEXT) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
-        if ('oxsellist' === strtolower($sFieldName) || 'oxuserbasketitems__oxsellist' === strtolower($sFieldName)
+        if (
+            'oxsellist' === strtolower($sFieldName) || 'oxuserbasketitems__oxsellist' === strtolower($sFieldName)
             || 'oxpersparam' === strtolower($sFieldName) || 'oxuserbasketitems__oxpersparam' === strtolower($sFieldName)
         ) {
             $iDataType = \OxidEsales\Eshop\Core\Field::T_RAW;

--- a/source/Application/Model/UserList.php
+++ b/source/Application/Model/UserList.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Application/Model/UserPayment.php
+++ b/source/Application/Model/UserPayment.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
@@ -135,7 +136,7 @@ class UserPayment extends \OxidEsales\Eshop\Core\Model\BaseModel
      *
      * @return bool
      */
-    protected function _insert()
+    protected function _insert() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         // @deprecated since v6.5.1 (2019-02-07); credit card payment method will be no longer supported
         // we do not store credit card information
@@ -170,7 +171,7 @@ class UserPayment extends \OxidEsales\Eshop\Core\Model\BaseModel
      *
      * @return bool
      */
-    protected function _update()
+    protected function _update() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
 
         //encode sensitive data

--- a/source/Application/Model/VariantHandler.php
+++ b/source/Application/Model/VariantHandler.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
@@ -128,7 +129,7 @@ class VariantHandler extends \OxidEsales\Eshop\Core\Base
      *
      * @return mixed
      */
-    protected function _assignValues($aValues, $oVariants, $oArticle, $aConfLanguages)
+    protected function _assignValues($aValues, $oVariants, $oArticle, $aConfLanguages) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $myConfig = $this->getConfig();
         $myLang = \OxidEsales\Eshop\Core\Registry::getLang();
@@ -214,7 +215,7 @@ class VariantHandler extends \OxidEsales\Eshop\Core\Base
      *
      * @return double
      */
-    protected function _getValuePrice($oValue, $dParentPrice)
+    protected function _getValuePrice($oValue, $dParentPrice) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $myConfig = $this->getConfig();
         $dPriceMod = 0;
@@ -242,7 +243,7 @@ class VariantHandler extends \OxidEsales\Eshop\Core\Base
      *
      * @return null
      */
-    protected function _createNewVariant($aParams = null, $sParentId = null)
+    protected function _createNewVariant($aParams = null, $sParentId = null) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         // checkbox handling
         $aParams['oxarticles__oxactive'] = 0;
@@ -268,7 +269,7 @@ class VariantHandler extends \OxidEsales\Eshop\Core\Base
      * @param string $sUpdate query for update variant name
      * @param string $sArtId  parent article id
      */
-    protected function _updateArticleVarName($sUpdate, $sArtId)
+    protected function _updateArticleVarName($sUpdate, $sArtId) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $oDb = \OxidEsales\Eshop\Core\DatabaseProvider::getDb();
         $sUpdate = "update oxarticles set " . $sUpdate . " where oxid = :oxid";
@@ -303,7 +304,7 @@ class VariantHandler extends \OxidEsales\Eshop\Core\Base
      *
      * @return array
      */
-    protected function _fillVariantSelections($oVariantList, $iVarSelCnt, &$aFilter, $sActVariantId)
+    protected function _fillVariantSelections($oVariantList, $iVarSelCnt, &$aFilter, $sActVariantId) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $aSelections = [];
 
@@ -336,7 +337,7 @@ class VariantHandler extends \OxidEsales\Eshop\Core\Base
      *
      * @return array | bool
      */
-    protected function _cleanFilter($aFilter)
+    protected function _cleanFilter($aFilter) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $aCleanFilter = false;
         if (is_array($aFilter) && count($aFilter)) {
@@ -358,7 +359,7 @@ class VariantHandler extends \OxidEsales\Eshop\Core\Base
      *
      * @return array
      */
-    protected function _applyVariantSelectionsFilter($aSelections, $aFilter)
+    protected function _applyVariantSelectionsFilter($aSelections, $aFilter) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $iMaxActiveCount = 0;
         $sMostSuitableVariantId = null;
@@ -409,7 +410,7 @@ class VariantHandler extends \OxidEsales\Eshop\Core\Base
      *
      * @return array
      */
-    protected function _buildVariantSelectionsList($aVarSelects, $aSelections)
+    protected function _buildVariantSelectionsList($aVarSelects, $aSelections) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         // creating selection lists
         foreach ($aVarSelects as $iKey => $sLabel) {
@@ -434,7 +435,7 @@ class VariantHandler extends \OxidEsales\Eshop\Core\Base
      *
      * @return array
      */
-    protected function _getSelections($sTitle)
+    protected function _getSelections($sTitle) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         if ($this->getConfig()->getConfigParam('blUseMultidimensionVariants')) {
             $aSelections = explode($this->_sMdSeparator, $sTitle);

--- a/source/Application/Model/VariantSelectList.php
+++ b/source/Application/Model/VariantSelectList.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Application/Model/VatSelector.php
+++ b/source/Application/Model/VatSelector.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
@@ -43,7 +44,8 @@ class VatSelector extends \OxidEsales\Eshop\Core\Base
         $cacheId = $oUser->getId() . '_' . $oUser->oxuser__oxcountryid->value;
 
         if (!$blCacheReset) {
-            if (array_key_exists($cacheId, self::$_aUserVatCache) &&
+            if (
+                array_key_exists($cacheId, self::$_aUserVatCache) &&
                 self::$_aUserVatCache[$cacheId] !== null
             ) {
                 return self::$_aUserVatCache[$cacheId];
@@ -77,7 +79,7 @@ class VatSelector extends \OxidEsales\Eshop\Core\Base
      *
      * @return mixed
      */
-    protected function _getForeignCountryUserVat(\OxidEsales\Eshop\Application\Model\User $oUser, \OxidEsales\Eshop\Application\Model\Country $oCountry)
+    protected function _getForeignCountryUserVat(\OxidEsales\Eshop\Application\Model\User $oUser, \OxidEsales\Eshop\Application\Model\Country $oCountry) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         if ($oCountry->isInEU()) {
             if ($oUser->oxuser__oxustid->value) {
@@ -97,7 +99,7 @@ class VatSelector extends \OxidEsales\Eshop\Core\Base
      *
      * @return float | false
      */
-    protected function _getVatForArticleCategory(\OxidEsales\Eshop\Application\Model\Article $oArticle)
+    protected function _getVatForArticleCategory(\OxidEsales\Eshop\Application\Model\Article $oArticle) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $oDb = \OxidEsales\Eshop\Core\DatabaseProvider::getDb();
         $sCatT = getViewName('oxcategories');
@@ -200,7 +202,7 @@ class VatSelector extends \OxidEsales\Eshop\Core\Base
      *
      * @return string
      */
-    protected function _getVatCountry(\OxidEsales\Eshop\Application\Model\User $oUser)
+    protected function _getVatCountry(\OxidEsales\Eshop\Application\Model\User $oUser) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $blUseShippingCountry = $this->getConfig()->getConfigParam("blShippingCountryVat");
 

--- a/source/Application/Model/Vendor.php
+++ b/source/Application/Model/Vendor.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
@@ -123,7 +124,7 @@ class Vendor extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements 
      *
      * @return bool
      */
-    protected function _setRootObjectData()
+    protected function _setRootObjectData() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $this->setId('root');
         $this->oxvendor__oxicon = new \OxidEsales\Eshop\Core\Field('', \OxidEsales\Eshop\Core\Field::T_RAW);

--- a/source/Application/Model/VendorList.php
+++ b/source/Application/Model/VendorList.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
@@ -147,7 +148,7 @@ class VendorList extends \OxidEsales\Eshop\Core\Model\ListModel
      *
      * @param object $oVendor vendor object
      */
-    protected function _addCategoryFields($oVendor)
+    protected function _addCategoryFields($oVendor) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $oVendor->oxcategories__oxid = new \OxidEsales\Eshop\Core\Field("v_" . $oVendor->oxvendor__oxid->value);
         $oVendor->oxcategories__oxicon = $oVendor->oxvendor__oxicon;
@@ -181,7 +182,7 @@ class VendorList extends \OxidEsales\Eshop\Core\Model\ListModel
     /**
      * Processes vendor category URLs
      */
-    protected function _seoSetVendorData()
+    protected function _seoSetVendorData() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         // only when SEO id on and in front end
         if (\OxidEsales\Eshop\Core\Registry::getUtils()->seoIsActive() && !$this->isAdmin()) {

--- a/source/Application/Model/Voucher.php
+++ b/source/Application/Model/Voucher.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
@@ -219,7 +220,7 @@ class Voucher extends \OxidEsales\Eshop\Core\Model\BaseModel
      *
      * @return array
      */
-    protected function _isAvailablePrice($dPrice)
+    protected function _isAvailablePrice($dPrice) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $oSeries = $this->getSerie();
         $oCur = $this->getConfig()->getActShopCurrencyObject();
@@ -244,7 +245,7 @@ class Voucher extends \OxidEsales\Eshop\Core\Model\BaseModel
      * @return bool
      *
      */
-    protected function _isAvailableWithSameSeries($aVouchers)
+    protected function _isAvailableWithSameSeries($aVouchers) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         if (is_array($aVouchers)) {
             $sId = $this->getId();
@@ -279,7 +280,7 @@ class Voucher extends \OxidEsales\Eshop\Core\Model\BaseModel
      *
      * @return bool
      */
-    protected function _isAvailableWithOtherSeries($aVouchers)
+    protected function _isAvailableWithOtherSeries($aVouchers) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         if (is_array($aVouchers) && count($aVouchers)) {
             $oSeries = $this->getSerie();
@@ -320,7 +321,7 @@ class Voucher extends \OxidEsales\Eshop\Core\Model\BaseModel
      *
      * @return bool
      */
-    protected function _isValidDate()
+    protected function _isValidDate() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $oSeries = $this->getSerie();
         $iTime = time();
@@ -357,7 +358,7 @@ class Voucher extends \OxidEsales\Eshop\Core\Model\BaseModel
      *
      * @return bool
      */
-    protected function _isNotReserved()
+    protected function _isNotReserved() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         if ($this->oxvouchers__oxreserved->value < time() - $this->_getVoucherTimeout()) {
             return true;
@@ -397,7 +398,7 @@ class Voucher extends \OxidEsales\Eshop\Core\Model\BaseModel
      *
      * @return boolean
      */
-    protected function _isAvailableInOtherOrder($oUser)
+    protected function _isAvailableInOtherOrder($oUser) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $oSeries = $this->getSerie();
         if (!$oSeries->oxvoucherseries__oxallowuseanother->value) {
@@ -432,7 +433,7 @@ class Voucher extends \OxidEsales\Eshop\Core\Model\BaseModel
      *
      * @return bool
      */
-    protected function _isValidUserGroup($oUser)
+    protected function _isValidUserGroup($oUser) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $oVoucherSeries = $this->getSerie();
         $oUserGroups = $oVoucherSeries->setUserGroups();
@@ -500,13 +501,13 @@ class Voucher extends \OxidEsales\Eshop\Core\Model\BaseModel
      *
      * @return boolean
      */
-    protected function _isProductVoucher()
+    protected function _isProductVoucher() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $oDb = \OxidEsales\Eshop\Core\DatabaseProvider::getDb();
         $oSeries = $this->getSerie();
         $sSelect = "select 1 from oxobject2discount 
             where oxdiscountid = :oxdiscountid and oxtype = :oxtype";
-        $blOk = ( bool ) $oDb->getOne($sSelect, [
+        $blOk = (bool) $oDb->getOne($sSelect, [
             ':oxdiscountid' => $oSeries->getId(),
             ':oxtype' => 'oxarticles'
         ]);
@@ -519,13 +520,13 @@ class Voucher extends \OxidEsales\Eshop\Core\Model\BaseModel
      *
      * @return boolean
      */
-    protected function _isCategoryVoucher()
+    protected function _isCategoryVoucher() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $oDb = \OxidEsales\Eshop\Core\DatabaseProvider::getDb();
         $oSeries = $this->getSerie();
         $sSelect = "select 1 from oxobject2discount 
             where oxdiscountid = :oxdiscountid and oxtype = :oxtype";
-        $blOk = ( bool ) $oDb->getOne($sSelect, [
+        $blOk = (bool) $oDb->getOne($sSelect, [
             ':oxdiscountid' => $oSeries->getId(),
             ':oxtype' => 'oxcategories'
         ]);
@@ -538,7 +539,7 @@ class Voucher extends \OxidEsales\Eshop\Core\Model\BaseModel
      *
      * @return object
      */
-    protected function _getSerieDiscount()
+    protected function _getSerieDiscount() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $oSeries = $this->getSerie();
         $oDiscount = oxNew(\OxidEsales\Eshop\Application\Model\Discount::class);
@@ -569,7 +570,7 @@ class Voucher extends \OxidEsales\Eshop\Core\Model\BaseModel
      *
      * @return array
      */
-    protected function _getBasketItems($oDiscount = null)
+    protected function _getBasketItems($oDiscount = null) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         if ($this->oxvouchers__oxorderid->value) {
             return $this->_getOrderBasketItems($oDiscount);
@@ -587,7 +588,7 @@ class Voucher extends \OxidEsales\Eshop\Core\Model\BaseModel
      *
      * @return array
      */
-    protected function _getOrderBasketItems($oDiscount = null)
+    protected function _getOrderBasketItems($oDiscount = null) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         if (is_null($oDiscount)) {
             $oDiscount = $this->_getSerieDiscount();
@@ -621,7 +622,7 @@ class Voucher extends \OxidEsales\Eshop\Core\Model\BaseModel
      *
      * @return array
      */
-    protected function _getSessionBasketItems($oDiscount = null)
+    protected function _getSessionBasketItems($oDiscount = null) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         if (is_null($oDiscount)) {
             $oDiscount = $this->_getSerieDiscount();
@@ -658,7 +659,7 @@ class Voucher extends \OxidEsales\Eshop\Core\Model\BaseModel
      *
      * @return double
      */
-    protected function _getGenericDiscoutValue($dPrice)
+    protected function _getGenericDiscoutValue($dPrice) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         return $this->_getGenericDiscountValue($dPrice);
     }
@@ -672,7 +673,7 @@ class Voucher extends \OxidEsales\Eshop\Core\Model\BaseModel
      *
      * @return double
      */
-    protected function _getGenericDiscountValue($dPrice)
+    protected function _getGenericDiscountValue($dPrice) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $oSeries = $this->getSerie();
         if ($oSeries->oxvoucherseries__oxdiscounttype->value == 'absolute') {
@@ -725,7 +726,7 @@ class Voucher extends \OxidEsales\Eshop\Core\Model\BaseModel
      *
      * @return double
      */
-    protected function _getProductDiscoutValue($dPrice)
+    protected function _getProductDiscoutValue($dPrice) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         return $this->_getProductDiscountValue($dPrice);
     }
@@ -739,7 +740,7 @@ class Voucher extends \OxidEsales\Eshop\Core\Model\BaseModel
      *
      * @return double
      */
-    protected function _getProductDiscountValue($dPrice)
+    protected function _getProductDiscountValue($dPrice) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $oDiscount = $this->_getSerieDiscount();
         $aBasketItems = $this->_getBasketItems($oDiscount);
@@ -806,7 +807,7 @@ class Voucher extends \OxidEsales\Eshop\Core\Model\BaseModel
      *
      * @return double
      */
-    protected function _getCategoryDiscoutValue($dPrice)
+    protected function _getCategoryDiscoutValue($dPrice) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         return $this->_getCategoryDiscountValue($dPrice);
     }
@@ -820,7 +821,7 @@ class Voucher extends \OxidEsales\Eshop\Core\Model\BaseModel
      *
      * @return double
      */
-    protected function _getCategoryDiscountValue($dPrice)
+    protected function _getCategoryDiscountValue($dPrice) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $oDiscount = $this->_getSerieDiscount();
         $aBasketItems = $this->_getBasketItems($oDiscount);
@@ -878,7 +879,7 @@ class Voucher extends \OxidEsales\Eshop\Core\Model\BaseModel
      *
      * @return integer Seconds a voucher can stay in status reserved
      */
-    protected function _getVoucherTimeout()
+    protected function _getVoucherTimeout() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $iVoucherTimeout = (int) \OxidEsales\Eshop\Core\Registry::getConfig()->getConfigParam('iVoucherTimeout') ?:
             3 * 3600;

--- a/source/Application/Model/VoucherList.php
+++ b/source/Application/Model/VoucherList.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Application/Model/VoucherSerie.php
+++ b/source/Application/Model/VoucherSerie.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
@@ -183,7 +184,8 @@ class VoucherSerie extends \OxidEsales\Eshop\Core\Model\BaseModel
         }
 
         //Check for active status.
-        if (($sBeginDate == '0000-00-00 00:00:00' && $sEndDate == '0000-00-00 00:00:00') || //If both dates are empty => treat it as always active
+        if (
+            ($sBeginDate == '0000-00-00 00:00:00' && $sEndDate == '0000-00-00 00:00:00') || //If both dates are empty => treat it as always active
             ($sBeginDate == '0000-00-00 00:00:00' && $sNow <= $sEndDate) || //check for end date without start date
             ($sBeginDate <= $sNow && $sEndDate == '0000-00-00 00:00:00') || //check for start date without end date
             ($sBeginDate <= $sNow && $sNow <= $sEndDate)

--- a/source/Application/Model/Wrapping.php
+++ b/source/Application/Model/Wrapping.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
@@ -153,7 +154,7 @@ class Wrapping extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel
      *
      * @return bool
      */
-    protected function _isPriceViewModeNetto()
+    protected function _isPriceViewModeNetto() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $blResult = (bool) $this->getConfig()->getConfigParam('blShowNetPrice');
         $oUser = $this->getUser();

--- a/source/Application/translations/de/lang.php
+++ b/source/Application/translations/de/lang.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Application/translations/de/translit_lang.php
+++ b/source/Application/translations/de/translit_lang.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Application/translations/en/lang.php
+++ b/source/Application/translations/en/lang.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Application/translations/en/translit_lang.php
+++ b/source/Application/translations/en/translit_lang.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Core/AdminLogSqlDecorator.php
+++ b/source/Core/AdminLogSqlDecorator.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Core/Autoload/BackwardsCompatibilityAutoload.php
+++ b/source/Core/Autoload/BackwardsCompatibilityAutoload.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Core/Autoload/BackwardsCompatibilityClassMap.php
+++ b/source/Core/Autoload/BackwardsCompatibilityClassMap.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Core/Autoload/BackwardsCompatibilityClassMapProvider.php
+++ b/source/Core/Autoload/BackwardsCompatibilityClassMapProvider.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Core\Autoload;
 

--- a/source/Core/Autoload/ModuleAutoload.php
+++ b/source/Core/Autoload/ModuleAutoload.php
@@ -1,8 +1,10 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
 namespace OxidEsales\EshopCommunity\Core\Autoload;
 
 use OxidEsales\Eshop\Core\Registry;

--- a/source/Core/Autoload/UnifiedNameSpaceClassMap.php
+++ b/source/Core/Autoload/UnifiedNameSpaceClassMap.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Core/BackwardsCompatibleClassNameProvider.php
+++ b/source/Core/BackwardsCompatibleClassNameProvider.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Core/Base.php
+++ b/source/Core/Base.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Core/CompanyVatInChecker.php
+++ b/source/Core/CompanyVatInChecker.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Core/CompanyVatInCountryChecker.php
+++ b/source/Core/CompanyVatInCountryChecker.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Core/CompanyVatInValidator.php
+++ b/source/Core/CompanyVatInValidator.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Core/Config.php
+++ b/source/Core/Config.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
@@ -362,7 +363,7 @@ class Config extends \OxidEsales\Eshop\Core\Base
     /**
      * Parse SEO url parameters.
      */
-    protected function _processSeoCall()
+    protected function _processSeoCall() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         // TODO: refactor shop bootstrap and parse url params as soon as possible
         if (isSearchEngineUrl()) {
@@ -473,7 +474,7 @@ class Config extends \OxidEsales\Eshop\Core\Base
     /**
      * Loads vars from default config file
      */
-    protected function _loadVarsFromFile()
+    protected function _loadVarsFromFile() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         //config variables from config.inc.php takes priority over the ones loaded from db
         include getShopBasePath() . '/config.inc.php';
@@ -492,7 +493,7 @@ class Config extends \OxidEsales\Eshop\Core\Base
     /**
      * Set important defaults.
      */
-    protected function _setDefaults()
+    protected function _setDefaults() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $this->setConfigParam('sTheme', 'azure');
 
@@ -535,7 +536,7 @@ class Config extends \OxidEsales\Eshop\Core\Base
     /**
      * Loads vars from custom config file
      */
-    protected function _loadCustomConfig()
+    protected function _loadCustomConfig() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $custConfig = getShopBasePath() . '/cust_config.inc.php';
         if (is_readable($custConfig)) {
@@ -552,7 +553,7 @@ class Config extends \OxidEsales\Eshop\Core\Base
      *
      * @return bool
      */
-    protected function _loadVarsFromDb($shopID, $onlyVars = null, $module = '')
+    protected function _loadVarsFromDb($shopID, $onlyVars = null, $module = '') // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $db = \OxidEsales\Eshop\Core\DatabaseProvider::getDb();
 
@@ -598,7 +599,7 @@ class Config extends \OxidEsales\Eshop\Core\Base
      *
      * @return string
      */
-    protected function _getConfigParamsSelectSnippet($vars)
+    protected function _getConfigParamsSelectSnippet($vars) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $select = '';
         if (is_array($vars) && !empty($vars)) {
@@ -621,9 +622,10 @@ class Config extends \OxidEsales\Eshop\Core\Base
      *
      * @return null
      */
-    protected function _setConfVarFromDb($varName, $varType, $varVal)
+    protected function _setConfVarFromDb($varName, $varType, $varVal) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
-        if (($varName == 'sShopURL' || $varName == 'sSSLShopURL') &&
+        if (
+            ($varName == 'sShopURL' || $varName == 'sSSLShopURL') &&
             (!$varVal || $this->isAdmin() === true)
         ) {
             return;
@@ -827,7 +829,7 @@ class Config extends \OxidEsales\Eshop\Core\Base
     /**
      * Checks if WEB session is SSL.
      */
-    protected function _checkSsl()
+    protected function _checkSsl() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $myUtilsServer = Registry::getUtilsServer();
         $serverVars = $myUtilsServer->getServerVar();
@@ -844,7 +846,8 @@ class Config extends \OxidEsales\Eshop\Core\Base
         }
 
         //additional special handling for profihost customers
-        if (isset($serverVars['HTTP_X_FORWARDED_SERVER']) &&
+        if (
+            isset($serverVars['HTTP_X_FORWARDED_SERVER']) &&
             (strpos($serverVars['HTTP_X_FORWARDED_SERVER'], 'ssl') !== false ||
              strpos($serverVars['HTTP_X_FORWARDED_SERVER'], 'secure-online-shopping.de') !== false)
         ) {
@@ -1977,7 +1980,7 @@ class Config extends \OxidEsales\Eshop\Core\Base
         $productive = $this->getConfigParam('blProductive');
         if (!isset($productive)) {
             $query = 'select oxproductive from oxshops where oxid = :oxid';
-            $productive = ( bool ) \OxidEsales\Eshop\Core\DatabaseProvider::getDb()->getOne($query, [
+            $productive = (bool) \OxidEsales\Eshop\Core\DatabaseProvider::getDb()->getOne($query, [
                 ':oxid' => $this->getShopId()
             ]);
             $this->setConfigParam('blProductive', $productive);
@@ -2003,7 +2006,8 @@ class Config extends \OxidEsales\Eshop\Core\Base
      */
     public function getActiveShop()
     {
-        if ($this->_oActShop && $this->_iShopId == $this->_oActShop->getId() &&
+        if (
+            $this->_oActShop && $this->_iShopId == $this->_oActShop->getId() &&
             $this->_oActShop->getLanguage() == Registry::getLang()->getBaseLanguage()
         ) {
             return $this->_oActShop;
@@ -2253,7 +2257,7 @@ class Config extends \OxidEsales\Eshop\Core\Base
      *
      * @param \OxidEsales\Eshop\Core\Exception\DatabaseException $exception
      */
-    protected function _handleDbConnectionException(\OxidEsales\Eshop\Core\Exception\DatabaseException $exception)
+    protected function _handleDbConnectionException(\OxidEsales\Eshop\Core\Exception\DatabaseException $exception) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $exceptionHandler = $this->getExceptionHandler();
         $exceptionHandler->handleDatabaseException($exception);
@@ -2264,7 +2268,7 @@ class Config extends \OxidEsales\Eshop\Core\Base
      *
      * @param \OxidEsales\Eshop\Core\Exception\StandardException $ex message to show on exit
      */
-    protected function _handleCookieException($ex)
+    protected function _handleCookieException($ex) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $this->_processSeoCall();
 
@@ -2307,7 +2311,7 @@ class Config extends \OxidEsales\Eshop\Core\Base
      *
      * @return bool
      */
-    protected function _isValidShopId($shopId)
+    protected function _isValidShopId($shopId) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         return !empty($shopId);
     }

--- a/source/Core/ConfigFile.php
+++ b/source/Core/ConfigFile.php
@@ -1,8 +1,10 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
 namespace OxidEsales\EshopCommunity\Core;
 
 /**
@@ -84,7 +86,7 @@ class ConfigFile
      *
      * @param string $fileName Configuration file name
      */
-    private function _loadVars($fileName)
+    private function _loadVars($fileName) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         include $fileName;
     }

--- a/source/Core/Contract/AbstractUpdatableFields.php
+++ b/source/Core/Contract/AbstractUpdatableFields.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Core/Contract/ClassNameResolverInterface.php
+++ b/source/Core/Contract/ClassNameResolverInterface.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Core/Contract/ClassProviderStorageInterface.php
+++ b/source/Core/Contract/ClassProviderStorageInterface.php
@@ -1,8 +1,10 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
 namespace OxidEsales\EshopCommunity\Core\Contract;
 
 /**

--- a/source/Core/Contract/ControllerMapProviderInterface.php
+++ b/source/Core/Contract/ControllerMapProviderInterface.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Core/Contract/IConfigurable.php
+++ b/source/Core/Contract/IConfigurable.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Core/Contract/ICountryAware.php
+++ b/source/Core/Contract/ICountryAware.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Core/Contract/IDisplayError.php
+++ b/source/Core/Contract/IDisplayError.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Core/Contract/IModuleValidator.php
+++ b/source/Core/Contract/IModuleValidator.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Core/Contract/ISelectList.php
+++ b/source/Core/Contract/ISelectList.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Core/Contract/IUrl.php
+++ b/source/Core/Contract/IUrl.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Core/Controller/BaseController.php
+++ b/source/Core/Controller/BaseController.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
@@ -532,7 +533,7 @@ class BaseController extends \OxidEsales\Eshop\Core\Base
             if (method_exists($this, $sFunction)) {
                 $sNewAction = $this->$sFunction();
                 self::$_blExecuted = true;
-                $this->dispatchEvent(new AfterRequestProcessedEvent);
+                $this->dispatchEvent(new AfterRequestProcessedEvent());
 
                 if (isset($sNewAction)) {
                     $this->_executeNewAction($sNewAction);
@@ -542,7 +543,7 @@ class BaseController extends \OxidEsales\Eshop\Core\Base
                 if (!$this->_blIsComponent) {
                     /** @var \OxidEsales\Eshop\Core\Exception\SystemComponentException $oEx */
                     $oEx = oxNew(\OxidEsales\Eshop\Core\Exception\SystemComponentException::class);
-                    $oEx->setMessage('ERROR_MESSAGE_SYSTEMCOMPONENT_FUNCTIONNOTFOUND'. ' ' . $sFunction);
+                    $oEx->setMessage('ERROR_MESSAGE_SYSTEMCOMPONENT_FUNCTIONNOTFOUND' . ' ' . $sFunction);
                     $oEx->setComponent($sFunction);
                     throw $oEx;
                 }
@@ -559,7 +560,7 @@ class BaseController extends \OxidEsales\Eshop\Core\Base
      *
      * @throws \OxidEsales\Eshop\Core\Exception\SystemComponentException system component exception
      */
-    protected function _executeNewAction($sNewAction)
+    protected function _executeNewAction($sNewAction) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         if ($sNewAction) {
             $myConfig = $this->getConfig();
@@ -603,7 +604,7 @@ class BaseController extends \OxidEsales\Eshop\Core\Base
 
             $this->onExecuteNewAction();
 
-            $this->dispatchEvent(new AfterRequestProcessedEvent);
+            $this->dispatchEvent(new AfterRequestProcessedEvent());
 
             //#M341 do not add redirect parameter
             \OxidEsales\Eshop\Core\Registry::getUtils()->redirect($url, (bool) $myConfig->getRequestParameter('redirected'), 302);

--- a/source/Core/Counter.php
+++ b/source/Core/Counter.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Core/CreditCardValidator.php
+++ b/source/Core/CreditCardValidator.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
@@ -38,7 +39,7 @@ class CreditCardValidator
      *
      * @return bool
      */
-    protected function _isValidType($type, $number)
+    protected function _isValidType($type, $number) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         // testing if card type is known and matches pattern
         if (isset($this->_aCardsInfo[$type])) {
@@ -55,7 +56,7 @@ class CreditCardValidator
      *
      * @return bool
      */
-    protected function _isExpired($date)
+    protected function _isExpired($date) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         if ($date) {
             $years = substr($date, 2, 2);
@@ -78,7 +79,7 @@ class CreditCardValidator
      *
      * @return bool
      */
-    protected function _isValidNumer($number)
+    protected function _isValidNumer($number) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $valid = false;
         if (($length = strlen($number))) {
@@ -88,7 +89,7 @@ class CreditCardValidator
             // Luhn algorithm
             for ($pos = 0; $pos < $length; $pos++) {
                 // taking digit to check..
-                $currDigit = ( int ) $number{$pos};
+                $currDigit = (int) $number{$pos};
 
                 // multiplying if needed..
                 $addValue = (($pos % 2 == $mod) ? 2 : 1) * $currDigit;

--- a/source/Core/Curl.php
+++ b/source/Core/Curl.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
@@ -338,7 +339,7 @@ class Curl
      *
      * @param resource $rCurl curl.
      */
-    protected function _setResource($rCurl)
+    protected function _setResource($rCurl) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $this->_rCurl = $rCurl;
     }
@@ -348,7 +349,7 @@ class Curl
      *
      * @return resource
      */
-    protected function _getResource()
+    protected function _getResource() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         if (is_null($this->_rCurl)) {
             $this->_setResource(curl_init());
@@ -360,7 +361,7 @@ class Curl
     /**
      * Set Curl Options
      */
-    protected function _setOptions()
+    protected function _setOptions() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         if (!is_null($this->getHeader())) {
             $this->_setOpt(CURLOPT_HTTPHEADER, $this->getHeader());
@@ -385,7 +386,7 @@ class Curl
      *
      * @return string
      */
-    protected function _execute()
+    protected function _execute() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         return curl_exec($this->_getResource());
     }
@@ -393,7 +394,7 @@ class Curl
     /**
      * Wrapper function to be mocked for testing.
      */
-    protected function _close()
+    protected function _close() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         curl_close($this->_getResource());
         $this->_setResource(null);
@@ -405,7 +406,7 @@ class Curl
      * @param string $name  curl option name to set value to.
      * @param string $value curl option value to set.
      */
-    protected function _setOpt($name, $value)
+    protected function _setOpt($name, $value) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         curl_setopt($this->_getResource(), $name, $value);
     }
@@ -415,7 +416,7 @@ class Curl
      *
      * @return int
      */
-    protected function _getErrorNumber()
+    protected function _getErrorNumber() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         return curl_errno($this->_getResource());
     }
@@ -423,7 +424,7 @@ class Curl
     /**
      * Sets current request HTTP status code.
      */
-    protected function _saveStatusCode()
+    protected function _saveStatusCode() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $this->_sStatusCode = curl_getinfo($this->_getResource(), CURLINFO_HTTP_CODE);
     }
@@ -435,7 +436,7 @@ class Curl
      *
      * @return array
      */
-    protected function _prepareQueryParameters($params)
+    protected function _prepareQueryParameters($params) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         return array_map([$this, '_htmlDecode'], array_filter($params));
     }
@@ -447,7 +448,7 @@ class Curl
      *
      * @return string
      */
-    protected function _htmlDecode($mParam)
+    protected function _htmlDecode($mParam) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         if (is_array($mParam)) {
             $mParam = $this->_prepareQueryParameters($mParam);

--- a/source/Core/Dao/ApplicationServerDao.php
+++ b/source/Core/Dao/ApplicationServerDao.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
@@ -164,7 +165,7 @@ class ApplicationServerDao implements \OxidEsales\Eshop\Core\Dao\ApplicationServ
         $parameter = [
             ':value' => $this->convertAppServerToConfigOption($appServer),
             ':key' => $this->config->getConfigParam('sConfigKey'),
-            ':oxvarname' => self::CONFIG_NAME_FOR_SERVER_INFO.$appServer->getId(),
+            ':oxvarname' => self::CONFIG_NAME_FOR_SERVER_INFO . $appServer->getId(),
             ':oxshopid' => $this->config->getBaseShopId()
         ];
 
@@ -184,7 +185,7 @@ class ApplicationServerDao implements \OxidEsales\Eshop\Core\Dao\ApplicationServ
         $parameter = [
             ':oxid' => \OxidEsales\Eshop\Core\Registry::getUtilsObject()->generateUID(),
             ':oxshopid' => $this->config->getBaseShopId(),
-            ':oxvarname' => self::CONFIG_NAME_FOR_SERVER_INFO.$appServer->getId(),
+            ':oxvarname' => self::CONFIG_NAME_FOR_SERVER_INFO . $appServer->getId(),
             ':oxvartype' => 'arr',
             ':value' => $this->convertAppServerToConfigOption($appServer),
             ':key' => $this->config->getConfigParam('sConfigKey')
@@ -208,7 +209,7 @@ class ApplicationServerDao implements \OxidEsales\Eshop\Core\Dao\ApplicationServ
               AND oxshopid = :oxshopid FOR UPDATE";
 
         $parameter = [
-            ":oxvarname" => self::CONFIG_NAME_FOR_SERVER_INFO.$id,
+            ":oxvarname" => self::CONFIG_NAME_FOR_SERVER_INFO . $id,
             ":oxshopid" => $this->config->getBaseShopId()
         ];
 

--- a/source/Core/Dao/ApplicationServerDaoInterface.php
+++ b/source/Core/Dao/ApplicationServerDaoInterface.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Core/Dao/BaseDaoInterface.php
+++ b/source/Core/Dao/BaseDaoInterface.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Core/DataObject/ApplicationServer.php
+++ b/source/Core/DataObject/ApplicationServer.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Core/Database/Adapter/DatabaseInterface.php
+++ b/source/Core/Database/Adapter/DatabaseInterface.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Core/Database/Adapter/Doctrine/Database.php
+++ b/source/Core/Database/Adapter/Doctrine/Database.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
@@ -1283,7 +1284,8 @@ class Database implements DatabaseInterface
         $dateTypes = ['YEAR'];
 
         $assignedType = strtoupper($assignedType);
-        if ((
+        if (
+            (
             in_array($assignedType, $integerTypes) ||
                 in_array($assignedType, $fixedPointTypes) ||
                 in_array($assignedType, $floatingPointTypes) ||

--- a/source/Core/Database/Adapter/Doctrine/ResultSet.php
+++ b/source/Core/Database/Adapter/Doctrine/ResultSet.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Core/Database/Adapter/ResultSetInterface.php
+++ b/source/Core/Database/Adapter/ResultSetInterface.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Core/DatabaseProvider.php
+++ b/source/Core/DatabaseProvider.php
@@ -1,8 +1,10 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
 namespace OxidEsales\EshopCommunity\Core;
 
 use OxidEsales\Eshop\Core\Database\Adapter\DatabaseInterface;

--- a/source/Core/DbMetaDataHandler.php
+++ b/source/Core/DbMetaDataHandler.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
@@ -213,7 +214,7 @@ class DbMetaDataHandler extends \OxidEsales\Eshop\Core\Base
      * @return string
      *
      */
-    protected function _getCreateTableSetSql($table, $lang)
+    protected function _getCreateTableSetSql($table, $lang) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $tableSet = getLangTableName($table, $lang);
 
@@ -615,7 +616,7 @@ class DbMetaDataHandler extends \OxidEsales\Eshop\Core\Base
                 //We start with language id 1 and rely on that all fields for language 0 exists.
                 //For language id 0 we have e.g. OXTITLE and logic here would expect it to
                 //be OXTITLE_0, add that as new field, leading to incorrect data in views later on.
-                for ($i=1; $i<=$maxLang; $i++) {
+                for ($i = 1; $i <= $maxLang; $i++) {
                     $this->ensureMultiLanguageFields($table, $i);
                 }
             }

--- a/source/Core/DebugInfo.php
+++ b/source/Core/DebugInfo.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
@@ -40,24 +41,24 @@ class DebugInfo
     {
         $log = '';
         if (function_exists('memory_get_usage')) {
-            $kb = ( int ) (memory_get_usage() / 1024);
+            $kb = (int) (memory_get_usage() / 1024);
             $mb = round($kb / 1024, 3);
             $log .= 'Memory usage: ' . $mb . ' MB';
 
             if (function_exists('memory_get_peak_usage')) {
-                $peakKb = ( int ) (memory_get_peak_usage() / 1024);
+                $peakKb = (int) (memory_get_peak_usage() / 1024);
                 $peakMb = round($peakKb / 1024, 3);
                 $log .= ' (peak: ' . $peakMb . ' MB)';
             }
             $log .= '<br />';
 
             if (version_compare(PHP_VERSION, '5.2.0', '>=')) {
-                $kb = ( int ) (memory_get_usage(true) / 1024);
+                $kb = (int) (memory_get_usage(true) / 1024);
                 $mb = round($kb / 1024, 3);
                 $log .= 'System memory usage: ' . $mb . ' MB';
 
                 if (function_exists('memory_get_peak_usage')) {
-                    $peakKb = ( int ) (memory_get_peak_usage(true) / 1024);
+                    $peakKb = (int) (memory_get_peak_usage(true) / 1024);
                     $peakMb = round($peakKb / 1024, 3);
                     $log .= ' (peak: ' . $peakMb . ' MB)';
                 }

--- a/source/Core/Decryptor.php
+++ b/source/Core/Decryptor.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
@@ -39,7 +40,7 @@ class Decryptor
      *
      * @return string
      */
-    protected function _formKey($key, $string)
+    protected function _formKey($key, $string) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $key = '_' . $key;
         $keyLength = (strlen($string) / strlen($key)) + 5;

--- a/source/Core/DisplayError.php
+++ b/source/Core/DisplayError.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Core/DynamicImageGenerator.php
+++ b/source/Core/DynamicImageGenerator.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
@@ -56,7 +57,6 @@ namespace {
         }
     }
 }
-
 namespace OxidEsales\EshopCommunity\Core {
 
     /**
@@ -172,7 +172,7 @@ namespace OxidEsales\EshopCommunity\Core {
          *
          * @return string
          */
-        protected function _getShopBasePath()
+        protected function _getShopBasePath() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
         {
             return Registry::getConfig()->getConfigParam("sShopDir");
         }
@@ -182,7 +182,7 @@ namespace OxidEsales\EshopCommunity\Core {
          *
          * @return string
          */
-        protected function _getImageUri()
+        protected function _getImageUri() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
         {
             if ($this->_sImageUri === null) {
                 $this->_sImageUri = "";
@@ -205,7 +205,7 @@ namespace OxidEsales\EshopCommunity\Core {
          *
          * @return string
          */
-        protected function _getImageName()
+        protected function _getImageName() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
         {
             return basename($this->_getImageUri());
         }
@@ -215,7 +215,7 @@ namespace OxidEsales\EshopCommunity\Core {
          *
          * @return string
          */
-        protected function _getImageMasterPath()
+        protected function _getImageMasterPath() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
         {
             $uri = $this->_getImageUri();
             $path = false;
@@ -232,7 +232,7 @@ namespace OxidEsales\EshopCommunity\Core {
          *
          * @return array
          */
-        protected function _getImageInfo()
+        protected function _getImageInfo() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
         {
             $info = [];
             if (($uri = $this->_getImageUri())) {
@@ -247,7 +247,7 @@ namespace OxidEsales\EshopCommunity\Core {
          *
          * @return string
          */
-        protected function _getImageTarget()
+        protected function _getImageTarget() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
         {
             return $this->_getShopBasePath() . $this->_getImageUri();
         }
@@ -257,7 +257,7 @@ namespace OxidEsales\EshopCommunity\Core {
          *
          * @return string
          */
-        protected function _getNopicImageTarget()
+        protected function _getNopicImageTarget() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
         {
             $path = $this->_getShopBasePath() . $this->_getImageUri();
 
@@ -269,7 +269,7 @@ namespace OxidEsales\EshopCommunity\Core {
          *
          * @return string
          */
-        protected function _getImageType()
+        protected function _getImageType() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
         {
             $fileExtension = strtolower(pathinfo($this->_getImageName(), PATHINFO_EXTENSION));
             if (!$this->validateImageFileExtension($fileExtension)) {
@@ -295,7 +295,7 @@ namespace OxidEsales\EshopCommunity\Core {
          *
          * @return string
          */
-        protected function _generatePng($source, $target, $width, $height)
+        protected function _generatePng($source, $target, $width, $height) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
         {
             return resizePng($source, $target, $width, $height, @getimagesize($source), getGdVersion(), null);
         }
@@ -311,7 +311,7 @@ namespace OxidEsales\EshopCommunity\Core {
          *
          * @return string
          */
-        protected function _generateJpg($source, $target, $width, $height, $quality)
+        protected function _generateJpg($source, $target, $width, $height, $quality) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
         {
             return resizeJpeg($source, $target, $width, $height, @getimagesize($source), getGdVersion(), null, $quality);
         }
@@ -326,7 +326,7 @@ namespace OxidEsales\EshopCommunity\Core {
          *
          * @return string
          */
-        protected function _generateGif($source, $target, $width, $height)
+        protected function _generateGif($source, $target, $width, $height) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
         {
             $imageInfo = @getimagesize($source);
 
@@ -341,7 +341,7 @@ namespace OxidEsales\EshopCommunity\Core {
          *
          * @return bool
          */
-        protected function _isTargetPathValid($path)
+        protected function _isTargetPathValid($path) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
         {
             $valid = true;
             $dir = dirname(trim($path));
@@ -362,7 +362,7 @@ namespace OxidEsales\EshopCommunity\Core {
          *
          * @return bool
          */
-        protected function _createFolders($dir)
+        protected function _createFolders($dir) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
         {
             $config = Registry::getConfig();
             $picFolderPath = dirname($config->getMasterPictureDir());
@@ -391,7 +391,7 @@ namespace OxidEsales\EshopCommunity\Core {
          *
          * @return bool
          */
-        protected function _isValidPath($path)
+        protected function _isValidPath($path) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
         {
             $valid = false;
 
@@ -469,7 +469,7 @@ namespace OxidEsales\EshopCommunity\Core {
          *
          * @return bool|string Return false on failure or file path of the generated image on success
          */
-        protected function _generateImage($imageSource, $imageTarget)
+        protected function _generateImage($imageSource, $imageTarget) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
         {
             $generatedImagePath = false;
             list($targetWidth, $targetHeight, $targetQuality) = $this->_getImageInfo();
@@ -478,12 +478,14 @@ namespace OxidEsales\EshopCommunity\Core {
             $fileExtensionTarget = strtolower(pathinfo($imageTarget, PATHINFO_EXTENSION));
 
             // Do some validation and return false on failure
-            if (!$this->validateGdVersion()
+            if (
+                !$this->validateGdVersion()
                 || !$this->validateFileExist($imageSource)
                 || !$this->_isTargetPathValid($imageTarget)
                 || !$this->validateImageFileExtension($fileExtensionSource)
                 || !$this->validateImageFileExtension($fileExtensionTarget)
-                || $fileExtensionSource !== $fileExtensionTarget) {
+                || $fileExtensionSource !== $fileExtensionTarget
+            ) {
                 return false;
             }
 
@@ -532,7 +534,7 @@ namespace OxidEsales\EshopCommunity\Core {
          *
          * @return string
          */
-        protected function _getLockName($name)
+        protected function _getLockName($name) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
         {
             return "$name.lck";
         }
@@ -544,7 +546,7 @@ namespace OxidEsales\EshopCommunity\Core {
          *
          * @return bool
          */
-        protected function _lock($source)
+        protected function _lock($source) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
         {
             $locked = false;
             $lockName = $this->_getLockName($source);
@@ -577,7 +579,7 @@ namespace OxidEsales\EshopCommunity\Core {
          *
          * @param string $source source file which should be locked
          */
-        protected function _unlock($source)
+        protected function _unlock($source) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
         {
             if (is_resource($this->_hLockHandle)) {
                 flock($this->_hLockHandle, LOCK_UN);
@@ -697,7 +699,7 @@ namespace OxidEsales\EshopCommunity\Core {
          *
          * @param string $header header
          */
-        protected function _setHeader($header)
+        protected function _setHeader($header) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
         {
             $this->_aHeaders[] = $header;
         }
@@ -707,7 +709,7 @@ namespace OxidEsales\EshopCommunity\Core {
          *
          * @return array
          */
-        protected function _getHeaders()
+        protected function _getHeaders() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
         {
             return $this->_aHeaders;
         }

--- a/source/Core/Edition/EditionPathProvider.php
+++ b/source/Core/Edition/EditionPathProvider.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Core/Edition/EditionRootPathProvider.php
+++ b/source/Core/Edition/EditionRootPathProvider.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
@@ -46,9 +47,9 @@ class EditionRootPathProvider
         $editionsPath = VENDOR_PATH . static::EDITIONS_DIRECTORY;
         $path = getShopBasePath();
         if ($this->getEditionSelector()->isEnterprise()) {
-            $path = $editionsPath  .'/'. static::ENTERPRISE_DIRECTORY;
+            $path = $editionsPath  . '/' . static::ENTERPRISE_DIRECTORY;
         } elseif ($this->getEditionSelector()->isProfessional()) {
-            $path = $editionsPath .'/'.  static::PROFESSIONAL_DIRECTORY;
+            $path = $editionsPath . '/' .  static::PROFESSIONAL_DIRECTORY;
         }
 
         return realpath($path) . DIRECTORY_SEPARATOR;

--- a/source/Core/Edition/EditionSelector.php
+++ b/source/Core/Edition/EditionSelector.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Core/Email.php
+++ b/source/Core/Email.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
@@ -381,7 +382,7 @@ class Email extends PHPMailer
      *
      * @return \Smarty
      */
-    protected function _getSmarty()
+    protected function _getSmarty() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         if ($this->_oSmarty === null) {
             $this->_oSmarty = \OxidEsales\Eshop\Core\Registry::getUtilsView()->getSmarty();
@@ -477,7 +478,7 @@ class Email extends PHPMailer
      *
      * @return string
      */
-    protected function _setSmtpProtocol($url)
+    protected function _setSmtpProtocol($url) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $protocol = '';
         $smtpHost = $url;
@@ -535,7 +536,7 @@ class Email extends PHPMailer
      *
      * @return bool
      */
-    protected function _isValidSmtpHost($smtpHost)
+    protected function _isValidSmtpHost($smtpHost) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $isSmtp = false;
         if ($smtpHost) {
@@ -886,7 +887,7 @@ class Email extends PHPMailer
      *
      * @return string $url
      */
-    protected function _getNewsSubsLink($id, $confirmCode = null)
+    protected function _getNewsSubsLink($id, $confirmCode = null) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $myConfig = $this->getConfig();
         $actShopLang = $myConfig->getActiveShop()->getLanguage();
@@ -1452,7 +1453,7 @@ class Email extends PHPMailer
      * @param string $absImageDir    Absolute path to images
      * @param string $absDynImageDir Absolute path to Dyn images
      */
-    protected function _includeImages($imageDir = null, $imageDirNoSSL = null, $dynImageDir = null, $absImageDir = null, $absDynImageDir = null)
+    protected function _includeImages($imageDir = null, $imageDirNoSSL = null, $dynImageDir = null, $absImageDir = null, $absDynImageDir = null) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $body = $this->getBody();
         if (preg_match_all('/<\s*img\s+[^>]*?src[\s]*=[\s]*[\'"]?([^[\'">]]+|.*?)?[\'">]/i', $body, $matches, PREG_SET_ORDER)) {
@@ -1896,7 +1897,7 @@ class Email extends PHPMailer
      *
      * @return bool
      */
-    protected function _getUseInlineImages()
+    protected function _getUseInlineImages() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         return $this->_blInlineImgEmail;
     }
@@ -1906,7 +1907,7 @@ class Email extends PHPMailer
      *
      * @return bool
      */
-    protected function _sendMailErrorMsg()
+    protected function _sendMailErrorMsg() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         // build addresses
         $recipients = $this->getRecipient();
@@ -1935,7 +1936,7 @@ class Email extends PHPMailer
      *
      * @return \OxidEsales\Eshop\Application\Model\Order
      */
-    protected function _addUserInfoOrderEMail($order)
+    protected function _addUserInfoOrderEMail($order) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         return $order;
     }
@@ -1949,7 +1950,7 @@ class Email extends PHPMailer
      *
      * @return \OxidEsales\Eshop\Application\Model\User
      */
-    protected function _addUserRegisterEmail($user)
+    protected function _addUserRegisterEmail($user) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         return $user;
     }
@@ -1963,7 +1964,7 @@ class Email extends PHPMailer
      *
      * @return \OxidEsales\Eshop\Application\Model\Shop
      */
-    protected function _addForgotPwdEmail($shop)
+    protected function _addForgotPwdEmail($shop) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         return $shop;
     }
@@ -1977,7 +1978,7 @@ class Email extends PHPMailer
      *
      * @return \OxidEsales\Eshop\Application\Model\User
      */
-    protected function _addNewsletterDbOptInMail($user)
+    protected function _addNewsletterDbOptInMail($user) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         return $user;
     }
@@ -1985,7 +1986,7 @@ class Email extends PHPMailer
     /**
      * Clears mailer settings (AllRecipients, ReplyTos, Attachments, Errors)
      */
-    protected function _clearMailer()
+    protected function _clearMailer() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $this->clearAllRecipients();
         $this->clearReplyTos();
@@ -1999,7 +2000,7 @@ class Email extends PHPMailer
      *
      * @param \OxidEsales\Eshop\Application\Model\Shop $shop Shop object
      */
-    protected function _setMailParams($shop = null)
+    protected function _setMailParams($shop = null) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $this->_clearMailer();
 
@@ -2020,7 +2021,7 @@ class Email extends PHPMailer
      *
      * @return \OxidEsales\Eshop\Application\Model\Shop
      */
-    protected function _getShop($langId = null, $shopId = null)
+    protected function _getShop($langId = null, $shopId = null) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         if ($langId === null && $shopId === null) {
             if (isset($this->_oShop)) {
@@ -2050,7 +2051,7 @@ class Email extends PHPMailer
      * @param string                                   $userName     smtp user
      * @param \OxidEsales\Eshop\Application\Model\Shop $userPassword smtp password
      */
-    protected function _setSmtpAuthInfo($userName = null, $userPassword = null)
+    protected function _setSmtpAuthInfo($userName = null, $userPassword = null) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $this->set("SMTPAuth", true);
         $this->set("Username", $userName);
@@ -2062,7 +2063,7 @@ class Email extends PHPMailer
      *
      * @param bool $debug show debug info or not
      */
-    protected function _setSmtpDebug($debug = null)
+    protected function _setSmtpDebug($debug = null) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $this->set("SMTPDebug", $debug);
     }
@@ -2071,7 +2072,7 @@ class Email extends PHPMailer
      * Process email body and alt body thought oxOutput.
      * Calls \OxidEsales\Eshop\Core\Output::processEmail() on class instance.
      */
-    protected function _makeOutputProcessing()
+    protected function _makeOutputProcessing() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $output = oxNew(\OxidEsales\Eshop\Core\Output::class);
         $this->setBody($output->process($this->getBody(), "oxemail"));
@@ -2084,7 +2085,7 @@ class Email extends PHPMailer
      *
      * @return bool
      */
-    protected function _sendMail()
+    protected function _sendMail() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $result = false;
         try {
@@ -2105,7 +2106,7 @@ class Email extends PHPMailer
     /**
      * Process view data array through oxOutput processor
      */
-    protected function _processViewArray()
+    protected function _processViewArray() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $outputProcessor = oxNew(\OxidEsales\Eshop\Core\Output::class);
 
@@ -2262,7 +2263,7 @@ class Email extends PHPMailer
      *
      * @return string
      */
-    private function _clearSidFromBody($altBody)
+    private function _clearSidFromBody($altBody) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         return Str::getStr()->preg_replace('/(\?|&(amp;)?)(force_)?(admin_)?sid=[A-Z0-9\.]+/i', '\1shp=' . $this->getConfig()->getShopId(), $altBody);
     }

--- a/source/Core/EmailBuilder.php
+++ b/source/Core/EmailBuilder.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Core/Encryptor.php
+++ b/source/Core/Encryptor.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
@@ -40,7 +41,7 @@ class Encryptor
      *
      * @return string
      */
-    protected function _formKey($key, $string)
+    protected function _formKey($key, $string) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $key = '_' . $key;
         $keyLength = (strlen($string) / strlen($key)) + 5;

--- a/source/Core/Exception/ArticleException.php
+++ b/source/Core/Exception/ArticleException.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Core/Exception/ArticleInputException.php
+++ b/source/Core/Exception/ArticleInputException.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Core/Exception/ConnectionException.php
+++ b/source/Core/Exception/ConnectionException.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Core/Exception/CookieException.php
+++ b/source/Core/Exception/CookieException.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Core/Exception/DatabaseConnectionException.php
+++ b/source/Core/Exception/DatabaseConnectionException.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Core/Exception/DatabaseErrorException.php
+++ b/source/Core/Exception/DatabaseErrorException.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Core/Exception/DatabaseException.php
+++ b/source/Core/Exception/DatabaseException.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Core/Exception/DatabaseNotConfiguredException.php
+++ b/source/Core/Exception/DatabaseNotConfiguredException.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Core/Exception/ExceptionHandler.php
+++ b/source/Core/Exception/ExceptionHandler.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Core/Exception/ExceptionToDisplay.php
+++ b/source/Core/Exception/ExceptionToDisplay.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Core/Exception/FileException.php
+++ b/source/Core/Exception/FileException.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Core/Exception/InputException.php
+++ b/source/Core/Exception/InputException.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Core/Exception/LanguageException.php
+++ b/source/Core/Exception/LanguageException.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Core/Exception/ModuleValidationException.php
+++ b/source/Core/Exception/ModuleValidationException.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Core/Exception/NoArticleException.php
+++ b/source/Core/Exception/NoArticleException.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Core/Exception/NoResultException.php
+++ b/source/Core/Exception/NoResultException.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Core/Exception/ObjectException.php
+++ b/source/Core/Exception/ObjectException.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Core/Exception/OutOfStockException.php
+++ b/source/Core/Exception/OutOfStockException.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Core/Exception/RoutingException.php
+++ b/source/Core/Exception/RoutingException.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Core/Exception/ShopException.php
+++ b/source/Core/Exception/ShopException.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Core/Exception/StandardException.php
+++ b/source/Core/Exception/StandardException.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Core/Exception/SystemComponentException.php
+++ b/source/Core/Exception/SystemComponentException.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Core/Exception/UserException.php
+++ b/source/Core/Exception/UserException.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Core/Exception/VoucherException.php
+++ b/source/Core/Exception/VoucherException.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
@@ -32,7 +33,7 @@ class VoucherException extends \OxidEsales\Eshop\Core\Exception\StandardExceptio
      */
     public function setVoucherNr($sVoucherNr)
     {
-        $this->_sVoucherNr = ( string ) $sVoucherNr;
+        $this->_sVoucherNr = (string) $sVoucherNr;
     }
 
     /**

--- a/source/Core/Field.php
+++ b/source/Core/Field.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
@@ -153,7 +154,7 @@ class Field // extends \OxidEsales\Eshop\Core\Base
      * @param mixed $value Field value
      * @param int   $type  Value type
      */
-    protected function _initValue($value = null, $type = self::T_TEXT)
+    protected function _initValue($value = null, $type = self::T_TEXT) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         switch ($type) {
             case self::T_TEXT:

--- a/source/Core/FileCache.php
+++ b/source/Core/FileCache.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
@@ -111,6 +112,6 @@ class FileCache
     {
         $name = strtolower(basename($key));
 
-        return self::CACHE_FILE_PREFIX .".all.$name.txt";
+        return self::CACHE_FILE_PREFIX . ".all.$name.txt";
     }
 }

--- a/source/Core/FileSystem/FileSystem.php
+++ b/source/Core/FileSystem/FileSystem.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Core/Form/FormFields.php
+++ b/source/Core/Form/FormFields.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Core/Form/FormFieldsCleaner.php
+++ b/source/Core/Form/FormFieldsCleaner.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Core/Form/FormFieldsTrimmer.php
+++ b/source/Core/Form/FormFieldsTrimmer.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Core/Form/FormFieldsTrimmerInterface.php
+++ b/source/Core/Form/FormFieldsTrimmerInterface.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Core/Form/UpdatableFieldsConstructor.php
+++ b/source/Core/Form/UpdatableFieldsConstructor.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Core/GenericImport/GenericImport.php
+++ b/source/Core/GenericImport/GenericImport.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
@@ -445,7 +446,7 @@ class GenericImport
      */
     protected function createImportObject($type)
     {
-        $className = __NAMESPACE__ . "\\ImportObject\\".$type;
+        $className = __NAMESPACE__ . "\\ImportObject\\" . $type;
 
         return oxNew($className);
     }

--- a/source/Core/GenericImport/ImportObject/Accessories2Article.php
+++ b/source/Core/GenericImport/ImportObject/Accessories2Article.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Core/GenericImport/ImportObject/Article.php
+++ b/source/Core/GenericImport/ImportObject/Article.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Core/GenericImport/ImportObject/Article2Action.php
+++ b/source/Core/GenericImport/ImportObject/Article2Action.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Core/GenericImport/ImportObject/Article2Category.php
+++ b/source/Core/GenericImport/ImportObject/Article2Category.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Core/GenericImport/ImportObject/ArticleExtends.php
+++ b/source/Core/GenericImport/ImportObject/ArticleExtends.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Core/GenericImport/ImportObject/Category.php
+++ b/source/Core/GenericImport/ImportObject/Category.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Core/GenericImport/ImportObject/Country.php
+++ b/source/Core/GenericImport/ImportObject/Country.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Core/GenericImport/ImportObject/CrossSelling.php
+++ b/source/Core/GenericImport/ImportObject/CrossSelling.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Core/GenericImport/ImportObject/ImportObject.php
+++ b/source/Core/GenericImport/ImportObject/ImportObject.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Core/GenericImport/ImportObject/Order.php
+++ b/source/Core/GenericImport/ImportObject/Order.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Core/GenericImport/ImportObject/OrderArticle.php
+++ b/source/Core/GenericImport/ImportObject/OrderArticle.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Core/GenericImport/ImportObject/ScalePrice.php
+++ b/source/Core/GenericImport/ImportObject/ScalePrice.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Core/GenericImport/ImportObject/User.php
+++ b/source/Core/GenericImport/ImportObject/User.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Core/GenericImport/ImportObject/Vendor.php
+++ b/source/Core/GenericImport/ImportObject/Vendor.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Core/Hasher.php
+++ b/source/Core/Hasher.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Core/Header.php
+++ b/source/Core/Header.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Core/InputValidator.php
+++ b/source/Core/InputValidator.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
@@ -110,7 +111,7 @@ class InputValidator extends \OxidEsales\Eshop\Core\Base
         }
 
         if (!\OxidEsales\Eshop\Core\Registry::getConfig()->getConfigParam('blAllowUnevenAmounts')) {
-            $amount = round(( string ) $amount);
+            $amount = round((string) $amount);
         }
 
         //negative amounts are not allowed
@@ -292,7 +293,7 @@ class InputValidator extends \OxidEsales\Eshop\Core\Base
      *
      * @return User|Address
      */
-    private function _setFields($object, $fields)
+    private function _setFields($object, $fields) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $fields = is_array($fields) ? $fields : [];
         foreach ($fields as $sKey => $sValue) {
@@ -386,7 +387,7 @@ class InputValidator extends \OxidEsales\Eshop\Core\Base
      *
      * @return \OxidEsales\Eshop\Application\Model\Country
      */
-    protected function _getCountry($countryId)
+    protected function _getCountry($countryId) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $country = oxNew(\OxidEsales\Eshop\Application\Model\Country::class);
         $country->load($countryId);
@@ -472,7 +473,7 @@ class InputValidator extends \OxidEsales\Eshop\Core\Base
      *
      * @return StandardException
      */
-    protected function _addValidationError($fieldName, $error)
+    protected function _addValidationError($fieldName, $error) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         return $this->addValidationError($fieldName, $error);
     }
@@ -498,7 +499,7 @@ class InputValidator extends \OxidEsales\Eshop\Core\Base
      *
      * @return bool|int
      */
-    protected function _validateDebitNote($debitInformation)
+    protected function _validateDebitNote($debitInformation) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $debitInformation = $this->_cleanDebitInformation($debitInformation);
         $bankCode = $debitInformation['lsblz'];
@@ -527,7 +528,7 @@ class InputValidator extends \OxidEsales\Eshop\Core\Base
      *
      * @return bool|int
      */
-    protected function _validateOldDebitInfo($debitInfo)
+    protected function _validateOldDebitInfo($debitInfo) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $stringHelper = getStr();
         $debitInfo = $this->_fixAccountNumber($debitInfo);
@@ -555,7 +556,7 @@ class InputValidator extends \OxidEsales\Eshop\Core\Base
      *
      * @return array
      */
-    protected function _fixAccountNumber($debitInfo)
+    protected function _fixAccountNumber($debitInfo) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $oStr = getStr();
 
@@ -578,7 +579,7 @@ class InputValidator extends \OxidEsales\Eshop\Core\Base
      *
      * @return bool
      */
-    protected function _isAllBankInformationSet($requiredFields, $bankInformation)
+    protected function _isAllBankInformationSet($requiredFields, $bankInformation) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $isSet = true;
         foreach ($requiredFields as $fieldName) {
@@ -598,7 +599,7 @@ class InputValidator extends \OxidEsales\Eshop\Core\Base
      *
      * @return mixed
      */
-    protected function _cleanDebitInformation($debitInformation)
+    protected function _cleanDebitInformation($debitInformation) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $debitInformation['lsblz'] = str_replace(' ', '', $debitInformation['lsblz']);
         $debitInformation['lsktonr'] = str_replace(' ', '', $debitInformation['lsktonr']);
@@ -613,7 +614,7 @@ class InputValidator extends \OxidEsales\Eshop\Core\Base
      *
      * @return bool
      */
-    protected function _hasRequiredParametersForVatInCheck($invAddress)
+    protected function _hasRequiredParametersForVatInCheck($invAddress) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         return $invAddress['oxuser__oxustid'] && $invAddress['oxuser__oxcountryid'] && $invAddress['oxuser__oxcompany'];
     }

--- a/source/Core/Language.php
+++ b/source/Core/Language.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
@@ -221,7 +222,8 @@ class Language extends \OxidEsales\Eshop\Core\Base
 
             if ($this->isAdmin()) {
                 $aLanguages = $this->getAdminTplLanguageArray();
-                if (!isset($aLanguages[$this->_iObjectTplLanguageId]) ||
+                if (
+                    !isset($aLanguages[$this->_iObjectTplLanguageId]) ||
                     $aLanguages[$this->_iObjectTplLanguageId]->active == 0
                 ) {
                     $this->_iObjectTplLanguageId = key($aLanguages);
@@ -469,7 +471,7 @@ class Language extends \OxidEsales\Eshop\Core\Base
      *
      * @return array
      */
-    protected function _collectSimilar($aData, $sKey, $aCollection = [])
+    protected function _collectSimilar($aData, $sKey, $aCollection = []) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         foreach ($aData as $sValKey => $sValue) {
             if (strpos($sValKey, $sKey) === 0) {
@@ -545,7 +547,7 @@ class Language extends \OxidEsales\Eshop\Core\Base
     public function formatVat($dValue, $oActCur = null)
     {
         $iDecPos = 0;
-        $sValue = ( string ) $dValue;
+        $sValue = (string) $dValue;
         /** @var \OxidEsales\Eshop\Core\StrRegular $oStr */
         $oStr = getStr();
         if (($iDotPos = $oStr->strpos($sValue, '.')) !== false) {
@@ -646,7 +648,7 @@ class Language extends \OxidEsales\Eshop\Core\Base
      *
      * @return array
      */
-    protected function _recodeLangArray($aLangArray, $sCharset, $blRecodeKeys = false)
+    protected function _recodeLangArray($aLangArray, $sCharset, $blRecodeKeys = false) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $newEncoding = $this->getTranslationsExpectedEncoding();
 
@@ -671,7 +673,7 @@ class Language extends \OxidEsales\Eshop\Core\Base
      *
      * @deprecated since 6.0 (2016-12-07) As the shop installation is utf-8, this method will be removed.
      */
-    protected function _recodeLangArrayValues(&$aLangArray, $sCharset, $newEncoding)
+    protected function _recodeLangArrayValues(&$aLangArray, $sCharset, $newEncoding) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         foreach ($aLangArray as $sItemKey => &$sValue) {
             $sValue = iconv($sCharset, $newEncoding, $sValue);
@@ -689,7 +691,7 @@ class Language extends \OxidEsales\Eshop\Core\Base
      *
      * @return array
      */
-    protected function _recodeLangArrayWithKeys($aLangArray, $sCharset, $newEncoding)
+    protected function _recodeLangArrayWithKeys($aLangArray, $sCharset, $newEncoding) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $aLangs = [];
         foreach ($aLangArray as $sItemKey => $sValue) {
@@ -718,7 +720,7 @@ class Language extends \OxidEsales\Eshop\Core\Base
      *
      * @return array
      */
-    protected function _getLangFilesPathArray($iLang)
+    protected function _getLangFilesPathArray($iLang) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $oConfig = $this->getConfig();
         $aLangFiles = [];
@@ -784,7 +786,7 @@ class Language extends \OxidEsales\Eshop\Core\Base
      *
      * @return array
      */
-    protected function _getAdminLangFilesPathArray($activeLanguage)
+    protected function _getAdminLangFilesPathArray($activeLanguage) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $config = $this->getConfig();
         $langFiles = [];
@@ -832,7 +834,7 @@ class Language extends \OxidEsales\Eshop\Core\Base
      *
      * @return array
      */
-    protected function _appendLangFile($aLangFiles, $sFullPath, $sFilePattern = "lang")
+    protected function _appendLangFile($aLangFiles, $sFullPath, $sFilePattern = "lang") // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $aFiles = glob($sFullPath . "/*_{$sFilePattern}.php");
         if (is_array($aFiles) && count($aFiles)) {
@@ -855,7 +857,7 @@ class Language extends \OxidEsales\Eshop\Core\Base
      *
      * @return array
      */
-    protected function _appendCustomLangFiles($languageFiles, $language, $forAdmin = false)
+    protected function _appendCustomLangFiles($languageFiles, $language, $forAdmin = false) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         if ($forAdmin) {
             $adminThemeName = $this->getContainer()->get(AdminThemeBridgeInterface::class)->getActiveTheme();
@@ -899,7 +901,7 @@ class Language extends \OxidEsales\Eshop\Core\Base
      *
      * @return array
      */
-    protected function _appendModuleLangFiles($aLangFiles, $aModulePaths, $sLang, $blForAdmin = false)
+    protected function _appendModuleLangFiles($aLangFiles, $aModulePaths, $sLang, $blForAdmin = false) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         if (is_array($aModulePaths)) {
             foreach ($aModulePaths as $sPath) {
@@ -926,7 +928,7 @@ class Language extends \OxidEsales\Eshop\Core\Base
      *
      * @return string
      */
-    protected function _getLangFileCacheName($blAdmin, $iLang, $aLangFiles = null)
+    protected function _getLangFileCacheName($blAdmin, $iLang, $aLangFiles = null) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $myConfig = $this->getConfig();
         $sLangFilesIdent = '_default';
@@ -946,7 +948,7 @@ class Language extends \OxidEsales\Eshop\Core\Base
      *
      * @return array
      */
-    protected function _getLanguageFileData($blAdmin = false, $iLang = 0, $aLangFiles = null)
+    protected function _getLanguageFileData($blAdmin = false, $iLang = 0, $aLangFiles = null) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $myUtils = \OxidEsales\Eshop\Core\Registry::getUtils();
 
@@ -1000,7 +1002,7 @@ class Language extends \OxidEsales\Eshop\Core\Base
      *
      * @return array
      */
-    protected function _getLanguageMap($language, $isAdmin = null)
+    protected function _getLanguageMap($language, $isAdmin = null) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $isAdmin = isset($isAdmin) ? $isAdmin : $this->isAdmin();
         $key = $language . ((int) $isAdmin);
@@ -1066,7 +1068,7 @@ class Language extends \OxidEsales\Eshop\Core\Base
      *
      * @return int
      */
-    protected function _getCacheLanguageId($blAdmin, $iLang = null)
+    protected function _getCacheLanguageId($blAdmin, $iLang = null) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $iLang = ($iLang === null && $blAdmin) ? $this->getTplLanguage() : $iLang;
         if (!isset($iLang)) {
@@ -1088,7 +1090,7 @@ class Language extends \OxidEsales\Eshop\Core\Base
      *
      * @return array
      */
-    protected function _getLangTranslationArray($iLang = null, $blAdmin = null, $aLangFiles = null)
+    protected function _getLangTranslationArray($iLang = null, $blAdmin = null, $aLangFiles = null) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         startProfile("_getLangTranslationArray");
 
@@ -1118,7 +1120,7 @@ class Language extends \OxidEsales\Eshop\Core\Base
      *
      * @return bool
      */
-    protected function _sortLanguagesCallback($a1, $a2)
+    protected function _sortLanguagesCallback($a1, $a2) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         return ($a1->sort > $a2->sort);
     }
@@ -1182,7 +1184,8 @@ class Language extends \OxidEsales\Eshop\Core\Base
 
         if (!$this->isAdmin()) {
             $sParam = $this->getUrlLang($iLang);
-            if (!$oStr->preg_match('/(\?|&(amp;)?)lang=[0-9]+/', $sUrl) &&
+            if (
+                !$oStr->preg_match('/(\?|&(amp;)?)lang=[0-9]+/', $sUrl) &&
                 ($iLang != $iDefaultLang || $iDefaultLang != $iBrowserLanguage)
             ) {
                 if ($sUrl) {
@@ -1273,7 +1276,7 @@ class Language extends \OxidEsales\Eshop\Core\Base
      *
      * @return array
      */
-    protected function _getActiveModuleInfo()
+    protected function _getActiveModuleInfo() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         if ($this->_aActiveModuleInfo === null) {
             $oModuleList = oxNew(\OxidEsales\Eshop\Core\Module\ModuleList::class);
@@ -1288,7 +1291,7 @@ class Language extends \OxidEsales\Eshop\Core\Base
      *
      * @return array
      */
-    protected function _getDisabledModuleInfo()
+    protected function _getDisabledModuleInfo() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         if ($this->_aDisabledModuleInfo === null) {
             $oModuleList = oxNew(\OxidEsales\Eshop\Core\Module\ModuleList::class);
@@ -1303,7 +1306,7 @@ class Language extends \OxidEsales\Eshop\Core\Base
      *
      * @return string
      */
-    protected function _getBrowserLanguage()
+    protected function _getBrowserLanguage() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         if (isset($_SERVER['HTTP_ACCEPT_LANGUAGE']) && $_SERVER['HTTP_ACCEPT_LANGUAGE']) {
             return strtolower(substr($_SERVER['HTTP_ACCEPT_LANGUAGE'], 0, 2));
@@ -1365,7 +1368,7 @@ class Language extends \OxidEsales\Eshop\Core\Base
      *
      * @return array
      */
-    protected function _getLanguageIdsFromDatabase($shopId = null)
+    protected function _getLanguageIdsFromDatabase($shopId = null) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         return $this->getLanguageIds();
     }
@@ -1378,7 +1381,7 @@ class Language extends \OxidEsales\Eshop\Core\Base
      *
      * @return array
      */
-    protected function _getConfigLanguageValues($sLanguageParameterName, $iShopId = null)
+    protected function _getConfigLanguageValues($sLanguageParameterName, $iShopId = null) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $aConfigDecodedValues = [];
         $aConfigValues = $this->_selectLanguageParamValues($sLanguageParameterName, $iShopId);
@@ -1407,7 +1410,7 @@ class Language extends \OxidEsales\Eshop\Core\Base
      *
      * @return array
      */
-    protected function _selectLanguageParamValues($sParamName, $sShopId = null)
+    protected function _selectLanguageParamValues($sParamName, $sShopId = null) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $oDb = \OxidEsales\Eshop\Core\DatabaseProvider::getDb(\OxidEsales\Eshop\Core\DatabaseProvider::FETCH_MODE_ASSOC);
         $oConfig = \OxidEsales\Eshop\Core\Registry::getConfig();
@@ -1435,7 +1438,7 @@ class Language extends \OxidEsales\Eshop\Core\Base
      *
      * @return array
      */
-    protected function _getLanguageIdsFromLanguageParamsArray($aLanguageParams)
+    protected function _getLanguageIdsFromLanguageParamsArray($aLanguageParams) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $aLanguages = [];
         foreach ($aLanguageParams as $sAbbr => $aValue) {
@@ -1453,7 +1456,7 @@ class Language extends \OxidEsales\Eshop\Core\Base
      *
      * @return array
      */
-    protected function _getLanguageIdsFromLanguagesArray($aLanguages)
+    protected function _getLanguageIdsFromLanguagesArray($aLanguages) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         return array_keys($aLanguages);
     }

--- a/source/Core/MailValidator.php
+++ b/source/Core/MailValidator.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Core/Model/BaseModel.php
+++ b/source/Core/Model/BaseModel.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
@@ -18,7 +19,7 @@ DEFINE('ACTION_UPDATE_STOCK', 4);
 use Exception;
 use OxidEsales\EshopCommunity\Core\Exception\DatabaseException;
 use oxObjectException;
-use \OxidEsales\Eshop\Core\Field;
+use OxidEsales\Eshop\Core\Field;
 use OxidEsales\EshopCommunity\Internal\Transition\ShopEvents\BeforeModelUpdateEvent;
 use OxidEsales\EshopCommunity\Internal\Transition\ShopEvents\BeforeModelDeleteEvent;
 use OxidEsales\EshopCommunity\Internal\Transition\ShopEvents\AfterModelUpdateEvent;
@@ -240,7 +241,8 @@ class BaseModel extends \OxidEsales\Eshop\Core\Base
         $this->$fieldName = $fieldValue;
         if ($this->_blUseLazyLoading && strpos($fieldName, $this->_sCoreTable . '__') === 0) {
             $preparedFieldName = str_replace($this->_sCoreTable . '__', '', $fieldName);
-            if ($preparedFieldName !== 'oxnid'
+            if (
+                $preparedFieldName !== 'oxnid'
                 && (!isset($this->_aFieldNames[$preparedFieldName]) || !$this->_aFieldNames[$preparedFieldName])
             ) {
                 $allFieldsList = $this->_getAllFields(true);
@@ -422,7 +424,7 @@ class BaseModel extends \OxidEsales\Eshop\Core\Base
      *
      * @param string $fieldName Field name that will be checked
      */
-    protected function _setUpdateSeoOnFieldChange($fieldName)
+    protected function _setUpdateSeoOnFieldChange($fieldName) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         if ($this->getId() && in_array($fieldName, $this->getFieldNames())) {
             $database = \OxidEsales\Eshop\Core\DatabaseProvider::getDb();
@@ -816,7 +818,7 @@ class BaseModel extends \OxidEsales\Eshop\Core\Base
      *
      * @param string $oxid Object ID
      */
-    protected function _removeElement2ShopRelations($oxid)
+    protected function _removeElement2ShopRelations($oxid) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
     }
 
@@ -914,7 +916,7 @@ class BaseModel extends \OxidEsales\Eshop\Core\Base
         $database = \OxidEsales\Eshop\Core\DatabaseProvider::getDb(\OxidEsales\Eshop\Core\DatabaseProvider::FETCH_MODE_ASSOC);
         $query = "select {$this->_sExistKey} from {$viewName} where {$this->_sExistKey} = :oxid";
 
-        return ( bool ) $database->getOne($query, [
+        return (bool) $database->getOne($query, [
             ':oxid' => $oxid
         ]);
     }
@@ -985,7 +987,7 @@ class BaseModel extends \OxidEsales\Eshop\Core\Base
      *
      * @return bool
      */
-    protected function _isInList()
+    protected function _isInList() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         return $this->_blIsInList;
     }
@@ -998,7 +1000,7 @@ class BaseModel extends \OxidEsales\Eshop\Core\Base
      *
      * @return string
      */
-    protected function _getObjectViewName($table, $shopID = null)
+    protected function _getObjectViewName($table, $shopID = null) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         return getViewName($table, -1, $shopID);
     }
@@ -1013,7 +1015,7 @@ class BaseModel extends \OxidEsales\Eshop\Core\Base
      *
      * @return array
      */
-    protected function _getTableFields($table, $returnSimpleArray = false)
+    protected function _getTableFields($table, $returnSimpleArray = false) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $myUtils = \OxidEsales\Eshop\Core\Registry::getUtils();
 
@@ -1056,7 +1058,7 @@ class BaseModel extends \OxidEsales\Eshop\Core\Base
      *
      * @return array
      */
-    protected function _getAllFields($returnSimple = false)
+    protected function _getAllFields($returnSimple = false) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         if (!$this->getCoreTableName()) {
             return [];
@@ -1071,7 +1073,7 @@ class BaseModel extends \OxidEsales\Eshop\Core\Base
      *
      * @param bool $forceFullStructure Set to true if you want to load full structure in any case.
      */
-    protected function _initDataStructure($forceFullStructure = false)
+    protected function _initDataStructure($forceFullStructure = false) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $myUtils = \OxidEsales\Eshop\Core\Registry::getUtils();
 
@@ -1107,7 +1109,7 @@ class BaseModel extends \OxidEsales\Eshop\Core\Base
      *
      * @return array|bool
      */
-    protected function _getNonCachedFieldNames($forceFullStructure = false)
+    protected function _getNonCachedFieldNames($forceFullStructure = false) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         //T2008-02-22
         //so if this method is executed on cached version we see it when profiling
@@ -1158,7 +1160,7 @@ class BaseModel extends \OxidEsales\Eshop\Core\Base
      *
      * @return int
      */
-    protected function _getFieldStatus($fieldName)
+    protected function _getFieldStatus($fieldName) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         return 0;
     }
@@ -1173,7 +1175,7 @@ class BaseModel extends \OxidEsales\Eshop\Core\Base
      *
      * @return null
      */
-    protected function _addField($fieldName, $fieldStatus, $type = null, $length = null)
+    protected function _addField($fieldName, $fieldStatus, $type = null, $length = null) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         //preparation
         $fieldName = strtolower($fieldName);
@@ -1216,7 +1218,7 @@ class BaseModel extends \OxidEsales\Eshop\Core\Base
      *
      * @return string
      */
-    protected function _getFieldLongName($fieldName)
+    protected function _getFieldLongName($fieldName) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         //trying to avoid strpos call as often as possible
         $coreTableName = $this->getCoreTableName();
@@ -1234,7 +1236,7 @@ class BaseModel extends \OxidEsales\Eshop\Core\Base
      * @param string $fieldValue Value of data field
      * @param int    $dataType   Field type
      */
-    protected function _setFieldData($fieldName, $fieldValue, $dataType = Field::T_TEXT)
+    protected function _setFieldData($fieldName, $fieldValue, $dataType = Field::T_TEXT) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $longFieldName = $this->_getFieldLongName($fieldName);
         //$sLongFieldName = $this->_sCoreTable . "__" . strtolower($sFieldName);
@@ -1246,7 +1248,8 @@ class BaseModel extends \OxidEsales\Eshop\Core\Base
 
 
         //in non lazy loading case we just add a field and do not care about it more
-        if (!$this->_blUseLazyLoading
+        if (
+            !$this->_blUseLazyLoading
             && !$this->isPropertyLoaded($longFieldName)
         ) {
             $fieldsList = $this->_getAllFields(true);
@@ -1256,7 +1259,8 @@ class BaseModel extends \OxidEsales\Eshop\Core\Base
         }
         // if we have a double field we replace "," with "." in case somebody enters it in european format
         $isPropertyLoaded = $this->isPropertyLoaded($longFieldName);
-        if ($isPropertyLoaded
+        if (
+            $isPropertyLoaded
             && isset($this->$longFieldName->fldtype)
             && $this->$longFieldName->fldtype == 'double'
         ) {
@@ -1264,7 +1268,8 @@ class BaseModel extends \OxidEsales\Eshop\Core\Base
         }
 
         // isset is REQUIRED here not to use getter
-        if ($isPropertyLoaded
+        if (
+            $isPropertyLoaded
             && is_object($this->$longFieldName)
         ) {
             $this->$longFieldName->setValue($fieldValue, $dataType);
@@ -1280,7 +1285,7 @@ class BaseModel extends \OxidEsales\Eshop\Core\Base
      *
      * @return bool
      */
-    protected function _canFieldBeNull($fieldName)
+    protected function _canFieldBeNull($fieldName) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $metaData = $this->_getAllFields();
         foreach ($metaData as $metaInfo) {
@@ -1299,7 +1304,7 @@ class BaseModel extends \OxidEsales\Eshop\Core\Base
      *
      * @return mixed
      */
-    protected function _getFieldDefaultValue($fieldName)
+    protected function _getFieldDefaultValue($fieldName) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $metaData = $this->_getAllFields();
         foreach ($metaData as $metaInfo) {
@@ -1319,7 +1324,7 @@ class BaseModel extends \OxidEsales\Eshop\Core\Base
      *
      * @return string
      */
-    protected function _getUpdateFieldValue($fieldName, $field)
+    protected function _getUpdateFieldValue($fieldName, $field) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $fieldValue = null;
         if ($field instanceof Field) {
@@ -1349,7 +1354,7 @@ class BaseModel extends \OxidEsales\Eshop\Core\Base
      *
      * @return string
      */
-    protected function _getUpdateFields($useSkipSaveFields = true)
+    protected function _getUpdateFields($useSkipSaveFields = true) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $query = '';
         $useSeparator = false;
@@ -1393,7 +1398,7 @@ class BaseModel extends \OxidEsales\Eshop\Core\Base
      *
      * @return bool Will always return true. On failure an exception is thrown.
      */
-    protected function _update()
+    protected function _update() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         //do not allow derived item update
         if (!$this->allowDerivedUpdate()) {
@@ -1443,7 +1448,7 @@ class BaseModel extends \OxidEsales\Eshop\Core\Base
      *
      * @return bool
      */
-    protected function _insert()
+    protected function _insert() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $myConfig = $this->getConfig();
         $myUtils = \OxidEsales\Eshop\Core\Registry::getUtils();
@@ -1459,7 +1464,8 @@ class BaseModel extends \OxidEsales\Eshop\Core\Base
 
         $shopIdField = $myUtils->getArrFldName($this->getCoreTableName() . '.oxshopid');
 
-        if ($this->isPropertyLoaded($shopIdField)
+        if (
+            $this->isPropertyLoaded($shopIdField)
             && (!$this->isPropertyField($shopIdField) || !$this->$shopIdField->value)
         ) {
             $this->$shopIdField = new Field(
@@ -1479,7 +1485,7 @@ class BaseModel extends \OxidEsales\Eshop\Core\Base
      *
      * @return bool
      */
-    protected function _isDisabledFieldCache()
+    protected function _isDisabledFieldCache() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $class = get_class($this);
         if (isset(self::$_blDisableFieldCaching[$class]) && self::$_blDisableFieldCaching[$class]) {
@@ -1492,14 +1498,14 @@ class BaseModel extends \OxidEsales\Eshop\Core\Base
     /**
      * Add additional fields to skipped save fields
      */
-    protected function _addSkippedSaveFieldsForMapping()
+    protected function _addSkippedSaveFieldsForMapping() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
     }
 
     /**
      * Disable lazy loading if cache is enabled
      */
-    protected function _disableLazyLoadingForCaching()
+    protected function _disableLazyLoadingForCaching() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
     }
 

--- a/source/Core/Model/FieldNameHelper.php
+++ b/source/Core/Model/FieldNameHelper.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Core/Model/ListModel.php
+++ b/source/Core/Model/ListModel.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
@@ -482,7 +483,7 @@ class ListModel extends \OxidEsales\Eshop\Core\Base implements \ArrayAccess, \It
      * @param BaseModel $oListObject List object (the one derived from BaseModel)
      * @param array     $aDbFields   An array holding db field values (normally the result of \OxidEsales\Eshop\Core\DatabaseProvider::Execute())
      */
-    protected function _assignElement($oListObject, $aDbFields)
+    protected function _assignElement($oListObject, $aDbFields) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $oListObject->assign($aDbFields);
     }
@@ -494,7 +495,7 @@ class ListModel extends \OxidEsales\Eshop\Core\Base implements \ArrayAccess, \It
      *
      * @return string
      */
-    protected function _getFieldLongName($sFieldName)
+    protected function _getFieldLongName($sFieldName) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         if ($this->_sCoreTable) {
             return $this->_sCoreTable . '__' . $sFieldName;

--- a/source/Core/Model/MultiLanguageModel.php
+++ b/source/Core/Model/MultiLanguageModel.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
@@ -241,7 +242,7 @@ class MultiLanguageModel extends \OxidEsales\Eshop\Core\Model\BaseModel
      *
      * @return int
      */
-    protected function _getFieldStatus($fieldName)
+    protected function _getFieldStatus($fieldName) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $allField = $this->_getAllFields(true);
         if (isset($allField[strtolower($fieldName) . "_1"])) {
@@ -262,7 +263,7 @@ class MultiLanguageModel extends \OxidEsales\Eshop\Core\Model\BaseModel
      *
      * @return array
      */
-    protected function _getNonCachedFieldNames($forceFullStructure = false)
+    protected function _getNonCachedFieldNames($forceFullStructure = false) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         //Tomas
         //TODO: this place could be optimized. please check what we can do.
@@ -300,7 +301,7 @@ class MultiLanguageModel extends \OxidEsales\Eshop\Core\Model\BaseModel
      *
      * @return bool
      */
-    protected function _getFieldLang($fieldName)
+    protected function _getFieldLang($fieldName) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         if (false === strpos($fieldName, '_')) {
             return 0;
@@ -337,7 +338,7 @@ class MultiLanguageModel extends \OxidEsales\Eshop\Core\Model\BaseModel
      *
      * @param string $field Field name that will be checked
      */
-    protected function _setUpdateSeoOnFieldChange($field)
+    protected function _setUpdateSeoOnFieldChange($field) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         parent::_setUpdateSeoOnFieldChange($this->getUpdateSqlFieldName($field));
     }
@@ -351,7 +352,7 @@ class MultiLanguageModel extends \OxidEsales\Eshop\Core\Model\BaseModel
      *
      * @return string
      */
-    protected function _getUpdateFieldsForTable($table, $useSkipSaveFields = true)
+    protected function _getUpdateFieldsForTable($table, $useSkipSaveFields = true) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $coreTable = $this->getCoreTableName();
 
@@ -430,7 +431,7 @@ class MultiLanguageModel extends \OxidEsales\Eshop\Core\Model\BaseModel
      *
      * @return string
      */
-    protected function _getUpdateFields($useSkipSaveFields = true)
+    protected function _getUpdateFields($useSkipSaveFields = true) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         return $this->_getUpdateFieldsForTable($this->getCoreTableName(), $useSkipSaveFields);
     }
@@ -445,7 +446,7 @@ class MultiLanguageModel extends \OxidEsales\Eshop\Core\Model\BaseModel
      *
      * @return bool
      */
-    protected function _update()
+    protected function _update() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $ret = parent::_update();
 
@@ -486,7 +487,7 @@ class MultiLanguageModel extends \OxidEsales\Eshop\Core\Model\BaseModel
      *
      * @return array
      */
-    protected function _getLanguageSetTables($coreTableName = null)
+    protected function _getLanguageSetTables($coreTableName = null) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $coreTableName = $coreTableName ? $coreTableName : $this->getCoreTableName();
 
@@ -500,7 +501,7 @@ class MultiLanguageModel extends \OxidEsales\Eshop\Core\Model\BaseModel
      *
      * @return bool
      */
-    protected function _insert()
+    protected function _insert() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $result = parent::_insert();
 
@@ -524,7 +525,7 @@ class MultiLanguageModel extends \OxidEsales\Eshop\Core\Model\BaseModel
      *
      * @return string
      */
-    protected function _getObjectViewName($table, $shopID = null)
+    protected function _getObjectViewName($table, $shopID = null) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         if (!$this->_blEmployMultilanguage) {
             return parent::_getObjectViewName($table, $shopID);
@@ -544,7 +545,7 @@ class MultiLanguageModel extends \OxidEsales\Eshop\Core\Model\BaseModel
      *
      * @return array
      */
-    protected function _getAllFields($returnSimple = false)
+    protected function _getAllFields($returnSimple = false) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         if ($this->_blEmployMultilanguage) {
             return parent::_getAllFields($returnSimple);
@@ -568,7 +569,7 @@ class MultiLanguageModel extends \OxidEsales\Eshop\Core\Model\BaseModel
      *
      * @return null;
      */
-    protected function _addField($name, $status, $type = null, $length = null)
+    protected function _addField($name, $status, $type = null, $length = null) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         if ($this->_blEmployMultilanguage && $this->_getFieldLang($name)) {
             return;
@@ -588,7 +589,7 @@ class MultiLanguageModel extends \OxidEsales\Eshop\Core\Model\BaseModel
      *
      * @return bool
      */
-    protected function _canFieldBeNull($fieldName)
+    protected function _canFieldBeNull($fieldName) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $fieldName = preg_replace('/_\d{1,2}$/', '', $fieldName);
 

--- a/source/Core/Module/Module.php
+++ b/source/Core/Module/Module.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Core/Module/ModuleCache.php
+++ b/source/Core/Module/ModuleCache.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
@@ -71,7 +72,7 @@ class ModuleCache extends \OxidEsales\Eshop\Core\Base
     /**
      * Cleans PHP APC cache
      */
-    protected function _clearApcCache()
+    protected function _clearApcCache() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         if (extension_loaded('apc') && ini_get('apc.enabled')) {
             apc_clear_cache();

--- a/source/Core/Module/ModuleChainsGenerator.php
+++ b/source/Core/Module/ModuleChainsGenerator.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
@@ -290,9 +291,11 @@ class ModuleChainsGenerator
          */
         /** @var \Composer\Autoload\ClassLoader $composerClassLoader */
         $composerClassLoader = include VENDOR_PATH . 'autoload.php';
-        if (!$this->isUnitTest() && // In unit test some classes are created dynamically, so the files would not exist :-(
+        if (
+            !$this->isUnitTest() && // In unit test some classes are created dynamically, so the files would not exist :-(
             !strpos($moduleClass, '_parent') &&
-            !$composerClassLoader->findFile($moduleClass)) {
+            !$composerClassLoader->findFile($moduleClass)
+        ) {
             $this->handleSpecialCases($parentClass);
             $this->onModuleExtensionCreationError($moduleClass);
 
@@ -333,8 +336,10 @@ class ModuleChainsGenerator
         /**
          * Test if the class file could be read
          */
-        if (!$this->isUnitTest() && // In unit test some classes are created dynamically, so the files would not exist :-(
-            !is_readable($moduleClassFile)) {
+        if (
+            !$this->isUnitTest() && // In unit test some classes are created dynamically, so the files would not exist :-(
+            !is_readable($moduleClassFile)
+        ) {
             $this->handleSpecialCases($parentClass);
             $this->onModuleExtensionCreationError($moduleClass);
 
@@ -494,7 +499,7 @@ class ModuleChainsGenerator
     /**
      * @return ModuleConfigurationDaoBridgeInterface
      */
-    private function getModuleConfigurationDaoBridge() : ModuleConfigurationDaoBridgeInterface
+    private function getModuleConfigurationDaoBridge(): ModuleConfigurationDaoBridgeInterface
     {
         return $this->getContainer()
                     ->get(ModuleConfigurationDaoBridgeInterface::class);
@@ -503,7 +508,7 @@ class ModuleChainsGenerator
     /**
      * @return ShopConfigurationDaoBridgeInterface
      */
-    private function getShopConfigurationDaoBridge() : ShopConfigurationDaoBridgeInterface
+    private function getShopConfigurationDaoBridge(): ShopConfigurationDaoBridgeInterface
     {
         return $this->getContainer()
                     ->get(ShopConfigurationDaoBridgeInterface::class);
@@ -512,7 +517,7 @@ class ModuleChainsGenerator
     /**
      * @return ModuleStateServiceInterface
      */
-    private function getModuleStateService() : ModuleStateServiceInterface
+    private function getModuleStateService(): ModuleStateServiceInterface
     {
         return $this->getContainer()->get(ModuleStateServiceInterface::class);
     }
@@ -520,7 +525,7 @@ class ModuleChainsGenerator
     /**
      * @return ContainerInterface
      */
-    private function getContainer() : ContainerInterface
+    private function getContainer(): ContainerInterface
     {
         return ContainerFactory::getInstance()->getContainer();
     }

--- a/source/Core/Module/ModuleExtensionsCleaner.php
+++ b/source/Core/Module/ModuleExtensionsCleaner.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Core/Module/ModuleInstaller.php
+++ b/source/Core/Module/ModuleInstaller.php
@@ -1,8 +1,10 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
 namespace OxidEsales\EshopCommunity\Core\Module;
 
 use OxidEsales\Eshop\Core\Registry;

--- a/source/Core/Module/ModuleList.php
+++ b/source/Core/Module/ModuleList.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
@@ -517,7 +518,7 @@ class ModuleList extends \OxidEsales\Eshop\Core\Base
      *
      * @return bool
      */
-    protected function _sortModules($oModule1, $oModule2)
+    protected function _sortModules($oModule1, $oModule2) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         return strcasecmp($oModule1->getTitle(), $oModule2->getTitle());
     }
@@ -529,7 +530,7 @@ class ModuleList extends \OxidEsales\Eshop\Core\Base
      *
      * @return bool
      */
-    protected function _isVendorDir($sModuleDir)
+    protected function _isVendorDir($sModuleDir) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         if (!is_dir($sModuleDir)) {
             return false;
@@ -553,7 +554,7 @@ class ModuleList extends \OxidEsales\Eshop\Core\Base
      *
      * @return array
      */
-    private function _getInvalidExtensions($moduleId)
+    private function _getInvalidExtensions($moduleId) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $extendedShopClasses = $this->getModuleExtensions($moduleId);
         $invalidModuleClasses = [];

--- a/source/Core/Module/ModuleMetadataValidator.php
+++ b/source/Core/Module/ModuleMetadataValidator.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
@@ -65,12 +66,13 @@ class ModuleMetadataValidator implements \OxidEsales\Eshop\Core\Contract\IModule
         $rawExtensions = $module->getExtensions();
 
         foreach ($rawExtensions as $classToBePatched => $moduleClass) {
-            if (NamespaceInformationProvider::isNamespacedClass($classToBePatched)
+            if (
+                NamespaceInformationProvider::isNamespacedClass($classToBePatched)
                  && (
                      NamespaceInformationProvider::classBelongsToShopEditionNamespace($classToBePatched)
                       || (NamespaceInformationProvider::classBelongsToShopUnifiedNamespace($classToBePatched) && !class_exists($classToBePatched))
                     )
-                ) {
+            ) {
                 $incorrect[$classToBePatched] = $moduleClass;
             }
         }

--- a/source/Core/Module/ModuleSmartyPluginDirectories.php
+++ b/source/Core/Module/ModuleSmartyPluginDirectories.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Core/Module/ModuleSmartyPluginDirectoryRepository.php
+++ b/source/Core/Module/ModuleSmartyPluginDirectoryRepository.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Core/Module/ModuleSmartyPluginDirectoryValidator.php
+++ b/source/Core/Module/ModuleSmartyPluginDirectoryValidator.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Core/Module/ModuleTemplateBlockContentReader.php
+++ b/source/Core/Module/ModuleTemplateBlockContentReader.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Core/Module/ModuleTemplateBlockPathFormatter.php
+++ b/source/Core/Module/ModuleTemplateBlockPathFormatter.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Core/Module/ModuleTemplateBlockRepository.php
+++ b/source/Core/Module/ModuleTemplateBlockRepository.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Core/Module/ModuleTemplatePathCalculator.php
+++ b/source/Core/Module/ModuleTemplatePathCalculator.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Core/Module/ModuleTranslationPathFinder.php
+++ b/source/Core/Module/ModuleTranslationPathFinder.php
@@ -1,8 +1,10 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
 namespace OxidEsales\EshopCommunity\Core\Module;
 
 use OxidEsales\Eshop\Core\Registry;

--- a/source/Core/Module/ModuleValidatorFactory.php
+++ b/source/Core/Module/ModuleValidatorFactory.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Core/Module/ModuleVariablesLocator.php
+++ b/source/Core/Module/ModuleVariablesLocator.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Core/NamespaceInformationProvider.php
+++ b/source/Core/NamespaceInformationProvider.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Core/NoJsValidator.php
+++ b/source/Core/NoJsValidator.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Core/OnlineCaller.php
+++ b/source/Core/OnlineCaller.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
@@ -7,7 +8,7 @@
 namespace OxidEsales\EshopCommunity\Core;
 
 use OxidEsales\EshopCommunity\Core\Exception\StandardException;
-use \Exception;
+use Exception;
 
 /**
  * Class oxOnlineCaller makes call to given URL which is taken from child classes and sends request parameter.
@@ -47,14 +48,14 @@ abstract class OnlineCaller
      *
      * @return string XML document tag name.
      */
-    abstract protected function _getXMLDocumentName();
+    abstract protected function _getXMLDocumentName(); // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
 
     /**
      * Gets service url.
      *
      * @return string Web service url.
      */
-    abstract protected function _getServiceUrl();
+    abstract protected function _getServiceUrl(); // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
 
     /**
      * Sets dependencies.
@@ -87,7 +88,7 @@ abstract class OnlineCaller
             $statusCode = $this->_getCurl()->getStatusCode();
             if ($statusCode != 200) {
                 /** @var \OxidEsales\Eshop\Core\Exception\StandardException $oException */
-                $oException = new StandardException('cUrl call to ' . $this->_getCurl()->getUrl() . ' failed with HTTP status '. $statusCode);
+                $oException = new StandardException('cUrl call to ' . $this->_getCurl()->getUrl() . ' failed with HTTP status ' . $statusCode);
                 throw $oException;
             }
             $this->_resetFailedCallsCount($iFailedCallsCount);
@@ -112,7 +113,7 @@ abstract class OnlineCaller
      *
      * @param \Exception $oEx
      */
-    protected function _castExceptionAndWriteToLog(\Exception $oEx)
+    protected function _castExceptionAndWriteToLog(\Exception $oEx) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         if (!($oEx instanceof \OxidEsales\Eshop\Core\Exception\StandardException)) {
             $oOxException = oxNew(\OxidEsales\Eshop\Core\Exception\StandardException::class);
@@ -130,7 +131,7 @@ abstract class OnlineCaller
      *
      * @return string
      */
-    protected function _formEmail($oRequest)
+    protected function _formEmail($oRequest) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         return $this->_formXMLRequest($oRequest);
     }
@@ -142,7 +143,7 @@ abstract class OnlineCaller
      *
      * @return string
      */
-    protected function _formXMLRequest($oRequest)
+    protected function _formXMLRequest($oRequest) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         return $this->_getSimpleXml()->objectToXml($oRequest, $this->_getXMLDocumentName());
     }
@@ -152,7 +153,7 @@ abstract class OnlineCaller
      *
      * @return \OxidEsales\Eshop\Core\SimpleXml
      */
-    protected function _getSimpleXml()
+    protected function _getSimpleXml() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         return $this->_oSimpleXml;
     }
@@ -162,7 +163,7 @@ abstract class OnlineCaller
      *
      * @return \OxidEsales\Eshop\Core\Curl
      */
-    protected function _getCurl()
+    protected function _getCurl() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         return $this->_oCurl;
     }
@@ -172,7 +173,7 @@ abstract class OnlineCaller
      *
      * @return \OxidEsales\Eshop\Core\OnlineServerEmailBuilder
      */
-    protected function _getEmailBuilder()
+    protected function _getEmailBuilder() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         return $this->_oEmailBuilder;
     }
@@ -185,7 +186,7 @@ abstract class OnlineCaller
      *
      * @return string
      */
-    private function _executeCurlCall($sUrl, $sXml)
+    private function _executeCurlCall($sUrl, $sXml) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $oCurl = $this->_getCurl();
         $oCurl->setMethod('POST');
@@ -204,7 +205,7 @@ abstract class OnlineCaller
      *
      * @param string $sBody Mail content.
      */
-    private function _sendEmail($sBody)
+    private function _sendEmail($sBody) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $oEmail = $this->_getEmailBuilder()->build($sBody);
         $oEmail->send();
@@ -215,7 +216,7 @@ abstract class OnlineCaller
      *
      * @param int $iFailedOnlineCallsCount Amount of calls which previously failed.
      */
-    private function _resetFailedCallsCount($iFailedOnlineCallsCount)
+    private function _resetFailedCallsCount($iFailedOnlineCallsCount) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         if ($iFailedOnlineCallsCount > 0) {
             \OxidEsales\Eshop\Core\Registry::getConfig()->saveSystemConfigParameter('int', 'iFailedOnlineCallsCount', 0);
@@ -227,7 +228,7 @@ abstract class OnlineCaller
      *
      * @param int $iFailedOnlineCallsCount Amount of calls which previously failed.
      */
-    private function _increaseFailedCallsCount($iFailedOnlineCallsCount)
+    private function _increaseFailedCallsCount($iFailedOnlineCallsCount) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         \OxidEsales\Eshop\Core\Registry::getConfig()->saveSystemConfigParameter('int', 'iFailedOnlineCallsCount', ++$iFailedOnlineCallsCount);
     }

--- a/source/Core/OnlineLicenseCheck.php
+++ b/source/Core/OnlineLicenseCheck.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
@@ -236,7 +237,8 @@ class OnlineLicenseCheck
     protected function validateResponse($response)
     {
         if (isset($response->code) && isset($response->message)) {
-            if ($response->code == $this->validResponseCode &&
+            if (
+                $response->code == $this->validResponseCode &&
                 $response->message == $this->validResponseMessage
             ) {
                 // serial keys are valid

--- a/source/Core/OnlineLicenseCheckCaller.php
+++ b/source/Core/OnlineLicenseCheckCaller.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
@@ -51,7 +52,7 @@ class OnlineLicenseCheckCaller extends \OxidEsales\Eshop\Core\OnlineCaller
      *
      * @return string
      */
-    protected function _formEmail($oRequest)
+    protected function _formEmail($oRequest) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $oRequest->keys = null;
 
@@ -67,7 +68,7 @@ class OnlineLicenseCheckCaller extends \OxidEsales\Eshop\Core\OnlineCaller
      *
      * @return \OxidEsales\Eshop\Core\OnlineLicenseCheckResponse
      */
-    protected function _formResponse($sRawResponse)
+    protected function _formResponse($sRawResponse) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         /** @var \OxidEsales\Eshop\Core\UtilsXml $oUtilsXml */
         $oUtilsXml = \OxidEsales\Eshop\Core\Registry::getUtilsXml();
@@ -105,7 +106,7 @@ class OnlineLicenseCheckCaller extends \OxidEsales\Eshop\Core\OnlineCaller
      *
      * @return string XML document tag name.
      */
-    protected function _getXMLDocumentName()
+    protected function _getXMLDocumentName() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         return self::XML_DOCUMENT_NAME;
     }
@@ -115,7 +116,7 @@ class OnlineLicenseCheckCaller extends \OxidEsales\Eshop\Core\OnlineCaller
      *
      * @return string Web service url.
      */
-    protected function _getServiceUrl()
+    protected function _getServiceUrl() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         return self::WEB_SERVICE_URL;
     }

--- a/source/Core/OnlineLicenseCheckRequest.php
+++ b/source/Core/OnlineLicenseCheckRequest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Core/OnlineLicenseCheckResponse.php
+++ b/source/Core/OnlineLicenseCheckResponse.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Core/OnlineModuleVersionNotifier.php
+++ b/source/Core/OnlineModuleVersionNotifier.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
@@ -60,7 +61,7 @@ class OnlineModuleVersionNotifier
      *
      * @return null
      */
-    protected function _prepareModulesInformation()
+    protected function _prepareModulesInformation() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $preparedModules = [];
 
@@ -93,7 +94,7 @@ class OnlineModuleVersionNotifier
      *
      * @return oxOnlineModulesNotifierRequest
      */
-    protected function _formRequest()
+    protected function _formRequest() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $oRequestParams = new \OxidEsales\Eshop\Core\OnlineModulesNotifierRequest();
 
@@ -108,7 +109,7 @@ class OnlineModuleVersionNotifier
      *
      * @return \OxidEsales\Eshop\Core\OnlineModuleVersionNotifierCaller
      */
-    protected function _getOnlineModuleNotifierCaller()
+    protected function _getOnlineModuleNotifierCaller() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         return $this->_oCaller;
     }
@@ -120,7 +121,7 @@ class OnlineModuleVersionNotifier
      *
      * @return array
      */
-    protected function _getModules()
+    protected function _getModules() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $container = ContainerFactory::getInstance()->getContainer();
         $shopConfiguration = $container->get(ShopConfigurationDaoBridgeInterface::class)->get();

--- a/source/Core/OnlineModuleVersionNotifierCaller.php
+++ b/source/Core/OnlineModuleVersionNotifierCaller.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
@@ -41,7 +42,7 @@ class OnlineModuleVersionNotifierCaller extends \OxidEsales\Eshop\Core\OnlineCal
      *
      * @return string XML document tag name.
      */
-    protected function _getXMLDocumentName()
+    protected function _getXMLDocumentName() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         return self::XML_DOCUMENT_NAME;
     }
@@ -51,7 +52,7 @@ class OnlineModuleVersionNotifierCaller extends \OxidEsales\Eshop\Core\OnlineCal
      *
      * @return string Web service url.
      */
-    protected function _getServiceUrl()
+    protected function _getServiceUrl() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         return self::WEB_SERVICE_URL;
     }

--- a/source/Core/OnlineModulesNotifierRequest.php
+++ b/source/Core/OnlineModulesNotifierRequest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Core/OnlineRequest.php
+++ b/source/Core/OnlineRequest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
@@ -74,7 +75,7 @@ class OnlineRequest
      *
      * @return string
      */
-    private function _getClusterId()
+    private function _getClusterId() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $oConfig = \OxidEsales\Eshop\Core\Registry::getConfig();
         $sBaseShop = $oConfig->getBaseShopId();

--- a/source/Core/OnlineServerEmailBuilder.php
+++ b/source/Core/OnlineServerEmailBuilder.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Core/OnlineVatIdCheck.php
+++ b/source/Core/OnlineVatIdCheck.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
@@ -110,7 +111,7 @@ class OnlineVatIdCheck extends \OxidEsales\Eshop\Core\CompanyVatInChecker
      *
      * @return bool
      */
-    protected function _isServiceAvailable()
+    protected function _isServiceAvailable() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         if ($this->_blServiceIsOn === null) {
             $this->_blServiceIsOn = class_exists('SoapClient') ? true : false;
@@ -147,7 +148,7 @@ class OnlineVatIdCheck extends \OxidEsales\Eshop\Core\CompanyVatInChecker
      *
      * @return bool
      */
-    protected function _checkOnline($oCheckVat)
+    protected function _checkOnline($oCheckVat) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         if ($this->_isServiceAvailable()) {
             $iTryMoreCnt = self::BUSY_RETRY_CNT;

--- a/source/Core/OpenSSLFunctionalityChecker.php
+++ b/source/Core/OpenSSLFunctionalityChecker.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Core/Output.php
+++ b/source/Core/Output.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Core/Oxid.php
+++ b/source/Core/Oxid.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Core/PasswordHasher.php
+++ b/source/Core/PasswordHasher.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
@@ -27,7 +28,7 @@ class PasswordHasher
      *
      * @return \OxidEsales\Eshop\Core\Hasher
      */
-    protected function _getHasher()
+    protected function _getHasher() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         return $this->_ohasher;
     }

--- a/source/Core/PasswordSaltGenerator.php
+++ b/source/Core/PasswordSaltGenerator.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
@@ -54,7 +55,7 @@ class PasswordSaltGenerator
      *
      * @return \OxidEsales\Eshop\Core\OpenSSLFunctionalityChecker
      */
-    protected function _getOpenSSLFunctionalityChecker()
+    protected function _getOpenSSLFunctionalityChecker() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         return $this->_openSSLFunctionalityChecker;
     }
@@ -64,7 +65,7 @@ class PasswordSaltGenerator
      *
      * @return string
      */
-    protected function _customSaltGenerator()
+    protected function _customSaltGenerator() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $sHash = '';
         $sSalt = '';

--- a/source/Core/PictureHandler.php
+++ b/source/Core/PictureHandler.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
@@ -191,7 +192,7 @@ class PictureHandler extends \OxidEsales\Eshop\Core\Base
      *
      * @return null
      */
-    protected function _getBaseMasterImageFileName($sMasterImageFile)
+    protected function _getBaseMasterImageFileName($sMasterImageFile) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         return basename($sMasterImageFile);
     }
@@ -235,7 +236,7 @@ class PictureHandler extends \OxidEsales\Eshop\Core\Base
      *
      * @return array
      */
-    protected function _getPictureInfo($sFilePath, $sFile, $blAdmin = false, $blSSL = null, $iLang = null, $iShopId = null)
+    protected function _getPictureInfo($sFilePath, $sFile, $blAdmin = false, $blSSL = null, $iLang = null, $iShopId = null) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         // custom server as image storage?
         if ($sAltUrl = $this->getAltImageUrl($sFilePath, $sFile, $blSSL)) {

--- a/source/Core/Price.php
+++ b/source/Core/Price.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
@@ -392,7 +393,7 @@ class Price
     {
         $oCur = \OxidEsales\Eshop\Core\Registry::getConfig()->getActShopCurrencyObject();
 
-        return (( double ) $dPrice) * $oCur->rate;
+        return ((double) $dPrice) * $oCur->rate;
     }
 
 
@@ -420,7 +421,7 @@ class Price
     /**
      * Flush assigned discounts
      */
-    protected function _flushDiscounts()
+    protected function _flushDiscounts() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $this->_aDiscounts = null;
     }

--- a/source/Core/PriceList.php
+++ b/source/Core/PriceList.php
@@ -1,9 +1,9 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
-
 
 namespace OxidEsales\EshopCommunity\Core;
 
@@ -87,7 +87,7 @@ class PriceList
         $aVatValues = [];
         $aPrices = [];
         foreach ($this->_aList as $oPrice) {
-            $sKey = ( string ) $oPrice->getVat();
+            $sKey = (string) $oPrice->getVat();
             if (!isset($aPrices[$sKey])) {
                 $aPrices[$sKey]['sum'] = 0;
                 $aPrices[$sKey]['vat'] = $oPrice->getVat();
@@ -117,7 +117,7 @@ class PriceList
     {
         $aPrices = [];
         foreach ($this->_aList as $oPrice) {
-            $sVat = ( string ) $oPrice->getVat();
+            $sVat = (string) $oPrice->getVat();
             if (!isset($aPrices[$sVat])) {
                 $aPrices[$sVat] = 0;
             }

--- a/source/Core/Registry.php
+++ b/source/Core/Registry.php
@@ -1,8 +1,10 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
 namespace OxidEsales\EshopCommunity\Core;
 
 use OxidEsales\EshopCommunity\Core\Autoload\BackwardsCompatibilityClassMapProvider;

--- a/source/Core/Request.php
+++ b/source/Core/Request.php
@@ -1,8 +1,10 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
 namespace OxidEsales\EshopCommunity\Core;
 
 /**

--- a/source/Core/Routing/ControllerClassNameResolver.php
+++ b/source/Core/Routing/ControllerClassNameResolver.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Core/Routing/Module/ClassProviderStorage.php
+++ b/source/Core/Routing/Module/ClassProviderStorage.php
@@ -1,8 +1,10 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
 namespace OxidEsales\EshopCommunity\Core\Routing\Module;
 
 use OxidEsales\Eshop\Core\Contract\ClassProviderStorageInterface;

--- a/source/Core/Routing/ModuleControllerMapProvider.php
+++ b/source/Core/Routing/ModuleControllerMapProvider.php
@@ -1,8 +1,10 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
 namespace OxidEsales\EshopCommunity\Core\Routing;
 
 use OxidEsales\Eshop\Core\Routing\Module\ClassProviderStorage;

--- a/source/Core/Routing/ShopControllerMapProvider.php
+++ b/source/Core/Routing/ShopControllerMapProvider.php
@@ -1,8 +1,10 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
 namespace OxidEsales\EshopCommunity\Core\Routing;
 
 /**

--- a/source/Core/SeoDecoder.php
+++ b/source/Core/SeoDecoder.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
@@ -40,7 +41,7 @@ class SeoDecoder extends \OxidEsales\Eshop\Core\Base
      *
      * @return string
      */
-    protected function _getIdent($sSeoUrl, $blIgnore = false)
+    protected function _getIdent($sSeoUrl, $blIgnore = false) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         return md5(strtolower($sSeoUrl));
     }
@@ -95,7 +96,7 @@ class SeoDecoder extends \OxidEsales\Eshop\Core\Base
      * @access         public
      * @return string || false
      */
-    protected function _decodeOldUrl($seoUrl)
+    protected function _decodeOldUrl($seoUrl) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $stringObject = getStr();
         $database = \OxidEsales\Eshop\Core\DatabaseProvider::getDb(\OxidEsales\Eshop\Core\DatabaseProvider::FETCH_MODE_ASSOC);
@@ -146,7 +147,7 @@ class SeoDecoder extends \OxidEsales\Eshop\Core\Base
      *
      * @return string
      */
-    protected function _addQueryString($sUrl)
+    protected function _addQueryString($sUrl) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         if (($sQ = $_SERVER["QUERY_STRING"])) {
             $sUrl = rtrim($sUrl, "&?");
@@ -169,7 +170,7 @@ class SeoDecoder extends \OxidEsales\Eshop\Core\Base
      *
      * @return string
      */
-    protected function _getSeoUrl($sObjectId, $iLang, $iShopId)
+    protected function _getSeoUrl($sObjectId, $iLang, $iShopId) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $oDb = \OxidEsales\Eshop\Core\DatabaseProvider::getDb(\OxidEsales\Eshop\Core\DatabaseProvider::FETCH_MODE_ASSOC);
         $aInfo = $oDb->getRow("select oxseourl, oxtype from oxseo where oxobjectid = :oxobjectid and oxlang = :oxlang and oxshopid = :oxshopid order by oxparams limit 1", [
@@ -246,7 +247,7 @@ class SeoDecoder extends \OxidEsales\Eshop\Core\Base
      *
      * @return string
      */
-    protected function _decodeSimpleUrl($sParams)
+    protected function _decodeSimpleUrl($sParams) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $sLastParam = trim($sParams, '/');
 
@@ -284,7 +285,7 @@ class SeoDecoder extends \OxidEsales\Eshop\Core\Base
      *
      * @return string
      */
-    protected function _getObjectUrl($sSeoId, $sTable, $iLanguage, $sType)
+    protected function _getObjectUrl($sSeoId, $sTable, $iLanguage, $sType) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $oDb = \OxidEsales\Eshop\Core\DatabaseProvider::getDb();
         $sTable = getViewName($sTable, $iLanguage);
@@ -292,9 +293,11 @@ class SeoDecoder extends \OxidEsales\Eshop\Core\Base
         // first checking of field exists at all
         if ($oDb->getOne("show columns from {$sTable} where field = 'oxseoid'")) {
             // if field exists - searching for object id
-            if ($sObjectId = $oDb->getOne("select oxid from {$sTable} where oxseoid = :oxseoid", [
+            if (
+                $sObjectId = $oDb->getOne("select oxid from {$sTable} where oxseoid = :oxseoid", [
                 ':oxseoid' => $sSeoId
-            ])) {
+                ])
+            ) {
                 return $oDb->getOne("select oxseourl from oxseo where oxtype = :oxtype and oxobjectid = :oxobjectid and oxlang = :oxlang", [
                     ':oxtype' => $sType,
                     ':oxobjectid' => $sObjectId,
@@ -312,7 +315,7 @@ class SeoDecoder extends \OxidEsales\Eshop\Core\Base
      *
      * @return array $aParams extracted params
      */
-    protected function _getParams($sRequest, $sPath)
+    protected function _getParams($sRequest, $sPath) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $oStr = getStr();
 

--- a/source/Core/SeoEncoder.php
+++ b/source/Core/SeoEncoder.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
@@ -98,7 +99,8 @@ class SeoEncoder extends \OxidEsales\Eshop\Core\Base
         $iDefLang = (int) $this->getConfig()->getConfigParam('iDefSeoLang');
         $aLangIds = \OxidEsales\Eshop\Core\Registry::getLang()->getLanguageIds();
 
-        if ($iLang != $iDefLang &&
+        if (
+            $iLang != $iDefLang &&
             isset($aLangIds[$iLang]) &&
             // #0006407 bugfix, we should not search for the string saved in the db but for the escaped string
             getStr()->strpos($sSeoUrl, $this->replaceSpecialChars($aLangIds[$iLang]) . '/') !== 0
@@ -121,7 +123,7 @@ class SeoEncoder extends \OxidEsales\Eshop\Core\Base
      *
      * @return string
      */
-    protected function _processSeoUrl($sSeoUrl, $sObjectId = null, $iLang = null, $blExclude = false)
+    protected function _processSeoUrl($sSeoUrl, $sObjectId = null, $iLang = null, $blExclude = false) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         if (!$blExclude) {
             $sSeoUrl = $this->addLanguageParam($sSeoUrl, $iLang);
@@ -154,7 +156,7 @@ class SeoEncoder extends \OxidEsales\Eshop\Core\Base
      * @param string $sType   object type (if you pass real object - type is not necessary)
      * @param string $sNewId  new object id, mostly used for static url updates (optional)
      */
-    protected function _copyToHistory($sId, $iShopId, $iLang, $sType = null, $sNewId = null)
+    protected function _copyToHistory($sId, $iShopId, $iLang, $sType = null, $sNewId = null) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $oDb = \OxidEsales\Eshop\Core\DatabaseProvider::getDb();
         $sObjectid = $sNewId ? $oDb->quote($sNewId) : 'oxobjectid';
@@ -191,7 +193,7 @@ class SeoEncoder extends \OxidEsales\Eshop\Core\Base
      *
      * @return string
      */
-    protected function _getDynamicUri($sStdUrl, $sSeoUrl, $iLang)
+    protected function _getDynamicUri($sStdUrl, $sSeoUrl, $iLang) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $iShopId = $this->getConfig()->getShopId();
 
@@ -228,7 +230,7 @@ class SeoEncoder extends \OxidEsales\Eshop\Core\Base
      *
      * @return string
      */
-    protected function _getFullUrl($sSeoUrl, $iLang = null, $blSsl = false)
+    protected function _getFullUrl($sSeoUrl, $iLang = null, $blSsl = false) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         if ($sSeoUrl) {
             $sFullUrl = ($blSsl ? $this->getConfig()->getSslShopUrl($iLang) : $this->getConfig()->getShopUrl($iLang, false)) . $sSeoUrl;
@@ -248,7 +250,7 @@ class SeoEncoder extends \OxidEsales\Eshop\Core\Base
      *
      * @return string
      */
-    protected function _getSeoIdent($sSeoUrl)
+    protected function _getSeoIdent($sSeoUrl) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         return md5(strtolower($sSeoUrl));
     }
@@ -262,7 +264,7 @@ class SeoEncoder extends \OxidEsales\Eshop\Core\Base
      *
      * @return string
      */
-    protected function _getStaticUri($sStdUrl, $iShopId, $iLang)
+    protected function _getStaticUri($sStdUrl, $iShopId, $iLang) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $sStdUrl = $this->_trimUrl($sStdUrl, $iLang);
 
@@ -274,7 +276,7 @@ class SeoEncoder extends \OxidEsales\Eshop\Core\Base
      *
      * @return null
      */
-    protected function _getUrlExtension()
+    protected function _getUrlExtension() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         return;
     }
@@ -291,7 +293,7 @@ class SeoEncoder extends \OxidEsales\Eshop\Core\Base
      *
      * @return string
      */
-    protected function _getUniqueSeoUrl($sSeoUrl, $sObjectId = null, $iObjectLang = null)
+    protected function _getUniqueSeoUrl($sSeoUrl, $sObjectId = null, $iObjectLang = null) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $sSeoUrl = $this->_prepareUri($sSeoUrl, $iObjectLang);
         $oStr = getStr();
@@ -347,7 +349,7 @@ class SeoEncoder extends \OxidEsales\Eshop\Core\Base
      *
      * @return bool
      */
-    protected function _isFixed($sType, $sId, $iLang, $iShopId = null, $sParams = null, $blStrictParamsCheck = true)
+    protected function _isFixed($sType, $sId, $iLang, $iShopId = null, $sParams = null, $blStrictParamsCheck = true) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         if ($iShopId === null) {
             $iShopId = $this->getConfig()->getShopId();
@@ -388,7 +390,7 @@ class SeoEncoder extends \OxidEsales\Eshop\Core\Base
      *
      * @return string
      */
-    protected function _getCacheKey($sType, $iLang = null, $iShopId = null, $sParams = null)
+    protected function _getCacheKey($sType, $iLang = null, $iShopId = null, $sParams = null) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $blAdmin = $this->isAdmin();
         if (!$blAdmin && $sType !== "oxarticle") {
@@ -417,7 +419,7 @@ class SeoEncoder extends \OxidEsales\Eshop\Core\Base
      *
      * @return string
      */
-    protected function _loadFromCache($sCacheIdent, $sType, $iLang = null, $iShopId = null, $sParams = null)
+    protected function _loadFromCache($sCacheIdent, $sType, $iLang = null, $iShopId = null, $sParams = null) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         if (!$this->getConfig()->getConfigParam('blEnableSeoCache')) {
             return false;
@@ -453,7 +455,7 @@ class SeoEncoder extends \OxidEsales\Eshop\Core\Base
      *
      * @return bool
      */
-    protected function _saveInCache($sCacheIdent, $sCache, $sType, $iLang = null, $iShopId = null, $sParams = null)
+    protected function _saveInCache($sCacheIdent, $sCache, $sType, $iLang = null, $iShopId = null, $sParams = null) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         if (!$this->getConfig()->getConfigParam('blEnableSeoCache')) {
             return false;
@@ -487,7 +489,7 @@ class SeoEncoder extends \OxidEsales\Eshop\Core\Base
      *
      * @return string || false
      */
-    protected function _loadFromDb($sType, $sId, $iLang, $iShopId = null, $sParams = null, $blStrictParamsCheck = true)
+    protected function _loadFromDb($sType, $sId, $iLang, $iShopId = null, $sParams = null, $blStrictParamsCheck = true) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         if ($iShopId === null) {
             $iShopId = $this->getConfig()->getShopId();
@@ -562,7 +564,7 @@ class SeoEncoder extends \OxidEsales\Eshop\Core\Base
      *
      * @return array
      */
-    protected function _getReservedEntryKeys()
+    protected function _getReservedEntryKeys() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         if (!isset(self::$_aReservedEntryKeys) || !is_array(self::$_aReservedEntryKeys)) {
             $sDir = getShopBasePath();
@@ -590,7 +592,7 @@ class SeoEncoder extends \OxidEsales\Eshop\Core\Base
      *
      * @return string
      */
-    protected function _prepareUri($sUri, $iLang = false)
+    protected function _prepareUri($sUri, $iLang = false) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         // decoding entities
         $sUri = $this->encodeString($sUri, true, $iLang);
@@ -658,7 +660,7 @@ class SeoEncoder extends \OxidEsales\Eshop\Core\Base
      *
      * @return string
      */
-    protected function _prepareTitle($sTitle, $blSkipTruncate = false, $iLang = false)
+    protected function _prepareTitle($sTitle, $blSkipTruncate = false, $iLang = false) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $sTitle = $this->encodeString($sTitle, true, $iLang);
         $sSep = self::$_sSeparator;
@@ -705,7 +707,7 @@ class SeoEncoder extends \OxidEsales\Eshop\Core\Base
      *
      * @return mixed
      */
-    protected function _saveToDb($sType, $sObjectId, $sStdUrl, $sSeoUrl, $iLang, $iShopId = null, $blFixed = null, $sParams = null)
+    protected function _saveToDb($sType, $sObjectId, $sStdUrl, $sSeoUrl, $iLang, $iShopId = null, $blFixed = null, $sParams = null) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         if ($iShopId === null) {
             $iShopId = $this->getConfig()->getShopId();
@@ -821,7 +823,7 @@ class SeoEncoder extends \OxidEsales\Eshop\Core\Base
      *
      * @return string
      */
-    protected function _trimUrl($sUrl, $iLang = null)
+    protected function _trimUrl($sUrl, $iLang = null) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $myConfig = $this->getConfig();
         $oStr = getStr();
@@ -849,7 +851,7 @@ class SeoEncoder extends \OxidEsales\Eshop\Core\Base
      *
      * @return int
      */
-    protected function _getMaxUrlLength()
+    protected function _getMaxUrlLength() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         if ($this->_iMaxUrlLength === null) {
             // max length <= 2048 / custom
@@ -974,7 +976,7 @@ class SeoEncoder extends \OxidEsales\Eshop\Core\Base
      *
      * @return string
      */
-    protected function _getPageUri($oObject, $sType, $sStdUrl, $sSeoUrl, $sParams, $iLang = null, $blFixed = false)
+    protected function _getPageUri($oObject, $sType, $sStdUrl, $sSeoUrl, $sParams, $iLang = null, $blFixed = false) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         if (!isset($iLang)) {
             $iLang = $oObject->getLanguage();
@@ -1003,7 +1005,7 @@ class SeoEncoder extends \OxidEsales\Eshop\Core\Base
      *
      * @return string
      */
-    protected function _getStaticObjectId($iShopId, $sStdUrl)
+    protected function _getStaticObjectId($iShopId, $sStdUrl) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         return md5(strtolower($iShopId . $this->_trimUrl($sStdUrl)));
     }
@@ -1219,7 +1221,7 @@ class SeoEncoder extends \OxidEsales\Eshop\Core\Base
      * @param string $sObjectId object id
      * @param int    $iLang     language id
      */
-    protected function _getAltUri($sObjectId, $iLang)
+    protected function _getAltUri($sObjectId, $iLang) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
     }
 

--- a/source/Core/SepaBICValidator.php
+++ b/source/Core/SepaBICValidator.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Core/SepaIBANValidator.php
+++ b/source/Core/SepaIBANValidator.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
@@ -91,7 +92,7 @@ class SepaIBANValidator
      *
      * @return bool
      */
-    protected function _isLengthValid($sIBAN)
+    protected function _isLengthValid($sIBAN) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $iActualLength = getStr()->strlen($sIBAN);
 
@@ -108,7 +109,7 @@ class SepaIBANValidator
      *
      * @return null
      */
-    protected function _getLengthForCountry($sIBAN)
+    protected function _getLengthForCountry($sIBAN) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $aIBANRegistry = $this->getCodeLengths();
 
@@ -126,7 +127,7 @@ class SepaIBANValidator
      *
      * @return bool
      */
-    protected function _isAlgorithmValid($sIBAN)
+    protected function _isAlgorithmValid($sIBAN) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $sIBAN = $this->_moveInitialCharactersToEnd($sIBAN);
 
@@ -142,7 +143,7 @@ class SepaIBANValidator
      *
      * @return string
      */
-    protected function _moveInitialCharactersToEnd($sIBAN)
+    protected function _moveInitialCharactersToEnd($sIBAN) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $oStr = getStr();
 
@@ -159,7 +160,7 @@ class SepaIBANValidator
      *
      * @return string
      */
-    protected function _replaceLettersToNumbers($sIBAN)
+    protected function _replaceLettersToNumbers($sIBAN) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $aReplaceArray = [
             'A' => 10,
@@ -204,7 +205,7 @@ class SepaIBANValidator
      *
      * @return bool
      */
-    protected function _isIBANChecksumValid($sIBAN)
+    protected function _isIBANChecksumValid($sIBAN) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         return (int) bcmod($sIBAN, self::IBAN_ALGORITHM_MOD_VALUE) === 1;
     }
@@ -216,7 +217,7 @@ class SepaIBANValidator
      *
      * @return bool
      */
-    protected function _isNotEmptyArray($aCodeLengths)
+    protected function _isNotEmptyArray($aCodeLengths) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         return is_array($aCodeLengths) && !empty($aCodeLengths);
     }
@@ -228,12 +229,13 @@ class SepaIBANValidator
      *
      * @return bool
      */
-    protected function _isEachCodeLengthValid($aCodeLengths)
+    protected function _isEachCodeLengthValid($aCodeLengths) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $blValid = true;
 
         foreach ($aCodeLengths as $sCountryAbbr => $iLength) {
-            if (!$this->_isCodeLengthKeyValid($sCountryAbbr) ||
+            if (
+                !$this->_isCodeLengthKeyValid($sCountryAbbr) ||
                 !$this->_isCodeLengthValueValid($iLength)
             ) {
                 $blValid = false;
@@ -251,7 +253,7 @@ class SepaIBANValidator
      *
      * @return bool
      */
-    protected function _isCodeLengthKeyValid($sCountryAbbr)
+    protected function _isCodeLengthKeyValid($sCountryAbbr) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         return (int) preg_match("/^[A-Z]{2}$/", $sCountryAbbr) !== 0;
     }
@@ -263,7 +265,7 @@ class SepaIBANValidator
      *
      * @return bool
      */
-    protected function _isCodeLengthValueValid($iLength)
+    protected function _isCodeLengthValueValid($iLength) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         return is_numeric($iLength) && (int) preg_match("/\./", $iLength) !== 1;
     }

--- a/source/Core/SepaValidator.php
+++ b/source/Core/SepaValidator.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Core/Service/ApplicationServerExporter.php
+++ b/source/Core/Service/ApplicationServerExporter.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Core/Service/ApplicationServerExporterInterface.php
+++ b/source/Core/Service/ApplicationServerExporterInterface.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Core/Service/ApplicationServerService.php
+++ b/source/Core/Service/ApplicationServerService.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Core/Service/ApplicationServerServiceInterface.php
+++ b/source/Core/Service/ApplicationServerServiceInterface.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Core/Session.php
+++ b/source/Core/Session.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
@@ -6,9 +7,9 @@
 
 namespace OxidEsales\EshopCommunity\Core;
 
-use \OxidEsales\Eshop\Application\Model\Basket;
-use \OxidEsales\Eshop\Application\Model\BasketItem;
-use \OxidEsales\Eshop\Application\Model\User;
+use OxidEsales\Eshop\Application\Model\Basket;
+use OxidEsales\Eshop\Application\Model\BasketItem;
+use OxidEsales\Eshop\Application\Model\User;
 
 /**
  * Session manager.
@@ -296,7 +297,7 @@ class Session extends \OxidEsales\Eshop\Core\Base
     /**
      * initialize new session challenge token
      */
-    protected function _initNewSessionChallenge()
+    protected function _initNewSessionChallenge() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $this->setVariable('sess_stoken', sprintf('%X', crc32(\OxidEsales\Eshop\Core\Registry::getUtilsObject()->generateUID())));
     }
@@ -306,7 +307,7 @@ class Session extends \OxidEsales\Eshop\Core\Base
      *
      * @return bool
      */
-    protected function _sessionStart()
+    protected function _sessionStart() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         if (!headers_sent() && (PHP_SESSION_NONE === session_status())) {
             if ($this->needToSetHeaders()) {
@@ -315,7 +316,8 @@ class Session extends \OxidEsales\Eshop\Core\Base
 
                 //cache limiter workaround for AOL browsers
                 //as suggested at http://ilia.ws/archives/59-AOL-Browser-Woes.html
-                if (isset($_SERVER['HTTP_USER_AGENT']) &&
+                if (
+                    isset($_SERVER['HTTP_USER_AGENT']) &&
                     strpos($_SERVER['HTTP_USER_AGENT'], 'AOL') !== false
                 ) {
                     session_cache_limiter('');
@@ -396,7 +398,7 @@ class Session extends \OxidEsales\Eshop\Core\Base
      *
      * @return string
      */
-    protected function _getNewSessionId($blUnset = true)
+    protected function _getNewSessionId($blUnset = true) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         session_regenerate_id(true);
 
@@ -604,7 +606,7 @@ class Session extends \OxidEsales\Eshop\Core\Base
      */
     protected function isClassOrNullInSerializedObjectAfterField($serializedObject, $fieldName, $className)
     {
-        $fieldAndClassPattern = '/'. preg_quote($fieldName, '/') . '";((?P<null>N);|O:\d+:"(?P<class>[\w\\\\]+)":)/';
+        $fieldAndClassPattern = '/' . preg_quote($fieldName, '/') . '";((?P<null>N);|O:\d+:"(?P<class>[\w\\\\]+)":)/';
         $matchFound = preg_match($fieldAndClassPattern, $serializedObject, $matches) === 1;
 
         return $matchFound &&
@@ -636,7 +638,7 @@ class Session extends \OxidEsales\Eshop\Core\Base
      *
      * @return null
      */
-    protected function _validateBasket(\OxidEsales\Eshop\Application\Model\Basket $oBasket)
+    protected function _validateBasket(\OxidEsales\Eshop\Application\Model\Basket $oBasket) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $aCurrContent = $oBasket->getContents();
         if (empty($aCurrContent)) {
@@ -812,9 +814,9 @@ class Session extends \OxidEsales\Eshop\Core\Base
      *
      * @return bool
      */
-    protected function _forceSessionStart()
+    protected function _forceSessionStart() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
-        return (!\OxidEsales\Eshop\Core\Registry::getUtils()->isSearchEngine()) && ((( bool ) $this->getConfig()->getConfigParam('blForceSessionStart')) || $this->getConfig()->getRequestParameter("su") || $this->_blForceNewSession);
+        return (!\OxidEsales\Eshop\Core\Registry::getUtils()->isSearchEngine()) && (((bool) $this->getConfig()->getConfigParam('blForceSessionStart')) || $this->getConfig()->getRequestParameter("su") || $this->_blForceNewSession);
     }
 
     /**
@@ -822,7 +824,7 @@ class Session extends \OxidEsales\Eshop\Core\Base
      *
      * @return bool
      */
-    protected function _allowSessionStart()
+    protected function _allowSessionStart() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $blAllowSessionStart = true;
         $myConfig = $this->getConfig();
@@ -837,7 +839,8 @@ class Session extends \OxidEsales\Eshop\Core\Base
                 // session is not needed to start when it is not necessary:
                 // - no sid in request and also user executes no session connected action
                 // - no cookie set and user executes no session connected action
-                if (!\OxidEsales\Eshop\Core\Registry::getUtilsServer()->getOxCookie($this->getName()) &&
+                if (
+                    !\OxidEsales\Eshop\Core\Registry::getUtilsServer()->getOxCookie($this->getName()) &&
                     !($myConfig->getRequestParameter($this->getName()) || $myConfig->getRequestParameter($this->getForcedName())) &&
                     !$this->_isSessionRequiredAction()
                 ) {
@@ -856,7 +859,7 @@ class Session extends \OxidEsales\Eshop\Core\Base
      *
      * @return bool
      */
-    protected function _isSwappedClient()
+    protected function _isSwappedClient() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $blSwapped = false;
         $myUtilsServer = \OxidEsales\Eshop\Core\Registry::getUtilsServer();
@@ -887,7 +890,7 @@ class Session extends \OxidEsales\Eshop\Core\Base
      *
      * @return bool
      */
-    protected function _checkUserAgent($sAgent, $sExistingAgent)
+    protected function _checkUserAgent($sAgent, $sExistingAgent) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $blCheck = false;
         // processing
@@ -914,7 +917,7 @@ class Session extends \OxidEsales\Eshop\Core\Base
      *
      * @return bool
      */
-    protected function _checkCookies($sCookieSid, $aSessCookieSetOnce)
+    protected function _checkCookies($sCookieSid, $aSessCookieSetOnce) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $blSwapped = false;
         $myConfig = $this->getConfig();
@@ -961,7 +964,7 @@ class Session extends \OxidEsales\Eshop\Core\Base
      *
      * @return null
      */
-    protected function _setSessionId($sSessId)
+    protected function _setSessionId($sSessId) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         //marking this session as new one, as it might be not writen to db yet
         if ($sSessId && session_id() != $sSessId) {
@@ -979,7 +982,7 @@ class Session extends \OxidEsales\Eshop\Core\Base
      *
      * @return string
      */
-    protected function _getBasketName()
+    protected function _getBasketName() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $myConfig = $this->getConfig();
         if ($myConfig->getConfigParam('blMallSharedBasket') == 0) {
@@ -994,7 +997,7 @@ class Session extends \OxidEsales\Eshop\Core\Base
      *
      * @return string
      */
-    protected function _getCookieSid()
+    protected function _getCookieSid() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         return \OxidEsales\Eshop\Core\Registry::getUtilsServer()->getOxCookie($this->getName());
     }
@@ -1005,7 +1008,7 @@ class Session extends \OxidEsales\Eshop\Core\Base
      *
      * @return array
      */
-    protected function _getRequireSessionWithParams()
+    protected function _getRequireSessionWithParams() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $aCfgArray = $this->getConfig()->getConfigParam('aRequireSessionWithParams');
         if (is_array($aCfgArray)) {
@@ -1027,7 +1030,7 @@ class Session extends \OxidEsales\Eshop\Core\Base
      *
      * @return bool
      */
-    protected function _isSessionRequiredAction()
+    protected function _isSessionRequiredAction() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         foreach ($this->_getRequireSessionWithParams() as $sParam => $aValues) {
             $sValue = $this->getConfig()->getRequestParameter($sParam);
@@ -1050,7 +1053,7 @@ class Session extends \OxidEsales\Eshop\Core\Base
      *
      * @return bool
      */
-    protected function _getSessionUseCookies()
+    protected function _getSessionUseCookies() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         return $this->isAdmin() || $this->getConfig()->getConfigParam('blSessionUseCookies');
     }
@@ -1060,7 +1063,7 @@ class Session extends \OxidEsales\Eshop\Core\Base
      *
      * @return bool
      */
-    protected function _isValidRemoteAccessToken()
+    protected function _isValidRemoteAccessToken() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $inputToken = $this->getConfig()->getRequestParameter('rtoken');
         $token = $this->getRemoteAccessToken(false);

--- a/source/Core/SettingsHandler.php
+++ b/source/Core/SettingsHandler.php
@@ -1,8 +1,10 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
 namespace OxidEsales\EshopCommunity\Core;
 
 /**

--- a/source/Core/Sha512Hasher.php
+++ b/source/Core/Sha512Hasher.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Core/ShopControl.php
+++ b/source/Core/ShopControl.php
@@ -1,8 +1,10 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
 namespace OxidEsales\EshopCommunity\Core;
 
 use OxidEsales\Eshop\Application\Controller\FrontendController;
@@ -171,7 +173,7 @@ class ShopControl extends \OxidEsales\Eshop\Core\Base
      *
      * @return string
      */
-    protected function _getStartController()
+    protected function _getStartController() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         return $this->getStartControllerKey();
     }
@@ -184,7 +186,7 @@ class ShopControl extends \OxidEsales\Eshop\Core\Base
      *
      * @return string
      */
-    protected function _getFrontendStartController()
+    protected function _getFrontendStartController() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         return 'start';
     }
@@ -260,7 +262,7 @@ class ShopControl extends \OxidEsales\Eshop\Core\Base
      * @param array  $parameters Parameters array
      * @param array  $viewsChain Array of views names that should be initialized also
      */
-    protected function _process($class, $function, $parameters = null, $viewsChain = null)
+    protected function _process($class, $function, $parameters = null, $viewsChain = null) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         startProfile('process');
         $config = $this->getConfig();
@@ -314,7 +316,7 @@ class ShopControl extends \OxidEsales\Eshop\Core\Base
      *
      * @return null
      */
-    protected function _executeMaintenanceTasks()
+    protected function _executeMaintenanceTasks() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         if (isset($this->_blMainTasksExecuted)) {
             return;
@@ -374,7 +376,7 @@ class ShopControl extends \OxidEsales\Eshop\Core\Base
      *
      * @return FrontendController
      */
-    protected function _initializeViewObject($class, $function, $parameters = null, $viewsChain = null)
+    protected function _initializeViewObject($class, $function, $parameters = null, $viewsChain = null) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $classKey = Registry::getControllerClassNameResolver()->getIdByClassName($class);
         $classKey = !is_null($classKey) ? $classKey : $class; //fallback
@@ -412,7 +414,7 @@ class ShopControl extends \OxidEsales\Eshop\Core\Base
      *
      * @return bool
      */
-    protected function _canExecuteFunction($view, $function)
+    protected function _canExecuteFunction($view, $function) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $canExecute = true;
         if (method_exists($view, $function)) {
@@ -432,7 +434,7 @@ class ShopControl extends \OxidEsales\Eshop\Core\Base
      *
      * @return array
      */
-    protected function _getFormattedErrors($controllerName)
+    protected function _getFormattedErrors($controllerName) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $errors = $this->_getErrors($controllerName);
         $formattedErrors = [];
@@ -455,7 +457,7 @@ class ShopControl extends \OxidEsales\Eshop\Core\Base
      *
      * @return string
      */
-    protected function _render($view)
+    protected function _render($view) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $renderer = $this->getRenderer();
 
@@ -523,7 +525,7 @@ class ShopControl extends \OxidEsales\Eshop\Core\Base
      *
      * @return oxOutput
      */
-    protected function _getOutputManager()
+    protected function _getOutputManager() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         if (!$this->_oOutput) {
             $this->_oOutput = oxNew(\OxidEsales\Eshop\Core\Output::class);
@@ -539,7 +541,7 @@ class ShopControl extends \OxidEsales\Eshop\Core\Base
      *
      * @return array
      */
-    protected function _getErrors($currentControllerName)
+    protected function _getErrors($currentControllerName) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         if (null === $this->_aErrors) {
             $this->_aErrors = \OxidEsales\Eshop\Core\Registry::getSession()->getVariable('Errors');
@@ -570,7 +572,7 @@ class ShopControl extends \OxidEsales\Eshop\Core\Base
      * This function is only executed one time here we perform checks if we
      * only need once per session.
      */
-    protected function _runOnce()
+    protected function _runOnce() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $config = $this->getConfig();
 
@@ -605,7 +607,7 @@ class ShopControl extends \OxidEsales\Eshop\Core\Base
      *
      * @return int
      */
-    protected function _getErrorReportingLevel()
+    protected function _getErrorReportingLevel() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $errorReporting = E_ALL ^ E_NOTICE;
         // some 3rd party libraries still use deprecated functions
@@ -626,7 +628,7 @@ class ShopControl extends \OxidEsales\Eshop\Core\Base
      *
      * @return bool
      */
-    protected function _isDebugMode()
+    protected function _isDebugMode() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         return (bool) Registry::get(\OxidEsales\Eshop\Core\ConfigFile::class)->getVar('iDebug');
     }
@@ -634,7 +636,7 @@ class ShopControl extends \OxidEsales\Eshop\Core\Base
     /**
      * Starts resource monitor.
      */
-    protected function _startMonitor()
+    protected function _startMonitor() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         if ($this->_isDebugMode()) {
             $this->_dTimeStart = microtime(true);
@@ -652,7 +654,7 @@ class ShopControl extends \OxidEsales\Eshop\Core\Base
      * @param array              $viewData       View data
      * @param FrontendController $view           View object
      */
-    protected function _stopMonitor($isCallForCache = false, $isCached = false, $viewId = null, $viewData = [], $view = null)
+    protected function _stopMonitor($isCallForCache = false, $isCached = false, $viewId = null, $viewData = [], $view = null) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         if (is_null($view)) {
             $controllerKey = $this->getStartControllerKey();
@@ -734,7 +736,7 @@ class ShopControl extends \OxidEsales\Eshop\Core\Base
      *
      * @param \OxidEsales\Eshop\Core\Exception\StandardException $exception
      */
-    protected function _handleSystemException($exception)
+    protected function _handleSystemException($exception) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $exception->debugOut();
 
@@ -764,7 +766,7 @@ class ShopControl extends \OxidEsales\Eshop\Core\Base
      *
      * @param \OxidEsales\Eshop\Core\Exception\StandardException $exception Exception
      */
-    protected function _handleCookieException($exception)
+    protected function _handleCookieException($exception) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         if ($this->_isDebugMode()) {
             \OxidEsales\Eshop\Core\Registry::getUtilsView()->addErrorToDisplay($exception);
@@ -813,7 +815,7 @@ class ShopControl extends \OxidEsales\Eshop\Core\Base
      *
      * @param \OxidEsales\Eshop\Core\Exception\StandardException $exception
      */
-    protected function _handleBaseException($exception)
+    protected function _handleBaseException($exception) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $this->logException($exception);
 

--- a/source/Core/ShopIdCalculator.php
+++ b/source/Core/ShopIdCalculator.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
@@ -46,7 +47,7 @@ class ShopIdCalculator
      *
      * @return string
      */
-    protected function _getConfKey()
+    protected function _getConfKey() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         if (Registry::instanceExists(\OxidEsales\Eshop\Core\ConfigFile::class)) {
             $config = Registry::get(\OxidEsales\Eshop\Core\ConfigFile::class);
@@ -62,7 +63,7 @@ class ShopIdCalculator
      *
      * @return array
      */
-    protected function _getShopUrlMap()
+    protected function _getShopUrlMap() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         //get from static cache
         if (isset(self::$urlMap)) {

--- a/source/Core/ShopVersion.php
+++ b/source/Core/ShopVersion.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Core/SimpleXml.php
+++ b/source/Core/SimpleXml.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
@@ -68,7 +69,7 @@ class SimpleXml
      *
      * @return SimpleXMLElement
      */
-    protected function _addSimpleXmlElement($oXml, $oInput, $sPreferredKey = null)
+    protected function _addSimpleXmlElement($oXml, $oInput, $sPreferredKey = null) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $aElements = is_object($oInput) ? get_object_vars($oInput) : (array) $oInput;
 
@@ -89,7 +90,7 @@ class SimpleXml
      *
      * @return SimpleXMLElement
      */
-    protected function _addChildNode($oXml, $sKey, $mElement, $sPreferredKey = null)
+    protected function _addChildNode($oXml, $sKey, $mElement, $sPreferredKey = null) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $aAttributes = [];
         if (is_array($mElement) && array_key_exists('attributes', $mElement) && is_array($mElement['attributes'])) {
@@ -101,12 +102,12 @@ class SimpleXml
             if (is_int(key($mElement))) {
                 $this->_addSimpleXmlElement($oXml, $mElement, $sKey);
             } else {
-                $oChildNode = $oXml->addChild($sPreferredKey? $sPreferredKey : $sKey);
+                $oChildNode = $oXml->addChild($sPreferredKey ? $sPreferredKey : $sKey);
                 $this->_addNodeAttributes($oChildNode, $aAttributes);
                 $this->_addSimpleXmlElement($oChildNode, $mElement);
             }
         } else {
-            $oChildNode = $oXml->addChild($sPreferredKey? $sPreferredKey : $sKey, $mElement);
+            $oChildNode = $oXml->addChild($sPreferredKey ? $sPreferredKey : $sKey, $mElement);
             $this->_addNodeAttributes($oChildNode, $aAttributes);
         }
 
@@ -121,7 +122,7 @@ class SimpleXml
      *
      * @return SimpleXMLElement
      */
-    protected function _addNodeAttributes($oNode, $aAttributes)
+    protected function _addNodeAttributes($oNode, $aAttributes) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $aAttributes = (array) $aAttributes;
         foreach ($aAttributes as $sKey => $sValue) {

--- a/source/Core/Smarty/Plugin/Emos.php
+++ b/source/Core/Smarty/Plugin/Emos.php
@@ -503,7 +503,7 @@ class Emos
      *
      * @return null
      */
-    protected function _emos_ItemFormat($oItem) // phpcs:ignore
+    protected function _emos_ItemFormat($oItem) // phpcs:ignore PSR1.Methods.CamelCapsMethodName.NotCamelCaps
     {
         $oItem->productId = $this->_emos_DataFormat($oItem->productId);
         $oItem->productName = $this->_emos_DataFormat($oItem->productName);
@@ -522,7 +522,7 @@ class Emos
      *
      * @return null
      */
-    protected function _emos_DataFormat($sStr) //phpcs:ignore
+    protected function _emos_DataFormat($sStr) //phpcs:ignore PSR1.Methods.CamelCapsMethodName.NotCamelCaps
     {
         //null check
         if (is_null($sStr)) {

--- a/source/Core/Smarty/Plugin/Emos.php
+++ b/source/Core/Smarty/Plugin/Emos.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * EMOS PHP Bib 2
  *
@@ -246,8 +247,8 @@ class Emos
     {
         $this->_prepareScript();
 
-        return $this->_sPrescript.
-               $this->_sIncScript.
+        return $this->_sPrescript .
+               $this->_sIncScript .
                $this->_sPostscript;
     }
 
@@ -449,7 +450,7 @@ class Emos
      * @param string $sCip            customer ip
      * @param string $sCity           customer city title
      */
-    protected function _setEmosBillingArray($sBillingId = "", $sCustomerNumber = "", $iTotal = 0, $sCountry = "", $sCip = "", $sCity = "")
+    protected function _setEmosBillingArray($sBillingId = "", $sCustomerNumber = "", $iTotal = 0, $sCountry = "", $sCip = "", $sCity = "") // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         /******************* prepare data *************************************/
         /* md5 the customer id to fullfill requirements of german datenschutzgeesetz */
@@ -466,7 +467,7 @@ class Emos
         }
 
         if ($sCip) {
-            $ort .= getStr()->substr($sCip, 0, 1)."/".getStr()->substr($sCip, 0, 2)."/";
+            $ort .= getStr()->substr($sCip, 0, 1) . "/" . getStr()->substr($sCip, 0, 2) . "/";
         }
 
         if ($sCity) {
@@ -474,7 +475,7 @@ class Emos
         }
 
         if ($sCip) {
-            $ort.=$sCip;
+            $ort .= $sCip;
         }
 
         $this->_billing = [$sBillingId, $sCustomerNumber, $ort, $iTotal];
@@ -486,7 +487,7 @@ class Emos
      * @param \OxidEsales\Eshop\Core\Smarty\Plugin\EmosItem $oItem      an instance of class EMOS_Item
      * @param string    $sEvent     Type of this event ("view","c_rmv","c_add")
      */
-    protected function _setEmosECPageArray($oItem, $sEvent)
+    protected function _setEmosECPageArray($oItem, $sEvent) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $oItem = $this->_emos_ItemFormat($oItem);
 
@@ -503,7 +504,7 @@ class Emos
      *
      * @return null
      */
-    protected function _emos_ItemFormat($oItem) // phpcs:ignore PSR1.Methods.CamelCapsMethodName.NotCamelCaps
+    protected function _emos_ItemFormat($oItem) // phpcs:ignore PSR1.Methods.CamelCapsMethodName.NotCamelCaps,PSR2.Methods.MethodDeclaration.Underscore
     {
         $oItem->productId = $this->_emos_DataFormat($oItem->productId);
         $oItem->productName = $this->_emos_DataFormat($oItem->productName);
@@ -522,7 +523,7 @@ class Emos
      *
      * @return null
      */
-    protected function _emos_DataFormat($sStr) //phpcs:ignore PSR1.Methods.CamelCapsMethodName.NotCamelCaps
+    protected function _emos_DataFormat($sStr) //phpcs:ignore PSR1.Methods.CamelCapsMethodName.NotCamelCaps,PSR2.Methods.MethodDeclaration.Underscore
     {
         //null check
         if (is_null($sStr)) {
@@ -564,7 +565,7 @@ class Emos
     /**
      * formats up the connector script in a Econda ver 2 JS format
      */
-    public function _prepareScript()
+    public function _prepareScript() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $this->_sPrescript =  '<script type="text/javascript">window.emosTrackVersion = 2;</script>' . $this->_br;
 
@@ -603,7 +604,7 @@ class Emos
      *
      * @return string
      */
-    protected function _addJsFormat($sVarName, $mContents)
+    protected function _addJsFormat($sVarName, $mContents) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         //get the first non array $mContents element
         $mVal = $mContents;
@@ -627,7 +628,7 @@ class Emos
      *
      * @return string
      */
-    protected function _jsEncode($mContents)
+    protected function _jsEncode($mContents) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         return json_encode($mContents);
     }

--- a/source/Core/Smarty/Plugin/Emos.php
+++ b/source/Core/Smarty/Plugin/Emos.php
@@ -503,7 +503,7 @@ class Emos
      *
      * @return null
      */
-    protected function _emos_ItemFormat($oItem)
+    protected function _emos_ItemFormat($oItem) // phpcs:ignore
     {
         $oItem->productId = $this->_emos_DataFormat($oItem->productId);
         $oItem->productName = $this->_emos_DataFormat($oItem->productName);
@@ -522,7 +522,7 @@ class Emos
      *
      * @return null
      */
-    protected function _emos_DataFormat($sStr)
+    protected function _emos_DataFormat($sStr) //phpcs:ignore
     {
         //null check
         if (is_null($sStr)) {

--- a/source/Core/Smarty/Plugin/EmosAdapter.php
+++ b/source/Core/Smarty/Plugin/EmosAdapter.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright (c) 2004 - 2007 ECONDA GmbH Karlsruhe
  * All rights reserved.
@@ -175,7 +176,7 @@ class EmosAdapter extends \OxidEsales\Eshop\Core\Base
      *
      * @return string
      */
-    protected function _getScriptPath()
+    protected function _getScriptPath() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $sShopUrl = $this->getConfig()->getCurrentShopUrl();
 
@@ -187,7 +188,7 @@ class EmosAdapter extends \OxidEsales\Eshop\Core\Base
      *
      * @return EMOS_Item
      */
-    protected function _getNewEmosItem()
+    protected function _getNewEmosItem() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         return new \OxidEsales\Eshop\Core\Smarty\Plugin\EmosItem();
     }
@@ -201,7 +202,7 @@ class EmosAdapter extends \OxidEsales\Eshop\Core\Base
      *
      * @return string
      */
-    protected function _convertToUtf($sContent)
+    protected function _convertToUtf($sContent) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $myConfig = $this->getConfig();
         if (!$myConfig->isUtf()) {
@@ -219,7 +220,7 @@ class EmosAdapter extends \OxidEsales\Eshop\Core\Base
      *
      * @return string
      */
-    protected function _prepareProductTitle($oProduct)
+    protected function _prepareProductTitle($oProduct) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $sTitle = $oProduct->oxarticles__oxtitle->value;
         if ($oProduct->oxarticles__oxvarselect->value) {
@@ -238,7 +239,7 @@ class EmosAdapter extends \OxidEsales\Eshop\Core\Base
      *
      * @return EMOS_Item
      */
-    protected function _convProd2EmosItem($oProduct, $sCatPath = "NULL", $iQty = 1)
+    protected function _convProd2EmosItem($oProduct, $sCatPath = "NULL", $iQty = 1) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $oItem = $this->_getNewEmosItem();
 
@@ -266,7 +267,7 @@ class EmosAdapter extends \OxidEsales\Eshop\Core\Base
      *
      * @return string
      */
-    protected function _getEmosPageTitle($aParams)
+    protected function _getEmosPageTitle($aParams) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         return isset($aParams['title']) ? $aParams['title'] : null;
     }
@@ -276,7 +277,7 @@ class EmosAdapter extends \OxidEsales\Eshop\Core\Base
      *
      * @return string
      */
-    protected function _getEmosCl()
+    protected function _getEmosCl() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $oActView = $this->getConfig()->getActiveView();
         // showLogin function is deprecated, but just in case if it is called
@@ -294,7 +295,7 @@ class EmosAdapter extends \OxidEsales\Eshop\Core\Base
      *
      * @return string
      */
-    protected function _getEmosCatPath()
+    protected function _getEmosCatPath() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         // #4016: econda: json function returns null if title has an umlaut
         if ($this->_sEmosCatPath === null) {
@@ -317,7 +318,7 @@ class EmosAdapter extends \OxidEsales\Eshop\Core\Base
      *
      * @return string
      */
-    protected function _getBasketProductCatPath($oArticle)
+    protected function _getBasketProductCatPath($oArticle) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $sCatPath = '';
         if ($oCategory = $oArticle->getCategory()) {
@@ -355,7 +356,7 @@ class EmosAdapter extends \OxidEsales\Eshop\Core\Base
      *
      * @return string
      */
-    protected function _getEmosPageId($sTplName)
+    protected function _getEmosPageId($sTplName) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $sPageId = $this->getConfig()->getShopId() .
             $this->_getEmosCl() .
@@ -372,9 +373,9 @@ class EmosAdapter extends \OxidEsales\Eshop\Core\Base
      *
      * @return string
      */
-    protected function _getTplName()
+    protected function _getTplName() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
-        if (!($sCurrTpl = basename(( string )\OxidEsales\Eshop\Core\Registry::getConfig()->getRequestParameter('tpl')))) {
+        if (!($sCurrTpl = basename((string)\OxidEsales\Eshop\Core\Registry::getConfig()->getRequestParameter('tpl')))) {
             // in case template was not defined in request
             $sCurrTpl = $this->getConfig()->getActiveView()->getTemplateName();
         }
@@ -387,7 +388,7 @@ class EmosAdapter extends \OxidEsales\Eshop\Core\Base
      *
      * @return array
      */
-    private function _getPagesContent()
+    private function _getPagesContent() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         return $this->_aPagesContent;
     }
@@ -397,7 +398,7 @@ class EmosAdapter extends \OxidEsales\Eshop\Core\Base
      *
      * @return array
      */
-    private function _getOrderStepNames()
+    private function _getOrderStepNames() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         return $this->_aOrderStepNames;
     }
@@ -409,7 +410,7 @@ class EmosAdapter extends \OxidEsales\Eshop\Core\Base
      * @param array $aParams
      * @param Smarty $oSmarty
      */
-    private function _setControllerInfo($oEmos, $aParams, $oSmarty)
+    private function _setControllerInfo($oEmos, $aParams, $oSmarty) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $sControllerName = $this->_getEmosCl();
         $aContent = $this->_getPagesContent();
@@ -531,7 +532,7 @@ class EmosAdapter extends \OxidEsales\Eshop\Core\Base
      * @param \OxidEsales\Eshop\Core\Smarty\Plugin\Emos $oEmos
      * @param Smarty $oSmarty
      */
-    private function _setSearchInformation($oEmos, $oSmarty)
+    private function _setSearchInformation($oEmos, $oSmarty) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $iPage = $this->getConfig()->getRequestParameter('pgNr');
         if (!$iPage) {
@@ -553,7 +554,7 @@ class EmosAdapter extends \OxidEsales\Eshop\Core\Base
      * @param \OxidEsales\Eshop\Application\Model\Order $oOrder
      * @param \OxidEsales\Eshop\Application\Model\Basket $oBasket
      */
-    private function _setBasketInformation($oEmos, $oUser, $oOrder, $oBasket)
+    private function _setBasketInformation($oEmos, $oUser, $oOrder, $oBasket) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $oConfig = $this->getConfig();
         $oCur = $oConfig->getActShopCurrencyObject();
@@ -591,7 +592,7 @@ class EmosAdapter extends \OxidEsales\Eshop\Core\Base
      * @param \OxidEsales\Eshop\Core\Smarty\Plugin\Emos $oEmos
      * @param \OxidEsales\Eshop\Application\Model\User $oUser
      */
-    private function _setUserRegistration($oEmos, $oUser)
+    private function _setUserRegistration($oEmos, $oUser) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $iError = \OxidEsales\Eshop\Core\Registry::getConfig()->getRequestParameter('newslettererror');
         $iSuccess = \OxidEsales\Eshop\Core\Registry::getConfig()->getRequestParameter('success');
@@ -610,7 +611,7 @@ class EmosAdapter extends \OxidEsales\Eshop\Core\Base
      *
      * @param \OxidEsales\Eshop\Core\Smarty\Plugin\Emos $oEmos
      */
-    private function _setBasketActionsInfo($oEmos)
+    private function _setBasketActionsInfo($oEmos) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         // get the last Call for special handling function "tobasket", "changebasket"
         if (($aLastCall = \OxidEsales\Eshop\Core\Registry::getSession()->getVariable('aLastcall'))) {

--- a/source/Core/Smarty/Plugin/EmosItem.php
+++ b/source/Core/Smarty/Plugin/EmosItem.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * EMOS PHP Bib 2
  *

--- a/source/Core/Smarty/Plugin/block.oxhasrights.php
+++ b/source/Core/Smarty/Plugin/block.oxhasrights.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Core/Smarty/Plugin/block.oxifcontent.php
+++ b/source/Core/Smarty/Plugin/block.oxifcontent.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
@@ -25,17 +26,19 @@ function smarty_block_oxifcontent($params, $content, &$smarty, &$repeat)
 {
     $myConfig = \OxidEsales\Eshop\Core\Registry::getConfig();
 
-    $sIdent  = isset($params['ident'])?$params['ident']:null;
-    $sOxid   = isset($params['oxid'])?$params['oxid']:null;
-    $sAssign = isset($params['assign'])?$params['assign']:null;
-    $sObject = isset($params['object'])?$params['object']:'oCont';
+    $sIdent  = isset($params['ident']) ? $params['ident'] : null;
+    $sOxid   = isset($params['oxid']) ? $params['oxid'] : null;
+    $sAssign = isset($params['assign']) ? $params['assign'] : null;
+    $sObject = isset($params['object']) ? $params['object'] : 'oCont';
 
     if ($repeat) {
         if ($sIdent || $sOxid) {
             static $aContentCache = [];
 
-            if (($sIdent && isset($aContentCache[$sIdent])) ||
-                 ($sOxid && isset($aContentCache[$sOxid]))) {
+            if (
+                ($sIdent && isset($aContentCache[$sIdent])) ||
+                 ($sOxid && isset($aContentCache[$sOxid]))
+            ) {
                 $oContent = $sOxid ? $aContentCache[$sOxid] : $aContentCache[$sIdent];
             } else {
                 $oContent = oxNew("oxContent");
@@ -65,7 +68,7 @@ function smarty_block_oxifcontent($params, $content, &$smarty, &$repeat)
         $oStr = getStr();
         $blHasSmarty = $oStr->strstr($content, '[{');
         if ($blHasSmarty) {
-            $content = \OxidEsales\Eshop\Core\Registry::getUtilsView()->parseThroughSmarty($content, $sIdent.md5($content), $myConfig->getActiveView());
+            $content = \OxidEsales\Eshop\Core\Registry::getUtilsView()->parseThroughSmarty($content, $sIdent . md5($content), $myConfig->getActiveView());
         }
 
         if ($sAssign) {

--- a/source/Core/Smarty/Plugin/compiler.defun.php
+++ b/source/Core/Smarty/Plugin/compiler.defun.php
@@ -9,7 +9,7 @@ function smarty_compiler_fun($tag_args, &$compiler)
         $compiler->_syntax_error("fun: missing name parameter");
     }
     $_func_name = $compiler->_dequote($_attrs['name']);
-    $_func = 'smarty_fun_'.$_func_name;
+    $_func = 'smarty_fun_' . $_func_name;
     $_params = 'array(';
     $_sep = '';
     unset($_attrs['name']);
@@ -34,7 +34,7 @@ function smarty_compiler_defun($tag_args, &$compiler)
     }
 
     $func_name = $compiler->_dequote($attrs['name']);
-    $func = 'smarty_fun_'.$func_name;
+    $func = 'smarty_fun_' . $func_name;
     return $func_key . "if (!function_exists('$func')) { function $func(&\$this, \$params) { \$_fun_tpl_vars = \$this->_tpl_vars; \$this->assign(\$params); ";
 }
     
@@ -43,7 +43,7 @@ function smarty_compiler_defun($tag_args, &$compiler)
 function smarty_compiler_defun_close($tag_args, &$compiler)
 {
     list($name, $attrs, $open_tag_args, $func_key) = array_pop($compiler->_tag_stack);
-    if ($name!='defun') {
+    if ($name != 'defun') {
         $compiler->_syntax_error("unexpected {/defun}");
     }
     return " \$this->_tpl_vars = \$_fun_tpl_vars; }} " . $func_key . smarty_compiler_fun($open_tag_args, $compiler);
@@ -71,7 +71,7 @@ function smarty_replace_fun($match)
     }
 
     /* replace */
-    for ($i=0, $count=count($tokens); $i<$count; $i++) {
+    for ($i = 0, $count = count($tokens); $i < $count; $i++) {
         if (is_array($tokens[$i])) {
             if ($tokens[$i][0] == T_VARIABLE && $tokens[$i][1] == '$this') {
                 $tokens[$i] = '$smarty';
@@ -88,12 +88,12 @@ function smarty_replace_fun($match)
 function smarty_postfilter_defun($source, &$compiler)
 {
     $search = '("' . md5('php-5') . '\[\[[0-9a-f]{32}";)';
-    if ((double)phpversion()>=5.0) {
+    if ((double)phpversion() >= 5.0) {
         /* filter sourcecode. look for func_keys and replace all $this
            in-between with $smarty */
         while (1) {
             $new_source = preg_replace_callback('/' . $search . '(.*)\\1/Us', 'smarty_replace_fun', $source);
-            if (strcmp($new_source, $source)==0) {
+            if (strcmp($new_source, $source) == 0) {
                 break;
             }
             $source = $new_source;

--- a/source/Core/Smarty/Plugin/function.assign_adv.php
+++ b/source/Core/Smarty/Plugin/function.assign_adv.php
@@ -92,9 +92,9 @@ function smarty_function_assign_adv($params, &$smarty)
         return;
     }
     if (preg_match('/^\s*array\s*\(\s*(.*)\s*\)\s*$/s', $value, $match)) {
-        eval('$value=array('.str_replace("\n", "", $match[1]).');');
+        eval('$value=array(' . str_replace("\n", "", $match[1]) . ');');
     } elseif (preg_match('/^\s*range\s*\(\s*(.*)\s*\)\s*$/s', $value, $match)) {
-        eval('$value=range('.str_replace("\n", "", $match[1]).');');
+        eval('$value=range(' . str_replace("\n", "", $match[1]) . ');');
     }
 
     $smarty->assign($var, $value);

--- a/source/Core/Smarty/Plugin/function.oxcontent.php
+++ b/source/Core/Smarty/Plugin/function.oxcontent.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
@@ -22,11 +23,11 @@
 function smarty_function_oxcontent($params, &$smarty)
 {
     $myConfig = \OxidEsales\Eshop\Core\Registry::getConfig();
-    $sText = $myConfig->getActiveShop()->oxshops__oxproductive->value ? null : "<b>content not found ! check ident(".$params['ident'].") !</b>";
+    $sText = $myConfig->getActiveShop()->oxshops__oxproductive->value ? null : "<b>content not found ! check ident(" . $params['ident'] . ") !</b>";
     $smarty->oxidcache = new \OxidEsales\Eshop\Core\Field($sText, \OxidEsales\Eshop\Core\Field::T_RAW);
 
-    $sIdent = isset($params['ident'])?$params['ident']:null;
-    $sOxid  = isset($params['oxid'])?$params['oxid']:null;
+    $sIdent = isset($params['ident']) ? $params['ident'] : null;
+    $sOxid  = isset($params['oxid']) ? $params['oxid'] : null;
 
     if ($sIdent || $sOxid) {
         $oContent = oxNew("oxcontent");
@@ -43,11 +44,11 @@ function smarty_function_oxcontent($params, &$smarty)
                 $sField = $params['field'];
             }
             // set value
-            $sProp = 'oxcontents__'.$sField;
+            $sProp = 'oxcontents__' . $sField;
             $smarty->oxidcache = clone $oContent->$sProp;
             $smarty->compile_check  = true;
             $sCacheId = \OxidEsales\Eshop\Core\Registry::getLang()->getBaseLanguage() . $myConfig->getShopId();
-            $sText = $smarty->fetch("ox:".(string)$sIdent.(string)$sOxid.$sField.$sCacheId);
+            $sText = $smarty->fetch("ox:" . (string)$sIdent . (string)$sOxid . $sField . $sCacheId);
             $smarty->compile_check  = $myConfig->getConfigParam('blCheckTemplates');
         }
     }

--- a/source/Core/Smarty/Plugin/function.oxeval.php
+++ b/source/Core/Smarty/Plugin/function.oxeval.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Core/Smarty/Plugin/function.oxgetseourl.php
+++ b/source/Core/Smarty/Plugin/function.oxgetseourl.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
@@ -52,7 +53,7 @@ function smarty_function_oxgetseourl($params, &$smarty)
         }
     }
 
-    $sDynParams = isset($params['params'])?$params['params']:false;
+    $sDynParams = isset($params['params']) ? $params['params'] : false;
     if ($sDynParams) {
         include_once $smarty->_get_plugin_filepath('modifier', 'oxaddparams');
         $sUrl = smarty_modifier_oxaddparams($sUrl, $sDynParams);

--- a/source/Core/Smarty/Plugin/function.oxid_include_dynamic.php
+++ b/source/Core/Smarty/Plugin/function.oxid_include_dynamic.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
@@ -29,20 +30,20 @@ function smarty_function_oxid_include_dynamic($params, &$smarty)
     if (!empty($smarty->_tpl_vars["_render4cache"])) {
         $sContent = "<oxid_dynamic>";
         foreach ($params as $key => $val) {
-            $sContent .= " $key='".base64_encode($val)."'";
+            $sContent .= " $key='" . base64_encode($val) . "'";
         }
         $sContent .= "</oxid_dynamic>";
         return $sContent;
     } else {
-        $sPrefix="_";
+        $sPrefix = "_";
         if (array_key_exists('type', $params)) {
-            $sPrefix.= $params['type']."_";
+            $sPrefix .= $params['type'] . "_";
         }
 
         foreach ($params as $key => $val) {
             if ($key != 'type' && $key != 'file') {
                 $sContent .= " $key='$val'";
-                $smarty->assign($sPrefix.$key, $val);
+                $smarty->assign($sPrefix . $key, $val);
             }
         }
 

--- a/source/Core/Smarty/Plugin/function.oxid_include_widget.php
+++ b/source/Core/Smarty/Plugin/function.oxid_include_widget.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Core/Smarty/Plugin/function.oxinputhelp.php
+++ b/source/Core/Smarty/Plugin/function.oxinputhelp.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Core/Smarty/Plugin/function.oxmailto.php
+++ b/source/Core/Smarty/Plugin/function.oxmailto.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
@@ -34,7 +35,7 @@ function smarty_function_oxmailto($aParams, &$oSmarty)
                     break;
                 case 'extra':
                 case 'text':
-                    $sName  = "s".ucfirst($sVarName);
+                    $sName  = "s" . ucfirst($sVarName);
                     $$sName = $sValue;
                     // no break
                 default:
@@ -46,9 +47,9 @@ function smarty_function_oxmailto($aParams, &$oSmarty)
             $sAddress .= $aMailParms[$iCtr];
         }
 
-        $sString = 'document.write(\'<a href="mailto:'.$sAddress.'" '.$sExtra.'>'.$sText.'</a>\');';
-        $sEncodedString = "%".wordwrap(current(unpack("H*", $sString)), 2, "%", true);
-        return '<script type="text/javascript">eval(decodeURIComponent(\''.$sEncodedString.'\'))</script>';
+        $sString = 'document.write(\'<a href="mailto:' . $sAddress . '" ' . $sExtra . '>' . $sText . '</a>\');';
+        $sEncodedString = "%" . wordwrap(current(unpack("H*", $sString)), 2, "%", true);
+        return '<script type="text/javascript">eval(decodeURIComponent(\'' . $sEncodedString . '\'))</script>';
     } else {
         include_once $oSmarty->_get_plugin_filepath('function', 'mailto');
         return smarty_function_mailto($aParams, $oSmarty);

--- a/source/Core/Smarty/Plugin/function.oxmultilang.php
+++ b/source/Core/Smarty/Plugin/function.oxmultilang.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
@@ -66,7 +67,7 @@ function smarty_function_oxmultilang($params, &$smarty)
             $sTranslation .= $sSuffixTranslation;
         }
     } elseif ($blShowError) {
-        $sTranslation = 'ERROR: Translation for '.$sIdent.' not found!';
+        $sTranslation = 'ERROR: Translation for ' . $sIdent . ' not found!';
     }
 
     stopProfile("smarty_function_oxmultilang");

--- a/source/Core/Smarty/Plugin/function.oxprice.php
+++ b/source/Core/Smarty/Plugin/function.oxprice.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Core/Smarty/Plugin/function.oxscript.php
+++ b/source/Core/Smarty/Plugin/function.oxscript.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Core/Smarty/Plugin/function.oxstyle.php
+++ b/source/Core/Smarty/Plugin/function.oxstyle.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Core/Smarty/Plugin/function.oxvariantselect.php
+++ b/source/Core/Smarty/Plugin/function.oxvariantselect.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
@@ -64,7 +65,7 @@ function oxvariantselect_addSubvariants($oMdVariants, $iLevel, &$aSelectBoxes, &
         $blVisible = false;
         $sSelectedVariant = null;
         foreach ($oMdVariants as $sKey => $oVariant) {
-            $sSelectBoxName = "mdVariantSelect_".$oVariant->getParentId();
+            $sSelectBoxName = "mdVariantSelect_" . $oVariant->getParentId();
             $aSelectBoxes[$iLevel][] = $sSelectBoxName;
             $aOptions[$oVariant->getId()] = $oVariant->getName();
             if ($oVariant->hasArticleId($sArtId)) {
@@ -81,7 +82,7 @@ function oxvariantselect_addSubvariants($oMdVariants, $iLevel, &$aSelectBoxes, &
 
         //add select boxes recursively
         foreach ($oMdVariants as $oVariant) {
-            $sRes .= oxvariantselect_addSubvariants($oVariant->getMdSubvariants(), $iLevel+1, $aSelectBoxes, $aRealVariants, $sSeparator, $sCallMethod, $sArtId);
+            $sRes .= oxvariantselect_addSubvariants($oVariant->getMdSubvariants(), $iLevel + 1, $aSelectBoxes, $aRealVariants, $sSeparator, $sCallMethod, $sArtId);
 
             //no more subvariants? Mseans we are the last level select box, good enought to register a real variant now
             if (!count($oVariant->getMdSubvariants())) {
@@ -107,10 +108,10 @@ function oxvariantselect_addSubvariants($oMdVariants, $iLevel, &$aSelectBoxes, &
  */
 function oxvariantselect_formatSelectBox($sId, $aOptions, $iLevel, $blVisible, $sSelected)
 {
-    $sStyle = $blVisible?"inline":"none";
+    $sStyle = $blVisible ? "inline" : "none";
     $sRes = "<select class='md_select_variant' id='$sId' style='display:$sStyle'>\n";
     foreach ($aOptions as $sVal => $sName) {
-        $sSelText = ($sVal === $sSelected)?" selected":"";
+        $sSelText = ($sVal === $sSelected) ? " selected" : "";
         $sRes .= " <option value='$sVal'$sSelText>$sName</option>\n";
     }
     $sRes .= "</select>\n";

--- a/source/Core/Smarty/Plugin/insert.oxid_cmplogin.php
+++ b/source/Core/Smarty/Plugin/insert.oxid_cmplogin.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Core/Smarty/Plugin/insert.oxid_cssmanager.php
+++ b/source/Core/Smarty/Plugin/insert.oxid_cssmanager.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
@@ -61,7 +62,7 @@ function smarty_insert_oxid_cssmanager($params, &$smarty)
     $sOutput = "";
     // checking if alternative CSS file exists and returning URL to CSS file
     if ($sTplName && file_exists($sAltFullPath) && is_file($sAltFullPath)) {
-        $sOutput = '<link rel="stylesheet" href="'.$sTplURL . $sAltCss.'">';
+        $sOutput = '<link rel="stylesheet" href="' . $sTplURL . $sAltCss . '">';
     }
 
     $smarty->caching = false;

--- a/source/Core/Smarty/Plugin/insert.oxid_newbasketitem.php
+++ b/source/Core/Smarty/Plugin/insert.oxid_newbasketitem.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
@@ -22,7 +23,7 @@ function smarty_insert_oxid_newbasketitem($params, &$smarty)
 {
     $myConfig  = \OxidEsales\Eshop\Core\Registry::getConfig();
 
-    $aTypes = ['0' => 'none','1' => 'message', '2' =>'popup', '3' =>'basket'];
+    $aTypes = ['0' => 'none','1' => 'message', '2' => 'popup', '3' => 'basket'];
     $iType  = $myConfig->getConfigParam('iNewBasketItemMessage');
 
     // If corect type of message is expected
@@ -31,7 +32,7 @@ function smarty_insert_oxid_newbasketitem($params, &$smarty)
     }
 
     //name of template file where is stored message text
-    $sTemplate = $params['tpl']?$params['tpl']:'inc_newbasketitem.snippet.tpl';
+    $sTemplate = $params['tpl'] ? $params['tpl'] : 'inc_newbasketitem.snippet.tpl';
 
     //allways render for ajaxstyle popup
     $blRender = $params['ajax'] && ($iType == 2);

--- a/source/Core/Smarty/Plugin/insert.oxid_nocache.php
+++ b/source/Core/Smarty/Plugin/insert.oxid_nocache.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Core/Smarty/Plugin/insert.oxid_tracker.php
+++ b/source/Core/Smarty/Plugin/insert.oxid_tracker.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Core/Smarty/Plugin/modifier.colon.php
+++ b/source/Core/Smarty/Plugin/modifier.colon.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Core/Smarty/Plugin/modifier.oxaddparams.php
+++ b/source/Core/Smarty/Plugin/modifier.oxaddparams.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
@@ -20,9 +21,9 @@ function smarty_modifier_oxaddparams($sUrl, $sDynParams)
 {
     $oStr = getStr();
     // removing empty parameters
-    $sDynParams = $sDynParams?$oStr->preg_replace([ '/^\?/', '/^\&(amp;)?$/' ], '', $sDynParams):false;
+    $sDynParams = $sDynParams ? $oStr->preg_replace([ '/^\?/', '/^\&(amp;)?$/' ], '', $sDynParams) : false;
     if ($sDynParams) {
-        $sUrl .= ((strpos($sUrl, '?') !== false) ? "&amp;":"?") . $sDynParams;
+        $sUrl .= ((strpos($sUrl, '?') !== false) ? "&amp;" : "?") . $sDynParams;
     }
     return \OxidEsales\Eshop\Core\Registry::getUtilsUrl()->processSeoUrl($sUrl);
 }

--- a/source/Core/Smarty/Plugin/modifier.oxaddslashes.php
+++ b/source/Core/Smarty/Plugin/modifier.oxaddslashes.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Core/Smarty/Plugin/modifier.oxenclose.php
+++ b/source/Core/Smarty/Plugin/modifier.oxenclose.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Core/Smarty/Plugin/modifier.oxescape.php
+++ b/source/Core/Smarty/Plugin/modifier.oxescape.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Core/Smarty/Plugin/modifier.oxfilesize.php
+++ b/source/Core/Smarty/Plugin/modifier.oxfilesize.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
@@ -18,22 +19,22 @@
 function smarty_modifier_oxfilesize($iSize)
 {
     if ($iSize < 1024) {
-        return $iSize. " B";
+        return $iSize . " B";
     }
 
-    $iSize = $iSize/1024;
+    $iSize = $iSize / 1024;
 
     if ($iSize < 1024) {
         return sprintf("%.1f KB", $iSize);
     }
 
-    $iSize = $iSize/1024;
+    $iSize = $iSize / 1024;
 
     if ($iSize < 1024) {
         return sprintf("%.1f MB", $iSize);
     }
 
-    $iSize = $iSize/1024;
+    $iSize = $iSize / 1024;
 
     return sprintf("%.1f GB", $iSize);
 }

--- a/source/Core/Smarty/Plugin/modifier.oxformattime.php
+++ b/source/Core/Smarty/Plugin/modifier.oxformattime.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Core/Smarty/Plugin/modifier.oxformdate.php
+++ b/source/Core/Smarty/Plugin/modifier.oxformdate.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Core/Smarty/Plugin/modifier.oxlower.php
+++ b/source/Core/Smarty/Plugin/modifier.oxlower.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Core/Smarty/Plugin/modifier.oxmultilangassign.php
+++ b/source/Core/Smarty/Plugin/modifier.oxmultilangassign.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
@@ -48,7 +49,7 @@ function smarty_modifier_oxmultilangassign($sIdent, $args = null)
             }
         }
     } elseif ($blShowError) {
-        $sTranslation = 'ERROR: Translation for '.$sIdent.' not found!';
+        $sTranslation = 'ERROR: Translation for ' . $sIdent . ' not found!';
     }
 
     return $sTranslation;

--- a/source/Core/Smarty/Plugin/modifier.oxmultilangsal.php
+++ b/source/Core/Smarty/Plugin/modifier.oxmultilangsal.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Core/Smarty/Plugin/modifier.oxnumberformat.php
+++ b/source/Core/Smarty/Plugin/modifier.oxnumberformat.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Core/Smarty/Plugin/modifier.oxtruncate.php
+++ b/source/Core/Smarty/Plugin/modifier.oxtruncate.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
@@ -38,7 +39,7 @@ function smarty_modifier_oxtruncate($sString, $iLength = 80, $sSufix = '...', $b
             $sString = getStr()->preg_replace('/\s+?(\S+)?$/', '', getStr()->substr($sString, 0, $iLength + 1));
         }
 
-        $sString = getStr()->substr($sString, 0, $iLength).$sSufix;
+        $sString = getStr()->substr($sString, 0, $iLength) . $sSufix;
 
         return str_replace([ "'",'"' ], ['&#039;', '&quot;'], $sString);
     }

--- a/source/Core/Smarty/Plugin/modifier.oxupper.php
+++ b/source/Core/Smarty/Plugin/modifier.oxupper.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Core/Smarty/Plugin/modifier.oxwordwrap.php
+++ b/source/Core/Smarty/Plugin/modifier.oxwordwrap.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Core/Smarty/Plugin/modifier.smartwordwrap.php
+++ b/source/Core/Smarty/Plugin/modifier.smartwordwrap.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Smarty plugin
  * @package Smarty
@@ -23,12 +24,12 @@ function smarty_modifier_smartwordwrap($string, $length = 80, $break = "\n", $cu
 {
     $wraptag = "<wrap>";
     $wrapchars = ["-"];
-    $afterwrapchars = ["-".$wraptag];
+    $afterwrapchars = ["-" . $wraptag];
     
     
     $string = trim($string);
     
-    if (strlen($string)<=$length) {
+    if (strlen($string) <= $length) {
         return $string;
     }
     
@@ -40,14 +41,14 @@ function smarty_modifier_smartwordwrap($string, $length = 80, $break = "\n", $cu
     
     $ok = true;
     foreach ($arr as $row) {
-        if (strlen($row) > ($length+$tollerance)) {
+        if (strlen($row) > ($length + $tollerance)) {
             $tmpstr = str_replace($wrapchars, $afterwrapchars, $row);
             $tmparr = explode($wraptag, $tmpstr);
             
             foreach ($tmparr as $altrow) {
                 array_push($alt, $altrow);
                  
-                if (strlen($altrow) > ($length+$tollerance)) {
+                if (strlen($altrow) > ($length + $tollerance)) {
                     $ok = false;
                 }
             }
@@ -64,14 +65,14 @@ function smarty_modifier_smartwordwrap($string, $length = 80, $break = "\n", $cu
         $arr  = explode($wraptag, $str);
     }
     
-    if ($cutrows && count($arr)>$cutrows) {
+    if ($cutrows && count($arr) > $cutrows) {
         $arr = array_splice($arr, 0, $cutrows);
         
-        if (strlen($arr[$cutrows].$etc) > $length + $tollerance) {
-            $arr[$cutrows-1]= substr($arr[$cutrows-1], 0, $length - strlen($etc));
+        if (strlen($arr[$cutrows] . $etc) > $length + $tollerance) {
+            $arr[$cutrows - 1] = substr($arr[$cutrows - 1], 0, $length - strlen($etc));
         }
         
-        $arr[$cutrows-1] = $arr[$cutrows-1].$etc;
+        $arr[$cutrows - 1] = $arr[$cutrows - 1] . $etc;
     }
     
     return implode($break, $arr);

--- a/source/Core/Smarty/Plugin/prefilter.oxblock.php
+++ b/source/Core/Smarty/Plugin/prefilter.oxblock.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
@@ -40,27 +41,27 @@ function smarty_prefilter_oxblock($sSource, &$oSmartyCompiler)
         $sPrepend = '';
         $sAppend  = '';
         if ($blUseSmarty3) {
-            $sPrepend = '[{__smartyblock__ name="'.$sBlockName.'"}]'.$sPrepend;
+            $sPrepend = '[{__smartyblock__ name="' . $sBlockName . '"}]' . $sPrepend;
             $sAppend .= '[{/__smartyblock__}]';
         }
         if ($blDebugTemplateBlocks) {
             $sTplDir = trim(\OxidEsales\Eshop\Core\Registry::getConfig()->getConfigParam('_sTemplateDir'), '/\\');
             $sFile = str_replace(['\\', '//'], '/', $oSmartyCompiler->_current_file);
-            if (preg_match('@/'.preg_quote($sTplDir, '@').'/(.*)$@', $sFile, $m)) {
+            if (preg_match('@/' . preg_quote($sTplDir, '@') . '/(.*)$@', $sFile, $m)) {
                 $sFile = $m[1];
             }
 
-            $sDbgName = $sFile.'-&gt;'.$sBlockName;
-            $sPrepend = '[{capture name="_dbg_blocks"}]'.$sPrepend;
-            $sDbgId = 'block_'.sprintf("%u", crc32($sDbgName)).'_[{$_dbg_block_idr1}][{$_dbg_block_idr2}]';
+            $sDbgName = $sFile . '-&gt;' . $sBlockName;
+            $sPrepend = '[{capture name="_dbg_blocks"}]' . $sPrepend;
+            $sDbgId = 'block_' . sprintf("%u", crc32($sDbgName)) . '_[{$_dbg_block_idr1}][{$_dbg_block_idr2}]';
             $sAppend .= '[{/capture}][{math equation="rand()" assign="_dbg_block_idr1"}][{math equation="rand()" assign="_dbg_block_idr2"}]'
-                       .'<hr style="visibility:hidden;height:0;margin:0;padding:0;border:0;line-height:0;font-size:0;" class="debugBlocksStart" id="'.$sDbgId.'" title="'.$sDbgName.'">'
-                       .'[{$smarty.capture._dbg_blocks}]'
-                       .'<hr style="visibility:hidden;height:0;margin:0;padding:0;border:0;line-height:0;font-size:0;" class="debugBlocksEnd" title="'.$sDbgId.'">';
+                       . '<hr style="visibility:hidden;height:0;margin:0;padding:0;border:0;line-height:0;font-size:0;" class="debugBlocksStart" id="' . $sDbgId . '" title="' . $sDbgName . '">'
+                       . '[{$smarty.capture._dbg_blocks}]'
+                       . '<hr style="visibility:hidden;height:0;margin:0;padding:0;border:0;line-height:0;font-size:0;" class="debugBlocksEnd" title="' . $sDbgId . '">';
         }
         if (!isset($aBlocks[$sBlockName]) || !is_array($aBlocks[$sBlockName])) {
             // block is unused, just use its content
-            $sSource = str_replace($sBlock, $sPrepend.$sBlockContent.$sAppend, $sSource);
+            $sSource = str_replace($sBlock, $sPrepend . $sBlockContent . $sAppend, $sSource);
         } else {
             // go through the replacement array and fill in parent values
             // specified by [{$smarty.block.parent}] tag
@@ -68,7 +69,7 @@ function smarty_prefilter_oxblock($sSource, &$oSmartyCompiler)
             foreach ($aBlocks[$sBlockName] as $sOverBlock) {
                 $sCurrBlock = preg_replace('/\[\{\s*\$smarty\.block\.parent\s*\}\]/i', $sCurrBlock, $sOverBlock);
             }
-            $sSource = str_replace($sBlock, $sPrepend.$sCurrBlock.$sAppend, $sSource);
+            $sSource = str_replace($sBlock, $sPrepend . $sCurrBlock . $sAppend, $sSource);
         }
     }
     if (!$iLimit) {

--- a/source/Core/Smarty/Plugin/prefilter.oxtpldebug.php
+++ b/source/Core/Smarty/Plugin/prefilter.oxtpldebug.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Core/SortingValidator.php
+++ b/source/Core/SortingValidator.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
@@ -19,7 +20,8 @@ class SortingValidator
     public function isValid($sortBy, $sortOrder)
     {
         $isValid = false;
-        if ($sortBy
+        if (
+            $sortBy
             && $sortOrder
             && in_array(strtolower($sortOrder), $this->getSortingOrders())
             && in_array($sortBy, \OxidEsales\Eshop\Core\Registry::getConfig()->getConfigParam('aSortCols'))

--- a/source/Core/Str.php
+++ b/source/Core/Str.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
@@ -53,7 +54,7 @@ class Str
      *
      * @return oxStrRegular|oxStrMb
      */
-    protected function _getStrHandler()
+    protected function _getStrHandler() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         if (function_exists('mb_strlen')) {
             return oxNew(\OxidEsales\Eshop\Core\StrMb::class);

--- a/source/Core/StrMb.php
+++ b/source/Core/StrMb.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Core/StrRegular.php
+++ b/source/Core/StrRegular.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Core/SubShopSpecificFileCache.php
+++ b/source/Core/SubShopSpecificFileCache.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Core/SystemEventHandler.php
+++ b/source/Core/SystemEventHandler.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Core/SystemRequirements.php
+++ b/source/Core/SystemRequirements.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
@@ -279,7 +280,8 @@ class SystemRequirements
 
         // special config file check
         $sFullPath = $sPath . "config.inc.php";
-        if (!is_readable($sFullPath) ||
+        if (
+            !is_readable($sFullPath) ||
             ($this->isAdmin() && is_writable($sFullPath)) ||
             (!$this->isAdmin() && !is_writable($sFullPath))
         ) {
@@ -341,7 +343,7 @@ class SystemRequirements
      *
      * @return array
      */
-    protected function _getShopHostInfoFromConfig()
+    protected function _getShopHostInfoFromConfig() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $sShopURL = $this->getConfig()->getConfigParam('sShopURL');
         if (preg_match('#^(https?://)?([^/:]+)(:([0-9]+))?(/.*)?$#i', $sShopURL, $m)) {
@@ -370,7 +372,7 @@ class SystemRequirements
      *
      * @return array
      */
-    protected function _getShopSSLHostInfoFromConfig()
+    protected function _getShopSSLHostInfoFromConfig() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $sSSLShopURL = $this->getConfig()->getConfigParam('sSSLShopURL');
         if (preg_match('#^(https?://)?([^/:]+)(:([0-9]+))?(/.*)?$#i', $sSSLShopURL, $m)) {
@@ -399,7 +401,7 @@ class SystemRequirements
      *
      * @return array
      */
-    protected function _getShopHostInfoFromServerVars()
+    protected function _getShopHostInfoFromServerVars() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         // got here from setup dir
         $sScript = $_SERVER['SCRIPT_NAME'];
@@ -423,7 +425,7 @@ class SystemRequirements
      *
      * @return array
      */
-    protected function _getShopHostInfo()
+    protected function _getShopHostInfo() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         if ($this->isAdmin()) {
             return $this->_getShopHostInfoFromConfig();
@@ -438,7 +440,7 @@ class SystemRequirements
      *
      * @return array
      */
-    protected function _getShopSSLHostInfo()
+    protected function _getShopSSLHostInfo() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         if ($this->isAdmin()) {
             return $this->_getShopSSLHostInfoFromConfig();
@@ -485,7 +487,7 @@ class SystemRequirements
      *
      * @return integer
      */
-    protected function _checkModRewrite($aHostInfo)
+    protected function _checkModRewrite($aHostInfo) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $sHostname = ($aHostInfo['ssl'] ? 'ssl://' : '') . $aHostInfo['host'];
         if ($rFp = @fsockopen($sHostname, $aHostInfo['port'], $iErrNo, $sErrStr, 10)) {
@@ -570,9 +572,11 @@ class SystemRequirements
             $requirementFits = static::MODULE_STATUS_BLOCKS_SETUP;
         }
 
-        if (is_null($requirementFits) &&
-            version_compare($installedPhpVersion, $minimalRecommendedVersion, '>=')
-            && version_compare($installedPhpVersion, $maximalRecommendedVersion, '<=')) {
+        if (
+            is_null($requirementFits) &&
+            version_compare($installedPhpVersion, $minimalRecommendedVersion, '>=') &&
+            version_compare($installedPhpVersion, $maximalRecommendedVersion, '<=')
+        ) {
             $requirementFits = static::MODULE_STATUS_OK;
         }
 
@@ -711,7 +715,8 @@ class SystemRequirements
          * Version MySQL 5.6.* in neither recommended nor supported by OXID eSales.
          * See https://bugs.mysql.com/bug.php?id=79203
          */
-        if (is_null($requirementFits) &&
+        if (
+            is_null($requirementFits) &&
             version_compare($installedVersion, '5.6.0', '>=') &&
             version_compare($installedVersion, '5.7.0', '<')
         ) {
@@ -793,7 +798,7 @@ class SystemRequirements
      *
      * @return string
      */
-    protected function _getAdditionalCheck()
+    protected function _getAdditionalCheck() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $sSelect = '';
         foreach ($this->_aException as $sTable => $sColumn) {
@@ -920,7 +925,7 @@ class SystemRequirements
             }
             $iModuleState = $this->getModuleInfo($sModule);
             $aSysInfo[$sGroup][$sModule] = $iModuleState;
-            $this->_blSysReqStatus = $this->_blSysReqStatus && ( bool ) abs($iModuleState);
+            $this->_blSysReqStatus = $this->_blSysReqStatus && (bool) abs($iModuleState);
         }
 
         return $aSysInfo;
@@ -1030,7 +1035,7 @@ class SystemRequirements
      *
      * @return int
      */
-    protected function _getBytes($sBytes)
+    protected function _getBytes($sBytes) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $sBytes = trim($sBytes);
         $sLast = strtolower($sBytes[strlen($sBytes) - 1]);
@@ -1063,7 +1068,7 @@ class SystemRequirements
      *
      * @return bool
      */
-    protected function _checkTemplateBlock($sTemplate, $sBlockName)
+    protected function _checkTemplateBlock($sTemplate, $sBlockName) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         /** @var TemplateLoaderInterface $templateLoader */
         $templateLoader = $this->getContainer()->get('oxid_esales.templating.template.loader');
@@ -1161,7 +1166,7 @@ class SystemRequirements
      *
      * @return string
      */
-    protected function _getMinimumMemoryLimit()
+    protected function _getMinimumMemoryLimit() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         return '32M';
     }
@@ -1171,7 +1176,7 @@ class SystemRequirements
      *
      * @return string
      */
-    protected function _getRecommendMemoryLimit()
+    protected function _getRecommendMemoryLimit() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         return '60M';
     }

--- a/source/Core/TableViewNameGenerator.php
+++ b/source/Core/TableViewNameGenerator.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Core/Theme.php
+++ b/source/Core/Theme.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Core/UniversallyUniqueIdGenerator.php
+++ b/source/Core/UniversallyUniqueIdGenerator.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
@@ -88,7 +89,7 @@ class UniversallyUniqueIdGenerator
      *
      * @return \OxidEsales\Eshop\Core\OpenSSLFunctionalityChecker
      */
-    protected function _getOpenSSLChecker()
+    protected function _getOpenSSLChecker() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         return $this->_openSSLChecker;
     }
@@ -98,7 +99,7 @@ class UniversallyUniqueIdGenerator
      *
      * @return string
      */
-    protected function _generateBasedOnOpenSSL()
+    protected function _generateBasedOnOpenSSL() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $sRandomData = openssl_random_pseudo_bytes(16);
         $sRandomData[6] = chr(ord($sRandomData[6]) & 0x0f | 0x40); // set version to 0100
@@ -112,7 +113,7 @@ class UniversallyUniqueIdGenerator
      *
      * @return string
      */
-    protected function _generateBasedOnMtRand()
+    protected function _generateBasedOnMtRand() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         return sprintf(
             '%04x%04x-%04x-%04x-%04x-%04x%04x%04x',

--- a/source/Core/UserCounter.php
+++ b/source/Core/UserCounter.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Core/Utils.php
+++ b/source/Core/Utils.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
@@ -480,7 +481,7 @@ class Utils extends \OxidEsales\Eshop\Core\Base
         // looking for cache meta
         $sCachePath = isset($aMeta["cachepath"]) ? $aMeta["cachepath"] : $this->getCacheFilePath($sKey);
 
-        return ( bool ) $this->_lockFile($sCachePath, $sKey);
+        return (bool) $this->_lockFile($sCachePath, $sKey);
     }
 
     /**
@@ -529,7 +530,7 @@ class Utils extends \OxidEsales\Eshop\Core\Base
      *
      * @return string
      */
-    protected function _readFile($sFilePath)
+    protected function _readFile($sFilePath) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $sRes = file_get_contents($sFilePath);
 
@@ -543,7 +544,7 @@ class Utils extends \OxidEsales\Eshop\Core\Base
      *
      * @return mixed
      */
-    protected function _includeFile($sFilePath)
+    protected function _includeFile($sFilePath) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $_aCacheContents = null;
         include $sFilePath;
@@ -559,7 +560,7 @@ class Utils extends \OxidEsales\Eshop\Core\Base
      *
      * @return mixed
      */
-    protected function _processCache($sKey, $mContents)
+    protected function _processCache($sKey, $mContents) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         // looking for cache meta
         $aCacheMeta = $this->getCacheMeta($sKey);
@@ -611,7 +612,7 @@ class Utils extends \OxidEsales\Eshop\Core\Base
      *
      * @return mixed lock file resource or false on error
      */
-    protected function _lockFile($sFilePath, $sIdent, $iLockMode = LOCK_EX)
+    protected function _lockFile($sFilePath, $sIdent, $iLockMode = LOCK_EX) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $rHandle = isset($this->_aLockedFileHandles[$iLockMode][$sIdent]) ? $this->_aLockedFileHandles[$iLockMode][$sIdent] : null;
         if ($rHandle === null) {
@@ -663,10 +664,11 @@ class Utils extends \OxidEsales\Eshop\Core\Base
      *
      * @return bool
      */
-    protected function _releaseFile($sIdent, $iLockMode = LOCK_EX)
+    protected function _releaseFile($sIdent, $iLockMode = LOCK_EX) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $blSuccess = true;
-        if (isset($this->_aLockedFileHandles[$iLockMode][$sIdent]) &&
+        if (
+            isset($this->_aLockedFileHandles[$iLockMode][$sIdent]) &&
             $this->_aLockedFileHandles[$iLockMode][$sIdent] !== false
         ) {
             // release the lock and close file
@@ -818,7 +820,8 @@ class Utils extends \OxidEsales\Eshop\Core\Base
     public function canPreview()
     {
         $blCan = null;
-        if (($sPrevId = \OxidEsales\Eshop\Core\Registry::getConfig()->getRequestParameter('preview')) &&
+        if (
+            ($sPrevId = \OxidEsales\Eshop\Core\Registry::getConfig()->getRequestParameter('preview')) &&
             ($sAdminSid = \OxidEsales\Eshop\Core\Registry::getUtilsServer()->getOxCookie('admin_sid'))
         ) {
             $sTable = getViewName('oxuser');
@@ -996,7 +999,7 @@ class Utils extends \OxidEsales\Eshop\Core\Base
      */
     public function isValidAlpha($sField)
     {
-        return (boolean) getStr()->preg_match('/^[a-zA-Z0-9_]*$/', $sField);
+        return (bool) getStr()->preg_match('/^[a-zA-Z0-9_]*$/', $sField);
     }
 
     /**
@@ -1006,7 +1009,7 @@ class Utils extends \OxidEsales\Eshop\Core\Base
      * @param string $sUrl        the URL to redirect to
      * @param string $sHeaderCode code to add to the header(e.g. "HTTP/1.1 301 Moved Permanently", or "HTTP/1.1 500 Internal Server Error"
      */
-    protected function _simpleRedirect($sUrl, $sHeaderCode)
+    protected function _simpleRedirect($sUrl, $sHeaderCode) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $oHeader = oxNew(\OxidEsales\Eshop\Core\Header::class);
         $oHeader->setHeader($sHeaderCode);
@@ -1133,7 +1136,7 @@ class Utils extends \OxidEsales\Eshop\Core\Base
      *
      * @return string
      */
-    protected function _addUrlParameters($sUrl, $aParams)
+    protected function _addUrlParameters($sUrl, $aParams) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $sDelimiter = ((getStr()->strpos($sUrl, '?') !== false)) ? '&' : '?';
         foreach ($aParams as $sName => $sVal) {
@@ -1155,7 +1158,7 @@ class Utils extends \OxidEsales\Eshop\Core\Base
      * @todo rename function more closely to actual purpose
      * @todo finish refactoring
      */
-    protected function _fillExplodeArray($aName, $dVat = null)
+    protected function _fillExplodeArray($aName, $dVat = null) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $myConfig = $this->getConfig();
         $oObject = new stdClass();
@@ -1218,7 +1221,7 @@ class Utils extends \OxidEsales\Eshop\Core\Base
      *
      * @return float
      */
-    protected function _preparePrice($dPrice, $dVat)
+    protected function _preparePrice($dPrice, $dVat) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $blCalculationModeNetto = $this->_isPriceViewModeNetto();
 
@@ -1239,7 +1242,7 @@ class Utils extends \OxidEsales\Eshop\Core\Base
      *
      * @return bool
      */
-    protected function _isPriceViewModeNetto()
+    protected function _isPriceViewModeNetto() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $blResult = (bool) $this->getConfig()->getConfigParam('blShowNetPrice');
         $oUser = $this->_getArticleUser();
@@ -1255,7 +1258,7 @@ class Utils extends \OxidEsales\Eshop\Core\Base
      *
      * @return oxUser
      */
-    protected function _getArticleUser()
+    protected function _getArticleUser() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         if ($this->_oUser) {
             return $this->_oUser;
@@ -1473,7 +1476,8 @@ class Utils extends \OxidEsales\Eshop\Core\Base
     public function extractDomain($sHost)
     {
         $oStr = getStr();
-        if (!$oStr->preg_match('/[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}/', $sHost) &&
+        if (
+            !$oStr->preg_match('/[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}/', $sHost) &&
             ($iLastDot = strrpos($sHost, '.')) !== false
         ) {
             $iLen = $oStr->strlen($sHost);

--- a/source/Core/UtilsCount.php
+++ b/source/Core/UtilsCount.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
@@ -384,7 +385,7 @@ class UtilsCount extends \OxidEsales\Eshop\Core\Base
      *
      * @return array
      */
-    protected function _getCatCache()
+    protected function _getCatCache() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $myConfig = $this->getConfig();
 
@@ -410,7 +411,7 @@ class UtilsCount extends \OxidEsales\Eshop\Core\Base
      *
      * @param array $aCache A cacheable data
      */
-    protected function _setCatCache($aCache)
+    protected function _setCatCache($aCache) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $this->getConfig()->setGlobalParameter('aLocalCatCache', $aCache);
         \OxidEsales\Eshop\Core\Registry::getUtils()->toFileCache('aLocalCatCache', $aCache);
@@ -421,7 +422,7 @@ class UtilsCount extends \OxidEsales\Eshop\Core\Base
      *
      * @param array $aCache A cacheable data
      */
-    protected function _setVendorCache($aCache)
+    protected function _setVendorCache($aCache) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $this->getConfig()->setGlobalParameter('aLocalVendorCache', $aCache);
         \OxidEsales\Eshop\Core\Registry::getUtils()->toFileCache('aLocalVendorCache', $aCache);
@@ -432,7 +433,7 @@ class UtilsCount extends \OxidEsales\Eshop\Core\Base
      *
      * @param array $aCache A cacheable data
      */
-    protected function _setManufacturerCache($aCache)
+    protected function _setManufacturerCache($aCache) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $this->getConfig()->setGlobalParameter('aLocalManufacturerCache', $aCache);
         \OxidEsales\Eshop\Core\Registry::getUtils()->toFileCache('aLocalManufacturerCache', $aCache);
@@ -443,7 +444,7 @@ class UtilsCount extends \OxidEsales\Eshop\Core\Base
      *
      * @return array
      */
-    protected function _getVendorCache()
+    protected function _getVendorCache() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $myConfig = $this->getConfig();
 
@@ -468,7 +469,7 @@ class UtilsCount extends \OxidEsales\Eshop\Core\Base
      *
      * @return array
      */
-    protected function _getManufacturerCache()
+    protected function _getManufacturerCache() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $myConfig = $this->getConfig();
 
@@ -495,7 +496,7 @@ class UtilsCount extends \OxidEsales\Eshop\Core\Base
      *
      * @return string
      */
-    protected function _getUserViewId($blReset = false)
+    protected function _getUserViewId($blReset = false) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         if ($this->_sUserViewId != null && !$blReset) {
             return $this->_sUserViewId;

--- a/source/Core/UtilsDate.php
+++ b/source/Core/UtilsDate.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
@@ -280,7 +281,7 @@ class UtilsDate extends \OxidEsales\Eshop\Core\Base
      *
      * @return null
      */
-    protected function _setDefaultFormatedValue($oObject, $sDate, $sLocalDateFormat, $sLocalTimeFormat, $blOnlyDate)
+    protected function _setDefaultFormatedValue($oObject, $sDate, $sLocalDateFormat, $sLocalTimeFormat, $blOnlyDate) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $aDefTimePatterns = $this->_defaultTimePattern();
         $aDFormats = $this->_defineDateFormattingRules();
@@ -318,7 +319,7 @@ class UtilsDate extends \OxidEsales\Eshop\Core\Base
      *
      * @return string
      */
-    protected function _defineAndCheckDefaultTimeValues($blToTimeStamp)
+    protected function _defineAndCheckDefaultTimeValues($blToTimeStamp) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         // defining time format
         // checking for default values
@@ -337,7 +338,7 @@ class UtilsDate extends \OxidEsales\Eshop\Core\Base
      *
      * @return string
      */
-    protected function _defineAndCheckDefaultDateValues($blToTimeStamp)
+    protected function _defineAndCheckDefaultDateValues($blToTimeStamp) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         // defining time format
         // checking for default values
@@ -354,7 +355,7 @@ class UtilsDate extends \OxidEsales\Eshop\Core\Base
      *
      * @return array
      */
-    protected function _defaultDatePattern()
+    protected function _defaultDatePattern() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         return ["/^0000-00-00/"   => "ISO",
                      "/^00\.00\.0000/" => "EUR",
@@ -367,7 +368,7 @@ class UtilsDate extends \OxidEsales\Eshop\Core\Base
      *
      * @return array
      */
-    protected function _defaultTimePattern()
+    protected function _defaultTimePattern() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         return ["/00:00:00$/"    => "ISO",
                      "/00\.00\.00$/"  => "EUR",
@@ -380,7 +381,7 @@ class UtilsDate extends \OxidEsales\Eshop\Core\Base
      *
      * @return array
      */
-    protected function _regexp2ValidateDateInput()
+    protected function _regexp2ValidateDateInput() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         return ["/^([0-9]{4})-([0-9]{2})-([0-9]{2})/"   => "ISO",
                      "/^([0-9]{2})\.([0-9]{2})\.([0-9]{4})/" => "EUR",
@@ -393,7 +394,7 @@ class UtilsDate extends \OxidEsales\Eshop\Core\Base
      *
      * @return array
      */
-    protected function _regexp2ValidateTimeInput()
+    protected function _regexp2ValidateTimeInput() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         return ["/([0-9]{2}):([0-9]{2}):([0-9]{2})$/"                 => "ISO",
                      "/([0-9]{2})\.([0-9]{2})\.([0-9]{2})$/"               => "EUR",
@@ -406,7 +407,7 @@ class UtilsDate extends \OxidEsales\Eshop\Core\Base
      *
      * @return array
      */
-    protected function _defineDateFormattingRules()
+    protected function _defineDateFormattingRules() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         return ["ISO" => ["Y-m-d", [2, 3, 1], "0000-00-00"],
                      "EUR" => ["d.m.Y", [2, 1, 3], "00.00.0000"],
@@ -419,7 +420,7 @@ class UtilsDate extends \OxidEsales\Eshop\Core\Base
      *
      * @return array
      */
-    protected function _defineTimeFormattingRules()
+    protected function _defineTimeFormattingRules() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         return ["ISO" => ["H:i:s", [1, 2, 3], "00:00:00"],
                      "EUR" => ["H.i.s", [1, 2, 3], "00.00.00"],
@@ -435,7 +436,7 @@ class UtilsDate extends \OxidEsales\Eshop\Core\Base
      * @param string $sLocalTimeFormat local format
      * @param bool   $blOnlyDate       marker to format only date field (no time)
      */
-    protected function _setDefaultDateTimeValue($oObject, $sLocalDateFormat, $sLocalTimeFormat, $blOnlyDate)
+    protected function _setDefaultDateTimeValue($oObject, $sLocalDateFormat, $sLocalTimeFormat, $blOnlyDate) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $aDFormats = $this->_defineDateFormattingRules();
         $aTFormats = $this->_defineTimeFormattingRules();
@@ -462,7 +463,7 @@ class UtilsDate extends \OxidEsales\Eshop\Core\Base
      * @param array  $aDFields     days
      * @param array  $aDateMatches new date as array (month, year)
      */
-    protected function _setDate($oObject, $sDateFormat, $aDFields, $aDateMatches)
+    protected function _setDate($oObject, $sDateFormat, $aDFields, $aDateMatches) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         // formatting correct time value
         $iTimestamp = mktime(
@@ -494,7 +495,7 @@ class UtilsDate extends \OxidEsales\Eshop\Core\Base
      * @param array  $aTFields     defines the time fields
      * @param array  $aDFields     defines the date fields
      */
-    protected function _formatCorrectTimeValue($oObject, $sDateFormat, $sTimeFormat, $aDateMatches, $aTimeMatches, $aTFields, $aDFields)
+    protected function _formatCorrectTimeValue($oObject, $sDateFormat, $sTimeFormat, $aDateMatches, $aTimeMatches, $aTFields, $aDFields) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         // formatting correct time value
         $iTimestamp = @mktime(
@@ -693,7 +694,7 @@ class UtilsDate extends \OxidEsales\Eshop\Core\Base
      *
      * @return string formatted string
      */
-    protected function _processDate($aTime, $aDate, $blGerman, $sFormat)
+    protected function _processDate($aTime, $aDate, $blGerman, $sFormat) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         if ($blGerman) {
             return date($sFormat, mktime($aTime[0], $aTime[1], $aTime[2], $aDate[1], $aDate[0], $aDate[2]));

--- a/source/Core/UtilsFile.php
+++ b/source/Core/UtilsFile.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
@@ -139,7 +140,7 @@ class UtilsFile extends \OxidEsales\Eshop\Core\Base
      *
      * @param integer $iNewFilesCounter New files count.
      */
-    protected function _setNewFilesCounter($iNewFilesCounter)
+    protected function _setNewFilesCounter($iNewFilesCounter) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $this->_iNewFilesCounter = (int) $iNewFilesCounter;
     }
@@ -260,7 +261,7 @@ class UtilsFile extends \OxidEsales\Eshop\Core\Base
      *
      * @return string
      */
-    protected function _prepareImageName($sValue, $sType, $blDemo, $sImagePath, $blUnique = true)
+    protected function _prepareImageName($sValue, $sType, $blDemo, $sImagePath, $blUnique = true) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         if ($sValue) {
             // add type to name
@@ -300,7 +301,7 @@ class UtilsFile extends \OxidEsales\Eshop\Core\Base
      *
      * @return string
      */
-    protected function _getImagePath($sType)
+    protected function _getImagePath($sType) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $sFolder = array_key_exists($sType, $this->_aTypeToPath) ? $this->_aTypeToPath[$sType] : '0';
 
@@ -317,7 +318,7 @@ class UtilsFile extends \OxidEsales\Eshop\Core\Base
      *
      * @return array | null
      */
-    protected function _getImageSize($sImgType, $iImgNum, $sImgConf)
+    protected function _getImageSize($sImgType, $iImgNum, $sImgConf) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $myConfig = $this->getConfig();
 
@@ -346,7 +347,7 @@ class UtilsFile extends \OxidEsales\Eshop\Core\Base
      *
      * @return bool
      */
-    protected function _copyFile($sSource, $sTarget)
+    protected function _copyFile($sSource, $sTarget) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         if (!is_dir(dirname($sTarget))) {
             mkdir(dirname($sTarget), 0744, true);
@@ -372,7 +373,7 @@ class UtilsFile extends \OxidEsales\Eshop\Core\Base
      *
      * @return bool
      */
-    protected function _moveImage($sSource, $sTarget)
+    protected function _moveImage($sSource, $sTarget) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         if (!is_dir(dirname($sTarget))) {
             mkdir(dirname($sTarget), 0744, true);
@@ -592,7 +593,7 @@ class UtilsFile extends \OxidEsales\Eshop\Core\Base
      *
      * @return string
      */
-    protected function _getUniqueFileName($sFilePath, $sFileName, $sFileExt, $sSufix = "", $blUnique = true)
+    protected function _getUniqueFileName($sFilePath, $sFileName, $sFileExt, $sSufix = "", $blUnique = true) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $sFilePath = $this->normalizeDir($sFilePath);
         $iFileCounter = 0;

--- a/source/Core/UtilsObject.php
+++ b/source/Core/UtilsObject.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Core/UtilsPic.php
+++ b/source/Core/UtilsPic.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
@@ -73,12 +74,13 @@ class UtilsPic extends \OxidEsales\Eshop\Core\Base
      *
      * @return null
      */
-    protected function _deletePicture($sPicName, $sAbsDynImageDir)
+    protected function _deletePicture($sPicName, $sAbsDynImageDir) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $blDeleted = false;
         $myConfig = $this->getConfig();
 
-        if (!$myConfig->isDemoShop() && (strpos($sPicName, 'nopic.jpg') === false ||
+        if (
+            !$myConfig->isDemoShop() && (strpos($sPicName, 'nopic.jpg') === false ||
                                          strpos($sPicName, 'nopic_ico.jpg') === false)
         ) {
             $sFile = "$sAbsDynImageDir/$sPicName";
@@ -113,7 +115,7 @@ class UtilsPic extends \OxidEsales\Eshop\Core\Base
      *
      * @return bool
      */
-    protected function _isPicDeletable($sPicName, $sTable, $sField)
+    protected function _isPicDeletable($sPicName, $sTable, $sField) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         if (!$sPicName || strpos($sPicName, 'nopic.jpg') !== false || strpos($sPicName, 'nopic_ico.jpg') !== false) {
             return false;
@@ -161,7 +163,8 @@ class UtilsPic extends \OxidEsales\Eshop\Core\Base
     public function overwritePic($oObject, $sPicTable, $sPicField, $sPicType, $sPicDir, $aParams, $sAbsDynImageDir)
     {
         $sPic = $sPicTable . '__' . $sPicField;
-        if (isset($oObject->{$sPic}) &&
+        if (
+            isset($oObject->{$sPic}) &&
             ($_FILES['myfile']['size'][$sPicType . '@' . $sPic] > 0 || $aParams[$sPic] != $oObject->{$sPic}->value)
         ) {
             $sImgDir = $sAbsDynImageDir . \OxidEsales\Eshop\Core\Registry::getUtilsFile()->getImageDirByType($sPicType);
@@ -185,7 +188,7 @@ class UtilsPic extends \OxidEsales\Eshop\Core\Base
      *
      * @return bool
      */
-    protected function _resizeGif($sSrc, $sTarget, $iNewWidth, $iNewHeight, $iOriginalWidth, $iOriginalHeigth, $iGDVer, $blDisableTouch)
+    protected function _resizeGif($sSrc, $sTarget, $iNewWidth, $iNewHeight, $iOriginalWidth, $iOriginalHeigth, $iGDVer, $blDisableTouch) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         return resizeGif($sSrc, $sTarget, $iNewWidth, $iNewHeight, $iOriginalWidth, $iOriginalHeigth, $iGDVer, $blDisableTouch);
     }
@@ -205,7 +208,7 @@ class UtilsPic extends \OxidEsales\Eshop\Core\Base
      *
      * @return bool
      */
-    protected function _resize($aImageInfo, $sSrc, $hDestinationImage, $sTarget, $iNewWidth, $iNewHeight, $iGdVer, $blDisableTouch, $iDefQuality)
+    protected function _resize($aImageInfo, $sSrc, $hDestinationImage, $sTarget, $iNewWidth, $iNewHeight, $iGdVer, $blDisableTouch, $iDefQuality) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         startProfile("PICTURE_RESIZE");
 
@@ -249,7 +252,7 @@ class UtilsPic extends \OxidEsales\Eshop\Core\Base
      *
      * @return null
      */
-    protected function _copyAlteredImage($sDestinationImage, $sSourceImage, $iNewWidth, $iNewHeight, $aImageInfo, $sTarget, $iGdVer, $blDisableTouch)
+    protected function _copyAlteredImage($sDestinationImage, $sSourceImage, $iNewWidth, $iNewHeight, $aImageInfo, $sTarget, $iGdVer, $blDisableTouch) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $blSuccess = copyAlteredImage($sDestinationImage, $sSourceImage, $iNewWidth, $iNewHeight, $aImageInfo, $sTarget, $iGdVer);
         if (!$blDisableTouch && $blSuccess) {

--- a/source/Core/UtilsServer.php
+++ b/source/Core/UtilsServer.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
@@ -79,7 +80,7 @@ class UtilsServer extends \OxidEsales\Eshop\Core\Base
      *
      * @return bool
      */
-    protected function _mustSaveToSession()
+    protected function _mustSaveToSession() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         if ($this->_blSaveToSession === null) {
             $this->_blSaveToSession = false;
@@ -109,7 +110,7 @@ class UtilsServer extends \OxidEsales\Eshop\Core\Base
      *
      * @return string
      */
-    protected function _getSessionCookieKey($blGet)
+    protected function _getSessionCookieKey($blGet) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $blSsl = $this->getConfig()->isSsl();
         $sKey = $blSsl ? 'nossl' : 'ssl';
@@ -130,12 +131,12 @@ class UtilsServer extends \OxidEsales\Eshop\Core\Base
      * @param string $sPath   cookie path
      * @param string $sDomain cookie domain
      */
-    protected function _saveSessionCookie($sName, $sValue, $iExpire, $sPath, $sDomain)
+    protected function _saveSessionCookie($sName, $sValue, $iExpire, $sPath, $sDomain) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         if ($this->_mustSaveToSession()) {
             $aCookieData = ['value' => $sValue, 'expire' => $iExpire, 'path' => $sPath, 'domain' => $sDomain];
 
-            $aSessionCookies = ( array ) \OxidEsales\Eshop\Core\Registry::getSession()->getVariable($this->_sSessionCookiesName);
+            $aSessionCookies = (array) \OxidEsales\Eshop\Core\Registry::getSession()->getVariable($this->_sSessionCookiesName);
             $aSessionCookies[$this->_getSessionCookieKey(false)][$sName] = $aCookieData;
 
             \OxidEsales\Eshop\Core\Registry::getSession()->setVariable($this->_sSessionCookiesName, $aSessionCookies);
@@ -173,7 +174,7 @@ class UtilsServer extends \OxidEsales\Eshop\Core\Base
      *
      * @return string
      */
-    protected function _getCookiePath($sPath)
+    protected function _getCookiePath($sPath) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         if ($aCookiePaths = $this->getConfig()->getConfigParam('aCookiePaths')) {
             // in case user wants to have shop specific setup
@@ -195,7 +196,7 @@ class UtilsServer extends \OxidEsales\Eshop\Core\Base
      *
      * @return string
      */
-    protected function _getCookieDomain($sDomain)
+    protected function _getCookieDomain($sDomain) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $sDomain = $sDomain ? $sDomain : "";
 
@@ -355,7 +356,7 @@ class UtilsServer extends \OxidEsales\Eshop\Core\Base
     public function isTrustedClientIp()
     {
         $blTrusted = false;
-        $aTrustedIPs = ( array ) $this->getConfig()->getConfigParam("aTrustedIPs");
+        $aTrustedIPs = (array) $this->getConfig()->getConfigParam("aTrustedIPs");
         if (count($aTrustedIPs)) {
             $blTrusted = in_array($this->getRemoteAddress(), $aTrustedIPs);
         }
@@ -406,17 +407,17 @@ class UtilsServer extends \OxidEsales\Eshop\Core\Base
     }
 
     /**
-      * Check if the given URL is same as used for request.
-      * The URL in this context is the base address for the shop e.g. https://www.domain.com/shop/
-      * the protocol is optional (www.domain.com/shop/)
-      * but the protocol relative syntax (//www.domain.com/shop/) is not yet supported.
-      *
-      * @param string $sURL        URL to check if is same as request.
-      * @param string $sServerHost request host.
-      *
-      * @return bool true if $sURL is equal to current page URL
-      */
-    public function _isCurrentUrl($sURL, $sServerHost)
+     * Check if the given URL is same as used for request.
+     * The URL in this context is the base address for the shop e.g. https://www.domain.com/shop/
+     * the protocol is optional (www.domain.com/shop/)
+     * but the protocol relative syntax (//www.domain.com/shop/) is not yet supported.
+     *
+     * @param string $sURL        URL to check if is same as request.
+     * @param string $sServerHost request host.
+     *
+     * @return bool true if $sURL is equal to current page URL
+     */
+    public function _isCurrentUrl($sURL, $sServerHost) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         // #4010: force_sid added in https to every link
         preg_match("/^(https?:\/\/)?(www\.)?([^\/]+)/i", $sURL, $matches);

--- a/source/Core/UtilsString.php
+++ b/source/Core/UtilsString.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Core/UtilsUrl.php
+++ b/source/Core/UtilsUrl.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
@@ -126,7 +127,8 @@ class UtilsUrl extends \OxidEsales\Eshop\Core\Base
         if (!\OxidEsales\Eshop\Core\Registry::getUtils()->seoIsActive()) {
             // non seo url has no language identifier..
             $iLang = \OxidEsales\Eshop\Core\Registry::getLang()->getBaseLanguage();
-            if (!$oStr->preg_match('/[&?](amp;)?lang=[0-9]+/i', $sUrl) &&
+            if (
+                !$oStr->preg_match('/[&?](amp;)?lang=[0-9]+/i', $sUrl) &&
                 $iLang != $oConfig->getConfigParam('sDefaultLang')
             ) {
                 $sUrl .= "{$sSep}lang=" . $iLang;
@@ -445,7 +447,8 @@ class UtilsUrl extends \OxidEsales\Eshop\Core\Base
 
         $sProtocol = "http://";
 
-        if (isset($aServerParams['HTTPS']) && (($aServerParams['HTTPS'] == 'on' || $aServerParams['HTTPS'] == 1))
+        if (
+            isset($aServerParams['HTTPS']) && (($aServerParams['HTTPS'] == 'on' || $aServerParams['HTTPS'] == 1))
             || (isset($aServerParams['HTTP_X_FORWARDED_PROTO']) && $aServerParams['HTTP_X_FORWARDED_PROTO'] == 'https')
         ) {
             $sProtocol = 'https://';
@@ -497,7 +500,7 @@ class UtilsUrl extends \OxidEsales\Eshop\Core\Base
      * @param string $sUrl   url to extract
      * @param array  $aHosts hosts array
      */
-    protected function _addHost($sUrl, &$aHosts)
+    protected function _addHost($sUrl, &$aHosts) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         if ($sUrl && ($sHost = @parse_url($sUrl, PHP_URL_HOST))) {
             if (!in_array($sHost, $aHosts)) {
@@ -512,7 +515,7 @@ class UtilsUrl extends \OxidEsales\Eshop\Core\Base
      * @param array $aLanguageUrls array of language urls to extract
      * @param array $aHosts        hosts array
      */
-    protected function _addLanguageHost($aLanguageUrls, &$aHosts)
+    protected function _addLanguageHost($aLanguageUrls, &$aHosts) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $iLanguageId = \OxidEsales\Eshop\Core\Registry::getLang()->getBaseLanguage();
 
@@ -526,7 +529,7 @@ class UtilsUrl extends \OxidEsales\Eshop\Core\Base
      *
      * @return array
      */
-    protected function _getHosts()
+    protected function _getHosts() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         if ($this->_aHosts === null) {
             $this->_aHosts = [];
@@ -555,7 +558,7 @@ class UtilsUrl extends \OxidEsales\Eshop\Core\Base
      *
      * @param array $aHosts hosts array
      */
-    protected function _addMallHosts(&$aHosts)
+    protected function _addMallHosts(&$aHosts) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
     }
 

--- a/source/Core/UtilsView.php
+++ b/source/Core/UtilsView.php
@@ -1,8 +1,10 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
 namespace OxidEsales\EshopCommunity\Core;
 
 use oxException;
@@ -224,7 +226,7 @@ class UtilsView extends \OxidEsales\Eshop\Core\Base
      *
      * @return string
      */
-    public function getRenderedContent(string $description, array $context, string $oxid = null) : string
+    public function getRenderedContent(string $description, array $context, string $oxid = null): string
     {
         if (\OxidEsales\Eshop\Core\Registry::getConfig()->isDemoShop()) {
             return $description;
@@ -362,7 +364,7 @@ class UtilsView extends \OxidEsales\Eshop\Core\Base
      *
      * @param Smarty $smarty template processor object (smarty)
      */
-    protected function _fillCommonSmartyProperties($smarty)
+    protected function _fillCommonSmartyProperties($smarty) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $config = $this->getConfig();
         $smarty->left_delimiter = '[{';
@@ -465,7 +467,7 @@ class UtilsView extends \OxidEsales\Eshop\Core\Base
      *
      * @param object $smarty template processor object (smarty)
      */
-    protected function _smartyCompileCheck($smarty)
+    protected function _smartyCompileCheck($smarty) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $config = $this->getConfig();
         $smarty->compile_check = $config->getConfigParam('blCheckTemplates');
@@ -488,7 +490,7 @@ class UtilsView extends \OxidEsales\Eshop\Core\Base
      *
      * @return bool
      */
-    public function _smartyDefaultTemplateHandler($resourceType, $resourceName, &$resourceContent, &$resourceTimestamp, $smarty)
+    public function _smartyDefaultTemplateHandler($resourceType, $resourceName, &$resourceContent, &$resourceTimestamp, $smarty) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $config = \OxidEsales\Eshop\Core\Registry::getConfig();
         if ($resourceType == 'file' && !is_readable($resourceName)) {
@@ -515,7 +517,7 @@ class UtilsView extends \OxidEsales\Eshop\Core\Base
      *
      * @return string
      */
-    protected function _getTemplateBlock($moduleId, $fileName)
+    protected function _getTemplateBlock($moduleId, $fileName) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $pathFormatter = oxNew(ModuleTemplateBlockPathFormatter::class);
         $pathFormatter->setModulesPath($this->getConfig()->getModulesDir());
@@ -574,7 +576,7 @@ class UtilsView extends \OxidEsales\Eshop\Core\Base
      *
      * @return array
      */
-    protected function _getActiveModuleInfo()
+    protected function _getActiveModuleInfo() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         if ($this->_aActiveModuleInfo === null) {
             $modulelist = oxNew(\OxidEsales\Eshop\Core\Module\ModuleList::class);
@@ -723,7 +725,8 @@ class UtilsView extends \OxidEsales\Eshop\Core\Base
     {
         $templateBlocks = [];
         foreach ($activeBlockTemplates as $activeBlockTemplate) {
-            if (!in_array($this->prepareBlockKey($activeBlockTemplate), $templateBlocksToExchange['theme'])
+            if (
+                !in_array($this->prepareBlockKey($activeBlockTemplate), $templateBlocksToExchange['theme'])
                 || $activeBlockTemplate['OXTHEME']
             ) {
                 $templateBlocks[] = $activeBlockTemplate;
@@ -747,7 +750,8 @@ class UtilsView extends \OxidEsales\Eshop\Core\Base
         $templateBlocks = [];
         $customThemeId = $this->getConfig()->getConfigParam('sCustomTheme');
         foreach ($activeBlockTemplates as $activeBlockTemplate) {
-            if (!in_array($this->prepareBlockKey($activeBlockTemplate), $templateBlocksToExchange['custom_theme'])
+            if (
+                !in_array($this->prepareBlockKey($activeBlockTemplate), $templateBlocksToExchange['custom_theme'])
                 || $activeBlockTemplate['OXTHEME'] === $customThemeId
             ) {
                 $templateBlocks[] = $activeBlockTemplate;

--- a/source/Core/UtilsXml.php
+++ b/source/Core/UtilsXml.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Core/ViewConfig.php
+++ b/source/Core/ViewConfig.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
@@ -189,7 +190,7 @@ class ViewConfig extends \OxidEsales\Eshop\Core\Base
      *
      * @return array
      */
-    protected function _getHelpContentIdents()
+    protected function _getHelpContentIdents() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $sClass = $this->getActiveClassName();
 
@@ -835,7 +836,8 @@ class ViewConfig extends \OxidEsales\Eshop\Core\Base
         $myConfig = $this->getConfig();
         $blShowCompareList = true;
 
-        if (!$myConfig->getConfigParam('bl_showCompareList') ||
+        if (
+            !$myConfig->getConfigParam('bl_showCompareList') ||
             ($myConfig->getConfigParam('blDisableNavBars') && $myConfig->getActiveView()->getIsOrderStep())
         ) {
             $blShowCompareList = false;
@@ -1211,7 +1213,7 @@ class ViewConfig extends \OxidEsales\Eshop\Core\Base
                 $shopUrl = $c->getConfigParam('sAdminSSLURL');
                 if ($shopUrl) {
                     // but we don't need the admin directory
-                    $adminDir = '/'.$c->getConfigParam('sAdminDir');
+                    $adminDir = '/' . $c->getConfigParam('sAdminDir');
                     $shopUrl = substr($shopUrl, 0, -strlen($adminDir));
                 } else {
                     // if no sAdminSSLURL directive were defined we use sSSLShopURL config directive instead
@@ -1398,7 +1400,7 @@ class ViewConfig extends \OxidEsales\Eshop\Core\Base
      *
      * @return bool
      */
-    private function _moduleExists($sModuleId, $aModuleVersions)
+    private function _moduleExists($sModuleId, $aModuleVersions) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         return (in_array($sModuleId, array_keys($aModuleVersions)));
     }
@@ -1431,7 +1433,7 @@ class ViewConfig extends \OxidEsales\Eshop\Core\Base
      *
      * @return bool
      */
-    private function _isModuleVersionCorrect($sModuleId, $sVersionFrom, $sVersionTo)
+    private function _isModuleVersionCorrect($sModuleId, $sVersionFrom, $sVersionTo) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $blModuleIsActive = true;
 

--- a/source/Core/ViewHelper/JavaScriptRegistrator.php
+++ b/source/Core/ViewHelper/JavaScriptRegistrator.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Core/ViewHelper/JavaScriptRenderer.php
+++ b/source/Core/ViewHelper/JavaScriptRenderer.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Core/ViewHelper/StyleRegistrator.php
+++ b/source/Core/ViewHelper/StyleRegistrator.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Core/ViewHelper/StyleRenderer.php
+++ b/source/Core/ViewHelper/StyleRenderer.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Core/WidgetControl.php
+++ b/source/Core/WidgetControl.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
@@ -70,7 +71,7 @@ class WidgetControl extends \OxidEsales\Eshop\Core\ShopControl
     /**
      * Runs actions that should be performed at the controller finish.
      */
-    protected function _runLast()
+    protected function _runLast() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $oConfig = $this->getConfig();
 
@@ -100,7 +101,7 @@ class WidgetControl extends \OxidEsales\Eshop\Core\ShopControl
      *
      * @return \OxidEsales\Eshop\Core\Controller\BaseController Current active view
      */
-    protected function _initializeViewObject($class, $function, $parameters = null, $viewsChain = null)
+    protected function _initializeViewObject($class, $function, $parameters = null, $viewsChain = null) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $config = $this->getConfig();
         $activeViewsIds = $config->getActiveViewsIds();

--- a/source/Core/utils/oxpicgenerator.php
+++ b/source/Core/utils/oxpicgenerator.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Internal/Container/BootstrapContainerBuilder.php
+++ b/source/Internal/Container/BootstrapContainerBuilder.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Container;
 

--- a/source/Internal/Container/BootstrapContainerFactory.php
+++ b/source/Internal/Container/BootstrapContainerFactory.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Container;
 

--- a/source/Internal/Container/ContainerBuilderFactory.php
+++ b/source/Internal/Container/ContainerBuilderFactory.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Container;
 

--- a/source/Internal/Container/ContainerFactory.php
+++ b/source/Internal/Container/ContainerFactory.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Container;
 

--- a/source/Internal/Container/Event/ConfigurationChangedEventSubscriber.php
+++ b/source/Internal/Container/Event/ConfigurationChangedEventSubscriber.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Container\Event;
 

--- a/source/Internal/Domain/Authentication/Bridge/PasswordServiceBridge.php
+++ b/source/Internal/Domain/Authentication/Bridge/PasswordServiceBridge.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Domain\Authentication\Bridge;
 

--- a/source/Internal/Domain/Authentication/Bridge/PasswordServiceBridgeInterface.php
+++ b/source/Internal/Domain/Authentication/Bridge/PasswordServiceBridgeInterface.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Domain\Authentication\Bridge;
 

--- a/source/Internal/Domain/Authentication/Exception/PasswordHashException.php
+++ b/source/Internal/Domain/Authentication/Exception/PasswordHashException.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Domain\Authentication\Exception;
 

--- a/source/Internal/Domain/Authentication/Exception/PasswordPolicyException.php
+++ b/source/Internal/Domain/Authentication/Exception/PasswordPolicyException.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Domain\Authentication\Exception;
 

--- a/source/Internal/Domain/Authentication/Exception/UnavailablePasswordHashException.php
+++ b/source/Internal/Domain/Authentication/Exception/UnavailablePasswordHashException.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Domain\Authentication\Exception;
 

--- a/source/Internal/Domain/Authentication/Policy/PasswordPolicy.php
+++ b/source/Internal/Domain/Authentication/Policy/PasswordPolicy.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Domain\Authentication\Policy;
 

--- a/source/Internal/Domain/Authentication/Policy/PasswordPolicyInterface.php
+++ b/source/Internal/Domain/Authentication/Policy/PasswordPolicyInterface.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Domain\Authentication\Policy;
 

--- a/source/Internal/Domain/Authentication/Service/Argon2IPasswordHashService.php
+++ b/source/Internal/Domain/Authentication/Service/Argon2IPasswordHashService.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Domain\Authentication\Service;
 
@@ -98,7 +101,7 @@ class Argon2IPasswordHashService implements PasswordHashServiceInterface
     /**
      * @return array
      */
-    private function getOptions() : array
+    private function getOptions(): array
     {
         return [
                 'memory_cost' => $this->memoryCost,

--- a/source/Internal/Domain/Authentication/Service/BcryptPasswordHashService.php
+++ b/source/Internal/Domain/Authentication/Service/BcryptPasswordHashService.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Domain\Authentication\Service;
 
@@ -84,7 +87,7 @@ class BcryptPasswordHashService implements PasswordHashServiceInterface
     /**
      * @return array
      */
-    private function getOptions() : array
+    private function getOptions(): array
     {
         return ['cost' => $this->cost];
     }

--- a/source/Internal/Domain/Authentication/Service/PasswordHashServiceInterface.php
+++ b/source/Internal/Domain/Authentication/Service/PasswordHashServiceInterface.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Domain\Authentication\Service;
 

--- a/source/Internal/Domain/Authentication/Service/PasswordVerificationService.php
+++ b/source/Internal/Domain/Authentication/Service/PasswordVerificationService.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Domain\Authentication\Service;
 

--- a/source/Internal/Domain/Authentication/Service/PasswordVerificationServiceInterface.php
+++ b/source/Internal/Domain/Authentication/Service/PasswordVerificationServiceInterface.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Domain\Authentication\Service;
 

--- a/source/Internal/Domain/Contact/Form/ContactFormBridge.php
+++ b/source/Internal/Domain/Contact/Form/ContactFormBridge.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Domain\Contact\Form;
 

--- a/source/Internal/Domain/Contact/Form/ContactFormBridgeInterface.php
+++ b/source/Internal/Domain/Contact/Form/ContactFormBridgeInterface.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Domain\Contact\Form;
 

--- a/source/Internal/Domain/Contact/Form/ContactFormConfigurationFactory.php
+++ b/source/Internal/Domain/Contact/Form/ContactFormConfigurationFactory.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Domain\Contact\Form;
 

--- a/source/Internal/Domain/Contact/Form/ContactFormEmailValidator.php
+++ b/source/Internal/Domain/Contact/Form/ContactFormEmailValidator.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Domain\Contact\Form;
 

--- a/source/Internal/Domain/Contact/Form/ContactFormFactory.php
+++ b/source/Internal/Domain/Contact/Form/ContactFormFactory.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Domain\Contact\Form;
 
@@ -39,9 +42,9 @@ class ContactFormFactory implements FormFactoryInterface
      * @param FormValidatorInterface     $requiredFieldsValidator
      */
     public function __construct(
-        FormConfigurationInterface  $contactFormConfiguration,
-        FormValidatorInterface      $contactFormEmailValidator,
-        FormValidatorInterface      $requiredFieldsValidator
+        FormConfigurationInterface $contactFormConfiguration,
+        FormValidatorInterface $contactFormEmailValidator,
+        FormValidatorInterface $requiredFieldsValidator
     ) {
         $this->contactFormConfiguration = $contactFormConfiguration;
         $this->contactFormEmailValidator = $contactFormEmailValidator;

--- a/source/Internal/Domain/Contact/Form/ContactFormFieldsConfigurationDataProvider.php
+++ b/source/Internal/Domain/Contact/Form/ContactFormFieldsConfigurationDataProvider.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Domain\Contact\Form;
 

--- a/source/Internal/Domain/Contact/Form/ContactFormMessageBuilder.php
+++ b/source/Internal/Domain/Contact/Form/ContactFormMessageBuilder.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Domain\Contact\Form;
 
@@ -46,7 +49,7 @@ class ContactFormMessageBuilder implements ContactFormMessageBuilderInterface
             $message .= $form->lastName->getValue() . ' ';
         }
 
-        $message .= '(' .$form->email->getValue() . ')<br /><br />';
+        $message .= '(' . $form->email->getValue() . ')<br /><br />';
 
         if ($form->message->getValue()) {
             $message .= nl2br($form->message->getValue());

--- a/source/Internal/Domain/Contact/Form/ContactFormMessageBuilderInterface.php
+++ b/source/Internal/Domain/Contact/Form/ContactFormMessageBuilderInterface.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Domain\Contact\Form;
 

--- a/source/Internal/Domain/Review/Bridge/ProductRatingBridge.php
+++ b/source/Internal/Domain/Review/Bridge/ProductRatingBridge.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Domain\Review\Bridge;
 

--- a/source/Internal/Domain/Review/Bridge/ProductRatingBridgeInterface.php
+++ b/source/Internal/Domain/Review/Bridge/ProductRatingBridgeInterface.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Domain\Review\Bridge;
 

--- a/source/Internal/Domain/Review/Bridge/UserRatingBridge.php
+++ b/source/Internal/Domain/Review/Bridge/UserRatingBridge.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Domain\Review\Bridge;
 

--- a/source/Internal/Domain/Review/Bridge/UserRatingBridgeInterface.php
+++ b/source/Internal/Domain/Review/Bridge/UserRatingBridgeInterface.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Domain\Review\Bridge;
 

--- a/source/Internal/Domain/Review/Bridge/UserReviewAndRatingBridge.php
+++ b/source/Internal/Domain/Review/Bridge/UserReviewAndRatingBridge.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Domain\Review\Bridge;
 

--- a/source/Internal/Domain/Review/Bridge/UserReviewAndRatingBridgeInterface.php
+++ b/source/Internal/Domain/Review/Bridge/UserReviewAndRatingBridgeInterface.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Domain\Review\Bridge;
 

--- a/source/Internal/Domain/Review/Bridge/UserReviewBridge.php
+++ b/source/Internal/Domain/Review/Bridge/UserReviewBridge.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Domain\Review\Bridge;
 

--- a/source/Internal/Domain/Review/Bridge/UserReviewBridgeInterface.php
+++ b/source/Internal/Domain/Review/Bridge/UserReviewBridgeInterface.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Domain\Review\Bridge;
 

--- a/source/Internal/Domain/Review/Dao/ProductRatingDao.php
+++ b/source/Internal/Domain/Review/Dao/ProductRatingDao.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Domain\Review\Dao;
 
@@ -29,8 +32,8 @@ class ProductRatingDao implements ProductRatingDaoInterface
      * @param ProductRatingDataMapperInterface $productRatingMapper
      */
     public function __construct(
-        QueryBuilderFactoryInterface    $queryBuilderFactory,
-        ProductRatingDataMapperInterface           $productRatingMapper
+        QueryBuilderFactoryInterface $queryBuilderFactory,
+        ProductRatingDataMapperInterface $productRatingMapper
     ) {
         $this->queryBuilderFactory = $queryBuilderFactory;
         $this->productRatingMapper = $productRatingMapper;

--- a/source/Internal/Domain/Review/Dao/ProductRatingDaoInterface.php
+++ b/source/Internal/Domain/Review/Dao/ProductRatingDaoInterface.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Domain\Review\Dao;
 

--- a/source/Internal/Domain/Review/Dao/RatingDao.php
+++ b/source/Internal/Domain/Review/Dao/RatingDao.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Domain\Review\Dao;
 
@@ -28,8 +31,8 @@ class RatingDao implements RatingDaoInterface
      * @param RatingDataMapperInterface    $ratingDataMapper
      */
     public function __construct(
-        QueryBuilderFactoryInterface    $queryBuilderFactory,
-        RatingDataMapperInterface           $ratingDataMapper
+        QueryBuilderFactoryInterface $queryBuilderFactory,
+        RatingDataMapperInterface $ratingDataMapper
     ) {
         $this->queryBuilderFactory = $queryBuilderFactory;
         $this->ratingDataMapper = $ratingDataMapper;

--- a/source/Internal/Domain/Review/Dao/RatingDaoInterface.php
+++ b/source/Internal/Domain/Review/Dao/RatingDaoInterface.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Domain\Review\Dao;
 

--- a/source/Internal/Domain/Review/Dao/ReviewDao.php
+++ b/source/Internal/Domain/Review/Dao/ReviewDao.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Domain\Review\Dao;
 
@@ -28,8 +31,8 @@ class ReviewDao implements ReviewDaoInterface
      * @param ReviewDataMapperInterface    $reviewDataMapper
      */
     public function __construct(
-        QueryBuilderFactoryInterface    $queryBuilderFactory,
-        ReviewDataMapperInterface           $reviewDataMapper
+        QueryBuilderFactoryInterface $queryBuilderFactory,
+        ReviewDataMapperInterface $reviewDataMapper
     ) {
         $this->queryBuilderFactory = $queryBuilderFactory;
         $this->reviewDataMapper = $reviewDataMapper;

--- a/source/Internal/Domain/Review/Dao/ReviewDaoInterface.php
+++ b/source/Internal/Domain/Review/Dao/ReviewDaoInterface.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Domain\Review\Dao;
 

--- a/source/Internal/Domain/Review/DataMapper/ProductRatingDataMapper.php
+++ b/source/Internal/Domain/Review/DataMapper/ProductRatingDataMapper.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Domain\Review\DataMapper;
 

--- a/source/Internal/Domain/Review/DataMapper/ProductRatingDataMapperInterface.php
+++ b/source/Internal/Domain/Review/DataMapper/ProductRatingDataMapperInterface.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Domain\Review\DataMapper;
 

--- a/source/Internal/Domain/Review/DataMapper/RatingDataMapper.php
+++ b/source/Internal/Domain/Review/DataMapper/RatingDataMapper.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Domain\Review\DataMapper;
 

--- a/source/Internal/Domain/Review/DataMapper/RatingDataMapperInterface.php
+++ b/source/Internal/Domain/Review/DataMapper/RatingDataMapperInterface.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Domain\Review\DataMapper;
 

--- a/source/Internal/Domain/Review/DataMapper/ReviewDataMapper.php
+++ b/source/Internal/Domain/Review/DataMapper/ReviewDataMapper.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Domain\Review\DataMapper;
 

--- a/source/Internal/Domain/Review/DataMapper/ReviewDataMapperInterface.php
+++ b/source/Internal/Domain/Review/DataMapper/ReviewDataMapperInterface.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Domain\Review\DataMapper;
 

--- a/source/Internal/Domain/Review/DataObject/ProductRating.php
+++ b/source/Internal/Domain/Review/DataObject/ProductRating.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Domain\Review\DataObject;
 

--- a/source/Internal/Domain/Review/DataObject/Rating.php
+++ b/source/Internal/Domain/Review/DataObject/Rating.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Domain\Review\DataObject;
 

--- a/source/Internal/Domain/Review/DataObject/Review.php
+++ b/source/Internal/Domain/Review/DataObject/Review.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Domain\Review\DataObject;
 

--- a/source/Internal/Domain/Review/Exception/RatingPermissionException.php
+++ b/source/Internal/Domain/Review/Exception/RatingPermissionException.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Domain\Review\Exception;
 

--- a/source/Internal/Domain/Review/Exception/ReviewAndRatingObjectTypeException.php
+++ b/source/Internal/Domain/Review/Exception/ReviewAndRatingObjectTypeException.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Domain\Review\Exception;
 

--- a/source/Internal/Domain/Review/Exception/ReviewPermissionException.php
+++ b/source/Internal/Domain/Review/Exception/ReviewPermissionException.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Domain\Review\Exception;
 

--- a/source/Internal/Domain/Review/Service/ProductRatingService.php
+++ b/source/Internal/Domain/Review/Service/ProductRatingService.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Domain\Review\Service;
 
@@ -34,9 +37,9 @@ class ProductRatingService implements ProductRatingServiceInterface
      * @param RatingCalculatorServiceInterface $ratingCalculator
      */
     public function __construct(
-        RatingDaoInterface                  $ratingDao,
-        ProductRatingDaoInterface           $productRatingDao,
-        RatingCalculatorServiceInterface    $ratingCalculator
+        RatingDaoInterface $ratingDao,
+        ProductRatingDaoInterface $productRatingDao,
+        RatingCalculatorServiceInterface $ratingCalculator
     ) {
         $this->ratingDao = $ratingDao;
         $this->productRatingDao = $productRatingDao;

--- a/source/Internal/Domain/Review/Service/ProductRatingServiceInterface.php
+++ b/source/Internal/Domain/Review/Service/ProductRatingServiceInterface.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Domain\Review\Service;
 

--- a/source/Internal/Domain/Review/Service/RatingCalculatorService.php
+++ b/source/Internal/Domain/Review/Service/RatingCalculatorService.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Domain\Review\Service;
 

--- a/source/Internal/Domain/Review/Service/RatingCalculatorServiceInterface.php
+++ b/source/Internal/Domain/Review/Service/RatingCalculatorServiceInterface.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Domain\Review\Service;
 

--- a/source/Internal/Domain/Review/Service/ReviewAndRatingMergingService.php
+++ b/source/Internal/Domain/Review/Service/ReviewAndRatingMergingService.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Domain\Review\Service;
 

--- a/source/Internal/Domain/Review/Service/ReviewAndRatingMergingServiceInterface.php
+++ b/source/Internal/Domain/Review/Service/ReviewAndRatingMergingServiceInterface.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Domain\Review\Service;
 

--- a/source/Internal/Domain/Review/Service/UserRatingService.php
+++ b/source/Internal/Domain/Review/Service/UserRatingService.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Domain\Review\Service;
 

--- a/source/Internal/Domain/Review/Service/UserRatingServiceInterface.php
+++ b/source/Internal/Domain/Review/Service/UserRatingServiceInterface.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Domain\Review\Service;
 

--- a/source/Internal/Domain/Review/Service/UserReviewAndRatingService.php
+++ b/source/Internal/Domain/Review/Service/UserReviewAndRatingService.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Domain\Review\Service;
 
@@ -34,9 +37,9 @@ class UserReviewAndRatingService implements UserReviewAndRatingServiceInterface
      * @param ReviewAndRatingMergingServiceInterface $reviewAndRatingMergingService
      */
     public function __construct(
-        UserReviewServiceInterface              $userReviewService,
-        UserRatingServiceInterface              $userRatingService,
-        ReviewAndRatingMergingServiceInterface  $reviewAndRatingMergingService
+        UserReviewServiceInterface $userReviewService,
+        UserRatingServiceInterface $userRatingService,
+        ReviewAndRatingMergingServiceInterface $reviewAndRatingMergingService
     ) {
         $this->userReviewService = $userReviewService;
         $this->userRatingService = $userRatingService;

--- a/source/Internal/Domain/Review/Service/UserReviewAndRatingServiceInterface.php
+++ b/source/Internal/Domain/Review/Service/UserReviewAndRatingServiceInterface.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Domain\Review\Service;
 

--- a/source/Internal/Domain/Review/Service/UserReviewService.php
+++ b/source/Internal/Domain/Review/Service/UserReviewService.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Domain\Review\Service;
 

--- a/source/Internal/Domain/Review/Service/UserReviewServiceInterface.php
+++ b/source/Internal/Domain/Review/Service/UserReviewServiceInterface.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Domain\Review\Service;
 

--- a/source/Internal/Domain/Review/ViewDataObject/ReviewAndRating.php
+++ b/source/Internal/Domain/Review/ViewDataObject/ReviewAndRating.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Domain\Review\ViewDataObject;
 

--- a/source/Internal/Framework/Config/Dao/ShopConfigurationSettingDao.php
+++ b/source/Internal/Framework/Config/Dao/ShopConfigurationSettingDao.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Framework\Config\Dao;
 
@@ -50,11 +53,11 @@ class ShopConfigurationSettingDao implements ShopConfigurationSettingDaoInterfac
      * @param EventDispatcherInterface     $eventDispatcher
      */
     public function __construct(
-        QueryBuilderFactoryInterface    $queryBuilderFactory,
-        ContextInterface                $context,
-        ShopSettingEncoderInterface     $shopSettingEncoder,
-        ShopAdapterInterface            $shopAdapter,
-        EventDispatcherInterface        $eventDispatcher
+        QueryBuilderFactoryInterface $queryBuilderFactory,
+        ContextInterface $context,
+        ShopSettingEncoderInterface $shopSettingEncoder,
+        ShopAdapterInterface $shopAdapter,
+        EventDispatcherInterface $eventDispatcher
     ) {
         $this->queryBuilderFactory = $queryBuilderFactory;
         $this->context = $context;

--- a/source/Internal/Framework/Config/Dao/ShopConfigurationSettingDaoInterface.php
+++ b/source/Internal/Framework/Config/Dao/ShopConfigurationSettingDaoInterface.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Framework\Config\Dao;
 

--- a/source/Internal/Framework/Config/DataObject/ShopConfigurationSetting.php
+++ b/source/Internal/Framework/Config/DataObject/ShopConfigurationSetting.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Framework\Config\DataObject;
 

--- a/source/Internal/Framework/Config/DataObject/ShopSettingType.php
+++ b/source/Internal/Framework/Config/DataObject/ShopSettingType.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Framework\Config\DataObject;
 

--- a/source/Internal/Framework/Config/Event/ShopConfigurationChangedEvent.php
+++ b/source/Internal/Framework/Config/Event/ShopConfigurationChangedEvent.php
@@ -1,10 +1,12 @@
 <?php
-declare(strict_types=1);
 
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
+
 namespace OxidEsales\EshopCommunity\Internal\Framework\Config\Event;
 
 use Symfony\Component\EventDispatcher\Event;

--- a/source/Internal/Framework/Config/Exception/InvalidShopSettingValueException.php
+++ b/source/Internal/Framework/Config/Exception/InvalidShopSettingValueException.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Framework\Config\Exception;
 

--- a/source/Internal/Framework/Config/Utility/ShopSettingEncoder.php
+++ b/source/Internal/Framework/Config/Utility/ShopSettingEncoder.php
@@ -1,13 +1,17 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
 
+declare(strict_types=1);
+
 namespace OxidEsales\EshopCommunity\Internal\Framework\Config\Utility;
 
 use OxidEsales\EshopCommunity\Internal\Framework\Config\DataObject\ShopSettingType;
 use OxidEsales\EshopCommunity\Internal\Framework\Config\Exception\InvalidShopSettingValueException;
+
 use function unserialize;
 use function serialize;
 

--- a/source/Internal/Framework/Config/Utility/ShopSettingEncoderInterface.php
+++ b/source/Internal/Framework/Config/Utility/ShopSettingEncoderInterface.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Framework\Config\Utility;
 

--- a/source/Internal/Framework/Console/AbstractShopAwareCommand.php
+++ b/source/Internal/Framework/Console/AbstractShopAwareCommand.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Framework\Console;
 

--- a/source/Internal/Framework/Console/CommandsProvider/CommandsProviderInterface.php
+++ b/source/Internal/Framework/Console/CommandsProvider/CommandsProviderInterface.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Framework\Console\CommandsProvider;
 

--- a/source/Internal/Framework/Console/CommandsProvider/ServicesCommandsProvider.php
+++ b/source/Internal/Framework/Console/CommandsProvider/ServicesCommandsProvider.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Framework\Console\CommandsProvider;
 

--- a/source/Internal/Framework/Console/Executor.php
+++ b/source/Internal/Framework/Console/Executor.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Framework\Console;
 

--- a/source/Internal/Framework/Console/ExecutorInterface.php
+++ b/source/Internal/Framework/Console/ExecutorInterface.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Framework\Console;
 

--- a/source/Internal/Framework/DIContainer/ContainerBuilder.php
+++ b/source/Internal/Framework/DIContainer/ContainerBuilder.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Framework\DIContainer;
 

--- a/source/Internal/Framework/DIContainer/Dao/ContainerAwareProjectYamlDao.php
+++ b/source/Internal/Framework/DIContainer/Dao/ContainerAwareProjectYamlDao.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Framework\DIContainer\Dao;
 

--- a/source/Internal/Framework/DIContainer/Dao/ProjectYamlDao.php
+++ b/source/Internal/Framework/DIContainer/Dao/ProjectYamlDao.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Framework\DIContainer\Dao;
 

--- a/source/Internal/Framework/DIContainer/Dao/ProjectYamlDaoInterface.php
+++ b/source/Internal/Framework/DIContainer/Dao/ProjectYamlDaoInterface.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Framework\DIContainer\Dao;
 

--- a/source/Internal/Framework/DIContainer/DataObject/DICallWrapper.php
+++ b/source/Internal/Framework/DIContainer/DataObject/DICallWrapper.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Framework\DIContainer\DataObject;
 

--- a/source/Internal/Framework/DIContainer/DataObject/DIConfigWrapper.php
+++ b/source/Internal/Framework/DIContainer/DataObject/DIConfigWrapper.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Framework\DIContainer\DataObject;
 
@@ -230,8 +233,10 @@ class DIConfigWrapper
     {
         $sections = [$this::IMPORTS_SECTION, $this::SERVICE_SECTION];
         foreach ($sections as $section) {
-            if (array_key_exists($section, $this->configArray) &&
-                (!$this->configArray[$section] || !count($this->configArray[$section]))) {
+            if (
+                array_key_exists($section, $this->configArray) &&
+                (!$this->configArray[$section] || !count($this->configArray[$section]))
+            ) {
                 unset($this->configArray[$section]);
             }
         }

--- a/source/Internal/Framework/DIContainer/DataObject/DIServiceWrapper.php
+++ b/source/Internal/Framework/DIContainer/DataObject/DIServiceWrapper.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Framework\DIContainer\DataObject;
 

--- a/source/Internal/Framework/DIContainer/Event/ProjectYamlChangedEvent.php
+++ b/source/Internal/Framework/DIContainer/Event/ProjectYamlChangedEvent.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Framework\DIContainer\Event;
 

--- a/source/Internal/Framework/DIContainer/Exception/MissingServiceException.php
+++ b/source/Internal/Framework/DIContainer/Exception/MissingServiceException.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Framework\DIContainer\Exception;
 

--- a/source/Internal/Framework/DIContainer/Exception/MissingUpdateCallException.php
+++ b/source/Internal/Framework/DIContainer/Exception/MissingUpdateCallException.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Framework\DIContainer\Exception;
 

--- a/source/Internal/Framework/DIContainer/Exception/NoServiceYamlException.php
+++ b/source/Internal/Framework/DIContainer/Exception/NoServiceYamlException.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Framework\DIContainer\Exception;
 

--- a/source/Internal/Framework/DIContainer/Exception/SystemServiceOverwriteException.php
+++ b/source/Internal/Framework/DIContainer/Exception/SystemServiceOverwriteException.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Framework\DIContainer\Exception;
 

--- a/source/Internal/Framework/DIContainer/Service/ProjectYamlImportService.php
+++ b/source/Internal/Framework/DIContainer/Service/ProjectYamlImportService.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Framework\DIContainer\Service;
 

--- a/source/Internal/Framework/DIContainer/Service/ProjectYamlImportServiceInterface.php
+++ b/source/Internal/Framework/DIContainer/Service/ProjectYamlImportServiceInterface.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Framework\DIContainer\Service;
 

--- a/source/Internal/Framework/DIContainer/Service/ShopStateService.php
+++ b/source/Internal/Framework/DIContainer/Service/ShopStateService.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Framework\DIContainer\Service;
 

--- a/source/Internal/Framework/DIContainer/Service/ShopStateServiceInterface.php
+++ b/source/Internal/Framework/DIContainer/Service/ShopStateServiceInterface.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Framework\DIContainer\Service;
 

--- a/source/Internal/Framework/Dao/EntryDoesNotExistDaoException.php
+++ b/source/Internal/Framework/Dao/EntryDoesNotExistDaoException.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Framework\Dao;
 

--- a/source/Internal/Framework/Dao/InvalidObjectIdDaoException.php
+++ b/source/Internal/Framework/Dao/InvalidObjectIdDaoException.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Framework\Dao;
 

--- a/source/Internal/Framework/Database/ConnectionFactory.php
+++ b/source/Internal/Framework/Database/ConnectionFactory.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Framework\Database;
 

--- a/source/Internal/Framework/Database/Logger/DatabaseLoggerFactory.php
+++ b/source/Internal/Framework/Database/Logger/DatabaseLoggerFactory.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Framework\Database\Logger;
 

--- a/source/Internal/Framework/Database/Logger/DatabaseLoggerFactoryInterface.php
+++ b/source/Internal/Framework/Database/Logger/DatabaseLoggerFactoryInterface.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Framework\Database\Logger;
 

--- a/source/Internal/Framework/Database/Logger/NullLogger.php
+++ b/source/Internal/Framework/Database/Logger/NullLogger.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Framework\Database\Logger;
 

--- a/source/Internal/Framework/Database/Logger/QueryFilter.php
+++ b/source/Internal/Framework/Database/Logger/QueryFilter.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Framework\Database\Logger;
 

--- a/source/Internal/Framework/Database/Logger/QueryFilterInterface.php
+++ b/source/Internal/Framework/Database/Logger/QueryFilterInterface.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Framework\Database\Logger;
 

--- a/source/Internal/Framework/Database/Logger/QueryLogger.php
+++ b/source/Internal/Framework/Database/Logger/QueryLogger.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Framework\Database\Logger;
 
@@ -82,8 +85,9 @@ class QueryLogger implements SQLLogger
     {
         $queryTraceItem = [];
 
-        foreach ((new \Exception)->getTrace() as $item) {
-            if ((false === stripos($item['class'], get_class($this))) &&
+        foreach ((new \Exception())->getTrace() as $item) {
+            if (
+                (false === stripos($item['class'], get_class($this))) &&
                 (false === stripos($item['class'], 'Doctrine'))
             ) {
                 $queryTraceItem = $item;

--- a/source/Internal/Framework/Database/QueryBuilderFactory.php
+++ b/source/Internal/Framework/Database/QueryBuilderFactory.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Framework\Database;
 

--- a/source/Internal/Framework/Database/QueryBuilderFactoryInterface.php
+++ b/source/Internal/Framework/Database/QueryBuilderFactoryInterface.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Framework\Database;
 

--- a/source/Internal/Framework/Database/TransactionService.php
+++ b/source/Internal/Framework/Database/TransactionService.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Framework\Database;
 

--- a/source/Internal/Framework/Database/TransactionServiceInterface.php
+++ b/source/Internal/Framework/Database/TransactionServiceInterface.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Framework\Database;
 

--- a/source/Internal/Framework/Event/AbstractShopAwareEventSubscriber.php
+++ b/source/Internal/Framework/Event/AbstractShopAwareEventSubscriber.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Framework\Event;
 

--- a/source/Internal/Framework/Event/ShopAwareEventDispatcher.php
+++ b/source/Internal/Framework/Event/ShopAwareEventDispatcher.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Framework\Event;
 
@@ -22,10 +25,12 @@ class ShopAwareEventDispatcher extends EventDispatcher
             if ($event->isPropagationStopped()) {
                 break;
             }
-            if (is_array($listener) &&
+            if (
+                is_array($listener) &&
                 is_object($listener[0]) &&
                 in_array(ShopAwareInterface::class, class_implements($listener[0])) &&
-                ! $listener[0]->isActive()) {
+                ! $listener[0]->isActive()
+            ) {
                 continue;
             }
             call_user_func($listener, $event, $eventName, $this);

--- a/source/Internal/Framework/Event/ShopAwareInterface.php
+++ b/source/Internal/Framework/Event/ShopAwareInterface.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Framework\Event;
 

--- a/source/Internal/Framework/Event/ShopAwareServiceTrait.php
+++ b/source/Internal/Framework/Event/ShopAwareServiceTrait.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Framework\Event;
 

--- a/source/Internal/Framework/FileSystem/DirectoryNotExistentException.php
+++ b/source/Internal/Framework/FileSystem/DirectoryNotExistentException.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Framework\FileSystem;
 

--- a/source/Internal/Framework/FileSystem/DirectoryNotReadableException.php
+++ b/source/Internal/Framework/FileSystem/DirectoryNotReadableException.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Framework\FileSystem;
 

--- a/source/Internal/Framework/FileSystem/FinderFactory.php
+++ b/source/Internal/Framework/FileSystem/FinderFactory.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Framework\FileSystem;
 

--- a/source/Internal/Framework/FileSystem/FinderFactoryInterface.php
+++ b/source/Internal/Framework/FileSystem/FinderFactoryInterface.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Framework\FileSystem;
 

--- a/source/Internal/Framework/Form/Form.php
+++ b/source/Internal/Framework/Form/Form.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Framework\Form;
 

--- a/source/Internal/Framework/Form/FormFactoryInterface.php
+++ b/source/Internal/Framework/Form/FormFactoryInterface.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Framework\Form;
 

--- a/source/Internal/Framework/Form/FormField.php
+++ b/source/Internal/Framework/Form/FormField.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Framework\Form;
 

--- a/source/Internal/Framework/Form/FormFieldInterface.php
+++ b/source/Internal/Framework/Form/FormFieldInterface.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Framework\Form;
 

--- a/source/Internal/Framework/Form/FormInterface.php
+++ b/source/Internal/Framework/Form/FormInterface.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Framework\Form;
 

--- a/source/Internal/Framework/Form/FormValidatorInterface.php
+++ b/source/Internal/Framework/Form/FormValidatorInterface.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Framework\Form;
 

--- a/source/Internal/Framework/Form/RequiredFieldsValidator.php
+++ b/source/Internal/Framework/Form/RequiredFieldsValidator.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Framework\Form;
 

--- a/source/Internal/Framework/FormConfiguration/FieldConfiguration.php
+++ b/source/Internal/Framework/FormConfiguration/FieldConfiguration.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Framework\FormConfiguration;
 

--- a/source/Internal/Framework/FormConfiguration/FieldConfigurationInterface.php
+++ b/source/Internal/Framework/FormConfiguration/FieldConfigurationInterface.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Framework\FormConfiguration;
 

--- a/source/Internal/Framework/FormConfiguration/FormConfiguration.php
+++ b/source/Internal/Framework/FormConfiguration/FormConfiguration.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Framework\FormConfiguration;
 

--- a/source/Internal/Framework/FormConfiguration/FormConfigurationFactoryInterface.php
+++ b/source/Internal/Framework/FormConfiguration/FormConfigurationFactoryInterface.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Framework\FormConfiguration;
 

--- a/source/Internal/Framework/FormConfiguration/FormConfigurationInterface.php
+++ b/source/Internal/Framework/FormConfiguration/FormConfigurationInterface.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Framework\FormConfiguration;
 

--- a/source/Internal/Framework/FormConfiguration/FormFieldsConfigurationDataProviderInterface.php
+++ b/source/Internal/Framework/FormConfiguration/FormFieldsConfigurationDataProviderInterface.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Framework\FormConfiguration;
 

--- a/source/Internal/Framework/Logger/Configuration/MonologConfiguration.php
+++ b/source/Internal/Framework/Logger/Configuration/MonologConfiguration.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Framework\Logger\Configuration;
 

--- a/source/Internal/Framework/Logger/Configuration/MonologConfigurationInterface.php
+++ b/source/Internal/Framework/Logger/Configuration/MonologConfigurationInterface.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Framework\Logger\Configuration;
 

--- a/source/Internal/Framework/Logger/Configuration/PsrLoggerConfigurationInterface.php
+++ b/source/Internal/Framework/Logger/Configuration/PsrLoggerConfigurationInterface.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Framework\Logger\Configuration;
 

--- a/source/Internal/Framework/Logger/Factory/LoggerFactoryInterface.php
+++ b/source/Internal/Framework/Logger/Factory/LoggerFactoryInterface.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Framework\Logger\Factory;
 

--- a/source/Internal/Framework/Logger/Factory/MonologLoggerFactory.php
+++ b/source/Internal/Framework/Logger/Factory/MonologLoggerFactory.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Framework\Logger\Factory;
 

--- a/source/Internal/Framework/Logger/LoggerServiceFactory.php
+++ b/source/Internal/Framework/Logger/LoggerServiceFactory.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Framework\Logger;
 

--- a/source/Internal/Framework/Logger/Validator/LoggerConfigurationValidatorInterface.php
+++ b/source/Internal/Framework/Logger/Validator/LoggerConfigurationValidatorInterface.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Framework\Logger\Validator;
 

--- a/source/Internal/Framework/Logger/Validator/PsrLoggerConfigurationValidator.php
+++ b/source/Internal/Framework/Logger/Validator/PsrLoggerConfigurationValidator.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Framework\Logger\Validator;
 

--- a/source/Internal/Framework/Logger/Wrapper/LoggerWrapper.php
+++ b/source/Internal/Framework/Logger/Wrapper/LoggerWrapper.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Framework\Logger\Wrapper;
 

--- a/source/Internal/Framework/Module/Cache/InvalidateModuleCacheEventSubscriber.php
+++ b/source/Internal/Framework/Module/Cache/InvalidateModuleCacheEventSubscriber.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Framework\Module\Cache;
 

--- a/source/Internal/Framework/Module/Cache/ModuleCacheServiceInterface.php
+++ b/source/Internal/Framework/Module/Cache/ModuleCacheServiceInterface.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Framework\Module\Cache;
 

--- a/source/Internal/Framework/Module/Cache/ShopModuleCacheService.php
+++ b/source/Internal/Framework/Module/Cache/ShopModuleCacheService.php
@@ -1,9 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
 
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Framework\Module\Cache;
 

--- a/source/Internal/Framework/Module/Command/ApplyModulesConfigurationCommand.php
+++ b/source/Internal/Framework/Module/Command/ApplyModulesConfigurationCommand.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Framework\Module\Command;
 
@@ -99,7 +102,8 @@ class ApplyModulesConfigurationCommand extends Command
 
     private function deactivateNotConfiguredActivateModules(ModuleConfiguration $moduleConfiguration, int $shopId): void
     {
-        if ($moduleConfiguration->isConfigured() === false
+        if (
+            $moduleConfiguration->isConfigured() === false
             && $this->moduleStateService->isActive($moduleConfiguration->getId(), $shopId)
         ) {
             $this->moduleActivationService->deactivate($moduleConfiguration->getId(), $shopId);
@@ -108,7 +112,8 @@ class ApplyModulesConfigurationCommand extends Command
 
     private function reactivateConfiguredActiveModules(ModuleConfiguration $moduleConfiguration, int $shopId): void
     {
-        if ($moduleConfiguration->isConfigured() === true
+        if (
+            $moduleConfiguration->isConfigured() === true
             && $this->moduleStateService->isActive($moduleConfiguration->getId(), $shopId) === true
         ) {
             $this->moduleActivationService->deactivate($moduleConfiguration->getId(), $shopId);
@@ -118,7 +123,8 @@ class ApplyModulesConfigurationCommand extends Command
 
     private function activateConfiguredNotActiveModules(ModuleConfiguration $moduleConfiguration, int $shopId): void
     {
-        if ($moduleConfiguration->isConfigured() === true
+        if (
+            $moduleConfiguration->isConfigured() === true
             && $this->moduleStateService->isActive($moduleConfiguration->getId(), $shopId) === false
         ) {
             $this->moduleActivationService->activate($moduleConfiguration->getId(), $shopId);

--- a/source/Internal/Framework/Module/Command/InstallModuleConfigurationCommand.php
+++ b/source/Internal/Framework/Module/Command/InstallModuleConfigurationCommand.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Framework\Module\Command;
 

--- a/source/Internal/Framework/Module/Command/ModuleActivateCommand.php
+++ b/source/Internal/Framework/Module/Command/ModuleActivateCommand.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Framework\Module\Command;
 
@@ -81,7 +84,7 @@ class ModuleActivateCommand extends Command
         if ($this->isInstalled($moduleId)) {
             $this->activateModule($output, $moduleId);
         } else {
-            $output->writeLn('<error>'.sprintf(static::MESSAGE_MODULE_NOT_FOUND, $moduleId).'</error>');
+            $output->writeLn('<error>' . sprintf(static::MESSAGE_MODULE_NOT_FOUND, $moduleId) . '</error>');
         }
     }
 
@@ -93,10 +96,10 @@ class ModuleActivateCommand extends Command
     {
         try {
             $this->moduleActivationService->activate($moduleId, $this->context->getCurrentShopId());
-            $output->writeLn('<info>'.sprintf(static::MESSAGE_MODULE_ACTIVATED, $moduleId).'</info>');
+            $output->writeLn('<info>' . sprintf(static::MESSAGE_MODULE_ACTIVATED, $moduleId) . '</info>');
         } catch (ModuleSetupException $exception) {
             $output->writeLn(
-                '<info>'.sprintf(static::MESSAGE_MODULE_ALREADY_ACTIVE, $moduleId).'</info>'
+                '<info>' . sprintf(static::MESSAGE_MODULE_ALREADY_ACTIVE, $moduleId) . '</info>'
             );
         }
     }

--- a/source/Internal/Framework/Module/Command/ModuleDeactivateCommand.php
+++ b/source/Internal/Framework/Module/Command/ModuleDeactivateCommand.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Framework\Module\Command;
 
@@ -82,7 +85,7 @@ class ModuleDeactivateCommand extends Command
         if ($this->isInstalled($moduleId)) {
             $this->deactivateModule($output, $moduleId);
         } else {
-            $output->writeLn('<error>'.sprintf(static::MESSAGE_MODULE_NOT_FOUND, $moduleId).'</error>');
+            $output->writeLn('<error>' . sprintf(static::MESSAGE_MODULE_NOT_FOUND, $moduleId) . '</error>');
         }
     }
 

--- a/source/Internal/Framework/Module/Command/ModuleTargetPathIsMissingException.php
+++ b/source/Internal/Framework/Module/Command/ModuleTargetPathIsMissingException.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Framework\Module\Command;
 

--- a/source/Internal/Framework/Module/Configuration/Bridge/ModuleConfigurationDaoBridge.php
+++ b/source/Internal/Framework/Module/Configuration/Bridge/ModuleConfigurationDaoBridge.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Framework\Module\Configuration\Bridge;
 

--- a/source/Internal/Framework/Module/Configuration/Bridge/ModuleConfigurationDaoBridgeInterface.php
+++ b/source/Internal/Framework/Module/Configuration/Bridge/ModuleConfigurationDaoBridgeInterface.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Framework\Module\Configuration\Bridge;
 

--- a/source/Internal/Framework/Module/Configuration/Bridge/ModuleSettingBridge.php
+++ b/source/Internal/Framework/Module/Configuration/Bridge/ModuleSettingBridge.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Framework\Module\Configuration\Bridge;
 

--- a/source/Internal/Framework/Module/Configuration/Bridge/ModuleSettingBridgeInterface.php
+++ b/source/Internal/Framework/Module/Configuration/Bridge/ModuleSettingBridgeInterface.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Framework\Module\Configuration\Bridge;
 

--- a/source/Internal/Framework/Module/Configuration/Bridge/ShopConfigurationDaoBridge.php
+++ b/source/Internal/Framework/Module/Configuration/Bridge/ShopConfigurationDaoBridge.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Framework\Module\Configuration\Bridge;
 

--- a/source/Internal/Framework/Module/Configuration/Bridge/ShopConfigurationDaoBridgeInterface.php
+++ b/source/Internal/Framework/Module/Configuration/Bridge/ShopConfigurationDaoBridgeInterface.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Framework\Module\Configuration\Bridge;
 

--- a/source/Internal/Framework/Module/Configuration/Cache/ClassPropertyShopConfigurationCache.php
+++ b/source/Internal/Framework/Module/Configuration/Cache/ClassPropertyShopConfigurationCache.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Framework\Module\Configuration\Cache;
 

--- a/source/Internal/Framework/Module/Configuration/Cache/ShopConfigurationCacheInterface.php
+++ b/source/Internal/Framework/Module/Configuration/Cache/ShopConfigurationCacheInterface.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Framework\Module\Configuration\Cache;
 

--- a/source/Internal/Framework/Module/Configuration/Dao/ModuleConfigurationDao.php
+++ b/source/Internal/Framework/Module/Configuration/Dao/ModuleConfigurationDao.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Framework\Module\Configuration\Dao;
 

--- a/source/Internal/Framework/Module/Configuration/Dao/ModuleConfigurationDaoInterface.php
+++ b/source/Internal/Framework/Module/Configuration/Dao/ModuleConfigurationDaoInterface.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Framework\Module\Configuration\Dao;
 

--- a/source/Internal/Framework/Module/Configuration/Dao/ProjectConfigurationDao.php
+++ b/source/Internal/Framework/Module/Configuration/Dao/ProjectConfigurationDao.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Framework\Module\Configuration\Dao;
 

--- a/source/Internal/Framework/Module/Configuration/Dao/ProjectConfigurationDaoInterface.php
+++ b/source/Internal/Framework/Module/Configuration/Dao/ProjectConfigurationDaoInterface.php
@@ -1,12 +1,15 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
 
+declare(strict_types=1);
+
 namespace OxidEsales\EshopCommunity\Internal\Framework\Module\Configuration\Dao;
 
-use \OxidEsales\EshopCommunity\Internal\Framework\Module\Configuration\DataObject\ProjectConfiguration;
+use OxidEsales\EshopCommunity\Internal\Framework\Module\Configuration\DataObject\ProjectConfiguration;
 
 interface ProjectConfigurationDaoInterface
 {

--- a/source/Internal/Framework/Module/Configuration/Dao/ShopConfigurationDao.php
+++ b/source/Internal/Framework/Module/Configuration/Dao/ShopConfigurationDao.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Framework\Module\Configuration\Dao;
 

--- a/source/Internal/Framework/Module/Configuration/Dao/ShopConfigurationDaoInterface.php
+++ b/source/Internal/Framework/Module/Configuration/Dao/ShopConfigurationDaoInterface.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Framework\Module\Configuration\Dao;
 

--- a/source/Internal/Framework/Module/Configuration/Dao/ShopEnvironmentConfigurationDao.php
+++ b/source/Internal/Framework/Module/Configuration/Dao/ShopEnvironmentConfigurationDao.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Framework\Module\Configuration\Dao;
 

--- a/source/Internal/Framework/Module/Configuration/Dao/ShopEnvironmentConfigurationDaoInterface.php
+++ b/source/Internal/Framework/Module/Configuration/Dao/ShopEnvironmentConfigurationDaoInterface.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Framework\Module\Configuration\Dao;
 

--- a/source/Internal/Framework/Module/Configuration/DataMapper/ModuleConfiguration/ClassExtensionsDataMapper.php
+++ b/source/Internal/Framework/Module/Configuration/DataMapper/ModuleConfiguration/ClassExtensionsDataMapper.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Framework\Module\Configuration\DataMapper\ModuleConfiguration;
 
@@ -44,7 +47,7 @@ class ClassExtensionsDataMapper implements ModuleConfigurationDataMapperInterfac
         return $extensions;
     }
 
-    private function setClassExtensions(ModuleConfiguration $moduleConfiguration, array $extensions) : void
+    private function setClassExtensions(ModuleConfiguration $moduleConfiguration, array $extensions): void
     {
         foreach ($extensions as $shopClass => $moduleClass) {
             $moduleConfiguration->addClassExtension(new ClassExtension(

--- a/source/Internal/Framework/Module/Configuration/DataMapper/ModuleConfiguration/ClassesWithoutNamespaceDataMapper.php
+++ b/source/Internal/Framework/Module/Configuration/DataMapper/ModuleConfiguration/ClassesWithoutNamespaceDataMapper.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Framework\Module\Configuration\DataMapper\ModuleConfiguration;
 

--- a/source/Internal/Framework/Module/Configuration/DataMapper/ModuleConfiguration/ControllersDataMapper.php
+++ b/source/Internal/Framework/Module/Configuration/DataMapper/ModuleConfiguration/ControllersDataMapper.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Framework\Module\Configuration\DataMapper\ModuleConfiguration;
 
@@ -38,7 +41,7 @@ class ControllersDataMapper implements ModuleConfigurationDataMapperInterface
      * @param ModuleConfiguration $moduleConfiguration
      * @param array               $controllers
      */
-    private function setControllers(ModuleConfiguration $moduleConfiguration, array $controllers) : void
+    private function setControllers(ModuleConfiguration $moduleConfiguration, array $controllers): void
     {
         foreach ($controllers as $id => $controllerClassNamespace) {
             $moduleConfiguration->addController(new Controller(

--- a/source/Internal/Framework/Module/Configuration/DataMapper/ModuleConfiguration/EventsDataMapper.php
+++ b/source/Internal/Framework/Module/Configuration/DataMapper/ModuleConfiguration/EventsDataMapper.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Framework\Module\Configuration\DataMapper\ModuleConfiguration;
 

--- a/source/Internal/Framework/Module/Configuration/DataMapper/ModuleConfiguration/ModuleSettingsDataMapper.php
+++ b/source/Internal/Framework/Module/Configuration/DataMapper/ModuleConfiguration/ModuleSettingsDataMapper.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Framework\Module\Configuration\DataMapper\ModuleConfiguration;
 

--- a/source/Internal/Framework/Module/Configuration/DataMapper/ModuleConfiguration/SmartyPluginDirectoriesDataMapper.php
+++ b/source/Internal/Framework/Module/Configuration/DataMapper/ModuleConfiguration/SmartyPluginDirectoriesDataMapper.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Framework\Module\Configuration\DataMapper\ModuleConfiguration;
 

--- a/source/Internal/Framework/Module/Configuration/DataMapper/ModuleConfiguration/TemplateBlocksDataMapper.php
+++ b/source/Internal/Framework/Module/Configuration/DataMapper/ModuleConfiguration/TemplateBlocksDataMapper.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Framework\Module\Configuration\DataMapper\ModuleConfiguration;
 

--- a/source/Internal/Framework/Module/Configuration/DataMapper/ModuleConfiguration/TemplateBlocksMappingKeys.php
+++ b/source/Internal/Framework/Module/Configuration/DataMapper/ModuleConfiguration/TemplateBlocksMappingKeys.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Framework\Module\Configuration\DataMapper\ModuleConfiguration;
 

--- a/source/Internal/Framework/Module/Configuration/DataMapper/ModuleConfiguration/TemplatesDataMapper.php
+++ b/source/Internal/Framework/Module/Configuration/DataMapper/ModuleConfiguration/TemplatesDataMapper.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Framework\Module\Configuration\DataMapper\ModuleConfiguration;
 

--- a/source/Internal/Framework/Module/Configuration/DataMapper/ModuleConfigurationDataMapper.php
+++ b/source/Internal/Framework/Module/Configuration/DataMapper/ModuleConfigurationDataMapper.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Framework\Module\Configuration\DataMapper;
 

--- a/source/Internal/Framework/Module/Configuration/DataMapper/ModuleConfigurationDataMapperInterface.php
+++ b/source/Internal/Framework/Module/Configuration/DataMapper/ModuleConfigurationDataMapperInterface.php
@@ -1,9 +1,11 @@
-<?php declare(strict_types=1);
+<?php
 
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Framework\Module\Configuration\DataMapper;
 

--- a/source/Internal/Framework/Module/Configuration/DataMapper/ProjectConfigurationDataMapper.php
+++ b/source/Internal/Framework/Module/Configuration/DataMapper/ProjectConfigurationDataMapper.php
@@ -1,9 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
 
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Framework\Module\Configuration\DataMapper;
 

--- a/source/Internal/Framework/Module/Configuration/DataMapper/ProjectConfigurationDataMapperInterface.php
+++ b/source/Internal/Framework/Module/Configuration/DataMapper/ProjectConfigurationDataMapperInterface.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Internal/Framework/Module/Configuration/DataMapper/ShopConfigurationDataMapper.php
+++ b/source/Internal/Framework/Module/Configuration/DataMapper/ShopConfigurationDataMapper.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Framework\Module\Configuration\DataMapper;
 
@@ -63,7 +66,7 @@ class ShopConfigurationDataMapper implements ShopConfigurationDataMapperInterfac
      * @param ShopConfiguration $shopConfiguration
      * @param array             $modulesData
      */
-    private function setModulesConfiguration(ShopConfiguration $shopConfiguration, array $modulesData) : void
+    private function setModulesConfiguration(ShopConfiguration $shopConfiguration, array $modulesData): void
     {
         foreach ($modulesData as $moduleId => $moduleData) {
             $moduleConfiguration = new ModuleConfiguration();
@@ -93,7 +96,7 @@ class ShopConfigurationDataMapper implements ShopConfigurationDataMapperInterfac
      * @param ShopConfiguration $shopConfiguration
      * @param array             $chainsData
      */
-    private function setModuleChains(ShopConfiguration $shopConfiguration, array $chainsData) : void
+    private function setModuleChains(ShopConfiguration $shopConfiguration, array $chainsData): void
     {
         if (isset($chainsData[ClassExtensionsChain::NAME])) {
             $chain = new ClassExtensionsChain();

--- a/source/Internal/Framework/Module/Configuration/DataMapper/ShopConfigurationDataMapperInterface.php
+++ b/source/Internal/Framework/Module/Configuration/DataMapper/ShopConfigurationDataMapperInterface.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Framework\Module\Configuration\DataMapper;
 

--- a/source/Internal/Framework/Module/Configuration/DataObject/ClassExtensionsChain.php
+++ b/source/Internal/Framework/Module/Configuration/DataObject/ClassExtensionsChain.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Framework\Module\Configuration\DataObject;
 
@@ -49,7 +52,7 @@ class ClassExtensionsChain implements \IteratorAggregate
      *
      * @return void
      */
-    public function addExtensions(array $extensions) : void
+    public function addExtensions(array $extensions): void
     {
         foreach ($extensions as $extension) {
             $this->addExtension($extension);
@@ -66,8 +69,10 @@ class ClassExtensionsChain implements \IteratorAggregate
         $extended = $classExtension->getShopClassName();
         $extension = $classExtension->getModuleExtensionClassName();
         
-        if (false === array_key_exists($extended, $this->chain) ||
-            false === \array_search($extension, $this->chain[$extended], true)) {
+        if (
+            false === array_key_exists($extended, $this->chain) ||
+            false === \array_search($extension, $this->chain[$extended], true)
+        ) {
             throw new ExtensionNotInChainException(
                 'There is no class ' . $extended . ' extended by class ' .
                 $extension . ' in the current chain'

--- a/source/Internal/Framework/Module/Configuration/DataObject/ModuleConfiguration.php
+++ b/source/Internal/Framework/Module/Configuration/DataObject/ModuleConfiguration.php
@@ -7,12 +7,12 @@
 namespace OxidEsales\EshopCommunity\Internal\Framework\Module\Configuration\DataObject;
 
 use OxidEsales\EshopCommunity\Internal\Framework\Module\Configuration\DataObject\ModuleConfiguration\ClassExtension;
-use OxidEsales\EshopCommunity\Internal\Framework\Module\Configuration\DataObject\ModuleConfiguration\Template;
+use OxidEsales\EshopCommunity\Internal\Framework\Module\Configuration\DataObject\ModuleConfiguration\ClassWithoutNamespace;
 use OxidEsales\EshopCommunity\Internal\Framework\Module\Configuration\DataObject\ModuleConfiguration\Controller;
 use OxidEsales\EshopCommunity\Internal\Framework\Module\Configuration\DataObject\ModuleConfiguration\Event;
 use OxidEsales\EshopCommunity\Internal\Framework\Module\Configuration\DataObject\ModuleConfiguration\SmartyPluginDirectory;
+use OxidEsales\EshopCommunity\Internal\Framework\Module\Configuration\DataObject\ModuleConfiguration\Template;
 use OxidEsales\EshopCommunity\Internal\Framework\Module\Configuration\DataObject\ModuleConfiguration\TemplateBlock;
-use OxidEsales\EshopCommunity\Internal\Framework\Module\Configuration\DataObject\ModuleConfiguration\ClassWithoutNamespace;
 use OxidEsales\EshopCommunity\Internal\Framework\Module\Configuration\Exception\ModuleSettingNotFountException;
 use OxidEsales\EshopCommunity\Internal\Framework\Module\Setting\Setting;
 

--- a/source/Internal/Framework/Module/Configuration/DataObject/ModuleConfiguration.php
+++ b/source/Internal/Framework/Module/Configuration/DataObject/ModuleConfiguration.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Framework\Module\Configuration\DataObject;
 

--- a/source/Internal/Framework/Module/Configuration/DataObject/ModuleConfiguration/ClassExtension.php
+++ b/source/Internal/Framework/Module/Configuration/DataObject/ModuleConfiguration/ClassExtension.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Framework\Module\Configuration\DataObject\ModuleConfiguration;
 

--- a/source/Internal/Framework/Module/Configuration/DataObject/ModuleConfiguration/ClassWithoutNamespace.php
+++ b/source/Internal/Framework/Module/Configuration/DataObject/ModuleConfiguration/ClassWithoutNamespace.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Framework\Module\Configuration\DataObject\ModuleConfiguration;
 

--- a/source/Internal/Framework/Module/Configuration/DataObject/ModuleConfiguration/Controller.php
+++ b/source/Internal/Framework/Module/Configuration/DataObject/ModuleConfiguration/Controller.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Framework\Module\Configuration\DataObject\ModuleConfiguration;
 

--- a/source/Internal/Framework/Module/Configuration/DataObject/ModuleConfiguration/Event.php
+++ b/source/Internal/Framework/Module/Configuration/DataObject/ModuleConfiguration/Event.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Framework\Module\Configuration\DataObject\ModuleConfiguration;
 

--- a/source/Internal/Framework/Module/Configuration/DataObject/ModuleConfiguration/SmartyPluginDirectory.php
+++ b/source/Internal/Framework/Module/Configuration/DataObject/ModuleConfiguration/SmartyPluginDirectory.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Framework\Module\Configuration\DataObject\ModuleConfiguration;
 

--- a/source/Internal/Framework/Module/Configuration/DataObject/ModuleConfiguration/Template.php
+++ b/source/Internal/Framework/Module/Configuration/DataObject/ModuleConfiguration/Template.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Framework\Module\Configuration\DataObject\ModuleConfiguration;
 

--- a/source/Internal/Framework/Module/Configuration/DataObject/ModuleConfiguration/TemplateBlock.php
+++ b/source/Internal/Framework/Module/Configuration/DataObject/ModuleConfiguration/TemplateBlock.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Framework\Module\Configuration\DataObject\ModuleConfiguration;
 

--- a/source/Internal/Framework/Module/Configuration/DataObject/ProjectConfiguration.php
+++ b/source/Internal/Framework/Module/Configuration/DataObject/ProjectConfiguration.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types = 1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Framework\Module\Configuration\DataObject;
 
@@ -37,7 +40,7 @@ class ProjectConfiguration
     /**
      * @return array
      */
-    public function getShopConfigurationIds() :array
+    public function getShopConfigurationIds(): array
     {
         return array_keys($this->projectConfiguration);
     }

--- a/source/Internal/Framework/Module/Configuration/DataObject/ShopConfiguration.php
+++ b/source/Internal/Framework/Module/Configuration/DataObject/ShopConfiguration.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types = 1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Framework\Module\Configuration\DataObject;
 

--- a/source/Internal/Framework/Module/Configuration/Definition/TreeBuilderFactory.php
+++ b/source/Internal/Framework/Module/Configuration/Definition/TreeBuilderFactory.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Framework\Module\Configuration\Definition;
 

--- a/source/Internal/Framework/Module/Configuration/Definition/TreeBuilderFactoryInterface.php
+++ b/source/Internal/Framework/Module/Configuration/Definition/TreeBuilderFactoryInterface.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Framework\Module\Configuration\Definition;
 

--- a/source/Internal/Framework/Module/Configuration/Exception/ExtensionNotInChainException.php
+++ b/source/Internal/Framework/Module/Configuration/Exception/ExtensionNotInChainException.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Framework\Module\Configuration\Exception;
 

--- a/source/Internal/Framework/Module/Configuration/Exception/ModuleConfigurationNotFoundException.php
+++ b/source/Internal/Framework/Module/Configuration/Exception/ModuleConfigurationNotFoundException.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Framework\Module\Configuration\Exception;
 

--- a/source/Internal/Framework/Module/Configuration/Exception/ModuleSettingNotFountException.php
+++ b/source/Internal/Framework/Module/Configuration/Exception/ModuleSettingNotFountException.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Framework\Module\Configuration\Exception;
 

--- a/source/Internal/Framework/Module/Configuration/Exception/ProjectConfigurationIsEmptyException.php
+++ b/source/Internal/Framework/Module/Configuration/Exception/ProjectConfigurationIsEmptyException.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Framework\Module\Configuration\Exception;
 

--- a/source/Internal/Framework/Module/Configuration/Exception/ShopConfigurationNotFoundException.php
+++ b/source/Internal/Framework/Module/Configuration/Exception/ShopConfigurationNotFoundException.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Framework\Module\Configuration\Exception;
 

--- a/source/Internal/Framework/Module/Configuration/Service/ModuleClassExtensionsMergingService.php
+++ b/source/Internal/Framework/Module/Configuration/Service/ModuleClassExtensionsMergingService.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Framework\Module\Configuration\Service;
 

--- a/source/Internal/Framework/Module/Configuration/Service/ModuleClassExtensionsMergingServiceInterface.php
+++ b/source/Internal/Framework/Module/Configuration/Service/ModuleClassExtensionsMergingServiceInterface.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Framework\Module\Configuration\Service;
 

--- a/source/Internal/Framework/Module/Configuration/Service/ModuleConfigurationMergingServiceInterface.php
+++ b/source/Internal/Framework/Module/Configuration/Service/ModuleConfigurationMergingServiceInterface.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Framework\Module\Configuration\Service;
 

--- a/source/Internal/Framework/Module/Configuration/Service/SettingsMergingService.php
+++ b/source/Internal/Framework/Module/Configuration/Service/SettingsMergingService.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Framework\Module\Configuration\Service;
 
@@ -24,7 +27,8 @@ class SettingsMergingService implements SettingsMergingServiceInterface
     ): ModuleConfiguration {
         if ($shopConfiguration->hasModuleConfiguration($moduleConfigurationToMerge->getId())) {
             $existingModuleConfiguration = $shopConfiguration->getModuleConfiguration($moduleConfigurationToMerge->getId());
-            if (!empty($existingModuleConfiguration->getModuleSettings()) &&
+            if (
+                !empty($existingModuleConfiguration->getModuleSettings()) &&
                 !empty($moduleConfigurationToMerge->getModuleSettings())
             ) {
                 $mergedModuleSettings = $this->mergeModuleSettings(
@@ -67,9 +71,11 @@ class SettingsMergingService implements SettingsMergingServiceInterface
             $existingSetting->getName() === $settingToMerge->getName() &&
             $existingSetting->getType() === $settingToMerge->getType();
 
-        if ($shouldMerge === true
+        if (
+            $shouldMerge === true
             && !empty($settingToMerge->getConstraints())
-            && ($settingToMerge->getType() === 'select')) {
+            && ($settingToMerge->getType() === 'select')
+        ) {
             $resultPosition = array_search($existingSetting->getValue(), $settingToMerge->getConstraints(), true);
             $shouldMerge = $resultPosition !== false;
         }

--- a/source/Internal/Framework/Module/Configuration/Service/SettingsMergingServiceInterface.php
+++ b/source/Internal/Framework/Module/Configuration/Service/SettingsMergingServiceInterface.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Framework\Module\Configuration\Service;
 

--- a/source/Internal/Framework/Module/Install/DataObject/OxidEshopPackage.php
+++ b/source/Internal/Framework/Module/Install/DataObject/OxidEshopPackage.php
@@ -1,9 +1,11 @@
-<?php declare(strict_types=1);
+<?php
 
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Framework\Module\Install\DataObject;
 
@@ -59,7 +61,7 @@ class OxidEshopPackage
     /**
      * @return string
      */
-    public function getPackageSourcePath() : string
+    public function getPackageSourcePath(): string
     {
         return !empty($this->sourceDirectory)
             ? $this->packagePath . DIRECTORY_SEPARATOR . $this->sourceDirectory

--- a/source/Internal/Framework/Module/Install/Service/ModuleConfigurationInstaller.php
+++ b/source/Internal/Framework/Module/Install/Service/ModuleConfigurationInstaller.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Framework\Module\Install\Service;
 

--- a/source/Internal/Framework/Module/Install/Service/ModuleConfigurationInstallerInterface.php
+++ b/source/Internal/Framework/Module/Install/Service/ModuleConfigurationInstallerInterface.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Framework\Module\Install\Service;
 

--- a/source/Internal/Framework/Module/Install/Service/ModuleFilesInstaller.php
+++ b/source/Internal/Framework/Module/Install/Service/ModuleFilesInstaller.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Framework\Module\Install\Service;
 
@@ -131,7 +134,7 @@ class ModuleFilesInstaller implements ModuleFilesInstallerInterface
      *
      * @return string
      */
-    private function getTargetPath(OxidEshopPackage $package) : string
+    private function getTargetPath(OxidEshopPackage $package): string
     {
         $targetDirectory = $package->getTargetDirectory();
         return Path::join($this->context->getModulesPath(), $targetDirectory);

--- a/source/Internal/Framework/Module/Install/Service/ModuleFilesInstallerInterface.php
+++ b/source/Internal/Framework/Module/Install/Service/ModuleFilesInstallerInterface.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Framework\Module\Install\Service;
 

--- a/source/Internal/Framework/Module/Install/Service/ModuleInstaller.php
+++ b/source/Internal/Framework/Module/Install/Service/ModuleInstaller.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Framework\Module\Install\Service;
 

--- a/source/Internal/Framework/Module/Install/Service/ModuleInstallerInterface.php
+++ b/source/Internal/Framework/Module/Install/Service/ModuleInstallerInterface.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Framework\Module\Install\Service;
 

--- a/source/Internal/Framework/Module/Install/Service/ProjectConfigurationGenerator.php
+++ b/source/Internal/Framework/Module/Install/Service/ProjectConfigurationGenerator.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Framework\Module\Install\Service;
 

--- a/source/Internal/Framework/Module/Install/Service/ProjectConfigurationGeneratorInterface.php
+++ b/source/Internal/Framework/Module/Install/Service/ProjectConfigurationGeneratorInterface.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Framework\Module\Install\Service;
 

--- a/source/Internal/Framework/Module/MetaData/Converter/MetaDataConverterAggregate.php
+++ b/source/Internal/Framework/Module/MetaData/Converter/MetaDataConverterAggregate.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Framework\Module\MetaData\Converter;
 

--- a/source/Internal/Framework/Module/MetaData/Converter/MetaDataConverterInterface.php
+++ b/source/Internal/Framework/Module/MetaData/Converter/MetaDataConverterInterface.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Framework\Module\MetaData\Converter;
 

--- a/source/Internal/Framework/Module/MetaData/Converter/ModuleSettingsBooleanConverter.php
+++ b/source/Internal/Framework/Module/MetaData/Converter/ModuleSettingsBooleanConverter.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Framework\Module\MetaData\Converter;
 

--- a/source/Internal/Framework/Module/MetaData/DataMapper/MetaDataMapper.php
+++ b/source/Internal/Framework/Module/MetaData/DataMapper/MetaDataMapper.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Framework\Module\MetaData\DataMapper;
 

--- a/source/Internal/Framework/Module/MetaData/DataMapper/MetaDataMapper.php
+++ b/source/Internal/Framework/Module/MetaData/DataMapper/MetaDataMapper.php
@@ -8,17 +8,17 @@ namespace OxidEsales\EshopCommunity\Internal\Framework\Module\MetaData\DataMappe
 
 use OxidEsales\EshopCommunity\Internal\Framework\Module\Configuration\DataMapper\ModuleConfiguration\TemplateBlocksMappingKeys;
 use OxidEsales\EshopCommunity\Internal\Framework\Module\Configuration\DataObject\ModuleConfiguration;
-use OxidEsales\EshopCommunity\Internal\Framework\Module\Configuration\DataObject\ModuleConfiguration\TemplateBlock;
+use OxidEsales\EshopCommunity\Internal\Framework\Module\Configuration\DataObject\ModuleConfiguration\ClassExtension;
+use OxidEsales\EshopCommunity\Internal\Framework\Module\Configuration\DataObject\ModuleConfiguration\ClassWithoutNamespace;
+use OxidEsales\EshopCommunity\Internal\Framework\Module\Configuration\DataObject\ModuleConfiguration\Controller;
+use OxidEsales\EshopCommunity\Internal\Framework\Module\Configuration\DataObject\ModuleConfiguration\Event;
+use OxidEsales\EshopCommunity\Internal\Framework\Module\Configuration\DataObject\ModuleConfiguration\SmartyPluginDirectory;
 use OxidEsales\EshopCommunity\Internal\Framework\Module\Configuration\DataObject\ModuleConfiguration\Template;
+use OxidEsales\EshopCommunity\Internal\Framework\Module\Configuration\DataObject\ModuleConfiguration\TemplateBlock;
 use OxidEsales\EshopCommunity\Internal\Framework\Module\MetaData\Exception\UnsupportedMetaDataValueTypeException;
 use OxidEsales\EshopCommunity\Internal\Framework\Module\MetaData\Service\MetaDataProvider;
 use OxidEsales\EshopCommunity\Internal\Framework\Module\MetaData\Validator\MetaDataSchemaValidator;
 use OxidEsales\EshopCommunity\Internal\Framework\Module\MetaData\Validator\MetaDataSchemaValidatorInterface;
-use OxidEsales\EshopCommunity\Internal\Framework\Module\Configuration\DataObject\ModuleConfiguration\ClassExtension;
-use OxidEsales\EshopCommunity\Internal\Framework\Module\Configuration\DataObject\ModuleConfiguration\SmartyPluginDirectory;
-use OxidEsales\EshopCommunity\Internal\Framework\Module\Configuration\DataObject\ModuleConfiguration\Controller;
-use OxidEsales\EshopCommunity\Internal\Framework\Module\Configuration\DataObject\ModuleConfiguration\ClassWithoutNamespace;
-use OxidEsales\EshopCommunity\Internal\Framework\Module\Configuration\DataObject\ModuleConfiguration\Event;
 use OxidEsales\EshopCommunity\Internal\Framework\Module\Setting\Setting;
 
 class MetaDataMapper implements MetaDataToModuleConfigurationDataMapperInterface

--- a/source/Internal/Framework/Module/MetaData/DataMapper/MetaDataToModuleConfigurationDataMapperInterface.php
+++ b/source/Internal/Framework/Module/MetaData/DataMapper/MetaDataToModuleConfigurationDataMapperInterface.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Framework\Module\MetaData\DataMapper;
 

--- a/source/Internal/Framework/Module/MetaData/Exception/InvalidMetaDataException.php
+++ b/source/Internal/Framework/Module/MetaData/Exception/InvalidMetaDataException.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Framework\Module\MetaData\Exception;
 

--- a/source/Internal/Framework/Module/MetaData/Exception/MetaDataVersionException.php
+++ b/source/Internal/Framework/Module/MetaData/Exception/MetaDataVersionException.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Framework\Module\MetaData\Exception;
 

--- a/source/Internal/Framework/Module/MetaData/Exception/ModuleIdNotValidException.php
+++ b/source/Internal/Framework/Module/MetaData/Exception/ModuleIdNotValidException.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Framework\Module\MetaData\Exception;
 

--- a/source/Internal/Framework/Module/MetaData/Exception/SettingNotValidException.php
+++ b/source/Internal/Framework/Module/MetaData/Exception/SettingNotValidException.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Framework\Module\MetaData\Exception;
 

--- a/source/Internal/Framework/Module/MetaData/Exception/UnsupportedMetaDataKeyException.php
+++ b/source/Internal/Framework/Module/MetaData/Exception/UnsupportedMetaDataKeyException.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Framework\Module\MetaData\Exception;
 

--- a/source/Internal/Framework/Module/MetaData/Exception/UnsupportedMetaDataValueTypeException.php
+++ b/source/Internal/Framework/Module/MetaData/Exception/UnsupportedMetaDataValueTypeException.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Framework\Module\MetaData\Exception;
 

--- a/source/Internal/Framework/Module/MetaData/Exception/UnsupportedMetaDataVersionException.php
+++ b/source/Internal/Framework/Module/MetaData/Exception/UnsupportedMetaDataVersionException.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Framework\Module\MetaData\Exception;
 

--- a/source/Internal/Framework/Module/MetaData/Service/MetaDataNormalizer.php
+++ b/source/Internal/Framework/Module/MetaData/Service/MetaDataNormalizer.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Framework\Module\MetaData\Service;
 

--- a/source/Internal/Framework/Module/MetaData/Service/MetaDataNormalizerInterface.php
+++ b/source/Internal/Framework/Module/MetaData/Service/MetaDataNormalizerInterface.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Framework\Module\MetaData\Service;
 

--- a/source/Internal/Framework/Module/MetaData/Service/MetaDataProvider.php
+++ b/source/Internal/Framework/Module/MetaData/Service/MetaDataProvider.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Framework\Module\MetaData\Service;
 

--- a/source/Internal/Framework/Module/MetaData/Service/MetaDataProviderInterface.php
+++ b/source/Internal/Framework/Module/MetaData/Service/MetaDataProviderInterface.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Framework\Module\MetaData\Service;
 

--- a/source/Internal/Framework/Module/MetaData/Service/MetaDataSchemataProvider.php
+++ b/source/Internal/Framework/Module/MetaData/Service/MetaDataSchemataProvider.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Framework\Module\MetaData\Service;
 

--- a/source/Internal/Framework/Module/MetaData/Service/MetaDataSchemataProviderInterface.php
+++ b/source/Internal/Framework/Module/MetaData/Service/MetaDataSchemataProviderInterface.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Framework\Module\MetaData\Service;
 

--- a/source/Internal/Framework/Module/MetaData/Validator/MetaDataSchemaValidator.php
+++ b/source/Internal/Framework/Module/MetaData/Validator/MetaDataSchemaValidator.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Framework\Module\MetaData\Validator;
 

--- a/source/Internal/Framework/Module/MetaData/Validator/MetaDataSchemaValidatorInterface.php
+++ b/source/Internal/Framework/Module/MetaData/Validator/MetaDataSchemaValidatorInterface.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Framework\Module\MetaData\Validator;
 

--- a/source/Internal/Framework/Module/MetaData/Validator/MetaDataValidatorAggregate.php
+++ b/source/Internal/Framework/Module/MetaData/Validator/MetaDataValidatorAggregate.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Framework\Module\MetaData\Validator;
 

--- a/source/Internal/Framework/Module/MetaData/Validator/MetaDataValidatorInterface.php
+++ b/source/Internal/Framework/Module/MetaData/Validator/MetaDataValidatorInterface.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Framework\Module\MetaData\Validator;
 

--- a/source/Internal/Framework/Module/MetaData/Validator/ModuleIdValidator.php
+++ b/source/Internal/Framework/Module/MetaData/Validator/ModuleIdValidator.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Framework\Module\MetaData\Validator;
 

--- a/source/Internal/Framework/Module/MetaData/Validator/ModuleSettingBooleanValidator.php
+++ b/source/Internal/Framework/Module/MetaData/Validator/ModuleSettingBooleanValidator.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Framework\Module\MetaData\Validator;
 

--- a/source/Internal/Framework/Module/MetaData/Validator/SettingValidatorInterface.php
+++ b/source/Internal/Framework/Module/MetaData/Validator/SettingValidatorInterface.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Framework\Module\MetaData\Validator;
 

--- a/source/Internal/Framework/Module/Path/ModulePathResolver.php
+++ b/source/Internal/Framework/Module/Path/ModulePathResolver.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Framework\Module\Path;
 

--- a/source/Internal/Framework/Module/Path/ModulePathResolverInterface.php
+++ b/source/Internal/Framework/Module/Path/ModulePathResolverInterface.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Framework\Module\Path;
 

--- a/source/Internal/Framework/Module/Setting/Event/SettingChangedEvent.php
+++ b/source/Internal/Framework/Module/Setting/Event/SettingChangedEvent.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Framework\Module\Setting\Event;
 

--- a/source/Internal/Framework/Module/Setting/Setting.php
+++ b/source/Internal/Framework/Module/Setting/Setting.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Framework\Module\Setting;
 

--- a/source/Internal/Framework/Module/Setting/SettingDao.php
+++ b/source/Internal/Framework/Module/Setting/SettingDao.php
@@ -1,12 +1,13 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
 
-namespace OxidEsales\EshopCommunity\Internal\Framework\Module\Setting;
+declare(strict_types=1);
 
-use function is_string;
+namespace OxidEsales\EshopCommunity\Internal\Framework\Module\Setting;
 
 use OxidEsales\EshopCommunity\Internal\Framework\Config\Utility\ShopSettingEncoderInterface;
 use OxidEsales\EshopCommunity\Internal\Transition\Adapter\ShopAdapterInterface;
@@ -14,6 +15,8 @@ use OxidEsales\EshopCommunity\Internal\Framework\Database\QueryBuilderFactoryInt
 use OxidEsales\EshopCommunity\Internal\Framework\Database\TransactionServiceInterface;
 use OxidEsales\EshopCommunity\Internal\Framework\Dao\EntryDoesNotExistDaoException;
 use OxidEsales\EshopCommunity\Internal\Transition\Utility\ContextInterface;
+
+use function is_string;
 
 class SettingDao implements SettingDaoInterface
 {
@@ -50,11 +53,11 @@ class SettingDao implements SettingDaoInterface
      * @param TransactionServiceInterface  $transactionService
      */
     public function __construct(
-        QueryBuilderFactoryInterface    $queryBuilderFactory,
-        ContextInterface                $context,
-        ShopSettingEncoderInterface     $shopSettingEncoder,
-        ShopAdapterInterface            $shopAdapter,
-        TransactionServiceInterface     $transactionService
+        QueryBuilderFactoryInterface $queryBuilderFactory,
+        ContextInterface $context,
+        ShopSettingEncoderInterface $shopSettingEncoder,
+        ShopAdapterInterface $shopAdapter,
+        TransactionServiceInterface $transactionService
     ) {
         $this->queryBuilderFactory = $queryBuilderFactory;
         $this->context = $context;
@@ -126,7 +129,8 @@ class SettingDao implements SettingDaoInterface
             ->setValue($this->shopSettingEncoder->decode($settingsData['type'], $settingsData['value']))
             ->setType($settingsData['type']);
 
-        if (isset($settingsData['oxvarconstraint'])
+        if (
+            isset($settingsData['oxvarconstraint'])
             && is_string($settingsData['oxvarconstraint'])
             && $settingsData['oxvarconstraint'] !== ''
         ) {

--- a/source/Internal/Framework/Module/Setting/SettingDaoInterface.php
+++ b/source/Internal/Framework/Module/Setting/SettingDaoInterface.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Framework\Module\Setting;
 

--- a/source/Internal/Framework/Module/Setup/Bridge/ClassExtensionChainBridge.php
+++ b/source/Internal/Framework/Module/Setup/Bridge/ClassExtensionChainBridge.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Framework\Module\Setup\Bridge;
 

--- a/source/Internal/Framework/Module/Setup/Bridge/ClassExtensionChainBridgeInterface.php
+++ b/source/Internal/Framework/Module/Setup/Bridge/ClassExtensionChainBridgeInterface.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Framework\Module\Setup\Bridge;
 

--- a/source/Internal/Framework/Module/Setup/Bridge/ModuleActivationBridge.php
+++ b/source/Internal/Framework/Module/Setup/Bridge/ModuleActivationBridge.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Framework\Module\Setup\Bridge;
 
@@ -29,8 +32,8 @@ class ModuleActivationBridge implements ModuleActivationBridgeInterface
      * @param ModuleStateServiceInterface      $moduleStateService
      */
     public function __construct(
-        ModuleActivationServiceInterface    $moduleActivationService,
-        ModuleStateServiceInterface         $moduleStateService
+        ModuleActivationServiceInterface $moduleActivationService,
+        ModuleStateServiceInterface $moduleStateService
     ) {
         $this->moduleActivationService = $moduleActivationService;
         $this->moduleStateService = $moduleStateService;

--- a/source/Internal/Framework/Module/Setup/Bridge/ModuleActivationBridgeInterface.php
+++ b/source/Internal/Framework/Module/Setup/Bridge/ModuleActivationBridgeInterface.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Framework\Module\Setup\Bridge;
 

--- a/source/Internal/Framework/Module/Setup/Event/BeforeModuleDeactivationEvent.php
+++ b/source/Internal/Framework/Module/Setup/Event/BeforeModuleDeactivationEvent.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Framework\Module\Setup\Event;
 

--- a/source/Internal/Framework/Module/Setup/Event/FinalizingModuleActivationEvent.php
+++ b/source/Internal/Framework/Module/Setup/Event/FinalizingModuleActivationEvent.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Framework\Module\Setup\Event;
 

--- a/source/Internal/Framework/Module/Setup/Event/FinalizingModuleDeactivationEvent.php
+++ b/source/Internal/Framework/Module/Setup/Event/FinalizingModuleDeactivationEvent.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Framework\Module\Setup\Event;
 

--- a/source/Internal/Framework/Module/Setup/Event/ModuleSetupEvent.php
+++ b/source/Internal/Framework/Module/Setup/Event/ModuleSetupEvent.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Framework\Module\Setup\Event;
 
@@ -29,7 +32,7 @@ abstract class ModuleSetupEvent extends Event
     /**
      * @return string
      */
-    public function getModuleId():string
+    public function getModuleId(): string
     {
         return $this->moduleId;
     }

--- a/source/Internal/Framework/Module/Setup/Event/ServicesYamlConfigurationErrorEvent.php
+++ b/source/Internal/Framework/Module/Setup/Event/ServicesYamlConfigurationErrorEvent.php
@@ -1,9 +1,11 @@
-<?php declare(strict_types=1);
+<?php
 
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Framework\Module\Setup\Event;
 

--- a/source/Internal/Framework/Module/Setup/EventSubscriber/DispatchLegacyEventsSubscriber.php
+++ b/source/Internal/Framework/Module/Setup/EventSubscriber/DispatchLegacyEventsSubscriber.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Framework\Module\Setup\EventSubscriber;
 
@@ -70,7 +73,7 @@ class DispatchLegacyEventsSubscriber implements EventSubscriberInterface
         $moduleConfiguration = $this->moduleConfigurationDao->get($moduleId, $shopId);
 
         if ($moduleConfiguration->hasEvents()) {
-            $events =[];
+            $events = [];
 
             foreach ($moduleConfiguration->getEvents() as $event) {
                 $events[$event->getAction()] = $event->getMethod();
@@ -85,7 +88,7 @@ class DispatchLegacyEventsSubscriber implements EventSubscriberInterface
     /**
      * @return array
      */
-    public static function getSubscribedEvents() : array
+    public static function getSubscribedEvents(): array
     {
         return [
             FinalizingModuleActivationEvent::NAME   => 'executeMetadataOnActivationEvent',

--- a/source/Internal/Framework/Module/Setup/EventSubscriber/EventLoggingSubscriber.php
+++ b/source/Internal/Framework/Module/Setup/EventSubscriber/EventLoggingSubscriber.php
@@ -1,9 +1,11 @@
-<?php declare(strict_types=1);
+<?php
 
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Framework\Module\Setup\EventSubscriber;
 

--- a/source/Internal/Framework/Module/Setup/Exception/ControllersDuplicationModuleConfigurationException.php
+++ b/source/Internal/Framework/Module/Setup/Exception/ControllersDuplicationModuleConfigurationException.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Framework\Module\Setup\Exception;
 

--- a/source/Internal/Framework/Module/Setup/Exception/InvalidClassExtensionNamespaceException.php
+++ b/source/Internal/Framework/Module/Setup/Exception/InvalidClassExtensionNamespaceException.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Framework\Module\Setup\Exception;
 

--- a/source/Internal/Framework/Module/Setup/Exception/ModuleSettingHandlerNotFoundException.php
+++ b/source/Internal/Framework/Module/Setup/Exception/ModuleSettingHandlerNotFoundException.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Framework\Module\Setup\Exception;
 

--- a/source/Internal/Framework/Module/Setup/Exception/ModuleSettingNotValidException.php
+++ b/source/Internal/Framework/Module/Setup/Exception/ModuleSettingNotValidException.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Framework\Module\Setup\Exception;
 

--- a/source/Internal/Framework/Module/Setup/Exception/ModuleSetupException.php
+++ b/source/Internal/Framework/Module/Setup/Exception/ModuleSetupException.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Framework\Module\Setup\Exception;
 

--- a/source/Internal/Framework/Module/Setup/Exception/ModuleSetupValidationException.php
+++ b/source/Internal/Framework/Module/Setup/Exception/ModuleSetupValidationException.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Framework\Module\Setup\Exception;
 

--- a/source/Internal/Framework/Module/Setup/Exception/ServicesYamlConfigurationError.php
+++ b/source/Internal/Framework/Module/Setup/Exception/ServicesYamlConfigurationError.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Framework\Module\Setup\Exception;
 

--- a/source/Internal/Framework/Module/Setup/Handler/ModuleConfigurationHandlerInterface.php
+++ b/source/Internal/Framework/Module/Setup/Handler/ModuleConfigurationHandlerInterface.php
@@ -5,6 +5,8 @@
  * See LICENSE file for license details.
  */
 
+declare(strict_types=1);
+
 namespace OxidEsales\EshopCommunity\Internal\Framework\Module\Setup\Handler;
 
 use OxidEsales\EshopCommunity\Internal\Framework\Module\Configuration\DataObject\ModuleConfiguration;

--- a/source/Internal/Framework/Module/Setup/Service/ActiveClassExtensionChainResolver.php
+++ b/source/Internal/Framework/Module/Setup/Service/ActiveClassExtensionChainResolver.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**Utility
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Framework\Module\Setup\Service;
 
@@ -82,9 +85,9 @@ class ActiveClassExtensionChainResolver implements ActiveClassExtensionChainReso
      * @return array
      */
     private function getActiveModuleExtensionClasses(
-        array               $moduleExtensionClasses,
-        int                 $shopId,
-        ShopConfiguration   $shopConfiguration
+        array $moduleExtensionClasses,
+        int $shopId,
+        ShopConfiguration $shopConfiguration
     ): array {
         $activeClasses = [];
 
@@ -105,12 +108,13 @@ class ActiveClassExtensionChainResolver implements ActiveClassExtensionChainReso
      * @return bool
      */
     private function isActiveExtension(
-        string              $classExtension,
-        int                 $shopId,
-        ShopConfiguration   $shopConfiguration
+        string $classExtension,
+        int $shopId,
+        ShopConfiguration $shopConfiguration
     ): bool {
         foreach ($shopConfiguration->getModuleConfigurations() as $moduleConfiguration) {
-            if ($moduleConfiguration->hasClassExtension($classExtension)
+            if (
+                $moduleConfiguration->hasClassExtension($classExtension)
                 && $this->moduleStateService->isActive($moduleConfiguration->getId(), $shopId)
             ) {
                 return true;

--- a/source/Internal/Framework/Module/Setup/Service/ActiveClassExtensionChainResolverInterface.php
+++ b/source/Internal/Framework/Module/Setup/Service/ActiveClassExtensionChainResolverInterface.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Framework\Module\Setup\Service;
 

--- a/source/Internal/Framework/Module/Setup/Service/ClassExtensionChainService.php
+++ b/source/Internal/Framework/Module/Setup/Service/ClassExtensionChainService.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Framework\Module\Setup\Service;
 
@@ -29,8 +32,8 @@ class ClassExtensionChainService implements ExtensionChainServiceInterface
      * @param ActiveClassExtensionChainResolverInterface $activeClassExtensionChainResolver
      */
     public function __construct(
-        ShopConfigurationSettingDaoInterface        $shopConfigurationSettingDao,
-        ActiveClassExtensionChainResolverInterface  $activeClassExtensionChainResolver
+        ShopConfigurationSettingDaoInterface $shopConfigurationSettingDao,
+        ActiveClassExtensionChainResolverInterface $activeClassExtensionChainResolver
     ) {
         $this->shopConfigurationSettingDao = $shopConfigurationSettingDao;
         $this->activeClassExtensionChainResolver = $activeClassExtensionChainResolver;

--- a/source/Internal/Framework/Module/Setup/Service/ExtensionChainServiceInterface.php
+++ b/source/Internal/Framework/Module/Setup/Service/ExtensionChainServiceInterface.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Framework\Module\Setup\Service;
 

--- a/source/Internal/Framework/Module/Setup/Service/ModuleActivationService.php
+++ b/source/Internal/Framework/Module/Setup/Service/ModuleActivationService.php
@@ -1,9 +1,11 @@
-<?php declare(strict_types=1);
+<?php
 
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Framework\Module\Setup\Service;
 
@@ -58,12 +60,12 @@ class ModuleActivationService implements ModuleActivationServiceInterface
      * @param ModuleServicesActivationServiceInterface    $moduleServicesActivationService
      */
     public function __construct(
-        ModuleConfigurationDaoInterface             $moduleConfigurationDao,
-        EventDispatcherInterface                    $eventDispatcher,
+        ModuleConfigurationDaoInterface $moduleConfigurationDao,
+        EventDispatcherInterface $eventDispatcher,
         ModuleConfigurationHandlingServiceInterface $moduleSettingsHandlingService,
-        ModuleStateServiceInterface                 $stateService,
-        ExtensionChainServiceInterface              $classExtensionChainService,
-        ModuleServicesActivationServiceInterface    $moduleServicesActivationService
+        ModuleStateServiceInterface $stateService,
+        ExtensionChainServiceInterface $classExtensionChainService,
+        ModuleServicesActivationServiceInterface $moduleServicesActivationService
     ) {
         $this->moduleConfigurationDao = $moduleConfigurationDao;
         $this->eventDispatcher = $eventDispatcher;
@@ -84,7 +86,7 @@ class ModuleActivationService implements ModuleActivationServiceInterface
     public function activate(string $moduleId, int $shopId)
     {
         if ($this->stateService->isActive($moduleId, $shopId) === true) {
-            throw new ModuleSetupException('Module with id "'. $moduleId . '" is already active.');
+            throw new ModuleSetupException('Module with id "' . $moduleId . '" is already active.');
         }
 
         $moduleConfiguration = $this->moduleConfigurationDao->get($moduleId, $shopId);
@@ -116,7 +118,7 @@ class ModuleActivationService implements ModuleActivationServiceInterface
     public function deactivate(string $moduleId, int $shopId)
     {
         if ($this->stateService->isActive($moduleId, $shopId) === false) {
-            throw new ModuleSetupException('Module with id "'. $moduleId . '" is not active.');
+            throw new ModuleSetupException('Module with id "' . $moduleId . '" is not active.');
         }
 
         $this->eventDispatcher->dispatch(

--- a/source/Internal/Framework/Module/Setup/Service/ModuleActivationServiceInterface.php
+++ b/source/Internal/Framework/Module/Setup/Service/ModuleActivationServiceInterface.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Framework\Module\Setup\Service;
 

--- a/source/Internal/Framework/Module/Setup/Service/ModuleConfigurationHandlingService.php
+++ b/source/Internal/Framework/Module/Setup/Service/ModuleConfigurationHandlingService.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Framework\Module\Setup\Service;
 

--- a/source/Internal/Framework/Module/Setup/Service/ModuleConfigurationHandlingServiceInterface.php
+++ b/source/Internal/Framework/Module/Setup/Service/ModuleConfigurationHandlingServiceInterface.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Framework\Module\Setup\Service;
 

--- a/source/Internal/Framework/Module/Setup/Service/ModuleServicesActivationService.php
+++ b/source/Internal/Framework/Module/Setup/Service/ModuleServicesActivationService.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Framework\Module\Setup\Service;
 

--- a/source/Internal/Framework/Module/Setup/Service/ModuleServicesActivationServiceInterface.php
+++ b/source/Internal/Framework/Module/Setup/Service/ModuleServicesActivationServiceInterface.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Framework\Module\Setup\Service;
 

--- a/source/Internal/Framework/Module/Setup/Validator/ClassExtensionsValidator.php
+++ b/source/Internal/Framework/Module/Setup/Validator/ClassExtensionsValidator.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Framework\Module\Setup\Validator;
 

--- a/source/Internal/Framework/Module/Setup/Validator/ControllersValidator.php
+++ b/source/Internal/Framework/Module/Setup/Validator/ControllersValidator.php
@@ -10,11 +10,13 @@ use function is_array;
 
 use OxidEsales\EshopCommunity\Internal\Framework\Config\Dao\ShopConfigurationSettingDaoInterface;
 use OxidEsales\EshopCommunity\Internal\Framework\Config\DataObject\ShopConfigurationSetting;
-use OxidEsales\EshopCommunity\Internal\Transition\Adapter\ShopAdapterInterface;
 use OxidEsales\EshopCommunity\Internal\Framework\Dao\EntryDoesNotExistDaoException;
 use OxidEsales\EshopCommunity\Internal\Framework\Module\Configuration\DataObject\ModuleConfiguration;
-use OxidEsales\EshopCommunity\Internal\Framework\Module\Setup\Exception\ControllersDuplicationModuleConfigurationException;
 use OxidEsales\EshopCommunity\Internal\Framework\Module\Configuration\DataObject\ModuleConfiguration\Controller;
+use OxidEsales\EshopCommunity\Internal\Framework\Module\Setup\Exception\ControllersDuplicationModuleConfigurationException;
+use OxidEsales\EshopCommunity\Internal\Transition\Adapter\ShopAdapterInterface;
+
+use function is_array;
 
 class ControllersValidator implements ModuleConfigurationValidatorInterface
 {

--- a/source/Internal/Framework/Module/Setup/Validator/ControllersValidator.php
+++ b/source/Internal/Framework/Module/Setup/Validator/ControllersValidator.php
@@ -1,12 +1,13 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
 
-namespace OxidEsales\EshopCommunity\Internal\Framework\Module\Setup\Validator;
+declare(strict_types=1);
 
-use function is_array;
+namespace OxidEsales\EshopCommunity\Internal\Framework\Module\Setup\Validator;
 
 use OxidEsales\EshopCommunity\Internal\Framework\Config\Dao\ShopConfigurationSettingDaoInterface;
 use OxidEsales\EshopCommunity\Internal\Framework\Config\DataObject\ShopConfigurationSetting;

--- a/source/Internal/Framework/Module/Setup/Validator/EventsValidator.php
+++ b/source/Internal/Framework/Module/Setup/Validator/EventsValidator.php
@@ -1,16 +1,19 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
 
-namespace OxidEsales\EshopCommunity\Internal\Framework\Module\Setup\Validator;
+declare(strict_types=1);
 
-use function is_array;
+namespace OxidEsales\EshopCommunity\Internal\Framework\Module\Setup\Validator;
 
 use OxidEsales\EshopCommunity\Internal\Transition\Adapter\ShopAdapterInterface;
 use OxidEsales\EshopCommunity\Internal\Framework\Module\Configuration\DataObject\ModuleConfiguration;
 use OxidEsales\EshopCommunity\Internal\Framework\Module\Setup\Exception\ModuleSettingNotValidException;
+
+use function is_array;
 
 class EventsValidator implements ModuleConfigurationValidatorInterface
 {

--- a/source/Internal/Framework/Module/Setup/Validator/ModuleConfigurationValidatorInterface.php
+++ b/source/Internal/Framework/Module/Setup/Validator/ModuleConfigurationValidatorInterface.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Framework\Module\Setup\Validator;
 

--- a/source/Internal/Framework/Module/Setup/Validator/ServicesYamlValidator.php
+++ b/source/Internal/Framework/Module/Setup/Validator/ServicesYamlValidator.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Framework\Module\Setup\Validator;
 

--- a/source/Internal/Framework/Module/Setup/Validator/SmartyPluginDirectoriesValidator.php
+++ b/source/Internal/Framework/Module/Setup/Validator/SmartyPluginDirectoriesValidator.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Framework\Module\Setup\Validator;
 

--- a/source/Internal/Framework/Module/State/ModuleStateIsAlreadySetException.php
+++ b/source/Internal/Framework/Module/State/ModuleStateIsAlreadySetException.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Framework\Module\State;
 

--- a/source/Internal/Framework/Module/State/ModuleStateService.php
+++ b/source/Internal/Framework/Module/State/ModuleStateService.php
@@ -1,17 +1,20 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
 
-namespace OxidEsales\EshopCommunity\Internal\Framework\Module\State;
+declare(strict_types=1);
 
-use function in_array;
+namespace OxidEsales\EshopCommunity\Internal\Framework\Module\State;
 
 use OxidEsales\EshopCommunity\Internal\Framework\Config\Dao\ShopConfigurationSettingDaoInterface;
 use OxidEsales\EshopCommunity\Internal\Framework\Config\DataObject\ShopConfigurationSetting;
 use OxidEsales\EshopCommunity\Internal\Framework\Config\DataObject\ShopSettingType;
 use OxidEsales\EshopCommunity\Internal\Framework\Dao\EntryDoesNotExistDaoException;
+
+use function in_array;
 
 class ModuleStateService implements ModuleStateServiceInterface
 {

--- a/source/Internal/Framework/Module/State/ModuleStateServiceInterface.php
+++ b/source/Internal/Framework/Module/State/ModuleStateServiceInterface.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Framework\Module\State;
 

--- a/source/Internal/Framework/Module/TemplateExtension/TemplateBlockExtension.php
+++ b/source/Internal/Framework/Module/TemplateExtension/TemplateBlockExtension.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Framework\Module\TemplateExtension;
 

--- a/source/Internal/Framework/Module/TemplateExtension/TemplateBlockExtensionDao.php
+++ b/source/Internal/Framework/Module/TemplateExtension/TemplateBlockExtensionDao.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Framework\Module\TemplateExtension;
 

--- a/source/Internal/Framework/Module/TemplateExtension/TemplateBlockExtensionDaoInterface.php
+++ b/source/Internal/Framework/Module/TemplateExtension/TemplateBlockExtensionDaoInterface.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Framework\Module\TemplateExtension;
 

--- a/source/Internal/Framework/Smarty/Bridge/SmartyEngineBridge.php
+++ b/source/Internal/Framework/Smarty/Bridge/SmartyEngineBridge.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Framework\Smarty\Bridge;
 

--- a/source/Internal/Framework/Smarty/Bridge/SmartyEngineBridgeInterface.php
+++ b/source/Internal/Framework/Smarty/Bridge/SmartyEngineBridgeInterface.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Framework\Smarty\Bridge;
 

--- a/source/Internal/Framework/Smarty/Bridge/SmartyTemplateRendererBridge.php
+++ b/source/Internal/Framework/Smarty/Bridge/SmartyTemplateRendererBridge.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Framework\Smarty\Bridge;
 

--- a/source/Internal/Framework/Smarty/Configuration/SmartyConfiguration.php
+++ b/source/Internal/Framework/Smarty/Configuration/SmartyConfiguration.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Framework\Smarty\Configuration;
 

--- a/source/Internal/Framework/Smarty/Configuration/SmartyConfigurationFactory.php
+++ b/source/Internal/Framework/Smarty/Configuration/SmartyConfigurationFactory.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Framework\Smarty\Configuration;
 

--- a/source/Internal/Framework/Smarty/Configuration/SmartyConfigurationFactoryInterface.php
+++ b/source/Internal/Framework/Smarty/Configuration/SmartyConfigurationFactoryInterface.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Framework\Smarty\Configuration;
 

--- a/source/Internal/Framework/Smarty/Configuration/SmartyConfigurationInterface.php
+++ b/source/Internal/Framework/Smarty/Configuration/SmartyConfigurationInterface.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Framework\Smarty\Configuration;
 

--- a/source/Internal/Framework/Smarty/Configuration/SmartyPluginsDataProvider.php
+++ b/source/Internal/Framework/Smarty/Configuration/SmartyPluginsDataProvider.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Framework\Smarty\Configuration;
 

--- a/source/Internal/Framework/Smarty/Configuration/SmartyPluginsDataProviderInterface.php
+++ b/source/Internal/Framework/Smarty/Configuration/SmartyPluginsDataProviderInterface.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Framework\Smarty\Configuration;
 

--- a/source/Internal/Framework/Smarty/Configuration/SmartyPrefiltersDataProvider.php
+++ b/source/Internal/Framework/Smarty/Configuration/SmartyPrefiltersDataProvider.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Framework\Smarty\Configuration;
 

--- a/source/Internal/Framework/Smarty/Configuration/SmartyPrefiltersDataProviderInterface.php
+++ b/source/Internal/Framework/Smarty/Configuration/SmartyPrefiltersDataProviderInterface.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Framework\Smarty\Configuration;
 

--- a/source/Internal/Framework/Smarty/Configuration/SmartyResourcesDataProvider.php
+++ b/source/Internal/Framework/Smarty/Configuration/SmartyResourcesDataProvider.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Framework\Smarty\Configuration;
 

--- a/source/Internal/Framework/Smarty/Configuration/SmartyResourcesDataProviderInterface.php
+++ b/source/Internal/Framework/Smarty/Configuration/SmartyResourcesDataProviderInterface.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Framework\Smarty\Configuration;
 

--- a/source/Internal/Framework/Smarty/Configuration/SmartySecuritySettingsDataProvider.php
+++ b/source/Internal/Framework/Smarty/Configuration/SmartySecuritySettingsDataProvider.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Framework\Smarty\Configuration;
 

--- a/source/Internal/Framework/Smarty/Configuration/SmartySecuritySettingsDataProviderInterface.php
+++ b/source/Internal/Framework/Smarty/Configuration/SmartySecuritySettingsDataProviderInterface.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Framework\Smarty\Configuration;
 

--- a/source/Internal/Framework/Smarty/Configuration/SmartySettingsDataProvider.php
+++ b/source/Internal/Framework/Smarty/Configuration/SmartySettingsDataProvider.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Framework\Smarty\Configuration;
 

--- a/source/Internal/Framework/Smarty/Configuration/SmartySettingsDataProviderInterface.php
+++ b/source/Internal/Framework/Smarty/Configuration/SmartySettingsDataProviderInterface.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Framework\Smarty\Configuration;
 

--- a/source/Internal/Framework/Smarty/Extension/CacheResourcePlugin.php
+++ b/source/Internal/Framework/Smarty/Extension/CacheResourcePlugin.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Framework\Smarty\Extension;
 

--- a/source/Internal/Framework/Smarty/Extension/SmartyDefaultTemplateHandler.php
+++ b/source/Internal/Framework/Smarty/Extension/SmartyDefaultTemplateHandler.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Framework\Smarty\Extension;
 

--- a/source/Internal/Framework/Smarty/Legacy/LegacySmartyEngine.php
+++ b/source/Internal/Framework/Smarty/Legacy/LegacySmartyEngine.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Framework\Smarty\Legacy;
 

--- a/source/Internal/Framework/Smarty/Legacy/LegacySmartyEngineFactory.php
+++ b/source/Internal/Framework/Smarty/Legacy/LegacySmartyEngineFactory.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Framework\Smarty\Legacy;
 

--- a/source/Internal/Framework/Smarty/Legacy/LegacySmartyEngineInterface.php
+++ b/source/Internal/Framework/Smarty/Legacy/LegacySmartyEngineInterface.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Framework\Smarty\Legacy;
 

--- a/source/Internal/Framework/Smarty/SmartyBuilder.php
+++ b/source/Internal/Framework/Smarty/SmartyBuilder.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Framework\Smarty;
 

--- a/source/Internal/Framework/Smarty/SmartyBuilderInterface.php
+++ b/source/Internal/Framework/Smarty/SmartyBuilderInterface.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Framework\Smarty;
 

--- a/source/Internal/Framework/Smarty/SmartyContext.php
+++ b/source/Internal/Framework/Smarty/SmartyContext.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Framework\Smarty;
 

--- a/source/Internal/Framework/Smarty/SmartyContextInterface.php
+++ b/source/Internal/Framework/Smarty/SmartyContextInterface.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Framework\Smarty;
 

--- a/source/Internal/Framework/Smarty/SmartyEngine.php
+++ b/source/Internal/Framework/Smarty/SmartyEngine.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Framework\Smarty;
 

--- a/source/Internal/Framework/Smarty/SmartyEngineFactory.php
+++ b/source/Internal/Framework/Smarty/SmartyEngineFactory.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Framework\Smarty;
 

--- a/source/Internal/Framework/Storage/ArrayStorageInterface.php
+++ b/source/Internal/Framework/Storage/ArrayStorageInterface.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Framework\Storage;
 

--- a/source/Internal/Framework/Storage/FileStorageFactoryInterface.php
+++ b/source/Internal/Framework/Storage/FileStorageFactoryInterface.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Framework\Storage;
 

--- a/source/Internal/Framework/Storage/YamlFileStorage.php
+++ b/source/Internal/Framework/Storage/YamlFileStorage.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Framework\Storage;
 

--- a/source/Internal/Framework/Storage/YamlFileStorageFactory.php
+++ b/source/Internal/Framework/Storage/YamlFileStorageFactory.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Framework\Storage;
 

--- a/source/Internal/Framework/Templating/Exception/TemplateFileNotFoundException.php
+++ b/source/Internal/Framework/Templating/Exception/TemplateFileNotFoundException.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Framework\Templating\Exception;
 

--- a/source/Internal/Framework/Templating/Loader/TemplateLoader.php
+++ b/source/Internal/Framework/Templating/Loader/TemplateLoader.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Framework\Templating\Loader;
 

--- a/source/Internal/Framework/Templating/Loader/TemplateLoaderInterface.php
+++ b/source/Internal/Framework/Templating/Loader/TemplateLoaderInterface.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Framework\Templating\Loader;
 

--- a/source/Internal/Framework/Templating/Locator/AdminNavigationFileLocator.php
+++ b/source/Internal/Framework/Templating/Locator/AdminNavigationFileLocator.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Framework\Templating\Locator;
 

--- a/source/Internal/Framework/Templating/Locator/AdminTemplateFileLocator.php
+++ b/source/Internal/Framework/Templating/Locator/AdminTemplateFileLocator.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Framework\Templating\Locator;
 

--- a/source/Internal/Framework/Templating/Locator/EditionMenuFileLocator.php
+++ b/source/Internal/Framework/Templating/Locator/EditionMenuFileLocator.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Framework\Templating\Locator;
 

--- a/source/Internal/Framework/Templating/Locator/EditionUserFileLocator.php
+++ b/source/Internal/Framework/Templating/Locator/EditionUserFileLocator.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Framework\Templating\Locator;
 

--- a/source/Internal/Framework/Templating/Locator/FileLocatorInterface.php
+++ b/source/Internal/Framework/Templating/Locator/FileLocatorInterface.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Framework\Templating\Locator;
 

--- a/source/Internal/Framework/Templating/Locator/NavigationFileLocatorInterface.php
+++ b/source/Internal/Framework/Templating/Locator/NavigationFileLocatorInterface.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Framework\Templating\Locator;
 

--- a/source/Internal/Framework/Templating/Locator/TemplateFileLocator.php
+++ b/source/Internal/Framework/Templating/Locator/TemplateFileLocator.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Framework\Templating\Locator;
 

--- a/source/Internal/Framework/Templating/Resolver/LegacyTemplateNameResolver.php
+++ b/source/Internal/Framework/Templating/Resolver/LegacyTemplateNameResolver.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Framework\Templating\Resolver;
 

--- a/source/Internal/Framework/Templating/Resolver/TemplateNameResolver.php
+++ b/source/Internal/Framework/Templating/Resolver/TemplateNameResolver.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Framework\Templating\Resolver;
 

--- a/source/Internal/Framework/Templating/Resolver/TemplateNameResolverInterface.php
+++ b/source/Internal/Framework/Templating/Resolver/TemplateNameResolverInterface.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Framework\Templating\Resolver;
 

--- a/source/Internal/Framework/Templating/TemplateEngineFactoryInterface.php
+++ b/source/Internal/Framework/Templating/TemplateEngineFactoryInterface.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Internal/Framework/Templating/TemplateEngineInterface.php
+++ b/source/Internal/Framework/Templating/TemplateEngineInterface.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Framework\Templating;
 

--- a/source/Internal/Framework/Templating/TemplateRenderer.php
+++ b/source/Internal/Framework/Templating/TemplateRenderer.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Framework\Templating;
 

--- a/source/Internal/Framework/Templating/TemplateRendererBridgeInterface.php
+++ b/source/Internal/Framework/Templating/TemplateRendererBridgeInterface.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Framework\Templating;
 

--- a/source/Internal/Framework/Templating/TemplateRendererInterface.php
+++ b/source/Internal/Framework/Templating/TemplateRendererInterface.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Framework\Templating;
 

--- a/source/Internal/Framework/Theme/Bridge/AdminThemeBridge.php
+++ b/source/Internal/Framework/Theme/Bridge/AdminThemeBridge.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Framework\Theme\Bridge;
 

--- a/source/Internal/Framework/Theme/Bridge/AdminThemeBridgeInterface.php
+++ b/source/Internal/Framework/Theme/Bridge/AdminThemeBridgeInterface.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Framework\Theme\Bridge;
 

--- a/source/Internal/Framework/Theme/Event/ThemeSettingChangedEvent.php
+++ b/source/Internal/Framework/Theme/Event/ThemeSettingChangedEvent.php
@@ -1,10 +1,11 @@
 <?php
-declare(strict_types=1);
 
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Framework\Theme\Event;
 

--- a/source/Internal/Transition/Adapter/ShopAdapter.php
+++ b/source/Internal/Transition/Adapter/ShopAdapter.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Transition\Adapter;
 

--- a/source/Internal/Transition/Adapter/ShopAdapterInterface.php
+++ b/source/Internal/Transition/Adapter/ShopAdapterInterface.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Transition\Adapter;
 

--- a/source/Internal/Transition/Adapter/TemplateLogic/AbstractInsertNewBasketItemLogic.php
+++ b/source/Internal/Transition/Adapter/TemplateLogic/AbstractInsertNewBasketItemLogic.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Internal/Transition/Adapter/TemplateLogic/AddUrlParametersLogic.php
+++ b/source/Internal/Transition/Adapter/TemplateLogic/AddUrlParametersLogic.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Internal/Transition/Adapter/TemplateLogic/AssignAdvancedLogic.php
+++ b/source/Internal/Transition/Adapter/TemplateLogic/AssignAdvancedLogic.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Internal/Transition/Adapter/TemplateLogic/ContentFactory.php
+++ b/source/Internal/Transition/Adapter/TemplateLogic/ContentFactory.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Internal/Transition/Adapter/TemplateLogic/DateFormatHelper.php
+++ b/source/Internal/Transition/Adapter/TemplateLogic/DateFormatHelper.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Internal/Transition/Adapter/TemplateLogic/FileSizeLogic.php
+++ b/source/Internal/Transition/Adapter/TemplateLogic/FileSizeLogic.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Internal/Transition/Adapter/TemplateLogic/FormatCurrencyLogic.php
+++ b/source/Internal/Transition/Adapter/TemplateLogic/FormatCurrencyLogic.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Internal/Transition/Adapter/TemplateLogic/FormatDateLogic.php
+++ b/source/Internal/Transition/Adapter/TemplateLogic/FormatDateLogic.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Internal/Transition/Adapter/TemplateLogic/FormatPriceLogic.php
+++ b/source/Internal/Transition/Adapter/TemplateLogic/FormatPriceLogic.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Internal/Transition/Adapter/TemplateLogic/FormatTimeLogic.php
+++ b/source/Internal/Transition/Adapter/TemplateLogic/FormatTimeLogic.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Internal/Transition/Adapter/TemplateLogic/IfContentLogic.php
+++ b/source/Internal/Transition/Adapter/TemplateLogic/IfContentLogic.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
@@ -18,8 +19,10 @@ class IfContentLogic
     {
         static $aContentCache = [];
 
-        if (($sIdent && isset($aContentCache[$sIdent])) ||
-            ($sOxid && isset($aContentCache[$sOxid]))) {
+        if (
+            ($sIdent && isset($aContentCache[$sIdent])) ||
+            ($sOxid && isset($aContentCache[$sOxid]))
+        ) {
             $oContent = $sOxid ? $aContentCache[$sOxid] : $aContentCache[$sIdent];
         } else {
             $oContent = oxNew("oxContent");

--- a/source/Internal/Transition/Adapter/TemplateLogic/IncludeDynamicLogic.php
+++ b/source/Internal/Transition/Adapter/TemplateLogic/IncludeDynamicLogic.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Internal/Transition/Adapter/TemplateLogic/IncludeWidgetLogic.php
+++ b/source/Internal/Transition/Adapter/TemplateLogic/IncludeWidgetLogic.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Internal/Transition/Adapter/TemplateLogic/InsertNewBasketItemLogicSmarty.php
+++ b/source/Internal/Transition/Adapter/TemplateLogic/InsertNewBasketItemLogicSmarty.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Internal/Transition/Adapter/TemplateLogic/InsertNewBasketItemLogicTwig.php
+++ b/source/Internal/Transition/Adapter/TemplateLogic/InsertNewBasketItemLogicTwig.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Internal/Transition/Adapter/TemplateLogic/ScriptLogic.php
+++ b/source/Internal/Transition/Adapter/TemplateLogic/ScriptLogic.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Internal/Transition/Adapter/TemplateLogic/SeoUrlLogic.php
+++ b/source/Internal/Transition/Adapter/TemplateLogic/SeoUrlLogic.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Internal/Transition/Adapter/TemplateLogic/SmartWordwrapLogic.php
+++ b/source/Internal/Transition/Adapter/TemplateLogic/SmartWordwrapLogic.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Internal/Transition/Adapter/TemplateLogic/StyleLogic.php
+++ b/source/Internal/Transition/Adapter/TemplateLogic/StyleLogic.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Internal/Transition/Adapter/TemplateLogic/TranslateFilterLogic.php
+++ b/source/Internal/Transition/Adapter/TemplateLogic/TranslateFilterLogic.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Internal/Transition/Adapter/TemplateLogic/TranslateFunctionLogic.php
+++ b/source/Internal/Transition/Adapter/TemplateLogic/TranslateFunctionLogic.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Internal/Transition/Adapter/TemplateLogic/TranslateSalutationLogic.php
+++ b/source/Internal/Transition/Adapter/TemplateLogic/TranslateSalutationLogic.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Internal/Transition/Adapter/TemplateLogic/TruncateLogic.php
+++ b/source/Internal/Transition/Adapter/TemplateLogic/TruncateLogic.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Internal/Transition/Adapter/TemplateLogic/WordwrapLogic.php
+++ b/source/Internal/Transition/Adapter/TemplateLogic/WordwrapLogic.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Internal/Transition/ShopEvents/AfterAdminAjaxRequestProcessedEvent.php
+++ b/source/Internal/Transition/ShopEvents/AfterAdminAjaxRequestProcessedEvent.php
@@ -1,10 +1,11 @@
 <?php
-declare(strict_types=1);
 
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Transition\ShopEvents;
 

--- a/source/Internal/Transition/ShopEvents/AfterModelDeleteEvent.php
+++ b/source/Internal/Transition/ShopEvents/AfterModelDeleteEvent.php
@@ -1,10 +1,12 @@
 <?php
-declare(strict_types=1);
 
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
+
 namespace OxidEsales\EshopCommunity\Internal\Transition\ShopEvents;
 
 use Symfony\Component\EventDispatcher\Event;
@@ -15,7 +17,7 @@ use Symfony\Component\EventDispatcher\Event;
  */
 class AfterModelDeleteEvent extends Event
 {
-    const NAME = self::class;
-
     use ModelChangeEventTrait;
+
+    const NAME = self::class;
 }

--- a/source/Internal/Transition/ShopEvents/AfterModelInsertEvent.php
+++ b/source/Internal/Transition/ShopEvents/AfterModelInsertEvent.php
@@ -1,10 +1,12 @@
 <?php
-declare(strict_types=1);
 
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
+
 namespace OxidEsales\EshopCommunity\Internal\Transition\ShopEvents;
 
 use Symfony\Component\EventDispatcher\Event;
@@ -15,7 +17,7 @@ use Symfony\Component\EventDispatcher\Event;
  */
 class AfterModelInsertEvent extends Event
 {
-    const NAME = self::class;
-
     use ModelChangeEventTrait;
+
+    const NAME = self::class;
 }

--- a/source/Internal/Transition/ShopEvents/AfterModelUpdateEvent.php
+++ b/source/Internal/Transition/ShopEvents/AfterModelUpdateEvent.php
@@ -1,10 +1,12 @@
 <?php
-declare(strict_types=1);
 
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
+
 namespace OxidEsales\EshopCommunity\Internal\Transition\ShopEvents;
 
 use Symfony\Component\EventDispatcher\Event;
@@ -15,7 +17,7 @@ use Symfony\Component\EventDispatcher\Event;
  */
 class AfterModelUpdateEvent extends Event
 {
-    const NAME = self::class;
-
     use ModelChangeEventTrait;
+
+    const NAME = self::class;
 }

--- a/source/Internal/Transition/ShopEvents/AfterRequestProcessedEvent.php
+++ b/source/Internal/Transition/ShopEvents/AfterRequestProcessedEvent.php
@@ -1,10 +1,11 @@
 <?php
-declare(strict_types=1);
 
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Transition\ShopEvents;
 

--- a/source/Internal/Transition/ShopEvents/AllCookiesRemovedEvent.php
+++ b/source/Internal/Transition/ShopEvents/AllCookiesRemovedEvent.php
@@ -1,10 +1,11 @@
 <?php
-declare(strict_types=1);
 
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Transition\ShopEvents;
 

--- a/source/Internal/Transition/ShopEvents/ApplicationExitEvent.php
+++ b/source/Internal/Transition/ShopEvents/ApplicationExitEvent.php
@@ -1,10 +1,11 @@
 <?php
-declare(strict_types=1);
 
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Transition\ShopEvents;
 

--- a/source/Internal/Transition/ShopEvents/BasketChangedEvent.php
+++ b/source/Internal/Transition/ShopEvents/BasketChangedEvent.php
@@ -1,10 +1,11 @@
 <?php
-declare(strict_types=1);
 
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Transition\ShopEvents;
 

--- a/source/Internal/Transition/ShopEvents/BeforeHeadersSendEvent.php
+++ b/source/Internal/Transition/ShopEvents/BeforeHeadersSendEvent.php
@@ -1,10 +1,11 @@
 <?php
-declare(strict_types=1);
 
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Transition\ShopEvents;
 

--- a/source/Internal/Transition/ShopEvents/BeforeModelDeleteEvent.php
+++ b/source/Internal/Transition/ShopEvents/BeforeModelDeleteEvent.php
@@ -1,10 +1,12 @@
 <?php
-declare(strict_types=1);
 
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
+
 namespace OxidEsales\EshopCommunity\Internal\Transition\ShopEvents;
 
 use Symfony\Component\EventDispatcher\Event;
@@ -15,7 +17,7 @@ use Symfony\Component\EventDispatcher\Event;
  */
 class BeforeModelDeleteEvent extends Event
 {
-    const NAME = self::class;
-
     use ModelChangeEventTrait;
+
+    const NAME = self::class;
 }

--- a/source/Internal/Transition/ShopEvents/BeforeModelUpdateEvent.php
+++ b/source/Internal/Transition/ShopEvents/BeforeModelUpdateEvent.php
@@ -1,10 +1,12 @@
 <?php
-declare(strict_types=1);
 
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
+
 namespace OxidEsales\EshopCommunity\Internal\Transition\ShopEvents;
 
 use Symfony\Component\EventDispatcher\Event;
@@ -15,7 +17,7 @@ use Symfony\Component\EventDispatcher\Event;
  */
 class BeforeModelUpdateEvent extends Event
 {
-    const NAME = self::class;
-
     use ModelChangeEventTrait;
+
+    const NAME = self::class;
 }

--- a/source/Internal/Transition/ShopEvents/BeforeSessionStartEvent.php
+++ b/source/Internal/Transition/ShopEvents/BeforeSessionStartEvent.php
@@ -1,10 +1,11 @@
 <?php
-declare(strict_types=1);
 
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Transition\ShopEvents;
 

--- a/source/Internal/Transition/ShopEvents/ModelChangeEventTrait.php
+++ b/source/Internal/Transition/ShopEvents/ModelChangeEventTrait.php
@@ -1,17 +1,19 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
 namespace OxidEsales\EshopCommunity\Internal\Transition\ShopEvents;
 
+/**
+ * Model object
+ *
+ * @var \OxidEsales\Eshop\Core\Model\BaseModel
+ */
 trait ModelChangeEventTrait
 {
-    /**
-     * Model object
-     *
-     * @var \OxidEsales\Eshop\Core\Model\BaseModel
-     */
     private $model;
 
     /**

--- a/source/Internal/Transition/ShopEvents/ViewRenderedEvent.php
+++ b/source/Internal/Transition/ShopEvents/ViewRenderedEvent.php
@@ -1,10 +1,11 @@
 <?php
-declare(strict_types=1);
 
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Transition\ShopEvents;
 

--- a/source/Internal/Transition/Utility/BasicContext.php
+++ b/source/Internal/Transition/Utility/BasicContext.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Transition\Utility;
 
@@ -64,7 +67,7 @@ class BasicContext implements BasicContextInterface
     /**
      * @return string
      */
-    public function getModulesPath() : string
+    public function getModulesPath(): string
     {
         return Path::join($this->getSourcePath(), 'modules');
     }

--- a/source/Internal/Transition/Utility/BasicContextInterface.php
+++ b/source/Internal/Transition/Utility/BasicContextInterface.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Transition\Utility;
 

--- a/source/Internal/Transition/Utility/Context.php
+++ b/source/Internal/Transition/Utility/Context.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Transition\Utility;
 

--- a/source/Internal/Transition/Utility/ContextInterface.php
+++ b/source/Internal/Transition/Utility/ContextInterface.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Transition\Utility;
 

--- a/source/Internal/Transition/Utility/Exception/AdminUserNotFoundException.php
+++ b/source/Internal/Transition/Utility/Exception/AdminUserNotFoundException.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Transition\Utility\Exception;
 

--- a/source/Setup/Controller.php
+++ b/source/Setup/Controller.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
@@ -7,11 +8,11 @@
 namespace OxidEsales\EshopCommunity\Setup;
 
 use Exception;
-use \OxidEsales\Facts\Edition\EditionSelector;
-use \OxidEsales\Eshop\Core\SystemRequirements;
-use \OxidEsales\EshopCommunity\Setup\Controller\ModuleStateMapGenerator;
-use \OxidEsales\EshopCommunity\Setup\Exception\CommandExecutionFailedException;
-use \OxidEsales\EshopCommunity\Setup\Exception\SetupControllerExitException;
+use OxidEsales\Facts\Edition\EditionSelector;
+use OxidEsales\Eshop\Core\SystemRequirements;
+use OxidEsales\EshopCommunity\Setup\Controller\ModuleStateMapGenerator;
+use OxidEsales\EshopCommunity\Setup\Exception\CommandExecutionFailedException;
+use OxidEsales\EshopCommunity\Setup\Exception\SetupControllerExitException;
 
 /**
  * Class holds scripts (controllers) needed to perform shop setup steps
@@ -412,7 +413,8 @@ class Controller extends Core
         $session->setSessionParam('aAdminData', $adminData);
 
         // check if important parameters are set
-        if (!$pathCollection['sShopURL'] || !$pathCollection['sShopDir'] || !$pathCollection['sCompileDir']
+        if (
+            !$pathCollection['sShopURL'] || !$pathCollection['sShopDir'] || !$pathCollection['sCompileDir']
             || !$adminData['sLoginName'] || !$adminData['sPassword'] || !$adminData['sPasswordConfirm']
         ) {
             $setup->setNextStep($setup->getStep('STEP_DIRS_INFO'));
@@ -447,7 +449,7 @@ class Controller extends Core
 
         // write it now
         try {
-            $parameters = array_merge(( array )$session->getSessionParam('aDB'), $pathCollection);
+            $parameters = array_merge((array)$session->getSessionParam('aDB'), $pathCollection);
 
             // updating config file
             $utils->updateConfigFile($parameters);
@@ -712,7 +714,8 @@ class Controller extends Core
             $systemRequirementsInfo,
             function ($groupId, $moduleId, $moduleState) {
                 // HtAccess check exception case
-                if (($groupId === SystemRequirements::MODULE_GROUP_ID_SERVER_CONFIG)
+                if (
+                    ($groupId === SystemRequirements::MODULE_GROUP_ID_SERVER_CONFIG)
                     && ($moduleId === SystemRequirements::MODULE_ID_MOD_REWRITE)
                     && (!$this->canUpdateHtaccess())
                 ) {
@@ -721,7 +724,8 @@ class Controller extends Core
 
                 // MySql version detect exception case
                 // More information can be obtained from commits with tag 'ESDEV-3999'
-                if (($groupId === SystemRequirements::MODULE_GROUP_ID_SERVER_CONFIG)
+                if (
+                    ($groupId === SystemRequirements::MODULE_GROUP_ID_SERVER_CONFIG)
                     && ($moduleId === SystemRequirements::MODULE_ID_MYSQL_VERSION)
                 ) {
                     return SystemRequirements::MODULE_STATUS_UNABLE_TO_DETECT;

--- a/source/Setup/Controller/ModuleStateMapGenerator.php
+++ b/source/Setup/Controller/ModuleStateMapGenerator.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Setup/Core.php
+++ b/source/Setup/Core.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
@@ -6,8 +7,8 @@
 
 namespace OxidEsales\EshopCommunity\Setup;
 
-use \OxidEsales\Eshop\Core\Edition\EditionPathProvider;
-use \OxidEsales\Facts\Facts;
+use OxidEsales\Eshop\Core\Edition\EditionPathProvider;
+use OxidEsales\Facts\Facts;
 use oxSystemComponentException;
 
 /**
@@ -78,8 +79,8 @@ class Core
         $facts = new Facts();
         $class =  'OxidEsales\\EshopCommunity\\Setup\\' . $sInstanceName;
 
-        $classEnterprise = '\\OxidEsales\\EshopEnterprise\\'.EditionPathProvider::SETUP_DIRECTORY.'\\'.$sInstanceName;
-        $classProfessional = '\\OxidEsales\\EshopProfessional\\'.EditionPathProvider::SETUP_DIRECTORY.'\\'.$sInstanceName;
+        $classEnterprise = '\\OxidEsales\\EshopEnterprise\\' . EditionPathProvider::SETUP_DIRECTORY . '\\' . $sInstanceName;
+        $classProfessional = '\\OxidEsales\\EshopProfessional\\' . EditionPathProvider::SETUP_DIRECTORY . '\\' . $sInstanceName;
         if (($facts->isProfessional() || $facts->isEnterprise()) && $this->classExists($classProfessional)) {
             $class = $classProfessional;
         }

--- a/source/Setup/Database.php
+++ b/source/Setup/Database.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
@@ -11,7 +12,7 @@ use Exception;
 use PDO;
 use PDOException;
 use PDOStatement;
-use \OxidEsales\Facts\Facts;
+use OxidEsales\Facts\Facts;
 
 /**
  * Setup database manager class

--- a/source/Setup/De/lang.php
+++ b/source/Setup/De/lang.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
@@ -9,7 +10,7 @@ $aLang = [
 'charset'                                       => 'UTF-8',
 'HEADER_META_MAIN_TITLE'                        => 'OXID eShop Installationsassistent',
 'HEADER_TEXT_SETUP_NOT_RUNS_AUTOMATICLY'        => 'Sollte das Setup nicht nach einigen Sekunden automatisch weiterspringen, dann klicken Sie bitte',
-'FOOTER_OXID_ESALES'                            => '&copy; OXID eSales AG 2003-'.@date("Y"),
+'FOOTER_OXID_ESALES'                            => '&copy; OXID eSales AG 2003-' . @date("Y"),
 
 'TAB_0_TITLE'                                   => 'Voraussetzungen',
 'TAB_1_TITLE'                                   => 'Willkommen',
@@ -40,7 +41,7 @@ $aLang = [
 'ERROR_BAD_DEMODATA'                            => 'FEHLER: (Demodaten)Probleme mit folgenden SQL Befehlen: ',
 'ERROR_NO_DEMODATA_INSTALLED'                   => 'ERROR: Demodaten-Paket ist nicht installiert. Bitte installieren Sie zuerst die Demodaten.',
 'NOTICE_NO_DEMODATA_INSTALLED'                  => 'Demodaten-Paket ist nicht installiert. Bitte installieren Sie zuerst die Demodaten. Details dazu finden Sie im Abschnitt Installation der Datei README.md.',
-'ERROR_CONFIG_FILE_IS_NOT_WRITABLE'             => 'FEHLER: %s/config.inc.php'.' nicht beschreibbar!',
+'ERROR_CONFIG_FILE_IS_NOT_WRITABLE'             => 'FEHLER: %s/config.inc.php' . ' nicht beschreibbar!',
 'ERROR_BAD_SERIAL_NUMBER'                       => 'FEHLER: Falsche Serienummer!',
 'ERROR_COULD_NOT_OPEN_CONFIG_FILE'              => 'Konnte config.inc.php nicht öffnen. Bitte in unserer FAQ oder im Forum nachlesen oder den OXID Support kontaktieren.',
 'ERROR_COULD_NOT_FIND_FILE'                     => 'Setup konnte die Datei \"%s\" nicht finden!',
@@ -95,11 +96,11 @@ $aLang = [
 
 'STEP_0_ERROR_TEXT'                             => 'Ihr System erfüllt nicht alle nötigen Systemvoraussetzungen',
 'STEP_0_ERROR_URL'                              => 'http://www.oxid-esales.com/de/support-services/dokumentation-und-hilfe/oxid-eshop/installation/oxid-eshop-neu-installieren/server-und-systemvoraussetzungen/systemvoraussetzungen-ce.html',
-'STEP_0_TEXT'                                   => '<ul class="req">'.
-                                                   '<li class="pass"> - Die Voraussetzung ist erfüllt.</li>'.
-                                                   '<li class="pmin"> - Die Voraussetzung ist nicht oder nur teilweise erfüllt. Der OXID eShop funktioniert trotzdem und kann installiert werden.</li>'.
-                                                   '<li class="fail"> - Die Voraussetzung ist nicht erfüllt. Der OXID eShop funktioniert nicht ohne diese Voraussetzung und kann nicht installiert werden.</li>'.
-                                                   '<li class="null"> - Die Voraussetzung konnte nicht überprüft werden.'.
+'STEP_0_TEXT'                                   => '<ul class="req">' .
+                                                   '<li class="pass"> - Die Voraussetzung ist erfüllt.</li>' .
+                                                   '<li class="pmin"> - Die Voraussetzung ist nicht oder nur teilweise erfüllt. Der OXID eShop funktioniert trotzdem und kann installiert werden.</li>' .
+                                                   '<li class="fail"> - Die Voraussetzung ist nicht erfüllt. Der OXID eShop funktioniert nicht ohne diese Voraussetzung und kann nicht installiert werden.</li>' .
+                                                   '<li class="null"> - Die Voraussetzung konnte nicht überprüft werden.' .
                                                    '</ul>',
 'STEP_0_DESC'                                   => 'In diesem Schritt wird überprüft, ob Ihr System die Voraussetzungen erfüllt:',
 'STEP_0_TITLE'                                  => 'Systemvoraussetzungen überprüfen',
@@ -196,11 +197,11 @@ $aLang = [
 
 'SHOP_CONFIG_SEND_TECHNICAL_INFORMATION_TO_OXID'      => 'Verbindung mit den OXID eSales Servern erlauben, um die Qualität unserer Open-Source-Produkte zu verbessern.',
 'HELP_SHOP_CONFIG_SEND_TECHNICAL_INFORMATION_TO_OXID' => 'Es werden keine geschäftsrelevanten Daten oder Kundeninformationen übermittelt. '
-                                                        .'Die gesammelten Daten sind ausschließlich technologische Informationen. '
-                                                        .'Um unsere Produktqualität zu verbessern, werden Informationen wie diese erhoben:'
-                                                        .'<ul>'
-                                                        .'  <li>Anzahl der installierten OXID eShop Community Editions weltweit</li>'
-                                                        .'  <li>durchschnittliche Anzahl installierter Erweiterungen pro OXID eShop</li>'
-                                                        .'  <li>die meist verbreiteten Erweiterungen für den OXID eShop</li>'
-                                                        .'</ul>',
+                                                        . 'Die gesammelten Daten sind ausschließlich technologische Informationen. '
+                                                        . 'Um unsere Produktqualität zu verbessern, werden Informationen wie diese erhoben:'
+                                                        . '<ul>'
+                                                        . '  <li>Anzahl der installierten OXID eShop Community Editions weltweit</li>'
+                                                        . '  <li>durchschnittliche Anzahl installierter Erweiterungen pro OXID eShop</li>'
+                                                        . '  <li>die meist verbreiteten Erweiterungen für den OXID eShop</li>'
+                                                        . '</ul>',
 ];

--- a/source/Setup/Dispatcher.php
+++ b/source/Setup/Dispatcher.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
@@ -6,7 +7,7 @@
 
 namespace OxidEsales\EshopCommunity\Setup;
 
-use \OxidEsales\EshopCommunity\Setup\Exception\SetupControllerExitException;
+use OxidEsales\EshopCommunity\Setup\Exception\SetupControllerExitException;
 
 /**
  * Chooses and executes controller action which must be executec to render expected view
@@ -41,7 +42,7 @@ class Dispatcher extends Core
      *
      * @return string | null
      */
-    protected function _chooseCurrentAction()
+    protected function _chooseCurrentAction() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         /** @var Setup $oSetup */
         $oSetup = $this->getInstance("Setup");

--- a/source/Setup/En/lang.php
+++ b/source/Setup/En/lang.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
@@ -9,7 +10,7 @@ $aLang = [
 'charset'                                       => 'UTF-8',
 'HEADER_META_MAIN_TITLE'                        => 'OXID eShop installation wizard',
 'HEADER_TEXT_SETUP_NOT_RUNS_AUTOMATICLY'        => 'If setup does not continue in a few seconds, please click ',
-'FOOTER_OXID_ESALES'                            => '&copy; OXID eSales AG 2003 - '.@date("Y"),
+'FOOTER_OXID_ESALES'                            => '&copy; OXID eSales AG 2003 - ' . @date("Y"),
 
 'TAB_0_TITLE'                                   => 'System Requirements',
 'TAB_1_TITLE'                                   => 'Welcome',
@@ -40,7 +41,7 @@ $aLang = [
 'ERROR_BAD_DEMODATA'                            => 'ERROR: Issue while inserting this SQL statements: ',
 'ERROR_NO_DEMODATA_INSTALLED'                   => 'ERROR: Demo data package not installed. Please install the demo data first.',
 'NOTICE_NO_DEMODATA_INSTALLED'                  => 'Demo data package not installed. Please install the demo data first. See the Installation section in the README.md file for details.',
-'ERROR_CONFIG_FILE_IS_NOT_WRITABLE'             => 'ERROR: %s/config.inc.php'.' not writeable!',
+'ERROR_CONFIG_FILE_IS_NOT_WRITABLE'             => 'ERROR: %s/config.inc.php' . ' not writeable!',
 'ERROR_BAD_SERIAL_NUMBER'                       => 'ERROR: Wrong license key!',
 'ERROR_COULD_NOT_OPEN_CONFIG_FILE'              => 'Could not open %s for reading! Please consult our FAQ, forum or contact OXID Support staff!',
 'ERROR_COULD_NOT_FIND_FILE'                     => 'Setup could not find %s !',
@@ -94,11 +95,11 @@ $aLang = [
 
 'STEP_0_ERROR_TEXT'                             => 'Your system does not fit system requirements',
 'STEP_0_ERROR_URL'                              => 'http://www.oxid-esales.com/en/products/community-edition/system-requirements',
-'STEP_0_TEXT'                                   => '<ul class="req">'.
-                                                   '<li class="pass"> - Your system fits the requirement.</li>'.
-                                                   '<li class="pmin"> - The requirement is not or only partly fit. The OXID eShop will work anyway and can be installed.</li>'.
-                                                   '<li class="fail"> - Your system doesn\'t fit the requirement. The OXID eShop will not work without it and cannot be installed.</li>'.
-                                                   '<li class="null"> - The requirement could  not be checked.'.
+'STEP_0_TEXT'                                   => '<ul class="req">' .
+                                                   '<li class="pass"> - Your system fits the requirement.</li>' .
+                                                   '<li class="pmin"> - The requirement is not or only partly fit. The OXID eShop will work anyway and can be installed.</li>' .
+                                                   '<li class="fail"> - Your system doesn\'t fit the requirement. The OXID eShop will not work without it and cannot be installed.</li>' .
+                                                   '<li class="null"> - The requirement could  not be checked.' .
                                                    '</ul>',
 'STEP_0_DESC'                                   => 'In this step we check if your system fits the requirements:',
 'STEP_0_TITLE'                                  => 'System requirements check',
@@ -195,11 +196,11 @@ $aLang = [
 
 'SHOP_CONFIG_SEND_TECHNICAL_INFORMATION_TO_OXID'      => 'Allow a connection to OXID eSales servers for improving the quality of our open source products.',
 'HELP_SHOP_CONFIG_SEND_TECHNICAL_INFORMATION_TO_OXID' => 'No business relevant date or client information will be transmitted. '
-                                                        .'The collected data exclusively apply to technological information. '
-                                                        .'To improve the quality of our products, information like this will be collected:'
-                                                        .'<ul>'
-                                                        .'  <li>number of the OXID eShop Community Edition installations world wide</li>'
-                                                        .'  <li>average number of installed extensions per OXID eShop</li>'
-                                                        .'  <li>top spread extensions for the OXID eShop</li>'
-                                                        .'</ul>',
+                                                        . 'The collected data exclusively apply to technological information. '
+                                                        . 'To improve the quality of our products, information like this will be collected:'
+                                                        . '<ul>'
+                                                        . '  <li>number of the OXID eShop Community Edition installations world wide</li>'
+                                                        . '  <li>average number of installed extensions per OXID eShop</li>'
+                                                        . '  <li>top spread extensions for the OXID eShop</li>'
+                                                        . '</ul>',
 ];

--- a/source/Setup/Exception/CommandExecutionFailedException.php
+++ b/source/Setup/Exception/CommandExecutionFailedException.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Setup/Exception/SetupControllerExitException.php
+++ b/source/Setup/Exception/SetupControllerExitException.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Setup/Exception/TemplateNotFoundException.php
+++ b/source/Setup/Exception/TemplateNotFoundException.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Setup/Language.php
+++ b/source/Setup/Language.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Setup/Messages.php
+++ b/source/Setup/Messages.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Setup/Session.php
+++ b/source/Setup/Session.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
@@ -54,7 +55,7 @@ class Session extends Core
     /**
      * Start session
      */
-    protected function _startSession()
+    protected function _startSession() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         session_name($this->_sSessionName);
 
@@ -80,7 +81,7 @@ class Session extends Core
      *
      * @return string Session ID
      */
-    protected function _validateSession()
+    protected function _validateSession() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         if ($this->getIsNewSession() === true) {
             $this->setSessionParam('setup_session', true);
@@ -101,7 +102,7 @@ class Session extends Core
      *
      * @return string
      */
-    protected function _getNewSessionID()
+    protected function _getNewSessionID() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         session_regenerate_id(false);
         $this->setIsNewSession(true);
@@ -133,7 +134,7 @@ class Session extends Core
     /**
      * Initializes setup session data array
      */
-    protected function _initSessionData()
+    protected function _initSessionData() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         /** @var Utilities $oUtils */
         $oUtils = $this->getInstance("Utilities");
@@ -174,7 +175,7 @@ class Session extends Core
      *
      * @return array
      */
-    protected function &_getSessionData()
+    protected function &_getSessionData() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         return $_SESSION;
     }

--- a/source/Setup/Setup.php
+++ b/source/Setup/Setup.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Setup/Utilities.php
+++ b/source/Setup/Utilities.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
@@ -7,13 +8,12 @@
 namespace OxidEsales\EshopCommunity\Setup;
 
 use Exception;
-
 use OxidEsales\DatabaseViewsGenerator\ViewsGenerator;
-use \OxidEsales\Eshop\Core\Edition\EditionRootPathProvider;
-use \OxidEsales\Eshop\Core\Edition\EditionPathProvider;
-use \OxidEsales\Facts\Facts;
-use \OxidEsales\Eshop\Core\Edition\EditionSelector;
-use \OxidEsales\DoctrineMigrationWrapper\Migrations;
+use OxidEsales\Eshop\Core\Edition\EditionRootPathProvider;
+use OxidEsales\Eshop\Core\Edition\EditionPathProvider;
+use OxidEsales\Facts\Facts;
+use OxidEsales\Eshop\Core\Edition\EditionSelector;
+use OxidEsales\DoctrineMigrationWrapper\Migrations;
 use OxidEsales\DoctrineMigrationWrapper\MigrationsBuilder;
 use OxidEsales\DemoDataInstaller\DemoDataInstallerBuilder;
 use Symfony\Component\Console\Output\ConsoleOutput;
@@ -122,7 +122,7 @@ class Utilities extends Core
      *
      * @return string
      */
-    protected function _extractPath($aPath)
+    protected function _extractPath($aPath) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $sExtPath = '';
         $blBuildPath = false;

--- a/source/Setup/View.php
+++ b/source/Setup/View.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Setup/functions.php
+++ b/source/Setup/functions.php
@@ -1,11 +1,12 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
 
-use \OxidEsales\Facts\Facts;
-use \OxidEsales\EshopProfessional\Core\Serial;
+use OxidEsales\Facts\Facts;
+use OxidEsales\EshopProfessional\Core\Serial;
 
 if (!function_exists('getInstallPath')) {
     /**
@@ -29,11 +30,11 @@ if (!function_exists('getSystemReqCheck')) {
     {
         $facts = new Facts();
         if ($facts->isEnterprise()) {
-            $systemRequirements = new \OxidEsales\EshopEnterprise\Core\SystemRequirements;
+            $systemRequirements = new \OxidEsales\EshopEnterprise\Core\SystemRequirements();
         } elseif ($facts->isProfessional()) {
-            $systemRequirements = new \OxidEsales\EshopProfessional\Core\SystemRequirements;
+            $systemRequirements = new \OxidEsales\EshopProfessional\Core\SystemRequirements();
         } else {
-            $systemRequirements = new \OxidEsales\EshopCommunity\Core\SystemRequirements;
+            $systemRequirements = new \OxidEsales\EshopCommunity\Core\SystemRequirements();
         }
 
         return $systemRequirements;
@@ -48,7 +49,7 @@ if (!function_exists('getCountryList')) {
      */
     function getCountryList()
     {
-        $cePath = (new Facts)->getCommunityEditionSourcePath();
+        $cePath = (new Facts())->getCommunityEditionSourcePath();
         $aCountries = [];
         $relativePath = 'Application/Controller/Admin/ShopCountries.php';
 
@@ -66,7 +67,7 @@ if (!function_exists('getLocation')) {
      */
     function getLocation()
     {
-        $cePath = (new Facts)->getCommunityEditionSourcePath();
+        $cePath = (new Facts())->getCommunityEditionSourcePath();
         $aLocationCountries = [];
         $relativePath = 'Application/Controller/Admin/ShopCountries.php';
 
@@ -84,7 +85,7 @@ if (!function_exists('getLanguages')) {
      */
     function getLanguages()
     {
-        $cePath = (new Facts)->getCommunityEditionSourcePath();
+        $cePath = (new Facts())->getCommunityEditionSourcePath();
         $aLanguages = [];
         $relativePath = 'Application/Controller/Admin/ShopCountries.php';
 
@@ -150,7 +151,7 @@ if (!class_exists("Conf", false)) {
      * because MySQL 8 removed ENCODE and DECODE methods
      *
      */
-    class Conf
+    class Conf // phpcs:ignore
     {
         /**
          * Conf constructor.

--- a/source/Setup/index.php
+++ b/source/Setup/index.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/Setup/tpl/_footer.php
+++ b/source/Setup/tpl/_footer.php
@@ -1,8 +1,10 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
 ?>
 </div>
 <div id="footer">

--- a/source/Setup/tpl/_header.php
+++ b/source/Setup/tpl/_header.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
@@ -77,7 +78,7 @@ $facts = new \OxidEsales\Facts\Facts();
         if ($facts->isCommunity()) {
             $iTabCount = 6;
         }
-            $iDocWidth = ($iTabWidth + $iSepWidth)*$iTabCount;
+            $iDocWidth = ($iTabWidth + $iSepWidth) * $iTabCount;
         ?>
         #page { width: <?php echo $iDocWidth; ?>px; }
         dl.tab { width: <?php echo $iTabWidth; ?>px; }
@@ -109,13 +110,13 @@ $facts = new \OxidEsales\Facts\Facts();
             $sTabClass = $sTabLinkOpen = $sTabLinkClose = '';
             if ($blAct) {
                 $sTabClass     = 'act';
-                $sTabLinkOpen  = '<a href="index.php?istep='.$iTab.'&sid='.$this->getSid(false).'">';
+                $sTabLinkOpen  = '<a href="index.php?istep=' . $iTab . '&sid=' . $this->getSid(false) . '">';
                 $sTabLinkClose = '</a>';
             }
             ?>
             <dl class="tab <?php echo $sTabClass; ?>">
-                <dt><?php echo $sTabLinkOpen ?><?php echo $iCntr ,'. ',$this->getText('TAB_'.$iStepId.'_TITLE', false); ?><?php echo $sTabLinkClose?></dt>
-                <dd><?php echo $sTabLinkOpen ?><?php $this->getText('TAB_'.$iStepId.'_DESC'); ?><?php echo $sTabLinkClose?></dd>
+                <dt><?php echo $sTabLinkOpen ?><?php echo $iCntr ,'. ',$this->getText('TAB_' . $iStepId . '_TITLE', false); ?><?php echo $sTabLinkClose?></dt>
+                <dd><?php echo $sTabLinkOpen ?><?php $this->getText('TAB_' . $iStepId . '_DESC'); ?><?php echo $sTabLinkClose?></dd>
             </dl>
             <?php
         endforeach;

--- a/source/Setup/tpl/dbconnect.php
+++ b/source/Setup/tpl/dbconnect.php
@@ -1,8 +1,10 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
 require "_header.php"; ?>
 <b><?php $this->getText('STEP_3_1_DB_CONNECT_IS_OK'); ?></b><br>
 <?php

--- a/source/Setup/tpl/dbinfo.php
+++ b/source/Setup/tpl/dbinfo.php
@@ -1,8 +1,10 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
 require "_header.php"; ?>
 <?php
 $this->getText('STEP_3_DESC');

--- a/source/Setup/tpl/default.php
+++ b/source/Setup/tpl/default.php
@@ -1,7 +1,9 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
 require "_header.php";
 require "_footer.php";

--- a/source/Setup/tpl/dirsinfo.php
+++ b/source/Setup/tpl/dirsinfo.php
@@ -1,8 +1,10 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
 require "_header.php"; ?>
 <br><br>
 <?php

--- a/source/Setup/tpl/finish.php
+++ b/source/Setup/tpl/finish.php
@@ -1,8 +1,10 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
 require "_header.php";
 
 // caching output

--- a/source/Setup/tpl/license.php
+++ b/source/Setup/tpl/license.php
@@ -1,8 +1,10 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
 require "_header.php"; ?>
 <textarea readonly="readonly" cols="180" rows="20" class="edittext" style="width: 98%; padding: 7px;"><?php echo $this->getViewParam("aLicenseText"); ?></textarea>
 <form action="index.php" method="post">

--- a/source/Setup/tpl/licenseerror.php
+++ b/source/Setup/tpl/licenseerror.php
@@ -1,8 +1,10 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
 require "_header.php"; ?>
 </br></br>
 <form action="index.php" method="post">

--- a/source/Setup/tpl/serial.php
+++ b/source/Setup/tpl/serial.php
@@ -1,8 +1,10 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
 require "_header.php"; ?>
 <b><?php $this->getText('STEP_5_DESC'); ?></b><br>
 <br>

--- a/source/Setup/tpl/systemreq.php
+++ b/source/Setup/tpl/systemreq.php
@@ -1,8 +1,10 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
 require "_header.php"; ?>
 <strong><?php $this->getText('STEP_0_DESC'); ?></strong><br><br>
 

--- a/source/Setup/tpl/welcome.php
+++ b/source/Setup/tpl/welcome.php
@@ -1,8 +1,10 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
 require "_header.php"; ?>
 <strong><?php $this->getText('STEP_1_DESC'); ?></strong><br>
 <br>

--- a/source/admin/index.php
+++ b/source/admin/index.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/admin/oxajax.php
+++ b/source/admin/oxajax.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
@@ -36,11 +37,13 @@ if ($blAjaxCall) {
     $myConfig->setConfigParam('blAdmin', true);
 
     // authorization
-    if (!(
+    if (
+        !(
         Registry::getSession()->checkSessionChallenge()
         && count(Registry::getUtilsServer()->getOxCookie())
         && Registry::getUtils()->checkAccessRights()
-    )) {
+        )
+    ) {
         header("location:index.php");
         Registry::getUtils()->showMessageAndExit("");
     }

--- a/source/bin/cron.php
+++ b/source/bin/cron.php
@@ -1,9 +1,9 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
-
 
 require_once dirname(__FILE__) . "/../bootstrap.php";
 

--- a/source/bootstrap.php
+++ b/source/bootstrap.php
@@ -67,6 +67,7 @@ register_shutdown_function(
     }
 );
 
+// phpcs:disable
 /**
  * Helper for loading and getting the config file contents
  */
@@ -90,6 +91,7 @@ class BootstrapConfigFileReader
         return (bool) $this->iDebug;
     }
 }
+// phpcs:enable
 
 /**
  * Ensure shop config and autoload files are available.

--- a/source/bootstrap.php
+++ b/source/bootstrap.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
@@ -140,7 +141,7 @@ require_once VENDOR_PATH . 'autoload.php';
  * but inside VENDOR_PATH.
  */
 if (!is_dir(OX_BASE_PATH . 'Core')) {
-    define('CORE_AUTOLOADER_PATH', (new \OxidEsales\Facts\Facts)->getCommunityEditionSourcePath() .
+    define('CORE_AUTOLOADER_PATH', (new \OxidEsales\Facts\Facts())->getCommunityEditionSourcePath() .
             DIRECTORY_SEPARATOR .
             'Core' . DIRECTORY_SEPARATOR .
             'Autoload' . DIRECTORY_SEPARATOR);

--- a/source/config.inc.php.dist
+++ b/source/config.inc.php.dist
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/getimg.php
+++ b/source/getimg.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/index.php
+++ b/source/index.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/migration/data/Version20170718124421.php
+++ b/source/migration/data/Version20170718124421.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/migration/data/Version20171018144650.php
+++ b/source/migration/data/Version20171018144650.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/migration/data/Version20180214152228.php
+++ b/source/migration/data/Version20180214152228.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
@@ -23,14 +24,14 @@ class Version20180214152228 extends AbstractMigration
     public function up(Schema $schema)
     {
         $facts = new Facts();
-        $configFile = new ConfigFile($facts->getSourcePath().'/config.inc.php');
+        $configFile = new ConfigFile($facts->getSourcePath() . '/config.inc.php');
         $configKey = !is_null($configFile->getVar('sConfigKey')) ? $configFile->getVar('sConfigKey') : Config::DEFAULT_CONFIG_KEY;
         $settingName = 'blAllowSuggestArticle';
 
         $this->addSql("INSERT INTO `oxconfig` (`OXID`, `OXSHOPID`, `OXMODULE`, `OXVARNAME`, `OXVARTYPE`, `OXVARVALUE`)
-                            SELECT SUBSTRING(md5(uuid_short()), 1, 32),  `OXID`, '', '".$settingName."', 'bool', ENCODE('1', '".$configKey."') FROM oxshops
+                            SELECT SUBSTRING(md5(uuid_short()), 1, 32),  `OXID`, '', '" . $settingName . "', 'bool', ENCODE('1', '" . $configKey . "') FROM oxshops
                             WHERE NOT EXISTS (
-                            SELECT `OXVARNAME` FROM `oxconfig` WHERE `OXVARNAME` = '".$settingName."'
+                            SELECT `OXVARNAME` FROM `oxconfig` WHERE `OXVARNAME` = '" . $settingName . "'
         )");
     }
 

--- a/source/migration/data/Version20180703135728.php
+++ b/source/migration/data/Version20180703135728.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/modules/oe/vendormetadata.php
+++ b/source/modules/oe/vendormetadata.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/overridablefunctions.php
+++ b/source/overridablefunctions.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/oxfunctions.php
+++ b/source/oxfunctions.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/oxseo.php
+++ b/source/oxseo.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.

--- a/source/widget.php
+++ b/source/widget.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.


### PR DESCRIPTION
Hello there :wave:,

this pull request:

- integrates PHPCodeSniffer the official way :heavy_check_mark: 
- provides a `phpcs.xml.dist` :heavy_check_mark: (configuration in a file and not hidden in the code of another repository) 
- cleans up with all the errors reported from PHP CodeSniffer :heavy_check_mark: 
- enforces PSR12 coding guidelines :heavy_check_mark: 
- allows us to deprecate [OXID-eSales/coding_standards_wrapper](https://github.com/OXID-eSales/coding_standards_wrapper) :fire:
- leaves all the warnings from PHPCodeSniffer untouched, so we still have a lot of work to do :wink:
- runs PHPCodeSniffer in Travis without the warnings :tada: 

If merged, this allows for the use of the PHP Code Beautifier and Fixer at `vendor/bin/phpcbf` that is shipped with the PHP CodeSniffer to just fix the coding style errors.

/Flo