### PR TITLE
Alternative to DbMetaDataHandler::fieldExists() or tableExists() a other concept

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,8 @@
         "symfony/console": "^v3.4.15",
         "webmozart/path-util": "^2.3",
         "symfony/finder": "^3.4",
-        "symfony/filesystem": "^3.4"
+        "symfony/filesystem": "^3.4",
+        "tumtum/oxid-schema-expander": "^1.0"
     },
     "require-dev": {
         "oxid-esales/flow-theme": "dev-master",

--- a/source/Internal/Framework/Module/Setup/DataObject/ParameterDatabaseSchemaExpander.php
+++ b/source/Internal/Framework/Module/Setup/DataObject/ParameterDatabaseSchemaExpander.php
@@ -1,0 +1,50 @@
+<?php
+/**
+ * Copyright © OXID eSales AG. All rights reserved.
+ * See LICENSE file for license details.
+ */
+
+namespace OxidEsales\EshopCommunity\Internal\Framework\Module\Setup\DataObject;
+
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use OxidEsales\EshopCommunity\Internal\Framework\Module\Setup\Event\FinalizingModuleActivationEvent;
+use tm\oxid\SchemaExpander\DesireExpander;
+
+/**
+ * Class ParameterDatabaseSchemaExpander
+ * @package OxidEsales\EshopCommunity\Internal\Framework\Module\Setup\DataObject
+ */
+class ParameterDatabaseSchemaExpander implements ParameterInterface, EventSubscriberInterface
+{
+    /**
+     * @var DesireExpander;
+     */
+    private $desireExpander;
+
+    /**
+     * Create new Paramerter
+     *
+     * @return DesireExpander
+     */
+    public function getParameter()
+    {
+        return $this->desireExpander = new DesireExpander();
+    }
+
+    /**
+     * Change Database Schema
+     */
+    public function commitDatabaseSchema()
+    {
+        if ($this->desireExpander) {
+            $this->desireExpander->execute();
+        }
+    }
+
+    public static function getSubscribedEvents()
+    {
+        return [
+            FinalizingModuleActivationEvent::class => ['commitDatabaseSchema', -10]
+        ];
+    }
+}

--- a/source/Internal/Framework/Module/Setup/DataObject/ParameterInterface.php
+++ b/source/Internal/Framework/Module/Setup/DataObject/ParameterInterface.php
@@ -1,0 +1,21 @@
+<?php
+/**
+ * Copyright © OXID eSales AG. All rights reserved.
+ * See LICENSE file for license details.
+ */
+
+namespace OxidEsales\EshopCommunity\Internal\Framework\Module\Setup\DataObject;
+
+/**
+ * Interface ParameterInterface
+ * @package OxidEsales\EshopCommunity\Internal\Framework\Module\Setup\DataObject
+ */
+interface ParameterInterface
+{
+    /**
+     * Returns the parameters for the function
+     *
+     * @return mixed
+     */
+    public function getParameter();
+}

--- a/source/Internal/Framework/Module/Setup/Iterator/EventModuleParameters.php
+++ b/source/Internal/Framework/Module/Setup/Iterator/EventModuleParameters.php
@@ -1,0 +1,44 @@
+<?php
+/**
+ * Copyright © OXID eSales AG. All rights reserved.
+ * See LICENSE file for license details.
+ */
+
+namespace OxidEsales\EshopCommunity\Internal\Framework\Module\Setup\Iterator;
+
+use OxidEsales\EshopCommunity\Internal\Framework\Module\Setup\DataObject\ParameterInterface;
+
+/**
+ * Class EventModuleParameters
+ * @package OxidEsales\EshopCommunity\Internal\Framework\Module\Setup\Iterator
+ */
+class EventModuleParameters implements EventModuleParametersInterface
+{
+    /**
+     * @var ParameterInterface[]
+     */
+    private $parameterInterfaces = [];
+
+    /**
+     * @return array
+     */
+    public function getParameters()
+    {
+        $parameters = array_map(
+            function ($parameterFunctionInterface) {
+                return $parameterFunctionInterface->getParameter();
+            },
+            $this->parameterInterfaces,
+        );
+
+        return $parameters;
+    }
+
+    /**
+     * @param ParameterInterface $parameter
+     */
+    public function addParameter(ParameterInterface $parameter)
+    {
+        $this->parameterInterfaces[] = $parameter;
+    }
+}

--- a/source/Internal/Framework/Module/Setup/Iterator/EventModuleParametersInterface.php
+++ b/source/Internal/Framework/Module/Setup/Iterator/EventModuleParametersInterface.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * Copyright © OXID eSales AG. All rights reserved.
+ * See LICENSE file for license details.
+ */
+
+namespace OxidEsales\EshopCommunity\Internal\Framework\Module\Setup\Iterator;
+
+use OxidEsales\EshopCommunity\Internal\Framework\Module\Setup\DataObject\ParameterInterface;
+
+/**
+ * Interface EventModuleParametersInterface
+ * @package OxidEsales\EshopCommunity\Internal\Framework\Module\Setup\Iterator
+ */
+interface EventModuleParametersInterface
+{
+    /**
+     * Returns the parameters for the function
+     * @return array
+     */
+    public function getParameters();
+
+    /**
+     * @param ParameterInterface $parameter
+     */
+    public function addParameter(ParameterInterface $parameter);
+}

--- a/source/Internal/Framework/Module/Setup/Iterator/services.yaml
+++ b/source/Internal/Framework/Module/Setup/Iterator/services.yaml
@@ -1,0 +1,14 @@
+services:
+  _defaults:
+    autowire: true
+    public: false
+
+  # Paramertes for activation functionen
+  oxid_esales.module.setup.event.paramerters.on.activation:
+    class: OxidEsales\EshopCommunity\Internal\Framework\Module\Setup\Iterator\EventModuleParameters
+
+  # Paramertes for deactivation functionen
+  oxid_esales.module.setup.event.paramerters.on.deactivation:
+    class: OxidEsales\EshopCommunity\Internal\Framework\Module\Setup\Iterator\EventModuleParameters
+
+  # Paramertes

--- a/source/Internal/Framework/Module/Setup/Iterator/services.yaml
+++ b/source/Internal/Framework/Module/Setup/Iterator/services.yaml
@@ -6,9 +6,15 @@ services:
   # Paramertes for activation functionen
   oxid_esales.module.setup.event.paramerters.on.activation:
     class: OxidEsales\EshopCommunity\Internal\Framework\Module\Setup\Iterator\EventModuleParameters
+    calls:
+      - [addParameter, ['@oxid_esales.module.setup.event.paramerter.DatabaseSchemaExpander']]
 
   # Paramertes for deactivation functionen
   oxid_esales.module.setup.event.paramerters.on.deactivation:
     class: OxidEsales\EshopCommunity\Internal\Framework\Module\Setup\Iterator\EventModuleParameters
 
   # Paramertes
+  oxid_esales.module.setup.event.paramerter.DatabaseSchemaExpander:
+    class: OxidEsales\EshopCommunity\Internal\Framework\Module\Setup\DataObject\ParameterDatabaseSchemaExpander
+    tags:
+      - { name: kernel.event_subscriber }

--- a/source/Internal/Framework/Module/Setup/Service/EventModuleParamerterService.php
+++ b/source/Internal/Framework/Module/Setup/Service/EventModuleParamerterService.php
@@ -1,0 +1,65 @@
+<?php
+
+/**
+ * Copyright © OXID eSales AG. All rights reserved.
+ * See LICENSE file for license details.
+ */
+
+namespace OxidEsales\EshopCommunity\Internal\Framework\Module\Setup\Service;
+
+use OxidEsales\EshopCommunity\Internal\Framework\Module\Setup\Iterator\EventModuleParametersInterface;
+
+/**
+ * Class EventModuleParamerterService
+ * @package OxidEsales\EshopCommunity\Internal\Framework\Module\Setup\Service
+ */
+class EventModuleParamerterService implements EventModuleParamerterServiceInterface
+{
+    /**
+     * @var EventModuleParametersInterface
+     */
+    private $onActivate = null;
+
+    /**
+     * @var EventModuleParametersInterface
+     */
+    private $onDeactivate = null;
+
+    /**
+     * EventModuleParamerterService constructor.
+     *
+     * @param EventModuleParametersInterface $forActivate
+     * @param EventModuleParametersInterface $forDeactivate
+     */
+    public function __construct(
+        EventModuleParametersInterface $forActivate,
+        EventModuleParametersInterface $forDeactivate
+    ) {
+        $this->onActivate = $forActivate;
+        $this->onDeactivate  = $forDeactivate;
+    }
+
+    /**
+     * Create function paramerter for event on Activate
+     *
+     * @param callable $callable
+     */
+    public function forActivate(callable $callable)
+    {
+        $parameters = $this->onActivate->getParameters();
+
+        call_user_func($callable, $parameters);
+    }
+
+    /**
+     * Create function paramerter for event on Deactivate
+     *
+     * @param callable $callable
+     */
+    public function forDeactivate(callable $callable)
+    {
+        $parameters = $this->onDeactivate->getParameters();
+
+        call_user_func($callable, $parameters);
+    }
+}

--- a/source/Internal/Framework/Module/Setup/Service/EventModuleParamerterServiceInterface.php
+++ b/source/Internal/Framework/Module/Setup/Service/EventModuleParamerterServiceInterface.php
@@ -1,0 +1,40 @@
+<?php
+
+/**
+ * Copyright © OXID eSales AG. All rights reserved.
+ * See LICENSE file for license details.
+ */
+
+namespace OxidEsales\EshopCommunity\Internal\Framework\Module\Setup\Service;
+
+use OxidEsales\EshopCommunity\Internal\Framework\Module\Setup\Iterator\EventModuleParametersInterface;
+
+/**
+ * Interface EventModuleParamerterServiceInterface
+ * @package OxidEsales\EshopCommunity\Internal\Framework\Module\Setup\Service
+ */
+interface EventModuleParamerterServiceInterface
+{
+
+    /**
+     * EventModuleParamerterServiceInterface constructor.
+     *
+     * @param EventModuleParametersInterface $forActivate
+     * @param EventModuleParametersInterface $forDeactivate
+     */
+    public function __construct(
+        EventModuleParametersInterface $forActivate,
+        EventModuleParametersInterface $forDeactivate
+    );
+
+    /**
+     * @param callable $callable
+     */
+    public function forActivate(callable $callable);
+
+    /**
+     * @param callable $callable
+     */
+    public function forDeactivate(callable $callable);
+
+}

--- a/source/Internal/Framework/Module/Setup/Template/ModuleEventsInterface.php
+++ b/source/Internal/Framework/Module/Setup/Template/ModuleEventsInterface.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * Copyright © OXID eSales AG. All rights reserved.
+ * See LICENSE file for license details.
+ */
+
+namespace OxidEsales\EshopCommunity\Internal\Framework\Module\Setup\Template;
+
+
+use tm\oxid\SchemaExpander\DesireExpander;
+
+/**
+ * Interface ModuleEventsInterface
+ *
+ * @package OxidEsales\EshopCommunity\Internal\Framework\Module\Setup\Template
+ */
+interface ModuleEventsInterface
+{
+    /**
+     * Called up when the module becomes active.
+     * As soon as it is registered in the metadata.php under event.
+     *
+     * @see https://docs.oxid-esales.com/developer/en/6.1/modules/skeleton/metadataphp/version12.html#events
+     * @param DesireExpander $desireExpander Database schema adjustments when activating the module
+     * @return void
+     */
+    public static function onActivate(DesireExpander $desireExpander);
+
+    /**
+     * Called up when the module will be deactive.
+     *
+     * @return void
+     */
+    public static function onDeactivate();
+}

--- a/source/Internal/Framework/Module/Setup/services.yaml
+++ b/source/Internal/Framework/Module/Setup/services.yaml
@@ -1,3 +1,6 @@
+imports:
+  - { resource: Iterator/services.yaml }
+
 services:
   _defaults:
     autowire: true
@@ -112,3 +115,9 @@ services:
 
   OxidEsales\EshopCommunity\Internal\Framework\Module\Setup\Service\ActiveClassExtensionChainResolverInterface:
     class: OxidEsales\EshopCommunity\Internal\Framework\Module\Setup\Service\ActiveClassExtensionChainResolver
+
+  OxidEsales\EshopCommunity\Internal\Framework\Module\Setup\Service\EventModuleParamerterServiceInterface:
+    class: OxidEsales\EshopCommunity\Internal\Framework\Module\Setup\Service\EventModuleParamerterService
+    arguments:
+      - '@oxid_esales.module.setup.event.paramerters.on.activation'
+      - '@oxid_esales.module.setup.event.paramerters.on.deactivation'


### PR DESCRIPTION
Sometimes the event 'onActivate' is used, when a module is activated. To adjust the database tables. For this purpose the DbMetaDataHandler class was used to adjust the tables.

My idea would be to use a library. That does a check of the database structure and automatically adds the columns or creates the whole table if it doesn't exist.

The developer writes exactly what he needs and the rest does the framework.

Example:

> module/my/metadata.php

```php
'events' => [
      'onActivate'   => 'my\\ModuleInit::onActivate',
      'onDeactivate' => 'my\\ModuleInit::onDeactivate'
  ],
```

> module/my/myModuleInit.php

```php
namespace my;

use OxidEsales\EshopCommunity\Internal\Framework\Module\Setup\Template\ModuleEventsInterface;
use tm\oxid\SchemaExpander\DesireExpander;

class ModuleInit implements ModuleEventsInterface
{
    /**
     * What is new: the onActivate function was given the library as parameter.
     * Which takes care that the table looks like it was described.
     *
     * @param DesireExpander $desireExpander
     */
    public function onActivate(DesireExpander $desireExpander)
    {
        // Simple create new table
        $desireExpander
            ->table('tm_example')
                ->addFieldOxid()
                ->addFieldOxactive()
                ->addFieldOxactiveFrom()
                ->addFieldOxactiveTo()
                ->addField('OXHASH', "char(32) COLLATE latin1_general_ci NOT NULL DEFAULT '' COMMENT 'Hash'")
                ->addField('OXTIME', "int(11) NOT NULL COMMENT 'Validation time'")
                ->addFieldOxtimestamp()
                ->setPrimaryKey('OXID');

        // Extent a oxarticles table
        $desireExpander
            ->table('oxarticles')
                ->addField('MYCOLUMN', "char(32) NOT NULL DEFAULT 'Wowo' COMMENT 'Extent only one Column'")
                ->after('oxlang');
    }

    public static function onDeactivate()
    {
    }
}
```

If you like that idea, I can write the appropriate tests.