### PR TITLE
OXDEV-3281 deprecate all underscore methods

### DIFF
--- a/source/Application/Component/BasketComponent.php
+++ b/source/Application/Component/BasketComponent.php
@@ -257,6 +257,13 @@ class BasketComponent extends \OxidEsales\Eshop\Core\Controller\BaseController
             $database->commitTransaction();
         }
     }
+    /**
+     * @deprecated use self::getRedirectUrl instead
+     */
+    protected function _getRedirectUrl() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getRedirectUrl();
+    }
 
     /**
      * Formats and returns redirect URL where shop must be redirected after
@@ -264,7 +271,7 @@ class BasketComponent extends \OxidEsales\Eshop\Core\Controller\BaseController
      *
      * @return string   $sClass.$sPosition  redirection URL
      */
-    protected function _getRedirectUrl() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getRedirectUrl()
     {
 
         // active controller id
@@ -314,6 +321,13 @@ class BasketComponent extends \OxidEsales\Eshop\Core\Controller\BaseController
         }
         return array_filter($persistedParameters) ?: null;
     }
+    /**
+     * @deprecated use self::getItems instead
+     */
+    protected function _getItems($sProductId = null, $dAmount = null, $aSel = null, $aPersParam = null, $blOverride = false) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getItems($sProductId, $dAmount, $aSel, $aPersParam, $blOverride);
+    }
 
     /**
      * Collects and returns array of items to add to basket. Product info is taken not only from
@@ -327,7 +341,7 @@ class BasketComponent extends \OxidEsales\Eshop\Core\Controller\BaseController
      *
      * @return mixed
      */
-    protected function _getItems( // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getItems(
         $sProductId = null,
         $dAmount = null,
         $aSel = null,
@@ -378,6 +392,13 @@ class BasketComponent extends \OxidEsales\Eshop\Core\Controller\BaseController
 
         return false;
     }
+    /**
+     * @deprecated use self::addItems instead
+     */
+    protected function _addItems($products) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->addItems($products);
+    }
 
     /**
      * Adds all articles user wants to add to basket. Returns
@@ -387,7 +408,7 @@ class BasketComponent extends \OxidEsales\Eshop\Core\Controller\BaseController
      *
      * @return  object  $oBasketItem    last added basket item
      */
-    protected function _addItems($products) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function addItems($products)
     {
         $activeView = $this->getConfig()->getActiveView();
         $errorDestination = $activeView->getErrorDestination();
@@ -440,6 +461,13 @@ class BasketComponent extends \OxidEsales\Eshop\Core\Controller\BaseController
 
         return $basketItem;
     }
+    /**
+     * @deprecated use self::setLastCall instead
+     */
+    protected function _setLastCall($sCallName, $aProductInfo, $aBasketInfo) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->setLastCall($sCallName, $aProductInfo, $aBasketInfo);
+    }
 
     /**
      * Setting last call data to session (data used by econda)
@@ -448,9 +476,16 @@ class BasketComponent extends \OxidEsales\Eshop\Core\Controller\BaseController
      * @param array  $aProductInfo data which comes from request when you press button "to basket"
      * @param array  $aBasketInfo  array returned by \OxidEsales\Eshop\Application\Model\Basket::getBasketSummary()
      */
-    protected function _setLastCall($sCallName, $aProductInfo, $aBasketInfo) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function setLastCall($sCallName, $aProductInfo, $aBasketInfo)
     {
         Registry::getSession()->setVariable('aLastcall', [$sCallName => $aProductInfo]);
+    }
+    /**
+     * @deprecated use self::setLastCallFnc instead
+     */
+    protected function _setLastCallFnc($sCallName) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->setLastCallFnc($sCallName);
     }
 
     /**
@@ -458,9 +493,16 @@ class BasketComponent extends \OxidEsales\Eshop\Core\Controller\BaseController
      *
      * @param string $sCallName name of action ('tobasket', 'changebasket')
      */
-    protected function _setLastCallFnc($sCallName) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function setLastCallFnc($sCallName)
     {
         $this->_sLastCallFnc = $sCallName;
+    }
+    /**
+     * @deprecated use self::getLastCallFnc instead
+     */
+    protected function _getLastCallFnc() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getLastCallFnc();
     }
 
     /**
@@ -468,7 +510,7 @@ class BasketComponent extends \OxidEsales\Eshop\Core\Controller\BaseController
      *
      * @return string
      */
-    protected function _getLastCallFnc() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getLastCallFnc()
     {
         return $this->_sLastCallFnc;
     }

--- a/source/Application/Component/CategoriesComponent.php
+++ b/source/Application/Component/CategoriesComponent.php
@@ -100,13 +100,20 @@ class CategoriesComponent extends \OxidEsales\Eshop\Core\Controller\BaseControll
             }
         }
     }
+    /**
+     * @deprecated use self::getActCat instead
+     */
+    protected function _getActCat() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getActCat();
+    }
 
     /**
      * get active category id
      *
      * @return string
      */
-    protected function _getActCat() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getActCat()
     {
         $sActManufacturer = \OxidEsales\Eshop\Core\Registry::getConfig()->getRequestParameter('mnid');
 
@@ -136,13 +143,20 @@ class CategoriesComponent extends \OxidEsales\Eshop\Core\Controller\BaseControll
 
         return $sActCat;
     }
+    /**
+     * @deprecated use self::loadCategoryTree instead
+     */
+    protected function _loadCategoryTree($sActCat) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->loadCategoryTree($sActCat);
+    }
 
     /**
      * Category tree loader
      *
      * @param string $sActCat active category id
      */
-    protected function _loadCategoryTree($sActCat) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function loadCategoryTree($sActCat)
     {
         /** @var \OxidEsales\Eshop\Application\Model\CategoryList $oCategoryTree */
         $oCategoryTree = oxNew(\OxidEsales\Eshop\Application\Model\CategoryList::class);
@@ -157,13 +171,20 @@ class CategoriesComponent extends \OxidEsales\Eshop\Core\Controller\BaseControll
         // setting active category
         $oParentView->setActiveCategory($oCategoryTree->getClickCat());
     }
+    /**
+     * @deprecated use self::loadManufacturerTree instead
+     */
+    protected function _loadManufacturerTree($sActManufacturer) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->loadManufacturerTree($sActManufacturer);
+    }
 
     /**
      * Manufacturer tree loader
      *
      * @param string $sActManufacturer active Manufacturer id
      */
-    protected function _loadManufacturerTree($sActManufacturer) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function loadManufacturerTree($sActManufacturer)
     {
         $myConfig = $this->getConfig();
         if ($myConfig->getConfigParam('bl_perfLoadManufacturerTree')) {
@@ -207,6 +228,13 @@ class CategoriesComponent extends \OxidEsales\Eshop\Core\Controller\BaseControll
             return $this->_oCategoryTree;
         }
     }
+    /**
+     * @deprecated use self::addAdditionalParams instead
+     */
+    protected function _addAdditionalParams($oProduct, $sActCat, $sActManufacturer, $sActVendor) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->addAdditionalParams($oProduct, $sActCat, $sActManufacturer, $sActVendor);
+    }
 
     /**
      * Adds additional parameters: active category, list type and category id
@@ -218,7 +246,7 @@ class CategoriesComponent extends \OxidEsales\Eshop\Core\Controller\BaseControll
      *
      * @return string $sActCat
      */
-    protected function _addAdditionalParams($oProduct, $sActCat, $sActManufacturer, $sActVendor) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function addAdditionalParams($oProduct, $sActCat, $sActManufacturer, $sActVendor)
     {
         $sSearchPar = \OxidEsales\Eshop\Core\Registry::getConfig()->getRequestParameter('searchparam');
         $sSearchCat = \OxidEsales\Eshop\Core\Registry::getConfig()->getRequestParameter('searchcnid');
@@ -254,6 +282,13 @@ class CategoriesComponent extends \OxidEsales\Eshop\Core\Controller\BaseControll
 
         return $sActCat;
     }
+    /**
+     * @deprecated use self::getDefaultParams instead
+     */
+    protected function _getDefaultParams($oProduct) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getDefaultParams($oProduct);
+    }
 
     /**
      * Returns array containing default list type and category (or manufacturer ir vendor) id
@@ -262,7 +297,7 @@ class CategoriesComponent extends \OxidEsales\Eshop\Core\Controller\BaseControll
      *
      * @return array
      */
-    protected function _getDefaultParams($oProduct) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getDefaultParams($oProduct)
     {
         $sListType = null;
         $aArticleCats = $oProduct->getCategoryIds(true);

--- a/source/Application/Component/Locator.php
+++ b/source/Application/Component/Locator.php
@@ -81,6 +81,13 @@ class Locator extends \OxidEsales\Eshop\Core\Base
         // passing list type to view
         $oLocatorTarget->setListType($this->_sType);
     }
+    /**
+     * @deprecated use self::setListLocatorData instead
+     */
+    protected function _setListLocatorData($oLocatorTarget, $oCurrArticle) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->setListLocatorData($oLocatorTarget, $oCurrArticle);
+    }
 
     /**
      * Sets details locator data for articles that came from regular list.
@@ -88,7 +95,7 @@ class Locator extends \OxidEsales\Eshop\Core\Base
      * @param FrontendController $oLocatorTarget view object
      * @param Article            $oCurrArticle   current article
      */
-    protected function _setListLocatorData($oLocatorTarget, $oCurrArticle) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function setListLocatorData($oLocatorTarget, $oCurrArticle)
     {
         // if no active category is loaded - lets check for category passed by post/get
         if (($oCategory = $oLocatorTarget->getActiveCategory())) {
@@ -124,6 +131,13 @@ class Locator extends \OxidEsales\Eshop\Core\Base
             }
         }
     }
+    /**
+     * @deprecated use self::setVendorLocatorData instead
+     */
+    protected function _setVendorLocatorData($oLocatorTarget, $oCurrArticle) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->setVendorLocatorData($oLocatorTarget, $oCurrArticle);
+    }
 
     /**
      * Sets details locator data for articles that came from vendor list.
@@ -131,7 +145,7 @@ class Locator extends \OxidEsales\Eshop\Core\Base
      * @param FrontendController $oLocatorTarget FrontendController object
      * @param Article            $oCurrArticle   current article
      */
-    protected function _setVendorLocatorData($oLocatorTarget, $oCurrArticle) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function setVendorLocatorData($oLocatorTarget, $oCurrArticle)
     {
         if (($oVendor = $oLocatorTarget->getActVendor())) {
             $sVendorId = $oVendor->getId();
@@ -168,6 +182,13 @@ class Locator extends \OxidEsales\Eshop\Core\Base
             $oVendor->prevProductLink = $oBackProduct ? $this->_makeLink($oBackProduct->getLink(), $sAdd) : null;
         }
     }
+    /**
+     * @deprecated use self::setManufacturerLocatorData instead
+     */
+    protected function _setManufacturerLocatorData($oLocatorTarget, $oCurrArticle) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->setManufacturerLocatorData($oLocatorTarget, $oCurrArticle);
+    }
 
     /**
      * Sets details locator data for articles that came from Manufacturer list.
@@ -175,7 +196,7 @@ class Locator extends \OxidEsales\Eshop\Core\Base
      * @param FrontendController $oLocatorTarget FrontendController object
      * @param Article            $oCurrArticle   current article
      */
-    protected function _setManufacturerLocatorData($oLocatorTarget, $oCurrArticle) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function setManufacturerLocatorData($oLocatorTarget, $oCurrArticle)
     {
         if (($oManufacturer = $oLocatorTarget->getActManufacturer())) {
             $sManufacturerId = $oManufacturer->getId();
@@ -222,6 +243,13 @@ class Locator extends \OxidEsales\Eshop\Core\Base
             }
         }
     }
+    /**
+     * @deprecated use self::setSearchLocatorData instead
+     */
+    protected function _setSearchLocatorData($oLocatorTarget, $oCurrArticle) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->setSearchLocatorData($oLocatorTarget, $oCurrArticle);
+    }
 
     /**
      * Sets details locator data for articles that came from search list.
@@ -229,7 +257,7 @@ class Locator extends \OxidEsales\Eshop\Core\Base
      * @param FrontendController $oLocatorTarget FrontendController object
      * @param Article            $oCurrArticle   current article
      */
-    protected function _setSearchLocatorData($oLocatorTarget, $oCurrArticle) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function setSearchLocatorData($oLocatorTarget, $oCurrArticle)
     {
         if (($oSearchCat = $oLocatorTarget->getActSearch())) {
             // #1834/1184M - specialchar search
@@ -286,6 +314,13 @@ class Locator extends \OxidEsales\Eshop\Core\Base
             $oLocatorTarget->setActiveCategory($oSearchCat);
         }
     }
+    /**
+     * @deprecated use self::setRecommlistLocatorData instead
+     */
+    protected function _setRecommlistLocatorData($oLocatorTarget, $oCurrArticle) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->setRecommlistLocatorData($oLocatorTarget, $oCurrArticle);
+    }
 
     /**
      * Sets details locator data for articles that came from recommlist.
@@ -298,7 +333,7 @@ class Locator extends \OxidEsales\Eshop\Core\Base
      *
      * @deprecated since v5.3 (2016-06-17); Listmania will be moved to an own module.
      */
-    protected function _setRecommlistLocatorData($oLocatorTarget, $oCurrArticle) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function setRecommlistLocatorData($oLocatorTarget, $oCurrArticle)
     {
         if (($oRecommList = $oLocatorTarget->getActiveRecommList())) {
             // loading data for article navigation
@@ -349,6 +384,13 @@ class Locator extends \OxidEsales\Eshop\Core\Base
             $oLocatorTarget->setActiveCategory($oRecommList);
         }
     }
+    /**
+     * @deprecated use self::loadIdsInList instead
+     */
+    protected function _loadIdsInList($oCategory, $oCurrArticle, $sOrderBy = null) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->loadIdsInList($oCategory, $oCurrArticle, $sOrderBy);
+    }
 
     /**
      * Setting product position in list, amount of articles etc
@@ -359,7 +401,7 @@ class Locator extends \OxidEsales\Eshop\Core\Base
      *
      * @return object
      */
-    protected function _loadIdsInList($oCategory, $oCurrArticle, $sOrderBy = null) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function loadIdsInList($oCategory, $oCurrArticle, $sOrderBy = null)
     {
         $oIdList = oxNew(\OxidEsales\Eshop\Application\Model\ArticleList::class);
         $oIdList->setCustomSorting($sOrderBy);
@@ -381,6 +423,13 @@ class Locator extends \OxidEsales\Eshop\Core\Base
 
         return $oIdList;
     }
+    /**
+     * @deprecated use self::makeLink instead
+     */
+    protected function _makeLink($sLink, $sParams) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->makeLink($sLink, $sParams);
+    }
 
     /**
      * Appends urs with currently passed parameters
@@ -390,13 +439,20 @@ class Locator extends \OxidEsales\Eshop\Core\Base
      *
      * @return string
      */
-    protected function _makeLink($sLink, $sParams) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function makeLink($sLink, $sParams)
     {
         if ($sParams) {
             $sLink .= ((strpos($sLink, '?') !== false) ? '&amp;' : '?') . $sParams;
         }
 
         return $sLink;
+    }
+    /**
+     * @deprecated use self::findActPageNumber instead
+     */
+    protected function _findActPageNumber($iPageNr, $oIdList = null, $oArticle = null) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->findActPageNumber($iPageNr, $oIdList, $oArticle);
     }
 
     /**
@@ -409,7 +465,7 @@ class Locator extends \OxidEsales\Eshop\Core\Base
      *
      * @return int
      */
-    protected function _findActPageNumber($iPageNr, $oIdList = null, $oArticle = null) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function findActPageNumber($iPageNr, $oIdList = null, $oArticle = null)
     {
         //page number
         $iPageNr = (int) $iPageNr;
@@ -426,6 +482,13 @@ class Locator extends \OxidEsales\Eshop\Core\Base
 
         return $iPageNr;
     }
+    /**
+     * @deprecated use self::getPageNumber instead
+     */
+    protected function _getPageNumber($iPageNr) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getPageNumber($iPageNr);
+    }
 
     /**
      * Gets current page number.
@@ -434,12 +497,19 @@ class Locator extends \OxidEsales\Eshop\Core\Base
      *
      * @return string $sPageNum
      */
-    protected function _getPageNumber($iPageNr) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getPageNumber($iPageNr)
     {
         //page number
         $iPageNr = (int) $iPageNr;
 
         return (($iPageNr > 0) ? "pgNr=$iPageNr" : '');
+    }
+    /**
+     * @deprecated use self::getProductPos instead
+     */
+    protected function _getProductPos($oArticle, $oIdList, $oLocatorTarget) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getProductPos($oArticle, $oIdList, $oLocatorTarget);
     }
 
     /**
@@ -451,7 +521,7 @@ class Locator extends \OxidEsales\Eshop\Core\Base
      *
      * @return integer
      */
-    protected function _getProductPos($oArticle, $oIdList, $oLocatorTarget) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getProductPos($oArticle, $oIdList, $oLocatorTarget)
     {
         // variant handling
         $sOxid = $oArticle->oxarticles__oxparentid->value

--- a/source/Application/Component/UserComponent.php
+++ b/source/Application/Component/UserComponent.php
@@ -117,6 +117,13 @@ class UserComponent extends \OxidEsales\Eshop\Core\Controller\BaseController
 
         return $this->getUser();
     }
+    /**
+     * @deprecated use self::checkPsState instead
+     */
+    protected function _checkPsState() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->checkPsState();
+    }
 
     /**
      * If private sales enabled, checks:
@@ -126,7 +133,7 @@ class UserComponent extends \OxidEsales\Eshop\Core\Controller\BaseController
      *  (1) login page;
      *  (2) terms agreement page;
      */
-    protected function _checkPsState() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function checkPsState()
     {
         $oConfig = $this->getConfig();
         if ($this->getParent()->isEnabledPrivateSales()) {
@@ -144,13 +151,20 @@ class UserComponent extends \OxidEsales\Eshop\Core\Controller\BaseController
             }
         }
     }
+    /**
+     * @deprecated use self::loadSessionUser instead
+     */
+    protected function _loadSessionUser() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->loadSessionUser();
+    }
 
     /**
      * Tries to load user ID from session.
      *
      * @return null
      */
-    protected function _loadSessionUser() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function loadSessionUser()
     {
         $myConfig = $this->getConfig();
         $oUser = $this->getUser();
@@ -216,6 +230,13 @@ class UserComponent extends \OxidEsales\Eshop\Core\Controller\BaseController
         // finalizing ..
         return $this->_afterLogin($oUser);
     }
+    /**
+     * @deprecated use self::afterLogin instead
+     */
+    protected function _afterLogin($oUser) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->afterLogin($oUser);
+    }
 
     /**
      * Special functionality which is performed after user logs in (or user is created without pass).
@@ -233,7 +254,7 @@ class UserComponent extends \OxidEsales\Eshop\Core\Controller\BaseController
      *
      * @return string
      */
-    protected function _afterLogin($oUser) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function afterLogin($oUser)
     {
         $oSession = $this->getSession();
         if ($oSession->isSessionStarted()) {
@@ -281,6 +302,13 @@ class UserComponent extends \OxidEsales\Eshop\Core\Controller\BaseController
             }
         }
     }
+    /**
+     * @deprecated use self::afterLogout instead
+     */
+    protected function _afterLogout() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->afterLogout();
+    }
 
     /**
      * Special utility function which is executed right after
@@ -288,7 +316,7 @@ class UserComponent extends \OxidEsales\Eshop\Core\Controller\BaseController
      * session parameters as user chosen payment id, delivery
      * address id, active delivery set.
      */
-    protected function _afterLogout() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function afterLogout()
     {
         Registry::getSession()->deleteVariable('paymentid');
         Registry::getSession()->deleteVariable('sShipSet');
@@ -603,22 +631,36 @@ class UserComponent extends \OxidEsales\Eshop\Core\Controller\BaseController
 
         return $canDelete;
     }
+    /**
+     * @deprecated use self::saveInvitor instead
+     */
+    protected function _saveInvitor() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->saveInvitor();
+    }
 
     /**
      * Saves invitor ID
      */
-    protected function _saveInvitor() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function saveInvitor()
     {
         if ($this->getConfig()->getConfigParam('blInvitationsEnabled')) {
             $this->getInvitor();
             $this->setRecipient();
         }
     }
+    /**
+     * @deprecated use self::saveDeliveryAddressState instead
+     */
+    protected function _saveDeliveryAddressState() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->saveDeliveryAddressState();
+    }
 
     /**
      * Saving show/hide delivery address state
      */
-    protected function _saveDeliveryAddressState() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function saveDeliveryAddressState()
     {
         $oSession = Registry::getSession();
 
@@ -628,6 +670,13 @@ class UserComponent extends \OxidEsales\Eshop\Core\Controller\BaseController
         }
 
         $oSession->setVariable('blshowshipaddress', $blShow);
+    }
+    /**
+     * @deprecated use self::changeUser_noRedirect instead
+     */
+    protected function _changeUser_noRedirect() // phpcs:ignore PSR1.Methods.CamelCapsMethodName.NotCamelCaps,PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->changeUser_noRedirect();
     }
 
     /**
@@ -645,7 +694,7 @@ class UserComponent extends \OxidEsales\Eshop\Core\Controller\BaseController
      *
      * @return  bool true on success, false otherwise
      */
-    protected function _changeUser_noRedirect() // phpcs:ignore PSR1.Methods.CamelCapsMethodName.NotCamelCaps,PSR2.Methods.MethodDeclaration.Underscore
+    protected function changeUser_noRedirect() // phpcs:ignore PSR1.Methods.CamelCapsMethodName.NotCamelCaps
     {
         return $this->changeUserWithoutRedirect();
     }
@@ -745,6 +794,13 @@ class UserComponent extends \OxidEsales\Eshop\Core\Controller\BaseController
 
         return true;
     }
+    /**
+     * @deprecated use self::getDelAddressData instead
+     */
+    protected function _getDelAddressData() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getDelAddressData();
+    }
 
     /**
      * Returns delivery address from request. Before returning array is checked if
@@ -752,7 +808,7 @@ class UserComponent extends \OxidEsales\Eshop\Core\Controller\BaseController
      *
      * @return array
      */
-    protected function _getDelAddressData() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getDelAddressData()
     {
         // if user company name, user name and additional info has special chars
         $blShowShipAddressParameter = Registry::getConfig()->getRequestParameter('blshowshipaddress');
@@ -775,12 +831,17 @@ class UserComponent extends \OxidEsales\Eshop\Core\Controller\BaseController
         return $aDelAdress;
     }
 
+    protected function _getLogoutLink() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getLogoutLink();
+    }
+
     /**
      * Returns logout link with additional params
      *
      * @return string $sLogoutLink
      */
-    protected function _getLogoutLink() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getLogoutLink()
     {
         $oConfig = $this->getConfig();
 

--- a/source/Application/Component/UtilsComponent.php
+++ b/source/Application/Component/UtilsComponent.php
@@ -125,6 +125,13 @@ class UtilsComponent extends \OxidEsales\Eshop\Core\Controller\BaseController
             $this->_toList('wishlist', $sProductId, $dAmount, $aSel);
         }
     }
+    /**
+     * @deprecated use self::toList instead
+     */
+    protected function _toList($sListType, $sProductId, $dAmount, $aSel) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->toList($sListType, $sProductId, $dAmount, $aSel);
+    }
 
     /**
      * Adds chosen product to defined user list. if amount is 0, item is removed from the list
@@ -134,7 +141,7 @@ class UtilsComponent extends \OxidEsales\Eshop\Core\Controller\BaseController
      * @param double $dAmount    product amount
      * @param array  $aSel       product selection list
      */
-    protected function _toList($sListType, $sProductId, $dAmount, $aSel) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function toList($sListType, $sProductId, $dAmount, $aSel)
     {
         // only if user is logged in
         if ($oUser = $this->getUser()) {

--- a/source/Application/Component/Widget/Actions.php
+++ b/source/Application/Component/Widget/Actions.php
@@ -43,13 +43,20 @@ class Actions extends \OxidEsales\Eshop\Application\Component\Widget\WidgetContr
             }
         }
     }
+    /**
+     * @deprecated use self::getLoadActionsParam instead
+     */
+    protected function _getLoadActionsParam() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getLoadActionsParam();
+    }
 
     /**
      * Returns if actions are ON
      *
      * @return string
      */
-    protected function _getLoadActionsParam() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getLoadActionsParam()
     {
         $this->_blLoadActions = $this->getConfig()->getConfigParam('bl_perfLoadAktion');
 

--- a/source/Application/Component/Widget/ArticleBox.php
+++ b/source/Application/Component/Widget/ArticleBox.php
@@ -240,6 +240,13 @@ class ArticleBox extends \OxidEsales\Eshop\Application\Component\Widget\WidgetCo
     {
         return (bool) $this->getViewParameter('altproduct');
     }
+    /**
+     * @deprecated use self::addDynParamsToLink instead
+     */
+    protected function _addDynParamsToLink($sAddDynParams, $oArticle) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->addDynParamsToLink($sAddDynParams, $oArticle);
+    }
 
     /**
      * Appends dyn params to url.
@@ -249,7 +256,7 @@ class ArticleBox extends \OxidEsales\Eshop\Application\Component\Widget\WidgetCo
      *
      * @return bool
      */
-    protected function _addDynParamsToLink($sAddDynParams, $oArticle) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function addDynParamsToLink($sAddDynParams, $oArticle)
     {
         $blAddedParams = false;
         if ($sAddDynParams) {
@@ -264,6 +271,13 @@ class ArticleBox extends \OxidEsales\Eshop\Application\Component\Widget\WidgetCo
 
         return $blAddedParams;
     }
+    /**
+     * @deprecated use self::getArticleById instead
+     */
+    protected function _getArticleById($sArticleId) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getArticleById($sArticleId);
+    }
 
     /**
      * Returns prepared article by id.
@@ -272,7 +286,7 @@ class ArticleBox extends \OxidEsales\Eshop\Application\Component\Widget\WidgetCo
      *
      * @return \OxidEsales\Eshop\Application\Model\Article
      */
-    protected function _getArticleById($sArticleId) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getArticleById($sArticleId)
     {
         /** @var \OxidEsales\Eshop\Application\Model\Article $oArticle */
         $oArticle = oxNew(\OxidEsales\Eshop\Application\Model\Article::class);

--- a/source/Application/Component/Widget/ArticleDetails.php
+++ b/source/Application/Component/Widget/ArticleDetails.php
@@ -218,6 +218,13 @@ class ArticleDetails extends \OxidEsales\Eshop\Application\Component\Widget\Widg
     {
         return 1;
     }
+    /**
+     * @deprecated use self::getParentProduct instead
+     */
+    protected function _getParentProduct($sParentId) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getParentProduct($sParentId);
+    }
 
     /**
      * Returns current product parent article object if it is available.
@@ -226,7 +233,7 @@ class ArticleDetails extends \OxidEsales\Eshop\Application\Component\Widget\Widg
      *
      * @return Article
      */
-    protected function _getParentProduct($sParentId) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getParentProduct($sParentId)
     {
         if ($sParentId && $this->_oParentProd === null) {
             $this->_oParentProd = false;
@@ -253,11 +260,19 @@ class ArticleDetails extends \OxidEsales\Eshop\Application\Component\Widget\Widg
     }
 
     /**
+     * @deprecated use self::processProduct instead
+     */
+    protected function _processProduct($oProduct) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->processProduct($oProduct);
+    }
+
+    /**
      * Processes product by setting link type and in case list type is search adds search parameters to details link.
      *
      * @param object $oProduct Product to process.
      */
-    protected function _processProduct($oProduct) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function processProduct($oProduct)
     {
         $oProduct->setLinkType($this->getLinkType());
         if ($sAddParams = $this->_getAddUrlParams()) {
@@ -689,6 +704,13 @@ class ArticleDetails extends \OxidEsales\Eshop\Application\Component\Widget\Widg
     {
         return $this->getProduct()->isPriceAlarm();
     }
+    /**
+     * @deprecated use self::getSubject instead
+     */
+    protected function _getSubject($iLang) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getSubject($iLang);
+    }
 
     /**
      * returns object, associated with current view.
@@ -698,7 +720,7 @@ class ArticleDetails extends \OxidEsales\Eshop\Application\Component\Widget\Widg
      *
      * @return object
      */
-    protected function _getSubject($iLang) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getSubject($iLang)
     {
         return $this->getProduct();
     }
@@ -895,11 +917,18 @@ class ArticleDetails extends \OxidEsales\Eshop\Application\Component\Widget\Widg
 
         return $this->_oProduct;
     }
+    /**
+     * @deprecated use self::setSortingParameters instead
+     */
+    protected function _setSortingParameters() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->setSortingParameters();
+    }
 
     /**
      * Set item sorting for widget based of retrieved parameters.
      */
-    protected function _setSortingParameters() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function setSortingParameters()
     {
         $sSortingParameters = $this->getViewParameter('sorting');
         if ($sSortingParameters) {
@@ -962,6 +991,13 @@ class ArticleDetails extends \OxidEsales\Eshop\Application\Component\Widget\Widg
 
         return $this->_blMdView;
     }
+    /**
+     * @deprecated use self::additionalChecksForArticle instead
+     */
+    protected function _additionalChecksForArticle($myUtils, $myConfig) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->additionalChecksForArticle($myUtils, $myConfig);
+    }
 
     /**
      * Runs additional checks for article.
@@ -969,7 +1005,7 @@ class ArticleDetails extends \OxidEsales\Eshop\Application\Component\Widget\Widg
      * @param Utils  $myUtils  General utils.
      * @param Config $myConfig Main shop configuration.
      */
-    protected function _additionalChecksForArticle($myUtils, $myConfig) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function additionalChecksForArticle($myUtils, $myConfig)
     {
         $blContinue = true;
         if (!$this->_oProduct->isVisible()) {

--- a/source/Application/Component/Widget/Information.php
+++ b/source/Application/Component/Widget/Information.php
@@ -49,13 +49,20 @@ class Information extends \OxidEsales\Eshop\Application\Component\Widget\WidgetC
 
         return $oContentList;
     }
+    /**
+     * @deprecated use self::getContentList instead
+     */
+    protected function _getContentList() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getContentList();
+    }
 
     /**
      * Returns content list object.
      *
      * @return object|oxContentList
      */
-    protected function _getContentList() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getContentList()
     {
         if (!$this->_oContentList) {
             $this->_oContentList = oxNew(\OxidEsales\Eshop\Application\Model\ContentList::class);

--- a/source/Application/Component/Widget/WidgetController.php
+++ b/source/Application/Component/Widget/WidgetController.php
@@ -55,12 +55,19 @@ class WidgetController extends \OxidEsales\Eshop\Application\Controller\Frontend
 
         parent::init();
     }
+    /**
+     * @deprecated use self::processRequest instead
+     */
+    protected function _processRequest() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->processRequest();
+    }
 
     /**
      * In widgets we do not need to parse seo and do any work related to that
      * Shop main control is responsible for that, and that has to be done once
      */
-    protected function _processRequest() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function processRequest()
     {
     }
 }

--- a/source/Application/Controller/AccountController.php
+++ b/source/Application/Controller/AccountController.php
@@ -134,6 +134,13 @@ class AccountController extends \OxidEsales\Eshop\Application\Controller\Fronten
 
         return $this->_sThisTemplate;
     }
+    /**
+     * @deprecated use self::getLoginTemplate instead
+     */
+    protected function _getLoginTemplate() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getLoginTemplate();
+    }
 
     /**
      * Returns login template name:
@@ -142,7 +149,7 @@ class AccountController extends \OxidEsales\Eshop\Application\Controller\Fronten
      *
      * @return string
      */
-    protected function _getLoginTemplate() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getLoginTemplate()
     {
         return $this->isEnabledPrivateSales() ? $this->_sThisAltLoginTemplate : $this->_sThisLoginTemplate;
     }

--- a/source/Application/Controller/AccountDownloadsController.php
+++ b/source/Application/Controller/AccountDownloadsController.php
@@ -79,6 +79,13 @@ class AccountDownloadsController extends \OxidEsales\Eshop\Application\Controlle
 
         return $this->_oOrderFilesList;
     }
+    /**
+     * @deprecated use self::prepareForTemplate instead
+     */
+    protected function _prepareForTemplate($oOrderFileList) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->prepareForTemplate($oOrderFileList);
+    }
 
     /**
      * Returns prepared orders files list
@@ -87,7 +94,7 @@ class AccountDownloadsController extends \OxidEsales\Eshop\Application\Controlle
      *
      * @return array
      */
-    protected function _prepareForTemplate($oOrderFileList) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function prepareForTemplate($oOrderFileList)
     {
         $oOrderArticles = [];
 

--- a/source/Application/Controller/Admin/ActionsArticleAjax.php
+++ b/source/Application/Controller/Admin/ActionsArticleAjax.php
@@ -38,13 +38,20 @@ class ActionsArticleAjax extends \OxidEsales\Eshop\Application\Controller\Admin\
         ['oxid', 'oxarticles', 0, 0, 1]
     ]
     ];
+    /**
+     * @deprecated use self::getQuery instead
+     */
+    protected function _getQuery() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getQuery();
+    }
 
     /**
      * Returns SQL query for data to fetc
      *
      * @return string
      */
-    protected function _getQuery() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getQuery()
     {
         $myConfig = $this->getConfig();
         $oDb = \OxidEsales\Eshop\Core\DatabaseProvider::getDb();
@@ -78,6 +85,13 @@ class ActionsArticleAjax extends \OxidEsales\Eshop\Application\Controller\Admin\
 
         return $sQAdd;
     }
+    /**
+     * @deprecated use self::addFilter instead
+     */
+    protected function _addFilter($sQ) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->addFilter($sQ);
+    }
 
     /**
      * Adds filter SQL to current query
@@ -86,10 +100,10 @@ class ActionsArticleAjax extends \OxidEsales\Eshop\Application\Controller\Admin\
      *
      * @return string
      */
-    protected function _addFilter($sQ) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function addFilter($sQ)
     {
         $sArtTable = $this->_getViewName('oxarticles');
-        $sQ = parent::_addFilter($sQ);
+        $sQ = parent::addFilter($sQ);
 
         // display variants or not ?
         $sQ .= $this->getConfig()->getConfigParam('blVariantsSelection') ? ' group by ' . $sArtTable . '.oxid ' : '';

--- a/source/Application/Controller/Admin/ActionsGroupsAjax.php
+++ b/source/Application/Controller/Admin/ActionsGroupsAjax.php
@@ -34,13 +34,20 @@ class ActionsGroupsAjax extends \OxidEsales\Eshop\Application\Controller\Admin\L
              ['oxid', 'oxobject2action', 0, 0, 1],
          ]
     ];
+    /**
+     * @deprecated use self::getQuery instead
+     */
+    protected function _getQuery() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getQuery();
+    }
 
     /**
      * Returns SQL query for data to fetc
      *
      * @return string
      */
-    protected function _getQuery() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getQuery()
     {
         // active AJAX component
         $sGroupTable = $this->_getViewName('oxgroups');

--- a/source/Application/Controller/Admin/ActionsList.php
+++ b/source/Application/Controller/Admin/ActionsList.php
@@ -52,6 +52,13 @@ class ActionsList extends \OxidEsales\Eshop\Application\Controller\Admin\AdminLi
 
         return $this->_sThisTemplate;
     }
+    /**
+     * @deprecated use self::prepareWhereQuery instead
+     */
+    protected function _prepareWhereQuery($aWhere, $sqlFull) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->prepareWhereQuery($aWhere, $sqlFull);
+    }
 
     /**
      * Adds active promotion check
@@ -61,9 +68,9 @@ class ActionsList extends \OxidEsales\Eshop\Application\Controller\Admin\AdminLi
      *
      * @return $sQ
      */
-    protected function _prepareWhereQuery($aWhere, $sqlFull) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function prepareWhereQuery($aWhere, $sqlFull)
     {
-        $sQ = parent::_prepareWhereQuery($aWhere, $sqlFull);
+        $sQ = parent::prepareWhereQuery($aWhere, $sqlFull);
         $sDisplayType = (int) \OxidEsales\Eshop\Core\Registry::getConfig()->getRequestParameter('displaytype');
         $sTable = getViewName("oxactions");
 

--- a/source/Application/Controller/Admin/ActionsMainAjax.php
+++ b/source/Application/Controller/Admin/ActionsMainAjax.php
@@ -49,13 +49,20 @@ class ActionsMainAjax extends \OxidEsales\Eshop\Application\Controller\Admin\Lis
                                      ['oxid', 'oxactions2article', 0, 0, 1]
                                  ]
     ];
+    /**
+     * @deprecated use self::getQuery instead
+     */
+    protected function _getQuery() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getQuery();
+    }
 
     /**
      * Returns SQL query for data to fetc
      *
      * @return string
      */
-    protected function _getQuery() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getQuery()
     {
         $myConfig = $this->getConfig();
         $oDb = \OxidEsales\Eshop\Core\DatabaseProvider::getDb();
@@ -96,6 +103,13 @@ class ActionsMainAjax extends \OxidEsales\Eshop\Application\Controller\Admin\Lis
 
         return $sQAdd;
     }
+    /**
+     * @deprecated use self::addFilter instead
+     */
+    protected function _addFilter($sQ) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->addFilter($sQ);
+    }
 
     /**
      * Adds filter SQL to current query
@@ -104,9 +118,9 @@ class ActionsMainAjax extends \OxidEsales\Eshop\Application\Controller\Admin\Lis
      *
      * @return string
      */
-    protected function _addFilter($sQ) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function addFilter($sQ)
     {
-        $sQ = parent::_addFilter($sQ);
+        $sQ = parent::addFilter($sQ);
 
         // display variants or not ?
         if ($this->getConfig()->getConfigParam('blVariantsSelection')) {
@@ -120,13 +134,20 @@ class ActionsMainAjax extends \OxidEsales\Eshop\Application\Controller\Admin\Lis
 
         return $sQ;
     }
+    /**
+     * @deprecated use self::getSorting instead
+     */
+    protected function _getSorting() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getSorting();
+    }
 
     /**
      * Returns SQL query addon for sorting
      *
      * @return string
      */
-    protected function _getSorting() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getSorting()
     {
         $sOxIdParameter = \OxidEsales\Eshop\Core\Registry::getConfig()->getRequestParameter('oxid');
         $sSynchOxidParameter = \OxidEsales\Eshop\Core\Registry::getConfig()->getRequestParameter('synchoxid');
@@ -134,7 +155,7 @@ class ActionsMainAjax extends \OxidEsales\Eshop\Application\Controller\Admin\Lis
             return 'order by oxactions2article.oxsort ';
         }
 
-        return parent::_getSorting();
+        return parent::getSorting();
     }
 
     /**
@@ -148,7 +169,7 @@ class ActionsMainAjax extends \OxidEsales\Eshop\Application\Controller\Admin\Lis
         $this->_getOxRssFeed()->removeCacheFile($sOxid);
 
         if (\OxidEsales\Eshop\Core\Registry::getConfig()->getRequestParameter('all')) {
-            $sQ = parent::_addFilter("delete oxactions2article.* " . $this->_getQuery());
+            $sQ = parent::addFilter("delete oxactions2article.* " . $this->_getQuery());
             \OxidEsales\Eshop\Core\DatabaseProvider::getDb()->Execute($sQ);
         } elseif (is_array($aChosenArt)) {
             $sChosenArticles = implode(", ", \OxidEsales\Eshop\Core\DatabaseProvider::getDb()->quoteArray($aChosenArt));
@@ -268,13 +289,20 @@ class ActionsMainAjax extends \OxidEsales\Eshop\Application\Controller\Admin\Lis
 
         $this->_outputResponse($this->_getData($sCountQ, $sQ));
     }
+    /**
+     * @deprecated use self::getOxRssFeed instead
+     */
+    protected function _getOxRssFeed() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getOxRssFeed();
+    }
 
     /**
      * Getter for the rss feed handler.
      *
      * @return \OxidEsales\Eshop\Application\Model\RssFeed The rss feed handler.
      */
-    protected function _getOxRssFeed() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getOxRssFeed()
     {
         return oxNew(\OxidEsales\Eshop\Application\Model\RssFeed::class);
     }

--- a/source/Application/Controller/Admin/ActionsOrderAjax.php
+++ b/source/Application/Controller/Admin/ActionsOrderAjax.php
@@ -28,13 +28,20 @@ class ActionsOrderAjax extends \OxidEsales\Eshop\Application\Controller\Admin\Li
         ['oxid', 'oxobject2selectlist', 0, 0, 1]
     ]
     ];
+    /**
+     * @deprecated use self::getQuery instead
+     */
+    protected function _getQuery() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getQuery();
+    }
 
     /**
      * Returns SQL query for data to fetc
      *
      * @return string
      */
-    protected function _getQuery() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getQuery()
     {
         $sSelTable = $this->_getViewName('oxselectlist');
         $sArtId = \OxidEsales\Eshop\Core\Registry::getConfig()->getRequestParameter('oxid');
@@ -42,13 +49,20 @@ class ActionsOrderAjax extends \OxidEsales\Eshop\Application\Controller\Admin\Li
         return " from $sSelTable left join oxobject2selectlist on oxobject2selectlist.oxselnid = $sSelTable.oxid " .
                  "where oxobjectid = " . \OxidEsales\Eshop\Core\DatabaseProvider::getDb()->quote($sArtId) . "  ";
     }
+    /**
+     * @deprecated use self::getSorting instead
+     */
+    protected function _getSorting() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getSorting();
+    }
 
     /**
      * Returns SQL query addon for sorting
      *
      * @return string
      */
-    protected function _getSorting() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getSorting()
     {
         return 'order by oxobject2selectlist.oxsort ';
     }

--- a/source/Application/Controller/Admin/AdminController.php
+++ b/source/Application/Controller/Admin/AdminController.php
@@ -126,6 +126,13 @@ class AdminController extends \OxidEsales\Eshop\Core\Controller\BaseController
             $this->_sShopVersion = oxNew(ShopVersion::class)->getVersion();
         }
     }
+    /**
+     * @deprecated use self::getEditShop instead
+     */
+    protected function _getEditShop($sShopId) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getEditShop($sShopId);
+    }
 
     /**
      * Returns (cached) shop object
@@ -134,7 +141,7 @@ class AdminController extends \OxidEsales\Eshop\Core\Controller\BaseController
      *
      * @return oxshop
      */
-    protected function _getEditShop($sShopId) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getEditShop($sShopId)
     {
         if (!$this->_oEditShop) {
             $this->_oEditShop = $this->getConfig()->getActiveShop();
@@ -211,13 +218,20 @@ class AdminController extends \OxidEsales\Eshop\Core\Controller\BaseController
 
         return $oShop;
     }
+    /**
+     * @deprecated use self::getServiceProtocol instead
+     */
+    protected function _getServiceProtocol() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getServiceProtocol();
+    }
 
     /**
      * Returns service url protocol: "https" is admin works in ssl mode, "http" if no ssl
      *
      * @return string
      */
-    protected function _getServiceProtocol() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getServiceProtocol()
     {
         return $this->getConfig()->isSsl() ? 'https' : 'http';
     }
@@ -255,6 +269,13 @@ class AdminController extends \OxidEsales\Eshop\Core\Controller\BaseController
 
         return $this->_sServiceUrl;
     }
+    /**
+     * @deprecated use self::getShopVersionNr instead
+     */
+    protected function _getShopVersionNr() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getShopVersionNr();
+    }
 
     /**
      * Returns shop version
@@ -263,9 +284,16 @@ class AdminController extends \OxidEsales\Eshop\Core\Controller\BaseController
      *
      * @return string
      */
-    protected function _getShopVersionNr() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getShopVersionNr()
     {
         return oxNew(ShopVersion::class)->getVersion();
+    }
+    /**
+     * @deprecated use self::setupNavigation instead
+     */
+    protected function _setupNavigation($sNode) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->setupNavigation($sNode);
     }
 
     /**
@@ -273,7 +301,7 @@ class AdminController extends \OxidEsales\Eshop\Core\Controller\BaseController
      *
      * @param string $sNode active view id
      */
-    protected function _setupNavigation($sNode) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function setupNavigation($sNode)
     {
         // navigation according to class
         if ($sNode) {
@@ -295,13 +323,20 @@ class AdminController extends \OxidEsales\Eshop\Core\Controller\BaseController
             $this->_aViewData['editurl'] = $myAdminNavig->getEditUrl($sNode, $iActTab) . $sActTab;
         }
     }
+    /**
+     * @deprecated use self::addNavigationHistory instead
+     */
+    protected function _addNavigationHistory($sNode) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->addNavigationHistory($sNode);
+    }
 
     /**
      * Store navigation history parameters to cookie
      *
      * @param string $sNode active view id
      */
-    protected function _addNavigationHistory($sNode) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function addNavigationHistory($sNode)
     {
         $myUtilsServer = \OxidEsales\Eshop\Core\Registry::getUtilsServer();
 
@@ -365,6 +400,13 @@ class AdminController extends \OxidEsales\Eshop\Core\Controller\BaseController
 
         return $sReturn;
     }
+    /**
+     * @deprecated use self::getMaxUploadFileInfo instead
+     */
+    protected function _getMaxUploadFileInfo($iMaxFileSize, $blFormatted = false) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getMaxUploadFileInfo($iMaxFileSize, $blFormatted);
+    }
 
     /**
      * Returns maximum allowed size of upload file and formatted size equivalent
@@ -374,7 +416,7 @@ class AdminController extends \OxidEsales\Eshop\Core\Controller\BaseController
      *
      * @return array
      */
-    protected function _getMaxUploadFileInfo($iMaxFileSize, $blFormatted = false) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getMaxUploadFileInfo($iMaxFileSize, $blFormatted = false)
     {
         $iMaxFileSize = $iMaxFileSize ? $iMaxFileSize : '2M';
 
@@ -464,6 +506,13 @@ class AdminController extends \OxidEsales\Eshop\Core\Controller\BaseController
     protected function _resetContentCache() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
     }
+    /**
+     * @deprecated use self::allowAdminEdit instead
+     */
+    protected function _allowAdminEdit($sUserId) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->allowAdminEdit($sUserId);
+    }
 
     /**
      * Checks if current $sUserId user is not an admin and checks if user is able to be edited by logged in user.
@@ -473,9 +522,16 @@ class AdminController extends \OxidEsales\Eshop\Core\Controller\BaseController
      *
      * @return bool
      */
-    protected function _allowAdminEdit($sUserId) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function allowAdminEdit($sUserId)
     {
         return true;
+    }
+    /**
+     * @deprecated use self::getCountryByCode instead
+     */
+    protected function _getCountryByCode($sCountryCode) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getCountryByCode($sCountryCode);
     }
 
     /**
@@ -485,7 +541,7 @@ class AdminController extends \OxidEsales\Eshop\Core\Controller\BaseController
      *
      * @return boolean
      */
-    protected function _getCountryByCode($sCountryCode) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getCountryByCode($sCountryCode)
     {
         //default country
         $sCountry = 'international';
@@ -516,13 +572,20 @@ class AdminController extends \OxidEsales\Eshop\Core\Controller\BaseController
 
         return strtolower($sCountry);
     }
+    /**
+     * @deprecated use self::authorize instead
+     */
+    protected function _authorize() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->authorize();
+    }
 
     /**
      * performs authorization of admin user
      *
      * @return boolean
      */
-    protected function _authorize() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function authorize()
     {
         return (bool) (
             $this->getSession()->checkSessionChallenge()

--- a/source/Application/Controller/Admin/AdminDetailsController.php
+++ b/source/Application/Controller/Admin/AdminDetailsController.php
@@ -60,6 +60,13 @@ class AdminDetailsController extends \OxidEsales\Eshop\Application\Controller\Ad
 
         return $languageAbbr === "de" ? 0 : 1;
     }
+    /**
+     * @deprecated use self::getEditValue instead
+     */
+    protected function _getEditValue($oObject, $sField) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getEditValue($oObject, $sField);
+    }
 
     /**
      * Returns string which must be edited by editor.
@@ -69,7 +76,7 @@ class AdminDetailsController extends \OxidEsales\Eshop\Application\Controller\Ad
      *
      * @return string
      */
-    protected function _getEditValue($oObject, $sField) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getEditValue($oObject, $sField)
     {
         $sEditObjectValue = '';
         if ($oObject && $sField && isset($oObject->$sField)) {
@@ -85,6 +92,13 @@ class AdminDetailsController extends \OxidEsales\Eshop\Application\Controller\Ad
 
         return $sEditObjectValue;
     }
+    /**
+     * @deprecated use self::processEditValue instead
+     */
+    protected function _processEditValue($sValue) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->processEditValue($sValue);
+    }
 
     /**
      * Processes edit value.
@@ -93,7 +107,7 @@ class AdminDetailsController extends \OxidEsales\Eshop\Application\Controller\Ad
      *
      * @return string
      */
-    protected function _processEditValue($sValue) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function processEditValue($sValue)
     {
         // A. replace ONLY if long description is not processed by smarty, or users will not be able to
         // store smarty tags ([{$shop->currenthomedir}]/[{$oViewConf->getCurrentHomeDir()}]) in long
@@ -104,6 +118,13 @@ class AdminDetailsController extends \OxidEsales\Eshop\Application\Controller\Ad
         }
 
         return $sValue;
+    }
+    /**
+     * @deprecated use self::getPlainEditor instead
+     */
+    protected function _getPlainEditor($width, $height, $object, $field) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getPlainEditor($width, $height, $object, $field);
     }
 
     /**
@@ -118,7 +139,7 @@ class AdminDetailsController extends \OxidEsales\Eshop\Application\Controller\Ad
      *
      * @return string
      */
-    protected function _getPlainEditor($width, $height, $object, $field) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getPlainEditor($width, $height, $object, $field)
     {
         $objectValue = $this->_getEditValue($object, $field);
 
@@ -192,6 +213,13 @@ class AdminDetailsController extends \OxidEsales\Eshop\Application\Controller\Ad
         // resetting manufacturers cache
         $this->resetContentCache();
     }
+    /**
+     * @deprecated use self::createCategoryTree instead
+     */
+    protected function _createCategoryTree($sTplVarName, $sEditCatId = '', $blForceNonCache = false, $iTreeShopId = null) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->createCategoryTree($sTplVarName, $sEditCatId, $blForceNonCache, $iTreeShopId);
+    }
 
     /**
      * Function creates category tree for select list used in "Category main", "Article extend" etc.
@@ -203,7 +231,7 @@ class AdminDetailsController extends \OxidEsales\Eshop\Application\Controller\Ad
      *
      * @return string
      */
-    protected function _createCategoryTree($sTplVarName, $sEditCatId = '', $blForceNonCache = false, $iTreeShopId = null) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function createCategoryTree($sTplVarName, $sEditCatId = '', $blForceNonCache = false, $iTreeShopId = null)
     {
         // caching category tree, to load it once, not many times
         if (!isset($this->oCatTree) || $blForceNonCache) {
@@ -235,6 +263,13 @@ class AdminDetailsController extends \OxidEsales\Eshop\Application\Controller\Ad
 
         return $oCatTree;
     }
+    /**
+     * @deprecated use self::getCategoryTree instead
+     */
+    protected function _getCategoryTree($sTplVarName, $sSelectedCatId, $sEditCatId = '', $blForceNonCache = false, $iTreeShopId = null) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getCategoryTree($sTplVarName, $sSelectedCatId, $sEditCatId, $blForceNonCache, $iTreeShopId);
+    }
 
     /**
      * Function creates category tree for select list used in "Category main", "Article extend" etc.
@@ -248,7 +283,7 @@ class AdminDetailsController extends \OxidEsales\Eshop\Application\Controller\Ad
      *
      * @return string
      */
-    protected function _getCategoryTree( // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getCategoryTree(
         $sTplVarName,
         $sSelectedCatId,
         $sEditCatId = '',
@@ -299,13 +334,20 @@ class AdminDetailsController extends \OxidEsales\Eshop\Application\Controller\Ad
             $oObject->save();
         }
     }
+    /**
+     * @deprecated use self::setupNavigation instead
+     */
+    protected function _setupNavigation($sNode) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->setupNavigation($sNode);
+    }
 
     /**
      * Sets-up navigation parameters.
      *
      * @param string $sNode active view id
      */
-    protected function _setupNavigation($sNode) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function setupNavigation($sNode)
     {
         // navigation according to class
         if ($sNode) {
@@ -318,13 +360,20 @@ class AdminDetailsController extends \OxidEsales\Eshop\Application\Controller\Ad
             $this->_aViewData['bottom_buttons'] = $myAdminNavig->getBtn($sNode);
         }
     }
+    /**
+     * @deprecated use self::resetCounts instead
+     */
+    protected function _resetCounts($aIds) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->resetCounts($aIds);
+    }
 
     /**
      * Resets count of vendor/manufacturer category items.
      *
      * @param array $aIds to reset type => id
      */
-    protected function _resetCounts($aIds) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function resetCounts($aIds)
     {
         foreach ($aIds as $sType => $aResetInfo) {
             foreach ($aResetInfo as $sResetId => $iPos) {

--- a/source/Application/Controller/Admin/AdminListController.php
+++ b/source/Application/Controller/Admin/AdminListController.php
@@ -184,13 +184,20 @@ class AdminListController extends \OxidEsales\Eshop\Application\Controller\Admin
     {
         return $this->_getViewListSize();
     }
+    /**
+     * @deprecated use self::getUserDefListSize instead
+     */
+    protected function _getUserDefListSize() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getUserDefListSize();
+    }
 
     /**
      * Viewable list size getter (used in list_*.php views)
      *
      * @return int
      */
-    protected function _getUserDefListSize() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getUserDefListSize()
     {
         if (!$this->_iViewListSize) {
             if (!($viewListSize = (int)\OxidEsales\Eshop\Core\Registry::getConfig()->getRequestParameter('viewListSize'))) {
@@ -245,13 +252,20 @@ class AdminListController extends \OxidEsales\Eshop\Application\Controller\Admin
 
         $this->init();
     }
+    /**
+     * @deprecated use self::calcListItemsCount instead
+     */
+    protected function _calcListItemsCount($sql) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->calcListItemsCount($sql);
+    }
 
     /**
      * Calculates list items count
      *
      * @param string $sql SQL query used co select list items
      */
-    protected function _calcListItemsCount($sql) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function calcListItemsCount($sql)
     {
         $stringModifier = getStr();
 
@@ -268,13 +282,20 @@ class AdminListController extends \OxidEsales\Eshop\Application\Controller\Admin
         // set it into session that other frames know about size of DB
         \OxidEsales\Eshop\Core\Registry::getSession()->setVariable('iArtCnt', $this->_iListSize);
     }
+    /**
+     * @deprecated use self::setCurrentListPosition instead
+     */
+    protected function _setCurrentListPosition($page = null) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->setCurrentListPosition($page);
+    }
 
     /**
      * Set current list position
      *
      * @param string $page jump page string
      */
-    protected function _setCurrentListPosition($page = null) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function setCurrentListPosition($page = null)
     {
         $adminListSize = $this->_getViewListSize();
 
@@ -290,6 +311,13 @@ class AdminListController extends \OxidEsales\Eshop\Application\Controller\Admin
 
         $this->_iCurrListPos = $this->_iOverPos = (int)$jumpToPage;
     }
+    /**
+     * @deprecated use self::prepareOrderByQuery instead
+     */
+    protected function _prepareOrderByQuery($query = null) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->prepareOrderByQuery($query);
+    }
 
     /**
      * Adds order by to SQL query string.
@@ -298,7 +326,7 @@ class AdminListController extends \OxidEsales\Eshop\Application\Controller\Admin
      *
      * @return string
      */
-    protected function _prepareOrderByQuery($query = null) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function prepareOrderByQuery($query = null)
     {
         // sorting
         $sortFields = $this->getListSorting();
@@ -334,6 +362,13 @@ class AdminListController extends \OxidEsales\Eshop\Application\Controller\Admin
 
         return $query;
     }
+    /**
+     * @deprecated use self::buildSelectString instead
+     */
+    protected function _buildSelectString($listObject = null) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->buildSelectString($listObject);
+    }
 
     /**
      * Builds and returns SQL query string.
@@ -342,9 +377,16 @@ class AdminListController extends \OxidEsales\Eshop\Application\Controller\Admin
      *
      * @return string
      */
-    protected function _buildSelectString($listObject = null) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function buildSelectString($listObject = null)
     {
         return $listObject !== null ? $listObject->buildSelectString(null) : "";
+    }
+    /**
+     * @deprecated use self::processFilter instead
+     */
+    protected function _processFilter($fieldValue) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->processFilter($fieldValue);
     }
 
 
@@ -357,7 +399,7 @@ class AdminListController extends \OxidEsales\Eshop\Application\Controller\Admin
      *
      * @return string
      */
-    protected function _processFilter($fieldValue) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function processFilter($fieldValue)
     {
         $stringModifier = getStr();
 
@@ -365,6 +407,13 @@ class AdminListController extends \OxidEsales\Eshop\Application\Controller\Admin
         $fieldValue = $stringModifier->preg_replace("/^%|%$/", "", trim($fieldValue));
 
         return $stringModifier->preg_replace("/\s+/", " ", $fieldValue);
+    }
+    /**
+     * @deprecated use self::buildFilter instead
+     */
+    protected function _buildFilter($value, $isSearchValue) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->buildFilter($value, $isSearchValue);
     }
 
     /**
@@ -375,7 +424,7 @@ class AdminListController extends \OxidEsales\Eshop\Application\Controller\Admin
      *
      * @return string
      */
-    protected function _buildFilter($value, $isSearchValue) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function buildFilter($value, $isSearchValue)
     {
         if ($isSearchValue) {
             //is search string, using LIKE
@@ -387,6 +436,13 @@ class AdminListController extends \OxidEsales\Eshop\Application\Controller\Admin
 
         return $query;
     }
+    /**
+     * @deprecated use self::isSearchValue instead
+     */
+    protected function _isSearchValue($fieldValue) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->isSearchValue($fieldValue);
+    }
 
     /**
      * Checks if filter contains wildcards like %
@@ -395,9 +451,16 @@ class AdminListController extends \OxidEsales\Eshop\Application\Controller\Admin
      *
      * @return bool
      */
-    protected function _isSearchValue($fieldValue) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function isSearchValue($fieldValue)
     {
         return (getStr()->preg_match('/^%/', $fieldValue) && getStr()->preg_match('/%$/', $fieldValue));
+    }
+    /**
+     * @deprecated use self::prepareWhereQuery instead
+     */
+    protected function _prepareWhereQuery($whereQuery, $fullQuery) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->prepareWhereQuery($whereQuery, $fullQuery);
     }
 
     /**
@@ -410,7 +473,7 @@ class AdminListController extends \OxidEsales\Eshop\Application\Controller\Admin
      *
      * @return string
      */
-    protected function _prepareWhereQuery($whereQuery, $fullQuery) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function prepareWhereQuery($whereQuery, $fullQuery)
     {
         if (is_array($whereQuery) && count($whereQuery)) {
             $myUtilsString = \OxidEsales\Eshop\Core\Registry::getUtilsString();
@@ -461,6 +524,13 @@ class AdminListController extends \OxidEsales\Eshop\Application\Controller\Admin
 
         return $fullQuery;
     }
+    /**
+     * @deprecated use self::changeselect instead
+     */
+    protected function _changeselect($query) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->changeselect($query);
+    }
 
     /**
      * Override this for individual search in admin.
@@ -469,7 +539,7 @@ class AdminListController extends \OxidEsales\Eshop\Application\Controller\Admin
      *
      * @return string
      */
-    protected function _changeselect($query) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function changeselect($query)
     {
         return $query;
     }
@@ -514,6 +584,13 @@ class AdminListController extends \OxidEsales\Eshop\Application\Controller\Admin
 
         return $this->_aWhere;
     }
+    /**
+     * @deprecated use self::convertToDBDate instead
+     */
+    protected function _convertToDBDate($value, $fieldType) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->convertToDBDate($value, $fieldType);
+    }
 
     /**
      * Converts date/datetime values to DB scheme (#M1260)
@@ -523,7 +600,7 @@ class AdminListController extends \OxidEsales\Eshop\Application\Controller\Admin
      *
      * @return string
      */
-    protected function _convertToDBDate($value, $fieldType) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function convertToDBDate($value, $fieldType)
     {
         $convertedObject = new \OxidEsales\Eshop\Core\Field();
         $convertedObject->setValue($value);
@@ -547,6 +624,13 @@ class AdminListController extends \OxidEsales\Eshop\Application\Controller\Admin
 
         return $convertedObject->value;
     }
+    /**
+     * @deprecated use self::convertDate instead
+     */
+    protected function _convertDate($date) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->convertDate($date);
+    }
 
     /**
      * Converter for date field search. If not full date will be searched.
@@ -555,7 +639,7 @@ class AdminListController extends \OxidEsales\Eshop\Application\Controller\Admin
      *
      * @return string
      */
-    protected function _convertDate($date) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function convertDate($date)
     {
         // regexps to validate input
         $datePatterns = [
@@ -585,6 +669,13 @@ class AdminListController extends \OxidEsales\Eshop\Application\Controller\Admin
 
         return $date;
     }
+    /**
+     * @deprecated use self::convertTime instead
+     */
+    protected function _convertTime($fullDate) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->convertTime($fullDate);
+    }
 
     /**
      * Converter for datetime field search. If not full time will be searched.
@@ -593,7 +684,7 @@ class AdminListController extends \OxidEsales\Eshop\Application\Controller\Admin
      *
      * @return string
      */
-    protected function _convertTime($fullDate) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function convertTime($fullDate)
     {
         $date = substr($fullDate, 0, 10);
         $convertedObject = new \OxidEsales\Eshop\Core\Field();
@@ -627,11 +718,18 @@ class AdminListController extends \OxidEsales\Eshop\Application\Controller\Admin
 
         return $convertedObject->value . " " . $time;
     }
+    /**
+     * @deprecated use self::setListNavigationParams instead
+     */
+    protected function _setListNavigationParams() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->setListNavigationParams();
+    }
 
     /**
      * Set parameters needed for list navigation
      */
-    protected function _setListNavigationParams() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function setListNavigationParams()
     {
         // list navigation
         $showNavigation = false;
@@ -710,13 +808,20 @@ class AdminListController extends \OxidEsales\Eshop\Application\Controller\Admin
 
         $this->_aViewData['iListFillsize'] = $space;
     }
+    /**
+     * @deprecated use self::setupNavigation instead
+     */
+    protected function _setupNavigation($node) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->setupNavigation($node);
+    }
 
     /**
      * Sets-up navigation parameters
      *
      * @param string $node active view id
      */
-    protected function _setupNavigation($node) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function setupNavigation($node)
     {
         // navigation according to class
         if ($node) {

--- a/source/Application/Controller/Admin/ArticleAccessoriesAjax.php
+++ b/source/Application/Controller/Admin/ArticleAccessoriesAjax.php
@@ -57,6 +57,13 @@ class ArticleAccessoriesAjax extends \OxidEsales\Eshop\Application\Controller\Ad
                                 ['oxid', 'oxaccessoire2article', 0, 0, 1]
                             ]
     ];
+    /**
+     * @deprecated use self::getQuery instead
+     */
+    protected function _getQuery() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getQuery();
+    }
 
     /**
      * Returns SQL query for data to fetc
@@ -64,7 +71,7 @@ class ArticleAccessoriesAjax extends \OxidEsales\Eshop\Application\Controller\Ad
      * @return string
      * @throws DatabaseConnectionException
      */
-    protected function _getQuery() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getQuery()
     {
         $myConfig = Registry::getConfig();
         $oxidId = Registry::getConfig()->getRequestEscapedParameter('oxid');
@@ -111,6 +118,13 @@ class ArticleAccessoriesAjax extends \OxidEsales\Eshop\Application\Controller\Ad
         // creating AJAX component
         return $outputQuery;
     }
+    /**
+     * @deprecated use self::getSorting instead
+     */
+    protected function _getSorting() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getSorting();
+    }
 
 
     /**
@@ -118,7 +132,7 @@ class ArticleAccessoriesAjax extends \OxidEsales\Eshop\Application\Controller\Ad
      *
      * @return string
      */
-    protected function _getSorting() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getSorting()
     {
         if ($this->containerId == 'container2') {
             return ' order by _2,_0';
@@ -156,7 +170,7 @@ class ArticleAccessoriesAjax extends \OxidEsales\Eshop\Application\Controller\Ad
         // adding
         if (\OxidEsales\Eshop\Core\Registry::getConfig()->getRequestParameter('all')) {
             $sArtTable = $this->_getViewName('oxarticles');
-            $aChosenArt = $this->_getAll(parent::_addFilter("select $sArtTable.oxid " . $this->_getQuery()));
+            $aChosenArt = $this->_getAll(parent::addFilter("select $sArtTable.oxid " . $this->_getQuery()));
         }
 
         if ($oArticle->load($soxId) && $soxId && $soxId != "-1" && is_array($aChosenArt)) {

--- a/source/Application/Controller/Admin/ArticleAttributeAjax.php
+++ b/source/Application/Controller/Admin/ArticleAttributeAjax.php
@@ -32,13 +32,20 @@ class ArticleAttributeAjax extends \OxidEsales\Eshop\Application\Controller\Admi
                                      ['oxattrid', 'oxobject2attribute', 0, 0, 1],
                                  ]
     ];
+    /**
+     * @deprecated use self::getQuery instead
+     */
+    protected function _getQuery() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getQuery();
+    }
 
     /**
      * Returns SQL query for data to fetc
      *
      * @return string
      */
-    protected function _getQuery() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getQuery()
     {
         $oDb = \OxidEsales\Eshop\Core\DatabaseProvider::getDb();
         $sArtId = \OxidEsales\Eshop\Core\Registry::getConfig()->getRequestParameter('oxid');

--- a/source/Application/Controller/Admin/ArticleBundleAjax.php
+++ b/source/Application/Controller/Admin/ArticleBundleAjax.php
@@ -37,13 +37,20 @@ class ArticleBundleAjax extends \OxidEsales\Eshop\Application\Controller\Admin\L
         ['oxid', 'oxarticles', 0, 0, 1]
     ]
     ];
+    /**
+     * @deprecated use self::getQuery instead
+     */
+    protected function _getQuery() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getQuery();
+    }
 
     /**
      * Returns SQL query for data to fetc
      *
      * @return string
      */
-    protected function _getQuery() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getQuery()
     {
         $myConfig = $this->getConfig();
         $oDb = \OxidEsales\Eshop\Core\DatabaseProvider::getDb();
@@ -78,6 +85,13 @@ class ArticleBundleAjax extends \OxidEsales\Eshop\Application\Controller\Admin\L
 
         return $sQAdd;
     }
+    /**
+     * @deprecated use self::addFilter instead
+     */
+    protected function _addFilter($sQ) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->addFilter($sQ);
+    }
 
     /**
      * Adds filter SQL to current query
@@ -86,10 +100,10 @@ class ArticleBundleAjax extends \OxidEsales\Eshop\Application\Controller\Admin\L
      *
      * @return string
      */
-    protected function _addFilter($sQ) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function addFilter($sQ)
     {
         $sArtTable = $this->_getViewName('oxarticles');
-        $sQ = parent::_addFilter($sQ);
+        $sQ = parent::addFilter($sQ);
 
         // display variants or not ?
         $sQ .= $this->getConfig()->getConfigParam('blVariantsSelection') ? ' group by ' . $sArtTable . '.oxid ' : '';

--- a/source/Application/Controller/Admin/ArticleCrosssellingAjax.php
+++ b/source/Application/Controller/Admin/ArticleCrosssellingAjax.php
@@ -47,13 +47,20 @@ class ArticleCrosssellingAjax extends \OxidEsales\Eshop\Application\Controller\A
                                      ['oxid', 'oxobject2article', 0, 0, 1]
                                  ]
     ];
+    /**
+     * @deprecated use self::getQuery instead
+     */
+    protected function _getQuery() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getQuery();
+    }
 
     /**
      * Returns SQL query for data to fetc
      *
      * @return string
      */
-    protected function _getQuery() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getQuery()
     {
         $myConfig = $this->getConfig();
         $sArticleTable = $this->_getViewName('oxarticles');
@@ -145,7 +152,7 @@ class ArticleCrosssellingAjax extends \OxidEsales\Eshop\Application\Controller\A
         // adding
         if (\OxidEsales\Eshop\Core\Registry::getConfig()->getRequestParameter('all')) {
             $sArtTable = $this->_getViewName('oxarticles');
-            $aChosenArt = $this->_getAll(parent::_addFilter("select $sArtTable.oxid " . $this->_getQuery()));
+            $aChosenArt = $this->_getAll(parent::addFilter("select $sArtTable.oxid " . $this->_getQuery()));
         }
 
         $oArticle = oxNew(\OxidEsales\Eshop\Application\Model\Article::class);

--- a/source/Application/Controller/Admin/ArticleExtendAjax.php
+++ b/source/Application/Controller/Admin/ArticleExtendAjax.php
@@ -37,13 +37,20 @@ class ArticleExtendAjax extends \OxidEsales\Eshop\Application\Controller\Admin\L
                                      ['oxid', 'oxcategories', 0, 0, 1]
                                  ],
     ];
+    /**
+     * @deprecated use self::getQuery instead
+     */
+    protected function _getQuery() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getQuery();
+    }
 
     /**
      * Returns SQL query for data to fetc
      *
      * @return string
      */
-    protected function _getQuery() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getQuery()
     {
         $categoriesTable = $this->_getViewName('oxcategories');
         $objectToCategoryView = $this->_getViewName('oxobject2category');
@@ -67,6 +74,13 @@ class ArticleExtendAjax extends \OxidEsales\Eshop\Application\Controller\Admin\L
 
         return $query;
     }
+    /**
+     * @deprecated use self::getDataFields instead
+     */
+    protected function _getDataFields($sQ) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getDataFields($sQ);
+    }
 
     /**
      * Returns array with DB records
@@ -75,9 +89,9 @@ class ArticleExtendAjax extends \OxidEsales\Eshop\Application\Controller\Admin\L
      *
      * @return array
      */
-    protected function _getDataFields($sQ) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getDataFields($sQ)
     {
-        $dataFields = parent::_getDataFields($sQ);
+        $dataFields = parent::getDataFields($sQ);
         if (\OxidEsales\Eshop\Core\Registry::getConfig()->getRequestParameter('oxid') && is_array($dataFields) && count($dataFields)) {
             // looking for smallest time value to mark record as main category ..
             $minimalPosition = null;
@@ -191,13 +205,20 @@ class ArticleExtendAjax extends \OxidEsales\Eshop\Application\Controller\Admin\L
             $this->onCategoriesAdd($categoriesToAdd);
         }
     }
+    /**
+     * @deprecated use self::updateOxTime instead
+     */
+    protected function _updateOxTime($oxId) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->updateOxTime($oxId);
+    }
 
     /**
      * Updates oxtime value for product
      *
      * @param string $oxId product id
      */
-    protected function _updateOxTime($oxId) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function updateOxTime($oxId)
     {
         $database = \OxidEsales\Eshop\Core\DatabaseProvider::getDb();
         $objectToCategoryView = $this->_getViewName('oxobject2category');

--- a/source/Application/Controller/Admin/ArticleFiles.php
+++ b/source/Application/Controller/Admin/ArticleFiles.php
@@ -196,6 +196,13 @@ class ArticleFiles extends \OxidEsales\Eshop\Application\Controller\Admin\AdminD
     {
         return ($iOption < 0) ? "" : $iOption;
     }
+    /**
+     * @deprecated use self::processOptions instead
+     */
+    protected function _processOptions($aParams) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->processOptions($aParams);
+    }
 
     /**
      * Process config options. If value is not set, save as "-1" to database
@@ -204,7 +211,7 @@ class ArticleFiles extends \OxidEsales\Eshop\Application\Controller\Admin\AdminD
      *
      * @return array
      */
-    protected function _processOptions($aParams) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function processOptions($aParams)
     {
         if (!is_array($aParams)) {
             $aParams = [];

--- a/source/Application/Controller/Admin/ArticleList.php
+++ b/source/Application/Controller/Admin/ArticleList.php
@@ -233,6 +233,13 @@ class ArticleList extends \OxidEsales\Eshop\Application\Controller\Admin\AdminLi
 
         return $oVndTree;
     }
+    /**
+     * @deprecated use self::buildSelectString instead
+     */
+    protected function _buildSelectString($oListObject = null) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->buildSelectString($oListObject);
+    }
 
     /**
      * Builds and returns SQL query string.
@@ -241,9 +248,9 @@ class ArticleList extends \OxidEsales\Eshop\Application\Controller\Admin\AdminLi
      *
      * @return string
      */
-    protected function _buildSelectString($oListObject = null) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function buildSelectString($oListObject = null)
     {
-        $sQ = parent::_buildSelectString($oListObject);
+        $sQ = parent::buildSelectString($oListObject);
         if ($sQ) {
             $sTable = getViewName("oxarticles");
             $sQ .= " and $sTable.oxparentid = '' ";

--- a/source/Application/Controller/Admin/ArticleMain.php
+++ b/source/Application/Controller/Admin/ArticleMain.php
@@ -103,6 +103,13 @@ class ArticleMain extends \OxidEsales\Eshop\Application\Controller\Admin\AdminDe
 
         return "article_main.tpl";
     }
+    /**
+     * @deprecated use self::getEditValue instead
+     */
+    protected function _getEditValue($oObject, $sField) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getEditValue($oObject, $sField);
+    }
 
     /**
      * Returns string which must be edited by editor
@@ -112,7 +119,7 @@ class ArticleMain extends \OxidEsales\Eshop\Application\Controller\Admin\AdminDe
      *
      * @return string
      */
-    protected function _getEditValue($oObject, $sField) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getEditValue($oObject, $sField)
     {
         $sEditObjectValue = '';
         if ($oObject) {
@@ -207,6 +214,13 @@ class ArticleMain extends \OxidEsales\Eshop\Application\Controller\Admin\AdminDe
 
         $this->setEditObjectId($oArticle->getId());
     }
+    /**
+     * @deprecated use self::processLongDesc instead
+     */
+    protected function _processLongDesc($sValue) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->processLongDesc($sValue);
+    }
 
     /**
      * Fixes html broken by html editor
@@ -215,7 +229,7 @@ class ArticleMain extends \OxidEsales\Eshop\Application\Controller\Admin\AdminDe
      *
      * @return string
      */
-    protected function _processLongDesc($sValue) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function processLongDesc($sValue)
     {
         // TODO: the code below is redundant, optimize it, assignments should go smooth without conversions
         // hack, if editor screws up text, htmledit tends to do so
@@ -228,13 +242,20 @@ class ArticleMain extends \OxidEsales\Eshop\Application\Controller\Admin\AdminDe
 
         return $sValue;
     }
+    /**
+     * @deprecated use self::resetCategoriesCounter instead
+     */
+    protected function _resetCategoriesCounter($sArticleId) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->resetCategoriesCounter($sArticleId);
+    }
 
     /**
      * Resets article categories counters
      *
      * @param string $sArticleId Article id
      */
-    protected function _resetCategoriesCounter($sArticleId) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function resetCategoriesCounter($sArticleId)
     {
         $oDb = DatabaseProvider::getDb();
         $sQ = "select oxcatnid from oxobject2category where oxobjectid = :oxobjectid";
@@ -370,6 +391,13 @@ class ArticleMain extends \OxidEsales\Eshop\Application\Controller\Admin\AdminDe
             }
         }
     }
+    /**
+     * @deprecated use self::copyCategories instead
+     */
+    protected function _copyCategories($sOldId, $newArticleId) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->copyCategories($sOldId, $newArticleId);
+    }
 
     /**
      * Copying category assignments
@@ -377,7 +405,7 @@ class ArticleMain extends \OxidEsales\Eshop\Application\Controller\Admin\AdminDe
      * @param string $sOldId       Id from old article
      * @param string $newArticleId Id from new article
      */
-    protected function _copyCategories($sOldId, $newArticleId) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function copyCategories($sOldId, $newArticleId)
     {
         $myUtilsObject = \OxidEsales\Eshop\Core\Registry::getUtilsObject();
         $oDb = DatabaseProvider::getDb();
@@ -398,6 +426,13 @@ class ArticleMain extends \OxidEsales\Eshop\Application\Controller\Admin\AdminDe
             }
         }
     }
+    /**
+     * @deprecated use self::copyAttributes instead
+     */
+    protected function _copyAttributes($sOldId, $sNewId) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->copyAttributes($sOldId, $sNewId);
+    }
 
     /**
      * Copying attributes assignments
@@ -405,7 +440,7 @@ class ArticleMain extends \OxidEsales\Eshop\Application\Controller\Admin\AdminDe
      * @param string $sOldId Id from old article
      * @param string $sNewId Id from new article
      */
-    protected function _copyAttributes($sOldId, $sNewId) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function copyAttributes($sOldId, $sNewId)
     {
         $myUtilsObject = \OxidEsales\Eshop\Core\Registry::getUtilsObject();
         $oDb = DatabaseProvider::getDb();
@@ -427,6 +462,13 @@ class ArticleMain extends \OxidEsales\Eshop\Application\Controller\Admin\AdminDe
             }
         }
     }
+    /**
+     * @deprecated use self::copyFiles instead
+     */
+    protected function _copyFiles($sOldId, $sNewId) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->copyFiles($sOldId, $sNewId);
+    }
 
     /**
      * Copying files
@@ -434,7 +476,7 @@ class ArticleMain extends \OxidEsales\Eshop\Application\Controller\Admin\AdminDe
      * @param string $sOldId Id from old article
      * @param string $sNewId Id from new article
      */
-    protected function _copyFiles($sOldId, $sNewId) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function copyFiles($sOldId, $sNewId)
     {
         $myUtilsObject = \OxidEsales\Eshop\Core\Registry::getUtilsObject();
         $oDb = DatabaseProvider::getDb(DatabaseProvider::FETCH_MODE_ASSOC);
@@ -457,6 +499,13 @@ class ArticleMain extends \OxidEsales\Eshop\Application\Controller\Admin\AdminDe
             }
         }
     }
+    /**
+     * @deprecated use self::copySelectlists instead
+     */
+    protected function _copySelectlists($sOldId, $sNewId) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->copySelectlists($sOldId, $sNewId);
+    }
 
     /**
      * Copying selectlists assignments
@@ -464,7 +513,7 @@ class ArticleMain extends \OxidEsales\Eshop\Application\Controller\Admin\AdminDe
      * @param string $sOldId Id from old article
      * @param string $sNewId Id from new article
      */
-    protected function _copySelectlists($sOldId, $sNewId) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function copySelectlists($sOldId, $sNewId)
     {
         $myUtilsObject = \OxidEsales\Eshop\Core\Registry::getUtilsObject();
         $oDb = DatabaseProvider::getDb();
@@ -488,6 +537,13 @@ class ArticleMain extends \OxidEsales\Eshop\Application\Controller\Admin\AdminDe
             }
         }
     }
+    /**
+     * @deprecated use self::copyCrossseling instead
+     */
+    protected function _copyCrossseling($sOldId, $sNewId) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->copyCrossseling($sOldId, $sNewId);
+    }
 
     /**
      * Copying crossseling assignments
@@ -495,7 +551,7 @@ class ArticleMain extends \OxidEsales\Eshop\Application\Controller\Admin\AdminDe
      * @param string $sOldId Id from old article
      * @param string $sNewId Id from new article
      */
-    protected function _copyCrossseling($sOldId, $sNewId) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function copyCrossseling($sOldId, $sNewId)
     {
         $myUtilsObject = \OxidEsales\Eshop\Core\Registry::getUtilsObject();
         $oDb = DatabaseProvider::getDb();
@@ -519,6 +575,13 @@ class ArticleMain extends \OxidEsales\Eshop\Application\Controller\Admin\AdminDe
             }
         }
     }
+    /**
+     * @deprecated use self::copyAccessoires instead
+     */
+    protected function _copyAccessoires($sOldId, $sNewId) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->copyAccessoires($sOldId, $sNewId);
+    }
 
     /**
      * Copying accessoires assignments
@@ -526,7 +589,7 @@ class ArticleMain extends \OxidEsales\Eshop\Application\Controller\Admin\AdminDe
      * @param string $sOldId Id from old article
      * @param string $sNewId Id from new article
      */
-    protected function _copyAccessoires($sOldId, $sNewId) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function copyAccessoires($sOldId, $sNewId)
     {
         $myUtilsObject = \OxidEsales\Eshop\Core\Registry::getUtilsObject();
         $oDb = DatabaseProvider::getDb();
@@ -550,6 +613,13 @@ class ArticleMain extends \OxidEsales\Eshop\Application\Controller\Admin\AdminDe
             }
         }
     }
+    /**
+     * @deprecated use self::copyStaffelpreis instead
+     */
+    protected function _copyStaffelpreis($sOldId, $sNewId) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->copyStaffelpreis($sOldId, $sNewId);
+    }
 
     /**
      * Copying staffelpreis assignments
@@ -557,7 +627,7 @@ class ArticleMain extends \OxidEsales\Eshop\Application\Controller\Admin\AdminDe
      * @param string $sOldId Id from old article
      * @param string $sNewId Id from new article
      */
-    protected function _copyStaffelpreis($sOldId, $sNewId) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function copyStaffelpreis($sOldId, $sNewId)
     {
         $sShopId = $this->getConfig()->getShopId();
         $oPriceList = oxNew(\OxidEsales\Eshop\Core\Model\ListModel::class);
@@ -576,6 +646,13 @@ class ArticleMain extends \OxidEsales\Eshop\Application\Controller\Admin\AdminDe
             }
         }
     }
+    /**
+     * @deprecated use self::copyArtExtends instead
+     */
+    protected function _copyArtExtends($sOldId, $sNewId) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->copyArtExtends($sOldId, $sNewId);
+    }
 
     /**
      * Copying article extends
@@ -583,7 +660,7 @@ class ArticleMain extends \OxidEsales\Eshop\Application\Controller\Admin\AdminDe
      * @param string $sOldId Id from old article
      * @param string $sNewId Id from new article
      */
-    protected function _copyArtExtends($sOldId, $sNewId) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function copyArtExtends($sOldId, $sNewId)
     {
         $oExt = oxNew(\OxidEsales\Eshop\Core\Model\BaseModel::class);
         $oExt->init("oxartextends");
@@ -612,6 +689,13 @@ class ArticleMain extends \OxidEsales\Eshop\Application\Controller\Admin\AdminDe
     {
         return $aParams;
     }
+    /**
+     * @deprecated use self::formJumpList instead
+     */
+    protected function _formJumpList($oArticle, $oParentArticle) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->formJumpList($oArticle, $oParentArticle);
+    }
 
     /**
      * Function forms article variants jump list.
@@ -619,7 +703,7 @@ class ArticleMain extends \OxidEsales\Eshop\Application\Controller\Admin\AdminDe
      * @param object $oArticle       article object
      * @param object $oParentArticle article parent object
      */
-    protected function _formJumpList($oArticle, $oParentArticle) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function formJumpList($oArticle, $oParentArticle)
     {
         $aJumpList = [];
         //fetching parent article variants
@@ -655,6 +739,13 @@ class ArticleMain extends \OxidEsales\Eshop\Application\Controller\Admin\AdminDe
             $this->_aViewData["thisvariantlist"] = $aJumpList;
         }
     }
+    /**
+     * @deprecated use self::getTitle instead
+     */
+    protected function _getTitle($oObj) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getTitle($oObj);
+    }
 
     /**
      * Returns formed variant title
@@ -663,7 +754,7 @@ class ArticleMain extends \OxidEsales\Eshop\Application\Controller\Admin\AdminDe
      *
      * @return string
      */
-    protected function _getTitle($oObj) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getTitle($oObj)
     {
         $sTitle = $oObj->oxarticles__oxtitle->value;
         if (!strlen($sTitle)) {

--- a/source/Application/Controller/Admin/ArticlePictures.php
+++ b/source/Application/Controller/Admin/ArticlePictures.php
@@ -128,6 +128,13 @@ class ArticlePictures extends \OxidEsales\Eshop\Application\Controller\Admin\Adm
 
         $oArticle->save();
     }
+    /**
+     * @deprecated use self::resetMasterPicture instead
+     */
+    protected function _resetMasterPicture($oArticle, $iIndex, $blDeleteMaster = false) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->resetMasterPicture($oArticle, $iIndex, $blDeleteMaster);
+    }
 
     /**
      * Deletes selected master picture and all pictures generated
@@ -137,7 +144,7 @@ class ArticlePictures extends \OxidEsales\Eshop\Application\Controller\Admin\Adm
      * @param int                                         $iIndex         master picture index
      * @param bool                                        $blDeleteMaster if TRUE - deletes and unsets master image file
      */
-    protected function _resetMasterPicture($oArticle, $iIndex, $blDeleteMaster = false) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function resetMasterPicture($oArticle, $iIndex, $blDeleteMaster = false)
     {
         if ($this->canResetMasterPicture($oArticle, $iIndex)) {
             if (!$oArticle->isDerived()) {
@@ -160,13 +167,20 @@ class ArticlePictures extends \OxidEsales\Eshop\Application\Controller\Admin\Adm
             }
         }
     }
+    /**
+     * @deprecated use self::deleteMainIcon instead
+     */
+    protected function _deleteMainIcon($oArticle) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->deleteMainIcon($oArticle);
+    }
 
     /**
      * Deletes main icon file
      *
      * @param \OxidEsales\Eshop\Application\Model\Article $oArticle article object
      */
-    protected function _deleteMainIcon($oArticle) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function deleteMainIcon($oArticle)
     {
         if ($this->canDeleteMainIcon($oArticle)) {
             if (!$oArticle->isDerived()) {
@@ -178,13 +192,20 @@ class ArticlePictures extends \OxidEsales\Eshop\Application\Controller\Admin\Adm
             $oArticle->oxarticles__oxicon = new \OxidEsales\Eshop\Core\Field();
         }
     }
+    /**
+     * @deprecated use self::deleteThumbnail instead
+     */
+    protected function _deleteThumbnail($oArticle) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->deleteThumbnail($oArticle);
+    }
 
     /**
      * Deletes thumbnail file
      *
      * @param \OxidEsales\Eshop\Application\Model\Article $oArticle article object
      */
-    protected function _deleteThumbnail($oArticle) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function deleteThumbnail($oArticle)
     {
         if ($this->canDeleteThumbnail($oArticle)) {
             if (!$oArticle->isDerived()) {
@@ -196,6 +217,13 @@ class ArticlePictures extends \OxidEsales\Eshop\Application\Controller\Admin\Adm
             $oArticle->oxarticles__oxthumb = new \OxidEsales\Eshop\Core\Field();
         }
     }
+    /**
+     * @deprecated use self::cleanupCustomFields instead
+     */
+    protected function _cleanupCustomFields($oArticle) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->cleanupCustomFields($oArticle);
+    }
 
     /**
      * Cleans up article custom fields oxicon and oxthumb. If there is custom
@@ -203,7 +231,7 @@ class ArticlePictures extends \OxidEsales\Eshop\Application\Controller\Admin\Adm
      *
      * @param \OxidEsales\Eshop\Application\Model\Article $oArticle article object
      */
-    protected function _cleanupCustomFields($oArticle) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function cleanupCustomFields($oArticle)
     {
         $sIcon = $oArticle->oxarticles__oxicon->value;
         $sThumb = $oArticle->oxarticles__oxthumb->value;

--- a/source/Application/Controller/Admin/ArticleReview.php
+++ b/source/Application/Controller/Admin/ArticleReview.php
@@ -69,6 +69,13 @@ class ArticleReview extends \OxidEsales\Eshop\Application\Controller\Admin\Admin
 
         return "article_review.tpl";
     }
+    /**
+     * @deprecated use self::getReviewList instead
+     */
+    protected function _getReviewList($article) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getReviewList($article);
+    }
 
     /**
      * returns reviews list for article
@@ -77,7 +84,7 @@ class ArticleReview extends \OxidEsales\Eshop\Application\Controller\Admin\Admin
      *
      * @return oxList
      */
-    protected function _getReviewList($article) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getReviewList($article)
     {
         $database = \OxidEsales\Eshop\Core\DatabaseProvider::getDb();
         $query = "select oxreviews.* from oxreviews

--- a/source/Application/Controller/Admin/ArticleSelectionAjax.php
+++ b/source/Application/Controller/Admin/ArticleSelectionAjax.php
@@ -35,13 +35,20 @@ class ArticleSelectionAjax extends \OxidEsales\Eshop\Application\Controller\Admi
                                      ['oxid', 'oxobject2selectlist', 0, 0, 1]
                                  ]
     ];
+    /**
+     * @deprecated use self::getQuery instead
+     */
+    protected function _getQuery() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getQuery();
+    }
 
     /**
      * Returns SQL query for data to fetc
      *
      * @return string
      */
-    protected function _getQuery() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getQuery()
     {
         $sSLViewName = $this->_getViewName('oxselectlist');
         $sArtViewName = $this->_getViewName('oxarticles');

--- a/source/Application/Controller/Admin/ArticleSeo.php
+++ b/source/Application/Controller/Admin/ArticleSeo.php
@@ -130,6 +130,13 @@ class ArticleSeo extends \OxidEsales\Eshop\Application\Controller\Admin\ObjectSe
 
         return $this->_aSelectionList;
     }
+    /**
+     * @deprecated use self::getCategoryList instead
+     */
+    protected function _getCategoryList($oArticle) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getCategoryList($oArticle);
+    }
 
     /**
      * Returns array of product categories
@@ -138,7 +145,7 @@ class ArticleSeo extends \OxidEsales\Eshop\Application\Controller\Admin\ObjectSe
      *
      * @return array
      */
-    protected function _getCategoryList($oArticle) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getCategoryList($oArticle)
     {
         $sMainCatId = false;
         if ($oMainCat = $oArticle->getCategory()) {
@@ -176,6 +183,13 @@ class ArticleSeo extends \OxidEsales\Eshop\Application\Controller\Admin\ObjectSe
 
         return $aCatList;
     }
+    /**
+     * @deprecated use self::getVendorList instead
+     */
+    protected function _getVendorList($oArticle) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getVendorList($oArticle);
+    }
 
     /**
      * Returns array containing product vendor object
@@ -184,7 +198,7 @@ class ArticleSeo extends \OxidEsales\Eshop\Application\Controller\Admin\ObjectSe
      *
      * @return array
      */
-    protected function _getVendorList($oArticle) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getVendorList($oArticle)
     {
         if ($oArticle->oxarticles__oxvendorid->value) {
             $oVendor = oxNew(\OxidEsales\Eshop\Application\Model\Vendor::class);
@@ -192,6 +206,13 @@ class ArticleSeo extends \OxidEsales\Eshop\Application\Controller\Admin\ObjectSe
                 return [$oVendor];
             }
         }
+    }
+    /**
+     * @deprecated use self::getManufacturerList instead
+     */
+    protected function _getManufacturerList($oArticle) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getManufacturerList($oArticle);
     }
 
     /**
@@ -201,7 +222,7 @@ class ArticleSeo extends \OxidEsales\Eshop\Application\Controller\Admin\ObjectSe
      *
      * @return array
      */
-    protected function _getManufacturerList($oArticle) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getManufacturerList($oArticle)
     {
         if ($oArticle->oxarticles__oxmanufacturerid->value) {
             $oManufacturer = oxNew(\OxidEsales\Eshop\Application\Model\Manufacturer::class);
@@ -272,15 +293,29 @@ class ArticleSeo extends \OxidEsales\Eshop\Application\Controller\Admin\ObjectSe
     {
         return $this->getActCatLang();
     }
+    /**
+     * @deprecated use self::getAltSeoEntryId instead
+     */
+    protected function _getAltSeoEntryId() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getAltSeoEntryId();
+    }
 
     /**
      * Returns alternative seo entry id
      *
      * @return null
      */
-    protected function _getAltSeoEntryId() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getAltSeoEntryId()
     {
         return $this->getEditObjectId();
+    }
+    /**
+     * @deprecated use self::getType instead
+     */
+    protected function _getType() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getType();
     }
 
     /**
@@ -288,7 +323,7 @@ class ArticleSeo extends \OxidEsales\Eshop\Application\Controller\Admin\ObjectSe
      *
      * @return string
      */
-    protected function _getType() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getType()
     {
         return 'oxarticle';
     }
@@ -304,13 +339,20 @@ class ArticleSeo extends \OxidEsales\Eshop\Application\Controller\Admin\ObjectSe
     {
         return $this->getActCatId();
     }
+    /**
+     * @deprecated use self::getEncoder instead
+     */
+    protected function _getEncoder() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getEncoder();
+    }
 
     /**
      * Returns current object type seo encoder object
      *
      * @return oxSeoEncoderCategory
      */
-    protected function _getEncoder() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getEncoder()
     {
         return \OxidEsales\Eshop\Core\Registry::get(\OxidEsales\Eshop\Application\Model\SeoEncoderArticle::class);
     }
@@ -351,6 +393,13 @@ class ArticleSeo extends \OxidEsales\Eshop\Application\Controller\Admin\ObjectSe
     {
         return true;
     }
+    /**
+     * @deprecated use self::getSaveObjectId instead
+     */
+    protected function _getSaveObjectId() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getSaveObjectId();
+    }
 
     /**
      * Returns id of object which must be saved
@@ -359,7 +408,7 @@ class ArticleSeo extends \OxidEsales\Eshop\Application\Controller\Admin\ObjectSe
      *
      * @return string
      */
-    protected function _getSaveObjectId() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getSaveObjectId()
     {
         return $this->getEditObjectId();
     }

--- a/source/Application/Controller/Admin/ArticleVariant.php
+++ b/source/Application/Controller/Admin/ArticleVariant.php
@@ -156,6 +156,13 @@ class ArticleVariant extends \OxidEsales\Eshop\Application\Controller\Admin\Admi
 
         $oArticle->save();
     }
+    /**
+     * @deprecated use self::isAnythingChanged instead
+     */
+    protected function _isAnythingChanged($oProduct, $aData) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->isAnythingChanged($oProduct, $aData);
+    }
 
     /**
      * Checks if anything is changed in given data compared with existing product values.
@@ -165,7 +172,7 @@ class ArticleVariant extends \OxidEsales\Eshop\Application\Controller\Admin\Admi
      *
      * @return bool
      */
-    protected function _isAnythingChanged($oProduct, $aData) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function isAnythingChanged($oProduct, $aData)
     {
         if (!is_array($aData)) {
             return true;
@@ -178,6 +185,13 @@ class ArticleVariant extends \OxidEsales\Eshop\Application\Controller\Admin\Admi
 
         return false;
     }
+    /**
+     * @deprecated use self::getProductParent instead
+     */
+    protected function _getProductParent($sParentId) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getProductParent($sParentId);
+    }
 
     /**
      * Returns variant parent object
@@ -186,7 +200,7 @@ class ArticleVariant extends \OxidEsales\Eshop\Application\Controller\Admin\Admi
      *
      * @return \OxidEsales\Eshop\Application\Model\Article
      */
-    protected function _getProductParent($sParentId) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getProductParent($sParentId)
     {
         if (
             $this->_oProductParent === null ||

--- a/source/Application/Controller/Admin/AttributeCategoryAjax.php
+++ b/source/Application/Controller/Admin/AttributeCategoryAjax.php
@@ -41,13 +41,20 @@ class AttributeCategoryAjax extends \OxidEsales\Eshop\Application\Controller\Adm
                                      ['oxid', 'oxcategory2attribute', 0, 0, 1]
                                  ]
     ];
+    /**
+     * @deprecated use self::getQuery instead
+     */
+    protected function _getQuery() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getQuery();
+    }
 
     /**
      * Returns SQL query for data to fetc
      *
      * @return string
      */
-    protected function _getQuery() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getQuery()
     {
         $myConfig = $this->getConfig();
         $oDb = \OxidEsales\Eshop\Core\DatabaseProvider::getDb();

--- a/source/Application/Controller/Admin/AttributeMainAjax.php
+++ b/source/Application/Controller/Admin/AttributeMainAjax.php
@@ -47,13 +47,20 @@ class AttributeMainAjax extends \OxidEsales\Eshop\Application\Controller\Admin\L
                                      ['oxid', 'oxobject2attribute', 0, 0, 1]
                                  ]
     ];
+    /**
+     * @deprecated use self::getQuery instead
+     */
+    protected function _getQuery() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getQuery();
+    }
 
     /**
      * Returns SQL query for data to fetc
      *
      * @return string
      */
-    protected function _getQuery() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getQuery()
     {
         $myConfig = $this->getConfig();
         $oDb = \OxidEsales\Eshop\Core\DatabaseProvider::getDb();
@@ -93,6 +100,13 @@ class AttributeMainAjax extends \OxidEsales\Eshop\Application\Controller\Admin\L
 
         return $sQAdd;
     }
+    /**
+     * @deprecated use self::addFilter instead
+     */
+    protected function _addFilter($sQ) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->addFilter($sQ);
+    }
 
     /**
      * Adds filter SQL to current query
@@ -101,9 +115,9 @@ class AttributeMainAjax extends \OxidEsales\Eshop\Application\Controller\Admin\L
      *
      * @return string
      */
-    protected function _addFilter($sQ) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function addFilter($sQ)
     {
-        $sQ = parent::_addFilter($sQ);
+        $sQ = parent::addFilter($sQ);
 
         // display variants or not ?
         if ($this->getConfig()->getConfigParam('blVariantsSelection')) {
@@ -128,7 +142,7 @@ class AttributeMainAjax extends \OxidEsales\Eshop\Application\Controller\Admin\L
         if (\OxidEsales\Eshop\Core\Registry::getConfig()->getRequestParameter('all')) {
             $sO2AttributeView = $this->_getViewName('oxobject2attribute');
 
-            $sQ = parent::_addFilter("delete $sO2AttributeView.* " . $this->_getQuery());
+            $sQ = parent::addFilter("delete $sO2AttributeView.* " . $this->_getQuery());
             \OxidEsales\Eshop\Core\DatabaseProvider::getDb()->Execute($sQ);
         } elseif (is_array($aChosenCat)) {
             $sChosenCategories = implode(", ", \OxidEsales\Eshop\Core\DatabaseProvider::getDb()->quoteArray($aChosenCat));

--- a/source/Application/Controller/Admin/AttributeOrderAjax.php
+++ b/source/Application/Controller/Admin/AttributeOrderAjax.php
@@ -26,13 +26,20 @@ class AttributeOrderAjax extends \OxidEsales\Eshop\Application\Controller\Admin\
         ['oxid', 'oxcategory2attribute', 0, 0, 1]
     ]
     ];
+    /**
+     * @deprecated use self::getQuery instead
+     */
+    protected function _getQuery() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getQuery();
+    }
 
     /**
      * Returns SQL query for data to fetc
      *
      * @return string
      */
-    protected function _getQuery() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getQuery()
     {
         $sSelTable = $this->_getViewName('oxattribute');
         $sArtId = \OxidEsales\Eshop\Core\Registry::getConfig()->getRequestParameter('oxid');
@@ -40,13 +47,20 @@ class AttributeOrderAjax extends \OxidEsales\Eshop\Application\Controller\Admin\
         return " from $sSelTable left join oxcategory2attribute on oxcategory2attribute.oxattrid = $sSelTable.oxid " .
                  "where oxobjectid = " . \OxidEsales\Eshop\Core\DatabaseProvider::getDb()->quote($sArtId) . " ";
     }
+    /**
+     * @deprecated use self::getSorting instead
+     */
+    protected function _getSorting() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getSorting();
+    }
 
     /**
      * Returns SQL query addon for sorting
      *
      * @return string
      */
-    protected function _getSorting() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getSorting()
     {
         return 'order by oxcategory2attribute.oxsort ';
     }

--- a/source/Application/Controller/Admin/CategoryMain.php
+++ b/source/Application/Controller/Admin/CategoryMain.php
@@ -167,6 +167,13 @@ class CategoryMain extends \OxidEsales\Eshop\Application\Controller\Admin\AdminD
 
         $this->setEditObjectId($oCategory->getId());
     }
+    /**
+     * @deprecated use self::processLongDesc instead
+     */
+    protected function _processLongDesc($sValue) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->processLongDesc($sValue);
+    }
 
     /**
      * Fixes html broken by html editor
@@ -175,7 +182,7 @@ class CategoryMain extends \OxidEsales\Eshop\Application\Controller\Admin\AdminD
      *
      * @return string
      */
-    protected function _processLongDesc($sValue) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function processLongDesc($sValue)
     {
         // workaround for firefox showing &lang= as &9001;= entity, mantis#0001272
         return str_replace('&lang=', '&amp;lang=', $sValue);
@@ -222,6 +229,13 @@ class CategoryMain extends \OxidEsales\Eshop\Application\Controller\Admin\AdminD
         $oItem->load($sOxId);
         $this->_deleteCatPicture($oItem, $sField);
     }
+    /**
+     * @deprecated use self::deleteCatPicture instead
+     */
+    protected function _deleteCatPicture($item, $field) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->deleteCatPicture($item, $field);
+    }
 
     /**
      * Delete category picture, specified in $sField parameter
@@ -231,7 +245,7 @@ class CategoryMain extends \OxidEsales\Eshop\Application\Controller\Admin\AdminD
      *
      * @return null
      */
-    protected function _deleteCatPicture($item, $field) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function deleteCatPicture($item, $field)
     {
         if ($item->isDerived()) {
             return;
@@ -270,6 +284,13 @@ class CategoryMain extends \OxidEsales\Eshop\Application\Controller\Admin\AdminD
             $item->save();
         }
     }
+    /**
+     * @deprecated use self::parseRequestParametersForSave instead
+     */
+    protected function _parseRequestParametersForSave($aReqParams) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->parseRequestParametersForSave($aReqParams);
+    }
 
     /**
      * Parse parameters prior to saving category.
@@ -278,7 +299,7 @@ class CategoryMain extends \OxidEsales\Eshop\Application\Controller\Admin\AdminD
      *
      * @return array
      */
-    protected function _parseRequestParametersForSave($aReqParams) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function parseRequestParametersForSave($aReqParams)
     {
         // checkbox handling
         if (!isset($aReqParams['oxcategories__oxactive'])) {

--- a/source/Application/Controller/Admin/CategoryMainAjax.php
+++ b/source/Application/Controller/Admin/CategoryMainAjax.php
@@ -46,13 +46,20 @@ class CategoryMainAjax extends \OxidEsales\Eshop\Application\Controller\Admin\Li
                                      ['oxid', 'oxarticles', 0, 0, 1]
                                  ]
     ];
+    /**
+     * @deprecated use self::getQuery instead
+     */
+    protected function _getQuery() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getQuery();
+    }
 
     /**
      * Returns SQL query for data to fetc
      *
      * @return string
      */
-    protected function _getQuery() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getQuery()
     {
         $myConfig = $this->getConfig();
 
@@ -86,6 +93,13 @@ class CategoryMainAjax extends \OxidEsales\Eshop\Application\Controller\Admin\Li
 
         return $sQAdd;
     }
+    /**
+     * @deprecated use self::addFilter instead
+     */
+    protected function _addFilter($sQ) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->addFilter($sQ);
+    }
 
     /**
      * Adds filter SQL to current query
@@ -94,10 +108,10 @@ class CategoryMainAjax extends \OxidEsales\Eshop\Application\Controller\Admin\Li
      *
      * @return string
      */
-    protected function _addFilter($sQ) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function addFilter($sQ)
     {
         $sArtTable = $this->_getViewName('oxarticles');
-        $sQ = parent::_addFilter($sQ);
+        $sQ = parent::addFilter($sQ);
 
         // display variants or not ?
         if (!$this->getConfig()->getConfigParam('blVariantsSelection')) {
@@ -171,13 +185,20 @@ class CategoryMainAjax extends \OxidEsales\Eshop\Application\Controller\Admin\Li
 
         \OxidEsales\Eshop\Core\DatabaseProvider::getDb()->commitTransaction();
     }
+    /**
+     * @deprecated use self::updateOxTime instead
+     */
+    protected function _updateOxTime($sProdIds) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->updateOxTime($sProdIds);
+    }
 
     /**
      * Updates oxtime value for products
      *
      * @param string $sProdIds product ids: "id1", "id2", "id3"
      */
-    protected function _updateOxTime($sProdIds) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function updateOxTime($sProdIds)
     {
         if ($sProdIds) {
             $sO2CView = $this->_getViewName('oxobject2category');

--- a/source/Application/Controller/Admin/CategoryOrderAjax.php
+++ b/source/Application/Controller/Admin/CategoryOrderAjax.php
@@ -41,13 +41,20 @@ class CategoryOrderAjax extends \OxidEsales\Eshop\Application\Controller\Admin\L
                                      ['oxid', 'oxarticles', 0, 0, 1]
                                  ]
     ];
+    /**
+     * @deprecated use self::getQuery instead
+     */
+    protected function _getQuery() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getQuery();
+    }
 
     /**
      * Returns SQL query for data to fetc
      *
      * @return string
      */
-    protected function _getQuery() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getQuery()
     {
         // looking for table/view
         $sArtTable = $this->_getViewName('oxarticles');
@@ -72,17 +79,24 @@ class CategoryOrderAjax extends \OxidEsales\Eshop\Application\Controller\Admin\L
 
         return $sQAdd;
     }
+    /**
+     * @deprecated use self::getSorting instead
+     */
+    protected function _getSorting() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getSorting();
+    }
 
     /**
      * Returns SQL query addon for sorting
      *
      * @return string
      */
-    protected function _getSorting() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getSorting()
     {
         $sOrder = '';
         if (\OxidEsales\Eshop\Core\Registry::getConfig()->getRequestParameter('synchoxid')) {
-            $sOrder = parent::_getSorting();
+            $sOrder = parent::getSorting();
         } elseif (($aSkipArt = \OxidEsales\Eshop\Core\Registry::getSession()->getVariable('neworder_sess'))) {
             $sOrderBy = '';
             $sArtTable = $this->_getViewName('oxarticles');

--- a/source/Application/Controller/Admin/CategorySeo.php
+++ b/source/Application/Controller/Admin/CategorySeo.php
@@ -35,13 +35,20 @@ class CategorySeo extends \OxidEsales\Eshop\Application\Controller\Admin\ObjectS
 
         return parent::save();
     }
+    /**
+     * @deprecated use self::getEncoder instead
+     */
+    protected function _getEncoder() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getEncoder();
+    }
 
     /**
      * Returns current object type seo encoder object
      *
      * @return oxSeoEncoderCategory
      */
-    protected function _getEncoder() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getEncoder()
     {
         return \OxidEsales\Eshop\Core\Registry::get(\OxidEsales\Eshop\Application\Model\SeoEncoderCategory::class);
     }
@@ -55,13 +62,20 @@ class CategorySeo extends \OxidEsales\Eshop\Application\Controller\Admin\ObjectS
     {
         return true;
     }
+    /**
+     * @deprecated use self::getType instead
+     */
+    protected function _getType() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getType();
+    }
 
     /**
      * Returns url type
      *
      * @return string
      */
-    protected function _getType() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getType()
     {
         return 'oxcategory';
     }

--- a/source/Application/Controller/Admin/CategoryUpdate.php
+++ b/source/Application/Controller/Admin/CategoryUpdate.php
@@ -25,13 +25,20 @@ class CategoryUpdate extends \OxidEsales\Eshop\Application\Controller\Admin\Admi
      * @var oxCategoryList
      */
     protected $_oCatList = null;
+    /**
+     * @deprecated use self::getCategoryList instead
+     */
+    protected function _getCategoryList() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getCategoryList();
+    }
 
     /**
      * Returns category list object
      *
      * @return oxCategoryList
      */
-    protected function _getCategoryList() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getCategoryList()
     {
         if ($this->_oCatList == null) {
             $this->_oCatList = oxNew(\OxidEsales\Eshop\Application\Model\CategoryList::class);

--- a/source/Application/Controller/Admin/ContentList.php
+++ b/source/Application/Controller/Admin/ContentList.php
@@ -57,6 +57,13 @@ class ContentList extends \OxidEsales\Eshop\Application\Controller\Admin\AdminLi
 
         return $this->_sThisTemplate;
     }
+    /**
+     * @deprecated use self::prepareWhereQuery instead
+     */
+    protected function _prepareWhereQuery($aWhere, $sqlFull) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->prepareWhereQuery($aWhere, $sqlFull);
+    }
 
     /**
      * Adding folder check and empty folder field check.
@@ -66,9 +73,9 @@ class ContentList extends \OxidEsales\Eshop\Application\Controller\Admin\AdminLi
      *
      * @return string
      */
-    protected function _prepareWhereQuery($aWhere, $sqlFull) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function prepareWhereQuery($aWhere, $sqlFull)
     {
-        $sQ = parent::_prepareWhereQuery($aWhere, $sqlFull);
+        $sQ = parent::prepareWhereQuery($aWhere, $sqlFull);
         $sFolder = \OxidEsales\Eshop\Core\Registry::getConfig()->getRequestParameter('folder');
         $sViewName = getviewName("oxcontents");
 

--- a/source/Application/Controller/Admin/ContentMain.php
+++ b/source/Application/Controller/Admin/ContentMain.php
@@ -189,6 +189,13 @@ class ContentMain extends \OxidEsales\Eshop\Application\Controller\Admin\AdminDe
         // set oxid if inserted
         $this->setEditObjectId($oContent->getId());
     }
+    /**
+     * @deprecated use self::prepareIdent instead
+     */
+    protected function _prepareIdent($sIdent) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->prepareIdent($sIdent);
+    }
 
     /**
      * Prepares ident (removes bad chars, leaves only thoose that fits in a-zA-Z0-9_ range)
@@ -197,11 +204,18 @@ class ContentMain extends \OxidEsales\Eshop\Application\Controller\Admin\AdminDe
      *
      * @return string
      */
-    protected function _prepareIdent($sIdent) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function prepareIdent($sIdent)
     {
         if ($sIdent) {
             return getStr()->preg_replace("/[^a-zA-Z0-9_]*/", "", $sIdent);
         }
+    }
+    /**
+     * @deprecated use self::checkIdent instead
+     */
+    protected function _checkIdent($sIdent, $sOxId) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->checkIdent($sIdent, $sOxId);
     }
 
     /**
@@ -212,7 +226,7 @@ class ContentMain extends \OxidEsales\Eshop\Application\Controller\Admin\AdminDe
      *
      * @return null
      */
-    protected function _checkIdent($sIdent, $sOxId) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function checkIdent($sIdent, $sOxId)
     {
         // We force reading from master to prevent issues with slow replications or open transactions (see ESDEV-3804).
         $masterDb = \OxidEsales\Eshop\Core\DatabaseProvider::getMaster();

--- a/source/Application/Controller/Admin/ContentSeo.php
+++ b/source/Application/Controller/Admin/ContentSeo.php
@@ -15,13 +15,27 @@ use oxRegistry;
 class ContentSeo extends \OxidEsales\Eshop\Application\Controller\Admin\ObjectSeo
 {
     /**
+     * @deprecated use self::getType instead
+     */
+    protected function _getType() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getType();
+    }
+    /**
      * Returns url type
      *
      * @return string
      */
-    protected function _getType() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getType()
     {
         return 'oxcontent';
+    }
+    /**
+     * @deprecated use self::getEncoder instead
+     */
+    protected function _getEncoder() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getEncoder();
     }
 
     /**
@@ -29,7 +43,7 @@ class ContentSeo extends \OxidEsales\Eshop\Application\Controller\Admin\ObjectSe
      *
      * @return oxSeoEncoderContent
      */
-    protected function _getEncoder() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getEncoder()
     {
         return \OxidEsales\Eshop\Core\Registry::get(\OxidEsales\Eshop\Application\Model\SeoEncoderContent::class);
     }

--- a/source/Application/Controller/Admin/CountryList.php
+++ b/source/Application/Controller/Admin/CountryList.php
@@ -69,13 +69,20 @@ class CountryList extends \OxidEsales\Eshop\Application\Controller\Admin\AdminLi
 
         return $aListSorting;
     }
+    /**
+     * @deprecated use self::getSecondSortFieldName instead
+     */
+    protected function _getSecondSortFieldName() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getSecondSortFieldName();
+    }
 
     /**
      * Getter for the second sort field name (for getting the expected oreder out of the databse).
      *
      * @return string The name of the field we want to be the second order by argument.
      */
-    protected function _getSecondSortFieldName() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getSecondSortFieldName()
     {
         return $this->sSecondDefSortField;
     }

--- a/source/Application/Controller/Admin/DeliveryArticlesAjax.php
+++ b/source/Application/Controller/Admin/DeliveryArticlesAjax.php
@@ -46,13 +46,20 @@ class DeliveryArticlesAjax extends \OxidEsales\Eshop\Application\Controller\Admi
      * @var bool
      */
     protected $_blAllowExtColumns = true;
+    /**
+     * @deprecated use self::getQuery instead
+     */
+    protected function _getQuery() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getQuery();
+    }
 
     /**
      * Returns SQL query for data to fetc
      *
      * @return string
      */
-    protected function _getQuery() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getQuery()
     {
         $myConfig = $this->getConfig();
         $oDb = \OxidEsales\Eshop\Core\DatabaseProvider::getDb();
@@ -100,7 +107,7 @@ class DeliveryArticlesAjax extends \OxidEsales\Eshop\Application\Controller\Admi
     /*protected function _addFilter( $sQ ) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $sArtTable = $this->_getViewName('oxarticles');
-        $sQ = parent::_addFilter( $sQ );
+        $sQ = parent::addFilter( $sQ );
 
         // display variants or not ?
         $sQ .= $this->getConfig()->getConfigParam( 'blVariantsSelection' ) ? ' group by '.$sArtTable.'.oxid ' : '';
@@ -115,7 +122,7 @@ class DeliveryArticlesAjax extends \OxidEsales\Eshop\Application\Controller\Admi
         $aChosenArt = $this->_getActionIds('oxobject2delivery.oxid');
         // removing all
         if ($this->getConfig()->getRequestParameter('all')) {
-            $sQ = parent::_addFilter("delete oxobject2delivery.* " . $this->_getQuery());
+            $sQ = parent::addFilter("delete oxobject2delivery.* " . $this->_getQuery());
             \OxidEsales\Eshop\Core\DatabaseProvider::getDb()->Execute($sQ);
         } elseif (is_array($aChosenArt)) {
             $sQ = "delete from oxobject2delivery where oxobject2delivery.oxid in (" . implode(", ", \OxidEsales\Eshop\Core\DatabaseProvider::getDb()->quoteArray($aChosenArt)) . ") ";

--- a/source/Application/Controller/Admin/DeliveryCategoriesAjax.php
+++ b/source/Application/Controller/Admin/DeliveryCategoriesAjax.php
@@ -34,13 +34,20 @@ class DeliveryCategoriesAjax extends \OxidEsales\Eshop\Application\Controller\Ad
                                      ['oxid', 'oxcategories', 0, 0, 1]
                                  ],
     ];
+    /**
+     * @deprecated use self::getQuery instead
+     */
+    protected function _getQuery() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getQuery();
+    }
 
     /**
      * Returns SQL query for data to fetc
      *
      * @return string
      */
-    protected function _getQuery() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getQuery()
     {
         // looking for table/view
         $sCatTable = $this->_getViewName('oxcategories');

--- a/source/Application/Controller/Admin/DeliveryGroupsAjax.php
+++ b/source/Application/Controller/Admin/DeliveryGroupsAjax.php
@@ -31,13 +31,20 @@ class DeliveryGroupsAjax extends \OxidEsales\Eshop\Application\Controller\Admin\
                                      ['oxid', 'oxobject2delivery', 0, 0, 1],
                                  ]
     ];
+    /**
+     * @deprecated use self::getQuery instead
+     */
+    protected function _getQuery() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getQuery();
+    }
 
     /**
      * Returns SQL query for data to fetc
      *
      * @return string
      */
-    protected function _getQuery() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getQuery()
     {
         $myConfig = $this->getConfig();
         $oDb = \OxidEsales\Eshop\Core\DatabaseProvider::getDb();

--- a/source/Application/Controller/Admin/DeliveryMainAjax.php
+++ b/source/Application/Controller/Admin/DeliveryMainAjax.php
@@ -35,13 +35,20 @@ class DeliveryMainAjax extends \OxidEsales\Eshop\Application\Controller\Admin\Li
                                      ['oxid', 'oxobject2delivery', 0, 0, 1]
                                  ]
     ];
+    /**
+     * @deprecated use self::getQuery instead
+     */
+    protected function _getQuery() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getQuery();
+    }
 
     /**
      * Returns SQL query for data to fetc
      *
      * @return string
      */
-    protected function _getQuery() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getQuery()
     {
         $sCountryTable = $this->_getViewName('oxcountry');
         $oDb = \OxidEsales\Eshop\Core\DatabaseProvider::getDb();

--- a/source/Application/Controller/Admin/DeliverySetCountryAjax.php
+++ b/source/Application/Controller/Admin/DeliverySetCountryAjax.php
@@ -35,13 +35,20 @@ class DeliverySetCountryAjax extends \OxidEsales\Eshop\Application\Controller\Ad
                                      ['oxid', 'oxobject2delivery', 0, 0, 1]
                                  ]
     ];
+    /**
+     * @deprecated use self::getQuery instead
+     */
+    protected function _getQuery() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getQuery();
+    }
 
     /**
      * Returns SQL query for data to fetc
      *
      * @return string
      */
-    protected function _getQuery() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getQuery()
     {
         $oDb = \OxidEsales\Eshop\Core\DatabaseProvider::getDb();
         $sId = $this->getConfig()->getRequestParameter('oxid');

--- a/source/Application/Controller/Admin/DeliverySetGroupsAjax.php
+++ b/source/Application/Controller/Admin/DeliverySetGroupsAjax.php
@@ -31,13 +31,20 @@ class DeliverySetGroupsAjax extends \OxidEsales\Eshop\Application\Controller\Adm
                                      ['oxid', 'oxobject2delivery', 0, 0, 1],
                                  ]
     ];
+    /**
+     * @deprecated use self::getQuery instead
+     */
+    protected function _getQuery() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getQuery();
+    }
 
     /**
      * Returns SQL query for data to fetc
      *
      * @return string
      */
-    protected function _getQuery() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getQuery()
     {
         $oDb = \OxidEsales\Eshop\Core\DatabaseProvider::getDb();
         $sId = $this->getConfig()->getRequestParameter('oxid');

--- a/source/Application/Controller/Admin/DeliverySetMainAjax.php
+++ b/source/Application/Controller/Admin/DeliverySetMainAjax.php
@@ -35,13 +35,20 @@ class DeliverySetMainAjax extends \OxidEsales\Eshop\Application\Controller\Admin
                                      ['oxid', 'oxdel2delset', 0, 0, 1]
                                  ]
     ];
+    /**
+     * @deprecated use self::getQuery instead
+     */
+    protected function _getQuery() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getQuery();
+    }
 
     /**
      * Returns SQL query for data to fetc
      *
      * @return string
      */
-    protected function _getQuery() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getQuery()
     {
         $sId = $this->getConfig()->getRequestParameter('oxid');
         $sSynchId = $this->getConfig()->getRequestParameter('synchoxid');

--- a/source/Application/Controller/Admin/DeliverySetPaymentAjax.php
+++ b/source/Application/Controller/Admin/DeliverySetPaymentAjax.php
@@ -34,13 +34,20 @@ class DeliverySetPaymentAjax extends \OxidEsales\Eshop\Application\Controller\Ad
                                      ['oxid', 'oxobject2payment', 0, 0, 1]
                                  ]
     ];
+    /**
+     * @deprecated use self::getQuery instead
+     */
+    protected function _getQuery() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getQuery();
+    }
 
     /**
      * Returns SQL query for data to fetc
      *
      * @return string
      */
-    protected function _getQuery() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getQuery()
     {
         $oDb = \OxidEsales\Eshop\Core\DatabaseProvider::getDb();
         $sId = $this->getConfig()->getRequestParameter('oxid');

--- a/source/Application/Controller/Admin/DeliverySetUsersAjax.php
+++ b/source/Application/Controller/Admin/DeliverySetUsersAjax.php
@@ -47,13 +47,20 @@ class DeliverySetUsersAjax extends \OxidEsales\Eshop\Application\Controller\Admi
              ['oxid', 'oxobject2delivery', 0, 0, 1],
          ]
     ];
+    /**
+     * @deprecated use self::getQuery instead
+     */
+    protected function _getQuery() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getQuery();
+    }
 
     /**
      * Returns SQL query for data to fetc
      *
      * @return string
      */
-    protected function _getQuery() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getQuery()
     {
         $myConfig = $this->getConfig();
         $oDb = \OxidEsales\Eshop\Core\DatabaseProvider::getDb();

--- a/source/Application/Controller/Admin/DeliveryUsersAjax.php
+++ b/source/Application/Controller/Admin/DeliveryUsersAjax.php
@@ -45,13 +45,20 @@ class DeliveryUsersAjax extends \OxidEsales\Eshop\Application\Controller\Admin\L
                                      ['oxid', 'oxobject2delivery', 0, 0, 1],
                                  ]
     ];
+    /**
+     * @deprecated use self::getQuery instead
+     */
+    protected function _getQuery() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getQuery();
+    }
 
     /**
      * Returns SQL query for data to fetc
      *
      * @return string
      */
-    protected function _getQuery() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getQuery()
     {
         $myConfig = $this->getConfig();
 

--- a/source/Application/Controller/Admin/DiagnosticsMain.php
+++ b/source/Application/Controller/Admin/DiagnosticsMain.php
@@ -59,15 +59,12 @@ class DiagnosticsMain extends \OxidEsales\Eshop\Application\Controller\Admin\Adm
      * @var mixed|string
      */
     protected $_sShopDir = '';
-
     /**
-     * Error status getter
-     *
-     * @return string
+     * @deprecated use self::hasError instead
      */
     protected function _hasError() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
-        return $this->_blError;
+        return $this->hasError();
     }
 
     /**
@@ -75,7 +72,24 @@ class DiagnosticsMain extends \OxidEsales\Eshop\Application\Controller\Admin\Adm
      *
      * @return string
      */
+    protected function hasError()
+    {
+        return $this->_blError;
+    }
+    /**
+     * @deprecated use self::getErrorMessage instead
+     */
     protected function _getErrorMessage() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getErrorMessage();
+    }
+
+    /**
+     * Error status getter
+     *
+     * @return string
+     */
+    protected function getErrorMessage()
     {
         return $this->_sErrorMessage;
     }
@@ -109,6 +123,13 @@ class DiagnosticsMain extends \OxidEsales\Eshop\Application\Controller\Admin\Adm
 
         return "diagnostics_form.tpl";
     }
+    /**
+     * @deprecated use self::getFilesToCheck instead
+     */
+    protected function _getFilesToCheck() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getFilesToCheck();
+    }
 
     /**
      * Gets list of files to be checked
@@ -117,7 +138,7 @@ class DiagnosticsMain extends \OxidEsales\Eshop\Application\Controller\Admin\Adm
      *
      * @return array list of shop files to be checked
      */
-    protected function _getFilesToCheck() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getFilesToCheck()
     {
         $oDiagnostics = oxNew(\OxidEsales\Eshop\Application\Model\Diagnostics::class);
         $aFilePathList = $oDiagnostics->getFileCheckerPathList();
@@ -136,6 +157,13 @@ class DiagnosticsMain extends \OxidEsales\Eshop\Application\Controller\Admin\Adm
 
         return $oFileCollector->getFiles();
     }
+    /**
+     * @deprecated use self::checkOxidFiles instead
+     */
+    protected function _checkOxidFiles($aFileList) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->checkOxidFiles($aFileList);
+    }
 
     /**
      * Checks versions for list of oxid files
@@ -146,7 +174,7 @@ class DiagnosticsMain extends \OxidEsales\Eshop\Application\Controller\Admin\Adm
      *
      * @return null|oxFileCheckerResult
      */
-    protected function _checkOxidFiles($aFileList) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function checkOxidFiles($aFileList)
     {
         $oFileChecker = oxNew(\OxidEsales\Eshop\Application\Model\FileChecker::class);
         $oFileChecker->setBaseDirectory($this->_sShopDir);
@@ -173,6 +201,13 @@ class DiagnosticsMain extends \OxidEsales\Eshop\Application\Controller\Admin\Adm
 
         return $oFileCheckerResult;
     }
+    /**
+     * @deprecated use self::getFileCheckReport instead
+     */
+    protected function _getFileCheckReport($oFileCheckerResult) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getFileCheckReport($oFileCheckerResult);
+    }
 
     /**
      * Returns body of file check report
@@ -183,7 +218,7 @@ class DiagnosticsMain extends \OxidEsales\Eshop\Application\Controller\Admin\Adm
      *
      * @return string body of report
      */
-    protected function _getFileCheckReport($oFileCheckerResult) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getFileCheckReport($oFileCheckerResult)
     {
         $aViewData = [
             "sVersion"       => $this->getConfig()->getVersion(),
@@ -227,6 +262,13 @@ class DiagnosticsMain extends \OxidEsales\Eshop\Application\Controller\Admin\Adm
         $sResult = $this->_oOutput->readResultFile();
         $this->_aViewData['sResult'] = $sResult;
     }
+    /**
+     * @deprecated use self::runBasicDiagnostics instead
+     */
+    protected function _runBasicDiagnostics() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->runBasicDiagnostics();
+    }
 
     /**
      * Performs main system diagnostic.
@@ -234,7 +276,7 @@ class DiagnosticsMain extends \OxidEsales\Eshop\Application\Controller\Admin\Adm
      *
      * @return array
      */
-    protected function _runBasicDiagnostics() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function runBasicDiagnostics()
     {
         $aViewData = [];
         $oDiagnostics = oxNew(\OxidEsales\Eshop\Application\Model\Diagnostics::class);

--- a/source/Application/Controller/Admin/DiscountArticlesAjax.php
+++ b/source/Application/Controller/Admin/DiscountArticlesAjax.php
@@ -51,13 +51,20 @@ class DiscountArticlesAjax extends \OxidEsales\Eshop\Application\Controller\Admi
             ['oxid', 'oxobject2discount', 0, 0, 1]
         ]
     ];
+    /**
+     * @deprecated use self::getQuery instead
+     */
+    protected function _getQuery() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getQuery();
+    }
 
     /**
      * Returns SQL query for data to fetc
      *
      * @return string
      */
-    protected function _getQuery() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getQuery()
     {
         $oConfig = $this->getConfig();
 
@@ -111,7 +118,7 @@ class DiscountArticlesAjax extends \OxidEsales\Eshop\Application\Controller\Admi
         $aChosenArt = $this->_getActionIds('oxobject2discount.oxid');
 
         if ($this->getConfig()->getRequestParameter('all')) {
-            $sQ = parent::_addFilter("delete oxobject2discount.* " . $this->_getQuery());
+            $sQ = parent::addFilter("delete oxobject2discount.* " . $this->_getQuery());
             \OxidEsales\Eshop\Core\DatabaseProvider::getDb()->execute($sQ);
         } elseif (is_array($aChosenArt)) {
             $sQ = "delete from oxobject2discount where oxobject2discount.oxid in (" . implode(", ", \OxidEsales\Eshop\Core\DatabaseProvider::getDb()->quoteArray($aChosenArt)) . ") ";
@@ -131,7 +138,7 @@ class DiscountArticlesAjax extends \OxidEsales\Eshop\Application\Controller\Admi
         // adding
         if ($config->getRequestParameter('all')) {
             $articleTable = $this->_getViewName('oxarticles');
-            $articleIds = $this->_getAll(parent::_addFilter("select $articleTable.oxid " . $this->_getQuery()));
+            $articleIds = $this->_getAll(parent::addFilter("select $articleTable.oxid " . $this->_getQuery()));
         }
         if ($discountListId && $discountListId != self::NEW_DISCOUNT_LIST_ID && is_array($articleIds)) {
             foreach ($articleIds as $articleId) {

--- a/source/Application/Controller/Admin/DiscountCategoriesAjax.php
+++ b/source/Application/Controller/Admin/DiscountCategoriesAjax.php
@@ -39,13 +39,20 @@ class DiscountCategoriesAjax extends \OxidEsales\Eshop\Application\Controller\Ad
              ['oxid', 'oxcategories', 0, 0, 1]
          ],
     ];
+    /**
+     * @deprecated use self::getQuery instead
+     */
+    protected function _getQuery() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getQuery();
+    }
 
     /**
      * Returns SQL query for data to fetc
      *
      * @return string
      */
-    protected function _getQuery() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getQuery()
     {
         $oDb = \OxidEsales\Eshop\Core\DatabaseProvider::getDb();
         $oConfig = $this->getConfig();

--- a/source/Application/Controller/Admin/DiscountGroupsAjax.php
+++ b/source/Application/Controller/Admin/DiscountGroupsAjax.php
@@ -36,13 +36,20 @@ class DiscountGroupsAjax extends \OxidEsales\Eshop\Application\Controller\Admin\
              ['oxid', 'oxobject2discount', 0, 0, 1],
          ]
     ];
+    /**
+     * @deprecated use self::getQuery instead
+     */
+    protected function _getQuery() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getQuery();
+    }
 
     /**
      * Returns SQL query for data to fetc
      *
      * @return string
      */
-    protected function _getQuery() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getQuery()
     {
         $oConfig = $this->getConfig();
         // active AJAX component

--- a/source/Application/Controller/Admin/DiscountItemAjax.php
+++ b/source/Application/Controller/Admin/DiscountItemAjax.php
@@ -41,13 +41,20 @@ class DiscountItemAjax extends \OxidEsales\Eshop\Application\Controller\Admin\Li
              ['oxitmartid', 'oxdiscount', 0, 0, 1]
          ]
     ];
+    /**
+     * @deprecated use self::getQuery instead
+     */
+    protected function _getQuery() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getQuery();
+    }
 
     /**
      * Returns SQL query for data to fetc
      *
      * @return string
      */
-    protected function _getQuery() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getQuery()
     {
         $oConfig = $this->getConfig();
 
@@ -131,6 +138,13 @@ class DiscountItemAjax extends \OxidEsales\Eshop\Application\Controller\Admin\Li
             ]);
         }
     }
+    /**
+     * @deprecated use self::getQueryCols instead
+     */
+    protected function _getQueryCols() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getQueryCols();
+    }
 
     /**
      * Formats and returns chunk of SQL query string with definition of
@@ -138,7 +152,7 @@ class DiscountItemAjax extends \OxidEsales\Eshop\Application\Controller\Admin\Li
      *
      * @return string
      */
-    protected function _getQueryCols() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getQueryCols()
     {
         $oConfig = $this->getConfig();
         $sLangTag = \OxidEsales\Eshop\Core\Registry::getLang()->getLanguageTag();

--- a/source/Application/Controller/Admin/DiscountMainAjax.php
+++ b/source/Application/Controller/Admin/DiscountMainAjax.php
@@ -35,13 +35,20 @@ class DiscountMainAjax extends \OxidEsales\Eshop\Application\Controller\Admin\Li
                                      ['oxid', 'oxobject2discount', 0, 0, 1]
                                  ]
     ];
+    /**
+     * @deprecated use self::getQuery instead
+     */
+    protected function _getQuery() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getQuery();
+    }
 
     /**
      * Returns SQL query for data to fetc
      *
      * @return string
      */
-    protected function _getQuery() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getQuery()
     {
         $oConfig = $this->getConfig();
         $sCountryTable = $this->_getViewName('oxcountry');

--- a/source/Application/Controller/Admin/DiscountUsersAjax.php
+++ b/source/Application/Controller/Admin/DiscountUsersAjax.php
@@ -45,13 +45,20 @@ class DiscountUsersAjax extends \OxidEsales\Eshop\Application\Controller\Admin\L
                                      ['oxid', 'oxobject2discount', 0, 0, 1],
                                  ]
     ];
+    /**
+     * @deprecated use self::getQuery instead
+     */
+    protected function _getQuery() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getQuery();
+    }
 
     /**
      * Returns SQL query for data to fetc
      *
      * @return string
      */
-    protected function _getQuery() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getQuery()
     {
         $oConfig = $this->getConfig();
 

--- a/source/Application/Controller/Admin/DynamicExportBaseController.php
+++ b/source/Application/Controller/Admin/DynamicExportBaseController.php
@@ -537,6 +537,13 @@ class DynamicExportBaseController extends \OxidEsales\Eshop\Application\Controll
 
         return $sInput;
     }
+    /**
+     * @deprecated use self::unHtmlEntities instead
+     */
+    protected function _unHtmlEntities($sInput) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->unHtmlEntities($sInput);
+    }
 
     /**
      * Replace HTML Entities
@@ -546,11 +553,18 @@ class DynamicExportBaseController extends \OxidEsales\Eshop\Application\Controll
      *
      * @return string
      */
-    protected function _unHtmlEntities($sInput) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function unHtmlEntities($sInput)
     {
         $aTransTbl = array_flip(get_html_translation_table(HTML_ENTITIES));
 
         return strtr($sInput, $aTransTbl);
+    }
+    /**
+     * @deprecated use self::getHeapTableName instead
+     */
+    protected function _getHeapTableName() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getHeapTableName();
     }
 
     /**
@@ -558,10 +572,17 @@ class DynamicExportBaseController extends \OxidEsales\Eshop\Application\Controll
      *
      * @return string
      */
-    protected function _getHeapTableName() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getHeapTableName()
     {
         // table name must not start with any digit
         return "tmp_" . str_replace("0", "", md5($this->getSession()->getId()));
+    }
+    /**
+     * @deprecated use self::generateTableCharSet instead
+     */
+    protected function _generateTableCharSet($sMysqlVersion) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->generateTableCharSet($sMysqlVersion);
     }
 
     /**
@@ -571,7 +592,7 @@ class DynamicExportBaseController extends \OxidEsales\Eshop\Application\Controll
      *
      * @return string
      */
-    protected function _generateTableCharSet($sMysqlVersion) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function generateTableCharSet($sMysqlVersion)
     {
         $sTableCharset = "";
 
@@ -589,6 +610,13 @@ class DynamicExportBaseController extends \OxidEsales\Eshop\Application\Controll
 
         return $sTableCharset;
     }
+    /**
+     * @deprecated use self::createHeapTable instead
+     */
+    protected function _createHeapTable($sHeapTable, $sTableCharset) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->createHeapTable($sHeapTable, $sTableCharset);
+    }
 
     /**
      * creates heaptable
@@ -598,7 +626,7 @@ class DynamicExportBaseController extends \OxidEsales\Eshop\Application\Controll
      *
      * @return bool
      */
-    protected function _createHeapTable($sHeapTable, $sTableCharset) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function createHeapTable($sHeapTable, $sTableCharset)
     {
         $blDone = false;
         $oDB = \OxidEsales\Eshop\Core\DatabaseProvider::getDb();
@@ -610,6 +638,13 @@ class DynamicExportBaseController extends \OxidEsales\Eshop\Application\Controll
 
         return $blDone;
     }
+    /**
+     * @deprecated use self::getCatAdd instead
+     */
+    protected function _getCatAdd($aChosenCat) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getCatAdd($aChosenCat);
+    }
 
     /**
      * creates additional cat string
@@ -618,7 +653,7 @@ class DynamicExportBaseController extends \OxidEsales\Eshop\Application\Controll
      *
      * @return string
      */
-    protected function _getCatAdd($aChosenCat) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getCatAdd($aChosenCat)
     {
         $sCatAdd = null;
         if (is_array($aChosenCat) && count($aChosenCat)) {
@@ -637,6 +672,13 @@ class DynamicExportBaseController extends \OxidEsales\Eshop\Application\Controll
 
         return $sCatAdd;
     }
+    /**
+     * @deprecated use self::insertArticles instead
+     */
+    protected function _insertArticles($sHeapTable, $sCatAdd) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->insertArticles($sHeapTable, $sCatAdd);
+    }
 
     /**
      * inserts articles into heaptable
@@ -646,7 +688,7 @@ class DynamicExportBaseController extends \OxidEsales\Eshop\Application\Controll
      *
      * @return bool
      */
-    protected function _insertArticles($sHeapTable, $sCatAdd) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function insertArticles($sHeapTable, $sCatAdd)
     {
         $oDB = \OxidEsales\Eshop\Core\DatabaseProvider::getDb();
 
@@ -691,13 +733,20 @@ class DynamicExportBaseController extends \OxidEsales\Eshop\Application\Controll
 
         return $oDB->execute($insertQuery) ? true : false;
     }
+    /**
+     * @deprecated use self::removeParentArticles instead
+     */
+    protected function _removeParentArticles($sHeapTable) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->removeParentArticles($sHeapTable);
+    }
 
     /**
      * removes parent articles so that we only have variants itself
      *
      * @param string $sHeapTable table name
      */
-    protected function _removeParentArticles($sHeapTable) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function removeParentArticles($sHeapTable)
     {
         if (!(\OxidEsales\Eshop\Core\Registry::getConfig()->getRequestParameter("blExportMainVars"))) {
             $oDB = \OxidEsales\Eshop\Core\DatabaseProvider::getDb();
@@ -724,11 +773,18 @@ class DynamicExportBaseController extends \OxidEsales\Eshop\Application\Controll
             $oDB->execute($sDel);
         }
     }
+    /**
+     * @deprecated use self::setSessionParams instead
+     */
+    protected function _setSessionParams() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->setSessionParams();
+    }
 
     /**
      * stores some info in session
      */
-    protected function _setSessionParams() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function setSessionParams()
     {
         // reset it from session
         \OxidEsales\Eshop\Core\Registry::getSession()->deleteVariable("sExportDelCost");
@@ -770,13 +826,20 @@ class DynamicExportBaseController extends \OxidEsales\Eshop\Application\Controll
         //setting the custom header
         \OxidEsales\Eshop\Core\Registry::getSession()->setVariable("sExportCustomHeader", \OxidEsales\Eshop\Core\Registry::getConfig()->getRequestParameter("sExportCustomHeader"));
     }
+    /**
+     * @deprecated use self::loadRootCats instead
+     */
+    protected function _loadRootCats() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->loadRootCats();
+    }
 
     /**
      * Load all root cat's == all trees
      *
      * @return null
      */
-    protected function _loadRootCats() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function loadRootCats()
     {
         if ($this->_aCatLvlCache === null) {
             $this->_aCatLvlCache = [];
@@ -819,6 +882,13 @@ class DynamicExportBaseController extends \OxidEsales\Eshop\Application\Controll
 
         return $this->_aCatLvlCache;
     }
+    /**
+     * @deprecated use self::findDeepestCatPath instead
+     */
+    protected function _findDeepestCatPath($oArticle) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->findDeepestCatPath($oArticle);
+    }
 
     /**
      * finds deepest category path
@@ -827,7 +897,7 @@ class DynamicExportBaseController extends \OxidEsales\Eshop\Application\Controll
      *
      * @return string
      */
-    protected function _findDeepestCatPath($oArticle) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function findDeepestCatPath($oArticle)
     {
         $sRet = "";
 
@@ -858,6 +928,13 @@ class DynamicExportBaseController extends \OxidEsales\Eshop\Application\Controll
 
         return $sRet;
     }
+    /**
+     * @deprecated use self::initArticle instead
+     */
+    protected function _initArticle($sHeapTable, $iCnt, &$blContinue) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->initArticle($sHeapTable, $iCnt, $blContinue);
+    }
 
     /**
      * initialize article
@@ -868,7 +945,7 @@ class DynamicExportBaseController extends \OxidEsales\Eshop\Application\Controll
      *
      * @return object
      */
-    protected function _initArticle($sHeapTable, $iCnt, &$blContinue) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function initArticle($sHeapTable, $iCnt, &$blContinue)
     {
         $oRs = $this->getDb()->selectLimit("select oxid from $sHeapTable", 1, $iCnt);
         if ($oRs != false && $oRs->count() > 0) {
@@ -894,6 +971,13 @@ class DynamicExportBaseController extends \OxidEsales\Eshop\Application\Controll
             }
         }
     }
+    /**
+     * @deprecated use self::setCampaignDetailLink instead
+     */
+    protected function _setCampaignDetailLink($oArticle) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->setCampaignDetailLink($oArticle);
+    }
 
     /**
      * sets detail link for campaigns
@@ -902,7 +986,7 @@ class DynamicExportBaseController extends \OxidEsales\Eshop\Application\Controll
      *
      * @return \OxidEsales\Eshop\Application\Model\Article
      */
-    protected function _setCampaignDetailLink($oArticle) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function setCampaignDetailLink($oArticle)
     {
         // #827
         if ($sCampaign = \OxidEsales\Eshop\Core\Registry::getConfig()->getRequestParameter("sExportCampaign")) {

--- a/source/Application/Controller/Admin/DynamicScreenController.php
+++ b/source/Application/Controller/Admin/DynamicScreenController.php
@@ -27,13 +27,20 @@ class DynamicScreenController extends \OxidEsales\Eshop\Application\Controller\A
      * @var string
      */
     protected $_sThisTemplate = 'dynscreen.tpl';
+    /**
+     * @deprecated use self::setupNavigation instead
+     */
+    protected function _setupNavigation($sNode) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->setupNavigation($sNode);
+    }
 
     /**
      * Sets up navigation for current view
      *
      * @param string $sNode None name
      */
-    protected function _setupNavigation($sNode) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function setupNavigation($sNode)
     {
         $myAdminNavig = $this->getNavigation();
         $sNode = \OxidEsales\Eshop\Core\Registry::getConfig()->getRequestParameter("menu");

--- a/source/Application/Controller/Admin/GenericImportMain.php
+++ b/source/Application/Controller/Admin/GenericImportMain.php
@@ -162,16 +162,30 @@ class GenericImportMain extends \OxidEsales\Eshop\Application\Controller\Admin\A
 
         return parent::render();
     }
+    /**
+     * @deprecated use self::deleteCsvFile instead
+     */
+    protected function _deleteCsvFile() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->deleteCsvFile();
+    }
 
     /**
      * Deletes uploaded csv file from temp directory
      */
-    protected function _deleteCsvFile() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function deleteCsvFile()
     {
         $sPath = $this->_getUploadedCsvFilePath();
         if (is_file($sPath)) {
             @unlink($sPath);
         }
+    }
+    /**
+     * @deprecated use self::getCsvFieldsNames instead
+     */
+    protected function _getCsvFieldsNames() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getCsvFieldsNames();
     }
 
     /**
@@ -180,7 +194,7 @@ class GenericImportMain extends \OxidEsales\Eshop\Application\Controller\Admin\A
      *
      * @return array
      */
-    protected function _getCsvFieldsNames() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getCsvFieldsNames()
     {
         $blCsvContainsHeader = $this->getConfig()->getRequestParameter('blContainsHeader');
         \OxidEsales\Eshop\Core\Registry::getSession()->setVariable('blCsvContainsHeader', $blCsvContainsHeader);
@@ -203,13 +217,20 @@ class GenericImportMain extends \OxidEsales\Eshop\Application\Controller\Admin\A
 
         return $aCsvFields;
     }
+    /**
+     * @deprecated use self::getCsvFirstRow instead
+     */
+    protected function _getCsvFirstRow() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getCsvFirstRow();
+    }
 
     /**
      * Get first row from uploaded CSV file
      *
      * @return array
      */
-    protected function _getCsvFirstRow() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getCsvFirstRow()
     {
         $sPath = $this->_getUploadedCsvFilePath();
         $iMaxLineLength = 8192;
@@ -222,15 +243,29 @@ class GenericImportMain extends \OxidEsales\Eshop\Application\Controller\Admin\A
 
         return $aRow;
     }
+    /**
+     * @deprecated use self::resetUploadedCsvData instead
+     */
+    protected function _resetUploadedCsvData() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->resetUploadedCsvData();
+    }
 
     /**
      * Resets CSV parameters stored in session
      */
-    protected function _resetUploadedCsvData() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function resetUploadedCsvData()
     {
         $this->_sCsvFilePath = null;
         \OxidEsales\Eshop\Core\Registry::getSession()->setVariable('sCsvFilePath', null);
         \OxidEsales\Eshop\Core\Registry::getSession()->setVariable('blCsvContainsHeader', null);
+    }
+    /**
+     * @deprecated use self::checkErrors instead
+     */
+    protected function _checkErrors($iNavStep) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->checkErrors($iNavStep);
     }
 
     /**
@@ -241,7 +276,7 @@ class GenericImportMain extends \OxidEsales\Eshop\Application\Controller\Admin\A
      *
      * @return int
      */
-    protected function _checkErrors($iNavStep) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function checkErrors($iNavStep)
     {
         if ($iNavStep == 2) {
             if (!$this->_getUploadedCsvFilePath()) {
@@ -274,6 +309,13 @@ class GenericImportMain extends \OxidEsales\Eshop\Application\Controller\Admin\A
 
         return $iNavStep;
     }
+    /**
+     * @deprecated use self::getUploadedCsvFilePath instead
+     */
+    protected function _getUploadedCsvFilePath() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getUploadedCsvFilePath();
+    }
 
     /**
      * Checks if CSV file was uploaded. If uploaded - moves it to temp dir
@@ -281,7 +323,7 @@ class GenericImportMain extends \OxidEsales\Eshop\Application\Controller\Admin\A
      *
      * @return string
      */
-    protected function _getUploadedCsvFilePath() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getUploadedCsvFilePath()
     {
         //try to get uploaded csv file path
         if ($this->_sCsvFilePath !== null) {
@@ -300,13 +342,20 @@ class GenericImportMain extends \OxidEsales\Eshop\Application\Controller\Admin\A
             return $this->_sCsvFilePath;
         }
     }
+    /**
+     * @deprecated use self::checkImportErrors instead
+     */
+    protected function _checkImportErrors($oErpImport) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->checkImportErrors($oErpImport);
+    }
 
     /**
      * Checks if any error occured during import and displays them
      *
      * @param object $oErpImport Import object
      */
-    protected function _checkImportErrors($oErpImport) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function checkImportErrors($oErpImport)
     {
         foreach ($oErpImport->getStatistics() as $aValue) {
             if (!$aValue ['r']) {
@@ -316,13 +365,20 @@ class GenericImportMain extends \OxidEsales\Eshop\Application\Controller\Admin\A
             }
         }
     }
+    /**
+     * @deprecated use self::getCsvFieldsTerminator instead
+     */
+    protected function _getCsvFieldsTerminator() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getCsvFieldsTerminator();
+    }
 
     /**
      * Get csv field terminator symbol
      *
      * @return string
      */
-    protected function _getCsvFieldsTerminator() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getCsvFieldsTerminator()
     {
         if ($this->_sStringTerminator === null) {
             $this->_sStringTerminator = $this->_sDefaultStringTerminator;
@@ -333,13 +389,20 @@ class GenericImportMain extends \OxidEsales\Eshop\Application\Controller\Admin\A
 
         return $this->_sStringTerminator;
     }
+    /**
+     * @deprecated use self::getCsvFieldsEncolser instead
+     */
+    protected function _getCsvFieldsEncolser() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getCsvFieldsEncolser();
+    }
 
     /**
      * Get csv field encloser symbol
      *
      * @return string
      */
-    protected function _getCsvFieldsEncolser() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getCsvFieldsEncolser()
     {
         if ($this->_sStringEncloser === null) {
             $this->_sStringEncloser = $this->_sDefaultStringEncloser;

--- a/source/Application/Controller/Admin/LanguageList.php
+++ b/source/Application/Controller/Admin/LanguageList.php
@@ -87,13 +87,20 @@ class LanguageList extends \OxidEsales\Eshop\Application\Controller\Admin\AdminL
 
         return "language_list.tpl";
     }
+    /**
+     * @deprecated use self::getLanguagesList instead
+     */
+    protected function _getLanguagesList() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getLanguagesList();
+    }
 
     /**
      * Collects shop languages list.
      *
      * @return array
      */
-    protected function _getLanguagesList() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getLanguagesList()
     {
         $aLangParams = $this->getConfig()->getConfigParam('aLanguageParams');
         $aLanguages = \OxidEsales\Eshop\Core\Registry::getLang()->getLanguageArray();
@@ -129,6 +136,13 @@ class LanguageList extends \OxidEsales\Eshop\Application\Controller\Admin\AdminL
 
         return $aLanguages;
     }
+    /**
+     * @deprecated use self::sortLanguagesCallback instead
+     */
+    protected function _sortLanguagesCallback($oLang1, $oLang2) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->sortLanguagesCallback($oLang1, $oLang2);
+    }
 
     /**
      * Callback function for sorting languages objects. Sorts array according
@@ -139,7 +153,7 @@ class LanguageList extends \OxidEsales\Eshop\Application\Controller\Admin\AdminL
      *
      * @return bool
      */
-    protected function _sortLanguagesCallback($oLang1, $oLang2) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function sortLanguagesCallback($oLang1, $oLang2)
     {
         $sSortParam = $this->_sDefSortField;
         $sVal1 = is_string($oLang1->$sSortParam) ? strtolower($oLang1->$sSortParam) : $oLang1->$sSortParam;
@@ -151,6 +165,13 @@ class LanguageList extends \OxidEsales\Eshop\Application\Controller\Admin\AdminL
             return ($sVal1 > $sVal2) ? -1 : 1;
         }
     }
+    /**
+     * @deprecated use self::resetMultiLangDbFields instead
+     */
+    protected function _resetMultiLangDbFields($iLangId) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->resetMultiLangDbFields($iLangId);
+    }
 
     /**
      * Resets all multilanguage fields with specific language id
@@ -158,7 +179,7 @@ class LanguageList extends \OxidEsales\Eshop\Application\Controller\Admin\AdminL
      *
      * @param string $iLangId language ID
      */
-    protected function _resetMultiLangDbFields($iLangId) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function resetMultiLangDbFields($iLangId)
     {
         $iLangId = (int) $iLangId;
 

--- a/source/Application/Controller/Admin/LanguageMain.php
+++ b/source/Application/Controller/Admin/LanguageMain.php
@@ -176,6 +176,13 @@ class LanguageMain extends \OxidEsales\Eshop\Application\Controller\Admin\AdminD
             }
         }
     }
+    /**
+     * @deprecated use self::getLanguageInfo instead
+     */
+    protected function _getLanguageInfo($sOxId) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getLanguageInfo($sOxId);
+    }
 
     /**
      * Get selected language info
@@ -184,7 +191,7 @@ class LanguageMain extends \OxidEsales\Eshop\Application\Controller\Admin\AdminD
      *
      * @return array
      */
-    protected function _getLanguageInfo($sOxId) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getLanguageInfo($sOxId)
     {
         $sDefaultLang = $this->getConfig()->getConfigParam('sDefaultLang');
 
@@ -197,15 +204,29 @@ class LanguageMain extends \OxidEsales\Eshop\Application\Controller\Admin\AdminD
 
         return $aLangData;
     }
+    /**
+     * @deprecated use self::setLanguages instead
+     */
+    protected function _setLanguages($aLangData) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->setLanguages($aLangData);
+    }
 
     /**
      * Languages array setter
      *
      * @param array $aLangData languages parameters array
      */
-    protected function _setLanguages($aLangData) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function setLanguages($aLangData)
     {
         $this->_aLangData = $aLangData;
+    }
+    /**
+     * @deprecated use self::getLanguages instead
+     */
+    protected function _getLanguages() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getLanguages();
     }
 
     /**
@@ -215,7 +236,7 @@ class LanguageMain extends \OxidEsales\Eshop\Application\Controller\Admin\AdminD
      *
      * @return array
      */
-    protected function _getLanguages() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getLanguages()
     {
         $aLangData['params'] = $this->getConfig()->getConfigParam('aLanguageParams');
         $aLangData['lang'] = $this->getConfig()->getConfigParam('aLanguages');
@@ -229,6 +250,13 @@ class LanguageMain extends \OxidEsales\Eshop\Application\Controller\Admin\AdminD
 
         return $aLangData;
     }
+    /**
+     * @deprecated use self::updateAbbervation instead
+     */
+    protected function _updateAbbervation($sOldId, $sNewId) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->updateAbbervation($sOldId, $sNewId);
+    }
 
     /**
      * Replaces languages arrays keys by new value.
@@ -236,7 +264,7 @@ class LanguageMain extends \OxidEsales\Eshop\Application\Controller\Admin\AdminD
      * @param string $sOldId old ID
      * @param string $sNewId new ID
      */
-    protected function _updateAbbervation($sOldId, $sNewId) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function updateAbbervation($sOldId, $sNewId)
     {
         foreach (array_keys($this->_aLangData) as $sTypeKey) {
             if (is_array($this->_aLangData[$sTypeKey]) && count($this->_aLangData[$sTypeKey]) > 0) {
@@ -254,12 +282,19 @@ class LanguageMain extends \OxidEsales\Eshop\Application\Controller\Admin\AdminD
             }
         }
     }
+    /**
+     * @deprecated use self::sortLangArraysByBaseId instead
+     */
+    protected function _sortLangArraysByBaseId() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->sortLangArraysByBaseId();
+    }
 
     /**
      * Sort languages, languages parameters, urls, ssl urls arrays according
      * base land ID
      */
-    protected function _sortLangArraysByBaseId() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function sortLangArraysByBaseId()
     {
         $aUrls = [];
         $aSslUrls = [];
@@ -278,6 +313,13 @@ class LanguageMain extends \OxidEsales\Eshop\Application\Controller\Admin\AdminD
         $this->_aLangData['urls'] = $aUrls;
         $this->_aLangData['sslUrls'] = $aSslUrls;
     }
+    /**
+     * @deprecated use self::assignDefaultLangParams instead
+     */
+    protected function _assignDefaultLangParams($aLanguages) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->assignDefaultLangParams($aLanguages);
+    }
 
     /**
      * Assign default values for eache language
@@ -286,7 +328,7 @@ class LanguageMain extends \OxidEsales\Eshop\Application\Controller\Admin\AdminD
      *
      * @return array
      */
-    protected function _assignDefaultLangParams($aLanguages) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function assignDefaultLangParams($aLanguages)
     {
         $aParams = [];
         $iBaseId = 0;
@@ -301,16 +343,30 @@ class LanguageMain extends \OxidEsales\Eshop\Application\Controller\Admin\AdminD
 
         return $aParams;
     }
+    /**
+     * @deprecated use self::setDefaultLang instead
+     */
+    protected function _setDefaultLang($sOxId) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->setDefaultLang($sOxId);
+    }
 
     /**
      * Sets default language base ID to config var 'sDefaultLang'
      *
      * @param string $sOxId language abbervation
      */
-    protected function _setDefaultLang($sOxId) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function setDefaultLang($sOxId)
     {
         $sDefaultId = $this->_aLangData['params'][$sOxId]['baseId'];
         $this->getConfig()->saveShopConfVar('str', 'sDefaultLang', $sDefaultId);
+    }
+    /**
+     * @deprecated use self::getAvailableLangBaseId instead
+     */
+    protected function _getAvailableLangBaseId() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getAvailableLangBaseId();
     }
 
     /**
@@ -318,7 +374,7 @@ class LanguageMain extends \OxidEsales\Eshop\Application\Controller\Admin\AdminD
      *
      * @return int
      */
-    protected function _getAvailableLangBaseId() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getAvailableLangBaseId()
     {
         $aBaseId = [];
         foreach ($this->_aLangData['params'] as $aLang) {
@@ -339,6 +395,13 @@ class LanguageMain extends \OxidEsales\Eshop\Application\Controller\Admin\AdminD
 
         return $iNewId;
     }
+    /**
+     * @deprecated use self::checkLangTranslations instead
+     */
+    protected function _checkLangTranslations($sOxId) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->checkLangTranslations($sOxId);
+    }
 
     /**
      * Check selected language has translation file lang.php
@@ -346,7 +409,7 @@ class LanguageMain extends \OxidEsales\Eshop\Application\Controller\Admin\AdminD
      *
      * @param string $sOxId language abbervation
      */
-    protected function _checkLangTranslations($sOxId) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function checkLangTranslations($sOxId)
     {
         $myConfig = $this->getConfig();
 
@@ -358,6 +421,13 @@ class LanguageMain extends \OxidEsales\Eshop\Application\Controller\Admin\AdminD
             \OxidEsales\Eshop\Core\Registry::getUtilsView()->addErrorToDisplay($oEx);
         }
     }
+    /**
+     * @deprecated use self::checkMultilangFieldsExistsInDb instead
+     */
+    protected function _checkMultilangFieldsExistsInDb($sOxId) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->checkMultilangFieldsExistsInDb($sOxId);
+    }
 
     /**
      * Check if selected language already has multilanguage fields in DB
@@ -366,7 +436,7 @@ class LanguageMain extends \OxidEsales\Eshop\Application\Controller\Admin\AdminD
      *
      * @return bool
      */
-    protected function _checkMultilangFieldsExistsInDb($sOxId) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function checkMultilangFieldsExistsInDb($sOxId)
     {
         $iBaseId = $this->_aLangData['params'][$sOxId]['baseId'];
         $sTable = getLangTableName('oxarticles', $iBaseId);
@@ -376,6 +446,13 @@ class LanguageMain extends \OxidEsales\Eshop\Application\Controller\Admin\AdminD
 
         return $oDbMetadata->tableExists($sTable) && $oDbMetadata->fieldExists($sColumn, $sTable);
     }
+    /**
+     * @deprecated use self::addNewMultilangFieldsToDb instead
+     */
+    protected function _addNewMultilangFieldsToDb() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->addNewMultilangFieldsToDb();
+    }
 
     /**
      * Adding new language to DB - creating new multilangue fields with new
@@ -383,7 +460,7 @@ class LanguageMain extends \OxidEsales\Eshop\Application\Controller\Admin\AdminD
      *
      * @return null
      */
-    protected function _addNewMultilangFieldsToDb() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function addNewMultilangFieldsToDb()
     {
         //creating new multilingual fields with new id over whole DB
         $oDbMeta = oxNew(\OxidEsales\Eshop\Core\DbMetaDataHandler::class);
@@ -404,6 +481,13 @@ class LanguageMain extends \OxidEsales\Eshop\Application\Controller\Admin\AdminD
             return;
         }
     }
+    /**
+     * @deprecated use self::checkLangExists instead
+     */
+    protected function _checkLangExists($sAbbr) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->checkLangExists($sAbbr);
+    }
 
     /**
      * Check if language already exists
@@ -412,11 +496,18 @@ class LanguageMain extends \OxidEsales\Eshop\Application\Controller\Admin\AdminD
      *
      * @return bool
      */
-    protected function _checkLangExists($sAbbr) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function checkLangExists($sAbbr)
     {
         $aAbbrs = array_keys($this->_aLangData['lang']);
 
         return in_array($sAbbr, $aAbbrs);
+    }
+    /**
+     * @deprecated use self::sortLangParamsByBaseIdCallback instead
+     */
+    protected function _sortLangParamsByBaseIdCallback($oLang1, $oLang2) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->sortLangParamsByBaseIdCallback($oLang1, $oLang2);
     }
 
     /**
@@ -428,9 +519,16 @@ class LanguageMain extends \OxidEsales\Eshop\Application\Controller\Admin\AdminD
      *
      * @return bool
      */
-    protected function _sortLangParamsByBaseIdCallback($oLang1, $oLang2) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function sortLangParamsByBaseIdCallback($oLang1, $oLang2)
     {
         return ($oLang1['baseId'] < $oLang2['baseId']) ? -1 : 1;
+    }
+    /**
+     * @deprecated use self::validateInput instead
+     */
+    protected function _validateInput() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->validateInput();
     }
 
     /**
@@ -438,7 +536,7 @@ class LanguageMain extends \OxidEsales\Eshop\Application\Controller\Admin\AdminD
      *
      * @return bool
      */
-    protected function _validateInput() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function validateInput()
     {
         $result = true;
 

--- a/source/Application/Controller/Admin/ListComponentAjax.php
+++ b/source/Application/Controller/Admin/ListComponentAjax.php
@@ -69,6 +69,13 @@ class ListComponentAjax extends \OxidEsales\Eshop\Core\Base
     {
         $this->_aColumns = $aColumns;
     }
+    /**
+     * @deprecated use self::getActionIds instead
+     */
+    protected function _getActionIds($sId) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getActionIds($sId);
+    }
 
     /**
      * Required data fields are returned by indexes/position in _aColumns array. This method
@@ -79,7 +86,7 @@ class ListComponentAjax extends \OxidEsales\Eshop\Core\Base
      *
      * @return array
      */
-    protected function _getActionIds($sId) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getActionIds($sId)
     {
         $aColumns = $this->_getColNames();
         foreach ($aColumns as $iPos => $aCol) {
@@ -98,15 +105,29 @@ class ListComponentAjax extends \OxidEsales\Eshop\Core\Base
     {
         $this->_sContainer = $sName;
     }
+    /**
+     * @deprecated use self::getQuery instead
+     */
+    protected function _getQuery() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getQuery();
+    }
 
     /**
      * Empty function, developer should override this method according requirements
      *
      * @return string
      */
-    protected function _getQuery() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getQuery()
     {
         return '';
+    }
+    /**
+     * @deprecated use self::getDataQuery instead
+     */
+    protected function _getDataQuery($sQ) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getDataQuery($sQ);
     }
 
     /**
@@ -116,9 +137,16 @@ class ListComponentAjax extends \OxidEsales\Eshop\Core\Base
      *
      * @return string
      */
-    protected function _getDataQuery($sQ) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getDataQuery($sQ)
     {
         return 'select ' . $this->_getQueryCols() . $sQ;
+    }
+    /**
+     * @deprecated use self::getCountQuery instead
+     */
+    protected function _getCountQuery($sQ) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getCountQuery($sQ);
     }
 
     /**
@@ -128,7 +156,7 @@ class ListComponentAjax extends \OxidEsales\Eshop\Core\Base
      *
      * @return string
      */
-    protected function _getCountQuery($sQ) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getCountQuery($sQ)
     {
         return 'select count( * ) ' . $sQ;
     }
@@ -153,13 +181,20 @@ class ListComponentAjax extends \OxidEsales\Eshop\Core\Base
             $this->_outputResponse($this->_getData($sCountQ, $sQ));
         }
     }
+    /**
+     * @deprecated use self::getSortCol instead
+     */
+    protected function _getSortCol() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getSortCol();
+    }
 
     /**
      * Returns column id to sort
      *
      * @return int
      */
-    protected function _getSortCol() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getSortCol()
     {
         $aVisibleNames = $this->_getVisibleColNames();
         $iCol = \OxidEsales\Eshop\Core\Registry::getConfig()->getRequestParameter('sort');
@@ -167,6 +202,13 @@ class ListComponentAjax extends \OxidEsales\Eshop\Core\Base
         $iCol = (!isset($aVisibleNames[$iCol])) ? 0 : $iCol;
 
         return $iCol;
+    }
+    /**
+     * @deprecated use self::getColNames instead
+     */
+    protected function _getColNames($sId = null) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getColNames($sId);
     }
 
 
@@ -178,7 +220,7 @@ class ListComponentAjax extends \OxidEsales\Eshop\Core\Base
      *
      * @return array
      */
-    protected function _getColNames($sId = null) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getColNames($sId = null)
     {
         if ($sId === null) {
             $sId = \OxidEsales\Eshop\Core\Registry::getConfig()->getRequestParameter('cmpid');
@@ -190,6 +232,13 @@ class ListComponentAjax extends \OxidEsales\Eshop\Core\Base
 
         return $this->_aColumns;
     }
+    /**
+     * @deprecated use self::getIdentColNames instead
+     */
+    protected function _getIdentColNames() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getIdentColNames();
+    }
 
     /**
      * Returns array of identifiers which are used as identifiers for specific actions
@@ -197,7 +246,7 @@ class ListComponentAjax extends \OxidEsales\Eshop\Core\Base
      *
      * @return array
      */
-    protected function _getIdentColNames() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getIdentColNames()
     {
         $aColNames = $this->_getColNames();
         $aCols = [];
@@ -210,13 +259,20 @@ class ListComponentAjax extends \OxidEsales\Eshop\Core\Base
 
         return $aCols;
     }
+    /**
+     * @deprecated use self::getVisibleColNames instead
+     */
+    protected function _getVisibleColNames() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getVisibleColNames();
+    }
 
     /**
      * Returns array of col names which are requested by AJAX call and will be fetched from DB
      *
      * @return array
      */
-    protected function _getVisibleColNames() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getVisibleColNames()
     {
         $aColNames = $this->_getColNames();
         $aUserCols = \OxidEsales\Eshop\Core\Registry::getConfig()->getRequestParameter('aCols');
@@ -244,6 +300,13 @@ class ListComponentAjax extends \OxidEsales\Eshop\Core\Base
 
         return $aVisibleCols;
     }
+    /**
+     * @deprecated use self::getQueryCols instead
+     */
+    protected function _getQueryCols() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getQueryCols();
+    }
 
     /**
      * Formats and returns chunk of SQL query string with definition of
@@ -251,12 +314,19 @@ class ListComponentAjax extends \OxidEsales\Eshop\Core\Base
      *
      * @return string
      */
-    protected function _getQueryCols() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getQueryCols()
     {
         $sQ = $this->_buildColsQuery($this->_getVisibleColNames(), false) . ", ";
         $sQ .= $this->_buildColsQuery($this->_getIdentColNames());
 
         return " $sQ ";
+    }
+    /**
+     * @deprecated use self::buildColsQuery instead
+     */
+    protected function _buildColsQuery($aIdentCols, $blIdentCols = true) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->buildColsQuery($aIdentCols, $blIdentCols);
     }
 
     /**
@@ -267,7 +337,7 @@ class ListComponentAjax extends \OxidEsales\Eshop\Core\Base
      *
      * @return string
      */
-    protected function _buildColsQuery($aIdentCols, $blIdentCols = true) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function buildColsQuery($aIdentCols, $blIdentCols = true)
     {
         $sQ = '';
         foreach ($aIdentCols as $iCnt => $aCol) {
@@ -285,6 +355,13 @@ class ListComponentAjax extends \OxidEsales\Eshop\Core\Base
 
         return $sQ;
     }
+    /**
+     * @deprecated use self::isExtendedColumn instead
+     */
+    protected function _isExtendedColumn($sColumn) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->isExtendedColumn($sColumn);
+    }
 
     /**
      * Checks if current column is extended
@@ -294,11 +371,18 @@ class ListComponentAjax extends \OxidEsales\Eshop\Core\Base
      *
      * @return bool
      */
-    protected function _isExtendedColumn($sColumn) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function isExtendedColumn($sColumn)
     {
         $blVariantsSelectionParameter = \OxidEsales\Eshop\Core\Registry::getConfig()->getConfigParam('blVariantsSelection');
 
         return $this->_blAllowExtColumns && $blVariantsSelectionParameter && $sColumn == 'oxtitle';
+    }
+    /**
+     * @deprecated use self::getExtendedColQuery instead
+     */
+    protected function _getExtendedColQuery($sViewTable, $sColumn, $iCnt) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getExtendedColQuery($sViewTable, $sColumn, $iCnt);
     }
 
     /**
@@ -311,7 +395,7 @@ class ListComponentAjax extends \OxidEsales\Eshop\Core\Base
      *
      * @return string
      */
-    protected function _getExtendedColQuery($sViewTable, $sColumn, $iCnt) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getExtendedColQuery($sViewTable, $sColumn, $iCnt)
     {
         // multilanguage
         $sVarSelect = "$sViewTable.oxvarselect";
@@ -320,15 +404,29 @@ class ListComponentAjax extends \OxidEsales\Eshop\Core\Base
                 "from {$sViewTable} as oxart " .
                 "where oxart.oxid = {$sViewTable}.oxparentid),', ',{$sVarSelect})) as _{$iCnt}";
     }
+    /**
+     * @deprecated use self::getSorting instead
+     */
+    protected function _getSorting() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getSorting();
+    }
 
     /**
      * Formats and returns part of SQL query for sorting
      *
      * @return string
      */
-    protected function _getSorting() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getSorting()
     {
         return ' order by _' . $this->_getSortCol() . ' ' . $this->_getSortDir() . ' ';
+    }
+    /**
+     * @deprecated use self::getLimit instead
+     */
+    protected function _getLimit($iStart) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getLimit($iStart);
     }
 
     /**
@@ -338,12 +436,19 @@ class ListComponentAjax extends \OxidEsales\Eshop\Core\Base
      *
      * @return string
      */
-    protected function _getLimit($iStart) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getLimit($iStart)
     {
         $iLimit = (int) \OxidEsales\Eshop\Core\Registry::getConfig()->getRequestParameter("results");
         $iLimit = $iLimit ? $iLimit : $this->_iSqlLimit;
 
         return " limit $iStart, $iLimit ";
+    }
+    /**
+     * @deprecated use self::getFilter instead
+     */
+    protected function _getFilter() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getFilter();
     }
 
     /**
@@ -351,7 +456,7 @@ class ListComponentAjax extends \OxidEsales\Eshop\Core\Base
      *
      * @return string
      */
-    protected function _getFilter() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getFilter()
     {
         $sQ = '';
         $oConfig = $this->getConfig();
@@ -387,6 +492,13 @@ class ListComponentAjax extends \OxidEsales\Eshop\Core\Base
 
         return $sQ;
     }
+    /**
+     * @deprecated use self::addFilter instead
+     */
+    protected function _addFilter($sQ) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->addFilter($sQ);
+    }
 
     /**
      * Adds filter SQL to current query
@@ -395,13 +507,20 @@ class ListComponentAjax extends \OxidEsales\Eshop\Core\Base
      *
      * @return string
      */
-    protected function _addFilter($sQ) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function addFilter($sQ)
     {
         if ($sQ && ($sFilter = $this->_getFilter())) {
             $sQ .= ((stristr($sQ, 'where') === false) ? 'where' : ' and ') . $sFilter;
         }
 
         return $sQ;
+    }
+    /**
+     * @deprecated use self::getAll instead
+     */
+    protected function _getAll($sQ) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getAll($sQ);
     }
 
     /**
@@ -411,7 +530,7 @@ class ListComponentAjax extends \OxidEsales\Eshop\Core\Base
      *
      * @return array
      */
-    protected function _getAll($sQ) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getAll($sQ)
     {
         $aReturn = [];
         $rs = \OxidEsales\Eshop\Core\DatabaseProvider::getDb()->select($sQ);
@@ -424,13 +543,20 @@ class ListComponentAjax extends \OxidEsales\Eshop\Core\Base
 
         return $aReturn;
     }
+    /**
+     * @deprecated use self::getSortDir instead
+     */
+    protected function _getSortDir() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getSortDir();
+    }
 
     /**
      * Checks user input and returns SQL sorting direction key
      *
      * @return string
      */
-    protected function _getSortDir() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getSortDir()
     {
         $sDir = \OxidEsales\Eshop\Core\Registry::getConfig()->getRequestParameter('dir');
         if (!in_array($sDir, $this->_aPosDir)) {
@@ -439,15 +565,29 @@ class ListComponentAjax extends \OxidEsales\Eshop\Core\Base
 
         return $sDir;
     }
+    /**
+     * @deprecated use self::getStartIndex instead
+     */
+    protected function _getStartIndex() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getStartIndex();
+    }
 
     /**
      * Returns position from where data must be loaded
      *
      * @return int
      */
-    protected function _getStartIndex() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getStartIndex()
     {
         return (int) \OxidEsales\Eshop\Core\Registry::getConfig()->getRequestParameter('startIndex');
+    }
+    /**
+     * @deprecated use self::getTotalCount instead
+     */
+    protected function _getTotalCount($sQ) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getTotalCount($sQ);
     }
 
     /**
@@ -457,7 +597,7 @@ class ListComponentAjax extends \OxidEsales\Eshop\Core\Base
      *
      * @return int
      */
-    protected function _getTotalCount($sQ) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getTotalCount($sQ)
     {
         // TODO: implement caching here
 
@@ -468,6 +608,13 @@ class ListComponentAjax extends \OxidEsales\Eshop\Core\Base
         // We force reading from master to prevent issues with slow replications or open transactions (see ESDEV-3804).
         return (int) \OxidEsales\Eshop\Core\DatabaseProvider::getMaster()->getOne($sQ);
     }
+    /**
+     * @deprecated use self::getDataFields instead
+     */
+    protected function _getDataFields($sQ) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getDataFields($sQ);
+    }
 
     /**
      * Returns array with DB records
@@ -476,10 +623,17 @@ class ListComponentAjax extends \OxidEsales\Eshop\Core\Base
      *
      * @return array
      */
-    protected function _getDataFields($sQ) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getDataFields($sQ)
     {
         // We force reading from master to prevent issues with slow replications or open transactions (see ESDEV-3804).
         return \OxidEsales\Eshop\Core\DatabaseProvider::getMaster(\OxidEsales\Eshop\Core\DatabaseProvider::FETCH_MODE_ASSOC)->getAll($sQ, false);
+    }
+    /**
+     * @deprecated use self::outputResponse instead
+     */
+    protected function _outputResponse($aData) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->outputResponse($aData);
     }
 
     /**
@@ -487,9 +641,16 @@ class ListComponentAjax extends \OxidEsales\Eshop\Core\Base
      *
      * @param array $aData data to output
      */
-    protected function _outputResponse($aData) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function outputResponse($aData)
     {
         $this->_output(json_encode($aData));
+    }
+    /**
+     * @deprecated use self::output instead
+     */
+    protected function _output($sOut) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->output($sOut);
     }
 
     /**
@@ -497,9 +658,16 @@ class ListComponentAjax extends \OxidEsales\Eshop\Core\Base
      *
      * @param string $sOut string to echo
      */
-    protected function _output($sOut) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function output($sOut)
     {
         echo $sOut;
+    }
+    /**
+     * @deprecated use self::getViewName instead
+     */
+    protected function _getViewName($sTable) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getViewName($sTable);
     }
 
     /**
@@ -509,9 +677,16 @@ class ListComponentAjax extends \OxidEsales\Eshop\Core\Base
      *
      * @return string
      */
-    protected function _getViewName($sTable) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getViewName($sTable)
     {
         return getViewName($sTable, \OxidEsales\Eshop\Core\Registry::getConfig()->getRequestParameter('editlanguage'));
+    }
+    /**
+     * @deprecated use self::getData instead
+     */
+    protected function _getData($sCountQ, $sQ) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getData($sCountQ, $sQ);
     }
 
     /**
@@ -522,7 +697,7 @@ class ListComponentAjax extends \OxidEsales\Eshop\Core\Base
      *
      * @return array
      */
-    protected function _getData($sCountQ, $sQ) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getData($sCountQ, $sQ)
     {
         $sQ = $this->_addFilter($sQ);
         $sCountQ = $this->_addFilter($sCountQ);
@@ -632,11 +807,18 @@ class ListComponentAjax extends \OxidEsales\Eshop\Core\Base
     protected function _resetContentCache() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
     }
+    /**
+     * @deprecated use self::resetCaches instead
+     */
+    protected function _resetCaches() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->resetCaches();
+    }
 
     /**
      * Resets output caches
      */
-    protected function _resetCaches() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function resetCaches()
     {
     }
 }

--- a/source/Application/Controller/Admin/ListReview.php
+++ b/source/Application/Controller/Admin/ListReview.php
@@ -53,6 +53,13 @@ class ListReview extends \OxidEsales\Eshop\Application\Controller\Admin\ArticleL
 
         return "list_review.tpl";
     }
+    /**
+     * @deprecated use self::buildSelectString instead
+     */
+    protected function _buildSelectString($oObject = null) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->buildSelectString($oObject);
+    }
 
     /**
      * Returns select query string
@@ -61,7 +68,7 @@ class ListReview extends \OxidEsales\Eshop\Application\Controller\Admin\ArticleL
      *
      * @return string
      */
-    protected function _buildSelectString($oObject = null) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function buildSelectString($oObject = null)
     {
         $sArtTable = getViewName('oxarticles', $this->_iEditLang);
 
@@ -78,6 +85,13 @@ class ListReview extends \OxidEsales\Eshop\Application\Controller\Admin\ArticleL
 
         return " $sQ and {$sArtTable}.oxid is not null ";
     }
+    /**
+     * @deprecated use self::prepareWhereQuery instead
+     */
+    protected function _prepareWhereQuery($aWhere, $sSql) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->prepareWhereQuery($aWhere, $sSql);
+    }
 
     /**
      * Adds filtering conditions to query string
@@ -87,9 +101,9 @@ class ListReview extends \OxidEsales\Eshop\Application\Controller\Admin\ArticleL
      *
      * @return string
      */
-    protected function _prepareWhereQuery($aWhere, $sSql) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function prepareWhereQuery($aWhere, $sSql)
     {
-        $sSql = parent::_prepareWhereQuery($aWhere, $sSql);
+        $sSql = parent::prepareWhereQuery($aWhere, $sSql);
 
         $sArtTable = getViewName('oxarticles', $this->_iEditLang);
         $sArtTitleField = "{$sArtTable}.oxtitle";

--- a/source/Application/Controller/Admin/LoginController.php
+++ b/source/Application/Controller/Admin/LoginController.php
@@ -171,6 +171,13 @@ class LoginController extends \OxidEsales\Eshop\Application\Controller\Admin\Adm
 
         return "admin_start";
     }
+    /**
+     * @deprecated use self::authorize instead
+     */
+    protected function _authorize() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->authorize();
+    }
 
     /**
      * Users are always authorized to use login page.
@@ -178,7 +185,7 @@ class LoginController extends \OxidEsales\Eshop\Application\Controller\Admin\Adm
      *
      * @return boolean
      */
-    protected function _authorize() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function authorize()
     {
         return true;
     }
@@ -192,13 +199,20 @@ class LoginController extends \OxidEsales\Eshop\Application\Controller\Admin\Adm
     {
         return self::VIEW_ID;
     }
+    /**
+     * @deprecated use self::getAvailableLanguages instead
+     */
+    protected function _getAvailableLanguages() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getAvailableLanguages();
+    }
 
     /**
      * Get available admin interface languages
      *
      * @return array
      */
-    protected function _getAvailableLanguages() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getAvailableLanguages()
     {
         $sDefLang = \OxidEsales\Eshop\Core\Registry::getUtilsServer()->getOxCookie('oxidadminlanguage');
         $sDefLang = $sDefLang ? $sDefLang : $this->_getBrowserLanguage();
@@ -210,13 +224,20 @@ class LoginController extends \OxidEsales\Eshop\Application\Controller\Admin\Adm
 
         return $aLanguages;
     }
+    /**
+     * @deprecated use self::getBrowserLanguage instead
+     */
+    protected function _getBrowserLanguage() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getBrowserLanguage();
+    }
 
     /**
      * Get detected user browser language abbervation
      *
      * @return string
      */
-    protected function _getBrowserLanguage() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getBrowserLanguage()
     {
         return strtolower(substr($_SERVER['HTTP_ACCEPT_LANGUAGE'], 0, 2));
     }

--- a/source/Application/Controller/Admin/ManufacturerMainAjax.php
+++ b/source/Application/Controller/Admin/ManufacturerMainAjax.php
@@ -47,13 +47,20 @@ class ManufacturerMainAjax extends \OxidEsales\Eshop\Application\Controller\Admi
             ['oxid', 'oxarticles', 0, 0, 1]
         ]
     ];
+    /**
+     * @deprecated use self::getQuery instead
+     */
+    protected function _getQuery() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getQuery();
+    }
 
     /**
      * Returns SQL query for data to fetc
      *
      * @return string
      */
-    protected function _getQuery() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getQuery()
     {
         $config = $this->getConfig();
 
@@ -83,6 +90,13 @@ class ManufacturerMainAjax extends \OxidEsales\Eshop\Application\Controller\Admi
 
         return $query;
     }
+    /**
+     * @deprecated use self::addFilter instead
+     */
+    protected function _addFilter($query) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->addFilter($query);
+    }
 
     /**
      * Adds filter SQL to current query
@@ -91,11 +105,11 @@ class ManufacturerMainAjax extends \OxidEsales\Eshop\Application\Controller\Admi
      *
      * @return string
      */
-    protected function _addFilter($query) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function addFilter($query)
     {
         $config = $this->getConfig();
         $articleViewName = $this->_getViewName('oxarticles');
-        $query = parent::_addFilter($query);
+        $query = parent::addFilter($query);
 
         // display variants or not ?
         $query .= $config->getConfigParam('blVariantsSelection') ? ' group by ' . $articleViewName . '.oxid ' : '';

--- a/source/Application/Controller/Admin/ManufacturerSeo.php
+++ b/source/Application/Controller/Admin/ManufacturerSeo.php
@@ -33,13 +33,20 @@ class ManufacturerSeo extends \OxidEsales\Eshop\Application\Controller\Admin\Obj
 
         return parent::save();
     }
+    /**
+     * @deprecated use self::getEncoder instead
+     */
+    protected function _getEncoder() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getEncoder();
+    }
 
     /**
      * Returns current object type seo encoder object
      *
      * @return oxSeoEncoderManufacturer
      */
-    protected function _getEncoder() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getEncoder()
     {
         return \OxidEsales\Eshop\Core\Registry::get(\OxidEsales\Eshop\Application\Model\SeoEncoderManufacturer::class);
     }
@@ -53,13 +60,20 @@ class ManufacturerSeo extends \OxidEsales\Eshop\Application\Controller\Admin\Obj
     {
         return true;
     }
+    /**
+     * @deprecated use self::getType instead
+     */
+    protected function _getType() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getType();
+    }
 
     /**
      * Returns url type
      *
      * @return string
      */
-    protected function _getType() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getType()
     {
         return 'oxmanufacturer';
     }

--- a/source/Application/Controller/Admin/ModuleConfiguration.php
+++ b/source/Application/Controller/Admin/ModuleConfiguration.php
@@ -69,6 +69,13 @@ class ModuleConfiguration extends \OxidEsales\Eshop\Application\Controller\Admin
 
         return 'module_config.tpl';
     }
+    /**
+     * @deprecated use self::getModuleForConfigVars instead
+     */
+    protected function _getModuleForConfigVars() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getModuleForConfigVars();
+    }
 
     /**
      * return module filter for config variables
@@ -77,9 +84,16 @@ class ModuleConfiguration extends \OxidEsales\Eshop\Application\Controller\Admin
      *
      * @return string
      */
-    protected function _getModuleForConfigVars() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getModuleForConfigVars()
     {
         return \OxidEsales\Eshop\Core\Config::OXMODULE_MODULE_PREFIX . $this->_sModuleId;
+    }
+    /**
+     * @deprecated use self::loadMetadataConfVars instead
+     */
+    public function _loadMetadataConfVars($aModuleSettings) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->loadMetadataConfVars($aModuleSettings);
     }
 
     /**
@@ -95,7 +109,7 @@ class ModuleConfiguration extends \OxidEsales\Eshop\Application\Controller\Admin
      *
      * @return array
      */
-    public function _loadMetadataConfVars($aModuleSettings) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    public function loadMetadataConfVars($aModuleSettings)
     {
         $oConfig = $this->getConfig();
 
@@ -324,6 +338,13 @@ class ModuleConfiguration extends \OxidEsales\Eshop\Application\Controller\Admin
             'grouping'    => $grouping,
         ];
     }
+    /**
+     * @deprecated use self::getDbConfigTypeName instead
+     */
+    private function _getDbConfigTypeName($type) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getDbConfigTypeName($type);
+    }
 
     /**
      * Convert metadata type to DB type.
@@ -332,7 +353,7 @@ class ModuleConfiguration extends \OxidEsales\Eshop\Application\Controller\Admin
      *
      * @return string
      */
-    private function _getDbConfigTypeName($type) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    private function getDbConfigTypeName($type)
     {
         return $type === 'password' ? 'str' : $type;
     }

--- a/source/Application/Controller/Admin/NavigationController.php
+++ b/source/Application/Controller/Admin/NavigationController.php
@@ -145,6 +145,13 @@ class NavigationController extends \OxidEsales\Eshop\Application\Controller\Admi
 
         $myUtils->showMessageAndExit("");
     }
+    /**
+     * @deprecated use self::doStartUpChecks instead
+     */
+    protected function _doStartUpChecks() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->doStartUpChecks();
+    }
 
     /**
      * Every Time Admin starts we perform these checks
@@ -152,7 +159,7 @@ class NavigationController extends \OxidEsales\Eshop\Application\Controller\Admi
      *
      * @return array
      */
-    protected function _doStartUpChecks() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function doStartUpChecks()
     {
         $messages = [];
 
@@ -197,13 +204,20 @@ class NavigationController extends \OxidEsales\Eshop\Application\Controller\Admi
 
         return $messages;
     }
+    /**
+     * @deprecated use self::checkVersion instead
+     */
+    protected function _checkVersion() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->checkVersion();
+    }
 
     /**
      * Checks if newer shop version available. If true - returns message
      *
      * @return string
      */
-    protected function _checkVersion() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function checkVersion()
     {
         $edition = $this->getConfig()->getEdition();
         $query = 'http://admin.oxid-esales.com/' . $edition . '/onlinecheck.php?getlatestversion';

--- a/source/Application/Controller/Admin/NavigationTree.php
+++ b/source/Application/Controller/Admin/NavigationTree.php
@@ -44,6 +44,13 @@ class NavigationTree extends \OxidEsales\Eshop\Core\Base
      * @var array
      */
     protected $_aSupportedExpathXmlEncodings = ['utf-8', 'utf-16', 'iso-8859-1', 'us-ascii'];
+    /**
+     * @deprecated use self::cleanEmptyParents instead
+     */
+    protected function _cleanEmptyParents($dom, $parentXPath, $childXPath) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->cleanEmptyParents($dom, $parentXPath, $childXPath);
+    }
 
     /**
      * clean empty nodes from tree
@@ -52,7 +59,7 @@ class NavigationTree extends \OxidEsales\Eshop\Core\Base
      * @param string $parentXPath parent xpath
      * @param string $childXPath  child xpath from parent
      */
-    protected function _cleanEmptyParents($dom, $parentXPath, $childXPath) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function cleanEmptyParents($dom, $parentXPath, $childXPath)
     {
         $xPath = new DomXPath($dom);
         $nodeList = $xPath->query($parentXPath);
@@ -65,13 +72,20 @@ class NavigationTree extends \OxidEsales\Eshop\Core\Base
             }
         }
     }
+    /**
+     * @deprecated use self::addLinks instead
+     */
+    protected function _addLinks($dom) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->addLinks($dom);
+    }
 
     /**
      * Adds links to xml nodes to resolve paths
      *
      * @param DomDocument $dom where to add links
      */
-    protected function _addLinks($dom) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function addLinks($dom)
     {
         $url = 'index.php?'; // session parameters will be included later (after cache processor)
         $xPath = new DomXPath($dom);
@@ -91,6 +105,13 @@ class NavigationTree extends \OxidEsales\Eshop\Core\Base
             $node->setAttribute('link', "{$url}{$cl}{$param}");
         }
     }
+    /**
+     * @deprecated use self::loadFromFile instead
+     */
+    protected function _loadFromFile($menuFile, $dom) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->loadFromFile($menuFile, $dom);
+    }
 
     /**
      * Loads data form XML file, and merges it with main oDomXML.
@@ -98,7 +119,7 @@ class NavigationTree extends \OxidEsales\Eshop\Core\Base
      * @param string      $menuFile which file to load
      * @param DomDocument $dom      where to load
      */
-    protected function _loadFromFile($menuFile, $dom) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function loadFromFile($menuFile, $dom)
     {
         $merge = false;
         $domFile = new DomDocument();
@@ -127,6 +148,13 @@ class NavigationTree extends \OxidEsales\Eshop\Core\Base
             $this->_merge($domFile, $dom);
         }
     }
+    /**
+     * @deprecated use self::addDynLinks instead
+     */
+    protected function _addDynLinks($dom) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->addDynLinks($dom);
+    }
 
     /**
      * Adds to element DynTabs
@@ -135,7 +163,7 @@ class NavigationTree extends \OxidEsales\Eshop\Core\Base
      *
      * @param object $dom dom element to add links
      */
-    protected function _addDynLinks($dom) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function addDynLinks($dom)
     {
         $myUtilsFile = \OxidEsales\Eshop\Core\Registry::getUtilsFile();
 
@@ -198,13 +226,20 @@ class NavigationTree extends \OxidEsales\Eshop\Core\Base
             }
         }
     }
+    /**
+     * @deprecated use self::sessionizeLocalUrls instead
+     */
+    protected function _sessionizeLocalUrls($dom) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->sessionizeLocalUrls($dom);
+    }
 
     /**
      * add session parameters to local urls
      *
      * @param object $dom dom element to add links
      */
-    protected function _sessionizeLocalUrls($dom) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function sessionizeLocalUrls($dom)
     {
         $url = $this->_getAdminUrl();
         $xPath = new DomXPath($dom);
@@ -219,13 +254,20 @@ class NavigationTree extends \OxidEsales\Eshop\Core\Base
             }
         }
     }
+    /**
+     * @deprecated use self::checkRights instead
+     */
+    protected function _checkRights($dom) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->checkRights($dom);
+    }
 
     /**
      * Removes form tree elements which does not have required user rights
      *
      * @param object $dom DOMDocument
      */
-    protected function _checkRights($dom) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function checkRights($dom)
     {
         $xPath = new DomXPath($dom);
         $nodeList = $xPath->query('//*[@rights or @norights]');
@@ -250,13 +292,20 @@ class NavigationTree extends \OxidEsales\Eshop\Core\Base
             }
         }
     }
+    /**
+     * @deprecated use self::checkGroups instead
+     */
+    protected function _checkGroups($dom) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->checkGroups($dom);
+    }
 
     /**
      * Removes from tree elements which don't have required groups
      *
      * @param DOMDocument $dom document to check group
      */
-    protected function _checkGroups($dom) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function checkGroups($dom)
     {
         $xPath = new DomXPath($dom);
         $nodeList = $xPath->query("//*[@nogroup or @group]");
@@ -281,6 +330,13 @@ class NavigationTree extends \OxidEsales\Eshop\Core\Base
             }
         }
     }
+    /**
+     * @deprecated use self::checkDemoShopDenials instead
+     */
+    protected function _checkDemoShopDenials($dom) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->checkDemoShopDenials($dom);
+    }
 
     /**
      * Removes form tree elements if this is demo shop and elements have disableForDemoShop="1"
@@ -289,7 +345,7 @@ class NavigationTree extends \OxidEsales\Eshop\Core\Base
      *
      * @return null
      */
-    protected function _checkDemoShopDenials($dom) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function checkDemoShopDenials($dom)
     {
         if (!$this->getConfig()->isDemoShop()) {
             // nothing to check for non demo shop
@@ -320,6 +376,13 @@ class NavigationTree extends \OxidEsales\Eshop\Core\Base
             }
         }
     }
+    /**
+     * @deprecated use self::copyAttributes instead
+     */
+    protected function _copyAttributes($domElemTo, $domElemFrom) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->copyAttributes($domElemTo, $domElemFrom);
+    }
 
     /**
      * Copys attributes form one element to another
@@ -327,11 +390,18 @@ class NavigationTree extends \OxidEsales\Eshop\Core\Base
      * @param object $domElemTo   DOMElement
      * @param object $domElemFrom DOMElement
      */
-    protected function _copyAttributes($domElemTo, $domElemFrom) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function copyAttributes($domElemTo, $domElemFrom)
     {
         foreach ($domElemFrom->attributes as $attr) {
             $domElemTo->setAttribute($attr->nodeName, $attr->nodeValue);
         }
+    }
+    /**
+     * @deprecated use self::mergeNodes instead
+     */
+    protected function _mergeNodes($domElemTo, $domElemFrom, $xPathTo, $domDocTo, $queryStart) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->mergeNodes($domElemTo, $domElemFrom, $xPathTo, $domDocTo, $queryStart);
     }
 
     /**
@@ -343,7 +413,7 @@ class NavigationTree extends \OxidEsales\Eshop\Core\Base
      * @param object $domDocTo    node to append child
      * @param string $queryStart  node query
      */
-    protected function _mergeNodes($domElemTo, $domElemFrom, $xPathTo, $domDocTo, $queryStart) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function mergeNodes($domElemTo, $domElemFrom, $xPathTo, $domDocTo, $queryStart)
     {
         foreach ($domElemFrom->childNodes as $fromNode) {
             if ($fromNode->nodeType === XML_ELEMENT_NODE) {
@@ -370,6 +440,13 @@ class NavigationTree extends \OxidEsales\Eshop\Core\Base
             }
         }
     }
+    /**
+     * @deprecated use self::merge instead
+     */
+    protected function _merge($domNew, $dom) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->merge($domNew, $dom);
+    }
 
     /**
      * If oDomXML exist meges nodes
@@ -377,7 +454,7 @@ class NavigationTree extends \OxidEsales\Eshop\Core\Base
      * @param DomDocument $domNew what to merge
      * @param DomDocument $dom    where to merge
      */
-    protected function _merge($domNew, $dom) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function merge($domNew, $dom)
     {
         $xPath = new DOMXPath($dom);
         $this->_mergeNodes($dom->documentElement, $domNew->documentElement, $xPath, $dom, '/OX');
@@ -451,13 +528,20 @@ class NavigationTree extends \OxidEsales\Eshop\Core\Base
 
         return $buttons;
     }
+    /**
+     * @deprecated use self::getMenuFiles instead
+     */
+    protected function _getMenuFiles() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getMenuFiles();
+    }
 
     /**
      * Returns array with paths + names ox menu xml files. Paths are checked
      *
      * @return array
      */
-    protected function _getMenuFiles() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getMenuFiles()
     {
         $adminNavigationFileLocator = $this->getContainer()->get('oxid_esales.templating.admin.navigation.file.locator');
         $filesToLoad = $adminNavigationFileLocator->locate();
@@ -482,6 +566,13 @@ class NavigationTree extends \OxidEsales\Eshop\Core\Base
 
         return $filesToLoad;
     }
+    /**
+     * @deprecated use self::checkDynFile instead
+     */
+    protected function _checkDynFile($dynFilePath) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->checkDynFile($dynFilePath);
+    }
 
     /**
      * Checks if dyn file is valid for inclusion
@@ -492,7 +583,7 @@ class NavigationTree extends \OxidEsales\Eshop\Core\Base
      *
      * @return bool
      */
-    protected function _checkDynFile($dynFilePath) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function checkDynFile($dynFilePath)
     {
         $dynFile = null;
         if (file_exists($dynFilePath)) {
@@ -515,6 +606,13 @@ class NavigationTree extends \OxidEsales\Eshop\Core\Base
 
         return $dynFile;
     }
+    /**
+     * @deprecated use self::processCachedFile instead
+     */
+    protected function _processCachedFile($cacheContents) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->processCachedFile($cacheContents);
+    }
 
     /**
      * Method is used for overriding.
@@ -523,9 +621,16 @@ class NavigationTree extends \OxidEsales\Eshop\Core\Base
      *
      * @return string
      */
-    protected function _processCachedFile($cacheContents) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function processCachedFile($cacheContents)
     {
         return $cacheContents;
+    }
+    /**
+     * @deprecated use self::getInitialDom instead
+     */
+    protected function _getInitialDom() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getInitialDom();
     }
 
     /**
@@ -533,7 +638,7 @@ class NavigationTree extends \OxidEsales\Eshop\Core\Base
      *
      * @return DOMDocument
      */
-    protected function _getInitialDom() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getInitialDom()
     {
         if ($this->_oInitialDom === null) {
             $myOxUtlis = \OxidEsales\Eshop\Core\Registry::getUtils();
@@ -704,13 +809,20 @@ class NavigationTree extends \OxidEsales\Eshop\Core\Base
             return "{$cl}{$params}";
         }
     }
+    /**
+     * @deprecated use self::getAdminUrl instead
+     */
+    protected function _getAdminUrl() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getAdminUrl();
+    }
 
     /**
      * Admin url getter
      *
      * @return string
      */
-    protected function _getAdminUrl() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getAdminUrl()
     {
         $myConfig = $this->getConfig();
 
@@ -722,6 +834,13 @@ class NavigationTree extends \OxidEsales\Eshop\Core\Base
 
         return \OxidEsales\Eshop\Core\Registry::getUtilsUrl()->processUrl("{$url}/index.php", false);
     }
+    /**
+     * @deprecated use self::hasRights instead
+     */
+    protected function _hasRights($rights) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->hasRights($rights);
+    }
 
     /**
      * Checks if user has required rights
@@ -730,9 +849,16 @@ class NavigationTree extends \OxidEsales\Eshop\Core\Base
      *
      * @return bool
      */
-    protected function _hasRights($rights) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function hasRights($rights)
     {
         return $this->getUser()->oxuser__oxrights->value == $rights;
+    }
+    /**
+     * @deprecated use self::hasGroup instead
+     */
+    protected function _hasGroup($groupId) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->hasGroup($groupId);
     }
 
     /**
@@ -742,7 +868,7 @@ class NavigationTree extends \OxidEsales\Eshop\Core\Base
      *
      * @return bool
      */
-    protected function _hasGroup($groupId) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function hasGroup($groupId)
     {
         return $this->getUser()->inGroup($groupId);
     }
@@ -762,6 +888,13 @@ class NavigationTree extends \OxidEsales\Eshop\Core\Base
             return $firstItem->getAttribute('id');
         }
     }
+    /**
+     * @deprecated use self::getDynMenuUrl instead
+     */
+    protected function _getDynMenuUrl($lang, $loadDynContents) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getDynMenuUrl($lang, $loadDynContents);
+    }
 
 
     /**
@@ -774,7 +907,7 @@ class NavigationTree extends \OxidEsales\Eshop\Core\Base
      *
      * @return string
      */
-    protected function _getDynMenuUrl($lang, $loadDynContents) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getDynMenuUrl($lang, $loadDynContents)
     {
         if (!$loadDynContents) {
             // getting dyn info from oxid server is off, so getting local menu path
@@ -787,6 +920,13 @@ class NavigationTree extends \OxidEsales\Eshop\Core\Base
 
         return $this->_sDynIncludeUrl . "menue/dynscreen.xml";
     }
+    /**
+     * @deprecated use self::getDynMenuLang instead
+     */
+    protected function _getDynMenuLang() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getDynMenuLang();
+    }
 
     /**
      * Get dynamic pages language code
@@ -795,7 +935,7 @@ class NavigationTree extends \OxidEsales\Eshop\Core\Base
      *
      * @return string
      */
-    protected function _getDynMenuLang() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getDynMenuLang()
     {
         $myConfig = $this->getConfig();
         $lang = \OxidEsales\Eshop\Core\Registry::getLang();

--- a/source/Application/Controller/Admin/NewsMainAjax.php
+++ b/source/Application/Controller/Admin/NewsMainAjax.php
@@ -36,13 +36,20 @@ class NewsMainAjax extends \OxidEsales\Eshop\Application\Controller\Admin\ListCo
             ['oxid', 'oxobject2group', 0, 0, 1],
         ]
     ];
+    /**
+     * @deprecated use self::getQuery instead
+     */
+    protected function _getQuery() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getQuery();
+    }
 
     /**
      * Returns SQL query for data to fetc
      *
      * @return string
      */
-    protected function _getQuery() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getQuery()
     {
         // active AJAX component
         $sGroupTable = $this->_getViewName('oxgroups');

--- a/source/Application/Controller/Admin/NewsletterSelectionAjax.php
+++ b/source/Application/Controller/Admin/NewsletterSelectionAjax.php
@@ -31,13 +31,20 @@ class NewsletterSelectionAjax extends \OxidEsales\Eshop\Application\Controller\A
                                      ['oxid', 'oxobject2group', 0, 0, 1],
                                  ]
     ];
+    /**
+     * @deprecated use self::getQuery instead
+     */
+    protected function _getQuery() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getQuery();
+    }
 
     /**
      * Returns SQL query for data to fetc
      *
      * @return string
      */
-    protected function _getQuery() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getQuery()
     {
         // active AJAX component
         $sGroupTable = $this->_getViewName('oxgroups');

--- a/source/Application/Controller/Admin/NewsletterSend.php
+++ b/source/Application/Controller/Admin/NewsletterSend.php
@@ -177,13 +177,20 @@ class NewsletterSend extends \OxidEsales\Eshop\Application\Controller\Admin\News
     {
         return $this->_aMailErrors;
     }
+    /**
+     * @deprecated use self::setupNavigation instead
+     */
+    protected function _setupNavigation($sNode) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->setupNavigation($sNode);
+    }
 
     /**
      * Overrides parent method to pass referred id
      *
      * @param string $sNode referred id
      */
-    protected function _setupNavigation($sNode) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function setupNavigation($sNode)
     {
         $sNode = 'newsletter_list';
 

--- a/source/Application/Controller/Admin/ObjectSeo.php
+++ b/source/Application/Controller/Admin/ObjectSeo.php
@@ -112,13 +112,20 @@ class ObjectSeo extends \OxidEsales\Eshop\Application\Controller\Admin\AdminDeta
         }
         return $sParams;
     }
+    /**
+     * @deprecated use self::getSaveObjectId instead
+     */
+    protected function _getSaveObjectId() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getSaveObjectId();
+    }
 
     /**
      * Returns id of object which must be saved
      *
      * @return string
      */
-    protected function _getSaveObjectId() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getSaveObjectId()
     {
         return $this->getEditObjectId();
     }
@@ -156,12 +163,26 @@ class ObjectSeo extends \OxidEsales\Eshop\Application\Controller\Admin\AdminDeta
             ':oxlang' => $iLang
         ]);
     }
+    /**
+     * @deprecated use self::getType instead
+     */
+    protected function _getType() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getType();
+    }
 
     /**
      * Returns url type
      */
-    protected function _getType() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getType()
     {
+    }
+    /**
+     * @deprecated use self::getStdUrl instead
+     */
+    protected function _getStdUrl($sOxid) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getStdUrl($sOxid);
     }
 
     /**
@@ -171,7 +192,7 @@ class ObjectSeo extends \OxidEsales\Eshop\Application\Controller\Admin\AdminDeta
      *
      * @return string
      */
-    protected function _getStdUrl($sOxid) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getStdUrl($sOxid)
     {
         if ($sType = $this->_getType()) {
             $oObject = oxNew($sType);
@@ -190,12 +211,26 @@ class ObjectSeo extends \OxidEsales\Eshop\Application\Controller\Admin\AdminDeta
     {
         return $this->_iEditLang;
     }
+    /**
+     * @deprecated use self::getAltSeoEntryId instead
+     */
+    protected function _getAltSeoEntryId() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getAltSeoEntryId();
+    }
 
     /**
      * Returns alternative seo entry id
      */
-    protected function _getAltSeoEntryId() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getAltSeoEntryId()
     {
+    }
+    /**
+     * @deprecated use self::getSeoEntryType instead
+     */
+    protected function _getSeoEntryType() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getSeoEntryType();
     }
 
     /**
@@ -203,7 +238,7 @@ class ObjectSeo extends \OxidEsales\Eshop\Application\Controller\Admin\AdminDeta
      *
      * @return string
      */
-    protected function _getSeoEntryType() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getSeoEntryType()
     {
         return $this->_getType();
     }
@@ -219,11 +254,18 @@ class ObjectSeo extends \OxidEsales\Eshop\Application\Controller\Admin\AdminDeta
     {
         return $sParam;
     }
+    /**
+     * @deprecated use self::getEncoder instead
+     */
+    protected function _getEncoder() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getEncoder();
+    }
 
     /**
      * Returns current object type seo encoder object
      */
-    protected function _getEncoder() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getEncoder()
     {
     }
 

--- a/source/Application/Controller/Admin/OrderAddress.php
+++ b/source/Application/Controller/Admin/OrderAddress.php
@@ -43,6 +43,13 @@ class OrderAddress extends \OxidEsales\Eshop\Application\Controller\Admin\AdminD
 
         return "order_address.tpl";
     }
+    /**
+     * @deprecated use self::processAddress instead
+     */
+    protected function _processAddress($aData, $sTypeToProcess, $aIgnore) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->processAddress($aData, $sTypeToProcess, $aIgnore);
+    }
 
     /**
      * Iterates through data array, checks if specified fields are filled
@@ -54,7 +61,7 @@ class OrderAddress extends \OxidEsales\Eshop\Application\Controller\Admin\AdminD
      *
      * @return null
      */
-    protected function _processAddress($aData, $sTypeToProcess, $aIgnore) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function processAddress($aData, $sTypeToProcess, $aIgnore)
     {
         // empty address fields?
         $blEmpty = true;

--- a/source/Application/Controller/Admin/OrderList.php
+++ b/source/Application/Controller/Admin/OrderList.php
@@ -109,6 +109,13 @@ class OrderList extends \OxidEsales\Eshop\Application\Controller\Admin\AdminList
 
         return $sorting;
     }
+    /**
+     * @deprecated use self::prepareWhereQuery instead
+     */
+    protected function _prepareWhereQuery($whereQuery, $fullQuery) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->prepareWhereQuery($whereQuery, $fullQuery);
+    }
 
     /**
      * Adding folder check
@@ -118,10 +125,10 @@ class OrderList extends \OxidEsales\Eshop\Application\Controller\Admin\AdminList
      *
      * @return string
      */
-    protected function _prepareWhereQuery($whereQuery, $fullQuery) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function prepareWhereQuery($whereQuery, $fullQuery)
     {
         $database = \OxidEsales\Eshop\Core\DatabaseProvider::getDb();
-        $query = parent::_prepareWhereQuery($whereQuery, $fullQuery);
+        $query = parent::prepareWhereQuery($whereQuery, $fullQuery);
         $config = $this->getConfig();
         $folders = $config->getConfigParam('aOrderfolder');
         $folder = \OxidEsales\Eshop\Core\Registry::getConfig()->getRequestParameter('folder');
@@ -135,6 +142,13 @@ class OrderList extends \OxidEsales\Eshop\Application\Controller\Admin\AdminList
 
         return $query;
     }
+    /**
+     * @deprecated use self::buildSelectString instead
+     */
+    protected function _buildSelectString($listObject = null) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->buildSelectString($listObject);
+    }
 
     /**
      * Builds and returns SQL query string. Adds additional order check.
@@ -143,9 +157,9 @@ class OrderList extends \OxidEsales\Eshop\Application\Controller\Admin\AdminList
      *
      * @return string
      */
-    protected function _buildSelectString($listObject = null) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function buildSelectString($listObject = null)
     {
-        $query = parent::_buildSelectString($listObject);
+        $query = parent::buildSelectString($listObject);
         $database = \OxidEsales\Eshop\Core\DatabaseProvider::getDb();
 
         $searchQuery = \OxidEsales\Eshop\Core\Registry::getConfig()->getRequestParameter('addsearch');

--- a/source/Application/Controller/Admin/OrderOverview.php
+++ b/source/Application/Controller/Admin/OrderOverview.php
@@ -66,6 +66,13 @@ class OrderOverview extends \OxidEsales\Eshop\Application\Controller\Admin\Admin
 
         return "order_overview.tpl";
     }
+    /**
+     * @deprecated use self::getPaymentType instead
+     */
+    protected function _getPaymentType($oOrder) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getPaymentType($oOrder);
+    }
 
     /**
      * Returns user payment used for current order. In case current order was executed using
@@ -76,7 +83,7 @@ class OrderOverview extends \OxidEsales\Eshop\Application\Controller\Admin\Admin
      *
      * @return oxUserPayment
      */
-    protected function _getPaymentType($oOrder) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getPaymentType($oOrder)
     {
         if (!($oUserPayment = $oOrder->getPaymentType()) && $oOrder->oxorder__oxpaymenttype->value) {
             $oPayment = oxNew(\OxidEsales\Eshop\Application\Model\Payment::class);

--- a/source/Application/Controller/Admin/PaymentCountryAjax.php
+++ b/source/Application/Controller/Admin/PaymentCountryAjax.php
@@ -35,13 +35,20 @@ class PaymentCountryAjax extends \OxidEsales\Eshop\Application\Controller\Admin\
                                      ['oxid', 'oxobject2payment', 0, 0, 1]
                                  ]
     ];
+    /**
+     * @deprecated use self::getQuery instead
+     */
+    protected function _getQuery() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getQuery();
+    }
 
     /**
      * Returns SQL query for data to fetc
      *
      * @return string
      */
-    protected function _getQuery() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getQuery()
     {
         // looking for table/view
         $sCountryTable = $this->_getViewName('oxcountry');

--- a/source/Application/Controller/Admin/PaymentMainAjax.php
+++ b/source/Application/Controller/Admin/PaymentMainAjax.php
@@ -33,13 +33,20 @@ class PaymentMainAjax extends \OxidEsales\Eshop\Application\Controller\Admin\Lis
             ['oxid', 'oxobject2group', 0, 0, 1],
         ]
     ];
+    /**
+     * @deprecated use self::getQuery instead
+     */
+    protected function _getQuery() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getQuery();
+    }
 
     /**
      * Returns SQL query for data to fetc
      *
      * @return string
      */
-    protected function _getQuery() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getQuery()
     {
         // looking for table/view
         $sGroupTable = $this->_getViewName('oxgroups');

--- a/source/Application/Controller/Admin/PriceAlarmList.php
+++ b/source/Application/Controller/Admin/PriceAlarmList.php
@@ -34,6 +34,13 @@ class PriceAlarmList extends \OxidEsales\Eshop\Application\Controller\Admin\Admi
      * @var string
      */
     protected $_sDefSortField = "oxuserid";
+    /**
+     * @deprecated use self::buildSelectString instead
+     */
+    protected function _buildSelectString($oListObject = null) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->buildSelectString($oListObject);
+    }
 
     /**
      * Modifying SQL query to load additional article and customer data
@@ -42,7 +49,7 @@ class PriceAlarmList extends \OxidEsales\Eshop\Application\Controller\Admin\Admi
      *
      * @return string
      */
-    protected function _buildSelectString($oListObject = null) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function buildSelectString($oListObject = null)
     {
         $sViewName = getViewName("oxarticles", (int) $this->getConfig()->getConfigParam("sDefaultLang"));
         $sSql = "select oxpricealarm.*, {$sViewName}.oxtitle AS articletitle, ";

--- a/source/Application/Controller/Admin/PriceAlarmSend.php
+++ b/source/Application/Controller/Admin/PriceAlarmSend.php
@@ -63,15 +63,22 @@ class PriceAlarmSend extends \OxidEsales\Eshop\Application\Controller\Admin\Admi
 
         return $template;
     }
+    /**
+     * @deprecated use self::setupNavigation instead
+     */
+    protected function _setupNavigation($sId) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->setupNavigation($sId);
+    }
 
     /**
      * Overrides parent method to pass referred id.
      *
      * @param string $sId Class name
      */
-    protected function _setupNavigation($sId) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function setupNavigation($sId)
     {
-        parent::_setupNavigation('pricealarm_list');
+        parent::setupNavigation('pricealarm_list');
     }
 
     /**

--- a/source/Application/Controller/Admin/SelectListMain.php
+++ b/source/Application/Controller/Admin/SelectListMain.php
@@ -310,6 +310,13 @@ class SelectListMain extends \OxidEsales\Eshop\Application\Controller\Admin\Admi
             }
         }
     }
+    /**
+     * @deprecated use self::rearrangeFields instead
+     */
+    protected function _rearrangeFields($oField, $iPos) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->rearrangeFields($oField, $iPos);
+    }
 
     /**
      * Resorts fields list and moves $oField to $iPos,
@@ -320,7 +327,7 @@ class SelectListMain extends \OxidEsales\Eshop\Application\Controller\Admin\Admi
      *
      * @return bool - true if failed.
      */
-    protected function _rearrangeFields($oField, $iPos) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function rearrangeFields($oField, $iPos)
     {
         if (!isset($this->aFieldArray) || !is_array($this->aFieldArray)) {
             return true;

--- a/source/Application/Controller/Admin/SelectListMainAjax.php
+++ b/source/Application/Controller/Admin/SelectListMainAjax.php
@@ -56,13 +56,20 @@ class SelectListMainAjax extends \OxidEsales\Eshop\Application\Controller\Admin\
                                      ['oxid', 'oxselectlist', 0, 0, 1]
                                  ]
     ];
+    /**
+     * @deprecated use self::getQuery instead
+     */
+    protected function _getQuery() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getQuery();
+    }
 
     /**
      * Returns SQL query for data to fetc
      *
      * @return string
      */
-    protected function _getQuery() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getQuery()
     {
         $myConfig = $this->getConfig();
 
@@ -107,7 +114,7 @@ class SelectListMainAjax extends \OxidEsales\Eshop\Application\Controller\Admin\
         $aChosenArt = $this->_getActionIds('oxobject2selectlist.oxid');
 
         if (\OxidEsales\Eshop\Core\Registry::getConfig()->getRequestParameter('all')) {
-            $sQ = parent::_addFilter("delete oxobject2selectlist.* " . $this->_getQuery());
+            $sQ = parent::addFilter("delete oxobject2selectlist.* " . $this->_getQuery());
             \OxidEsales\Eshop\Core\DatabaseProvider::getDb()->Execute($sQ);
         } elseif (is_array($aChosenArt)) {
             $sQ = "delete from oxobject2selectlist where oxobject2selectlist.oxid in (" . implode(", ", \OxidEsales\Eshop\Core\DatabaseProvider::getDb()->quoteArray($aChosenArt)) . ") ";
@@ -127,7 +134,7 @@ class SelectListMainAjax extends \OxidEsales\Eshop\Application\Controller\Admin\
 
         if (\OxidEsales\Eshop\Core\Registry::getConfig()->getRequestParameter('all')) {
             $sArtTable = $this->_getViewName('oxarticles');
-            $aAddArticle = $this->_getAll(parent::_addFilter("select $sArtTable.oxid " . $this->_getQuery()));
+            $aAddArticle = $this->_getAll(parent::addFilter("select $sArtTable.oxid " . $this->_getQuery()));
         }
 
         if ($soxId && $soxId != "-1" && is_array($aAddArticle)) {

--- a/source/Application/Controller/Admin/SelectListOrderAjax.php
+++ b/source/Application/Controller/Admin/SelectListOrderAjax.php
@@ -28,13 +28,20 @@ class SelectListOrderAjax extends \OxidEsales\Eshop\Application\Controller\Admin
         ['oxid', 'oxobject2selectlist', 0, 0, 1]
     ]
     ];
+    /**
+     * @deprecated use self::getQuery instead
+     */
+    protected function _getQuery() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getQuery();
+    }
 
     /**
      * Returns SQL query for data to fetc
      *
      * @return string
      */
-    protected function _getQuery() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getQuery()
     {
         $sSelTable = $this->_getViewName('oxselectlist');
         $sArtId = \OxidEsales\Eshop\Core\Registry::getConfig()->getRequestParameter('oxid');
@@ -42,13 +49,20 @@ class SelectListOrderAjax extends \OxidEsales\Eshop\Application\Controller\Admin
         return " from $sSelTable left join oxobject2selectlist on oxobject2selectlist.oxselnid = $sSelTable.oxid " .
                  "where oxobjectid = " . DatabaseProvider::getDb()->quote($sArtId) . " ";
     }
+    /**
+     * @deprecated use self::getSorting instead
+     */
+    protected function _getSorting() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getSorting();
+    }
 
     /**
      * Returns SQL query addon for sorting
      *
      * @return string
      */
-    protected function _getSorting() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getSorting()
     {
         return 'order by oxobject2selectlist.oxsort ';
     }

--- a/source/Application/Controller/Admin/ShopConfiguration.php
+++ b/source/Application/Controller/Admin/ShopConfiguration.php
@@ -117,13 +117,20 @@ class ShopConfiguration extends \OxidEsales\Eshop\Application\Controller\Admin\A
 
         return $this->_sThisTemplate;
     }
+    /**
+     * @deprecated use self::getModuleForConfigVars instead
+     */
+    protected function _getModuleForConfigVars() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getModuleForConfigVars();
+    }
 
     /**
      * return theme filter for config variables
      *
      * @return string
      */
-    protected function _getModuleForConfigVars() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getModuleForConfigVars()
     {
         return '';
     }
@@ -258,6 +265,13 @@ class ShopConfiguration extends \OxidEsales\Eshop\Application\Controller\Admin\A
 
         return true;
     }
+    /**
+     * @deprecated use self::parseConstraint instead
+     */
+    protected function _parseConstraint($type, $constraint) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->parseConstraint($type, $constraint);
+    }
 
     /**
      * parse constraint from type and serialized values
@@ -267,7 +281,7 @@ class ShopConfiguration extends \OxidEsales\Eshop\Application\Controller\Admin\A
      *
      * @return mixed
      */
-    protected function _parseConstraint($type, $constraint) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function parseConstraint($type, $constraint)
     {
         switch ($type) {
             case "select":
@@ -275,6 +289,13 @@ class ShopConfiguration extends \OxidEsales\Eshop\Application\Controller\Admin\A
                 break;
         }
         return null;
+    }
+    /**
+     * @deprecated use self::serializeConstraint instead
+     */
+    protected function _serializeConstraint($type, $constraint) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->serializeConstraint($type, $constraint);
     }
 
     /**
@@ -285,7 +306,7 @@ class ShopConfiguration extends \OxidEsales\Eshop\Application\Controller\Admin\A
      *
      * @return string
      */
-    protected function _serializeConstraint($type, $constraint) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function serializeConstraint($type, $constraint)
     {
         switch ($type) {
             case "select":
@@ -293,6 +314,13 @@ class ShopConfiguration extends \OxidEsales\Eshop\Application\Controller\Admin\A
                 break;
         }
         return '';
+    }
+    /**
+     * @deprecated use self::unserializeConfVar instead
+     */
+    public function _unserializeConfVar($type, $name, $value) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->unserializeConfVar($type, $name, $value);
     }
 
     /**
@@ -304,7 +332,7 @@ class ShopConfiguration extends \OxidEsales\Eshop\Application\Controller\Admin\A
      *
      * @return mixed
      */
-    public function _unserializeConfVar($type, $name, $value) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    public function unserializeConfVar($type, $name, $value)
     {
         $str = getStr();
         $data = null;
@@ -343,6 +371,13 @@ class ShopConfiguration extends \OxidEsales\Eshop\Application\Controller\Admin\A
 
         return $data;
     }
+    /**
+     * @deprecated use self::serializeConfVar instead
+     */
+    public function _serializeConfVar($type, $name, $value) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->serializeConfVar($type, $name, $value);
+    }
 
     /**
      * Prepares data for storing to database.
@@ -354,7 +389,7 @@ class ShopConfiguration extends \OxidEsales\Eshop\Application\Controller\Admin\A
      *
      * @return string
      */
-    public function _serializeConfVar($type, $name, $value) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    public function serializeConfVar($type, $name, $value)
     {
         $data = $value;
 
@@ -383,6 +418,13 @@ class ShopConfiguration extends \OxidEsales\Eshop\Application\Controller\Admin\A
 
         return $data;
     }
+    /**
+     * @deprecated use self::arrayToMultiline instead
+     */
+    protected function _arrayToMultiline($input) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->arrayToMultiline($input);
+    }
 
     /**
      * Converts simple array to multiline text. Returns this text.
@@ -391,9 +433,16 @@ class ShopConfiguration extends \OxidEsales\Eshop\Application\Controller\Admin\A
      *
      * @return string
      */
-    protected function _arrayToMultiline($input) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function arrayToMultiline($input)
     {
         return implode("\n", (array) $input);
+    }
+    /**
+     * @deprecated use self::multilineToArray instead
+     */
+    protected function _multilineToArray($multiline) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->multilineToArray($multiline);
     }
 
     /**
@@ -403,7 +452,7 @@ class ShopConfiguration extends \OxidEsales\Eshop\Application\Controller\Admin\A
      *
      * @return array
      */
-    protected function _multilineToArray($multiline) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function multilineToArray($multiline)
     {
         $array = explode("\n", $multiline);
         if (is_array($array)) {
@@ -417,6 +466,13 @@ class ShopConfiguration extends \OxidEsales\Eshop\Application\Controller\Admin\A
             return $array;
         }
     }
+    /**
+     * @deprecated use self::aarrayToMultiline instead
+     */
+    protected function _aarrayToMultiline($input) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->aarrayToMultiline($input);
+    }
 
     /**
      * Converts associative array to multiline text. Returns this text.
@@ -425,7 +481,7 @@ class ShopConfiguration extends \OxidEsales\Eshop\Application\Controller\Admin\A
      *
      * @return string
      */
-    protected function _aarrayToMultiline($input) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function aarrayToMultiline($input)
     {
         if (is_array($input)) {
             $multiline = '';
@@ -439,6 +495,13 @@ class ShopConfiguration extends \OxidEsales\Eshop\Application\Controller\Admin\A
             return $multiline;
         }
     }
+    /**
+     * @deprecated use self::multilineToAarray instead
+     */
+    protected function _multilineToAarray($multiline) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->multilineToAarray($multiline);
+    }
 
     /**
      * Converts Multiline text to associative array. Returns this array.
@@ -447,7 +510,7 @@ class ShopConfiguration extends \OxidEsales\Eshop\Application\Controller\Admin\A
      *
      * @return array
      */
-    protected function _multilineToAarray($multiline) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function multilineToAarray($multiline)
     {
         $string = getStr();
         $array = [];

--- a/source/Application/Controller/Admin/ShopDefaultCategoryAjax.php
+++ b/source/Application/Controller/Admin/ShopDefaultCategoryAjax.php
@@ -27,13 +27,20 @@ class ShopDefaultCategoryAjax extends \OxidEsales\Eshop\Application\Controller\A
         ['oxid', 'oxcategories', 0, 0, 1]
     ]
     ];
+    /**
+     * @deprecated use self::getQuery instead
+     */
+    protected function _getQuery() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getQuery();
+    }
 
     /**
      * Returns SQL query for data to fetc
      *
      * @return string
      */
-    protected function _getQuery() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getQuery()
     {
         $oCat = oxNew(\OxidEsales\Eshop\Application\Model\Category::class);
         $oCat->setLanguage(\OxidEsales\Eshop\Core\Registry::getConfig()->getRequestParameter('editlanguage'));

--- a/source/Application/Controller/Admin/ShopLicense.php
+++ b/source/Application/Controller/Admin/ShopLicense.php
@@ -61,13 +61,20 @@ class ShopLicense extends \OxidEsales\Eshop\Application\Controller\Admin\ShopCon
 
         return $this->_sThisTemplate;
     }
+    /**
+     * @deprecated use self::canUpdate instead
+     */
+    protected function _canUpdate() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->canUpdate();
+    }
 
     /**
      * Checks if the license key update is allowed.
      *
      * @return bool
      */
-    protected function _canUpdate() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function canUpdate()
     {
         $myConfig = $this->getConfig();
 
@@ -81,13 +88,20 @@ class ShopLicense extends \OxidEsales\Eshop\Application\Controller\Admin\ShopCon
 
         return true;
     }
+    /**
+     * @deprecated use self::fetchCurVersionInfo instead
+     */
+    protected function _fetchCurVersionInfo($sUrl) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->fetchCurVersionInfo($sUrl);
+    }
 
     /**
      * Fetch current shop version information from url
      * @param string $sUrl current version info fetching url by edition
      * @return string
      */
-    protected function _fetchCurVersionInfo($sUrl) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function fetchCurVersionInfo($sUrl)
     {
         try {
             $response = $this->requestVersionInfo($sUrl);

--- a/source/Application/Controller/Admin/ShopMain.php
+++ b/source/Application/Controller/Admin/ShopMain.php
@@ -140,13 +140,20 @@ class ShopMain extends \OxidEsales\Eshop\Application\Controller\Admin\AdminDetai
 
         \OxidEsales\Eshop\Core\Registry::getSession()->setVariable("actshop", $shopId);
     }
+    /**
+     * @deprecated use self::getNonCopyConfigVars instead
+     */
+    protected function _getNonCopyConfigVars() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getNonCopyConfigVars();
+    }
 
     /**
      * Returns array of config variables which cannot be copied
      *
      * @return array
      */
-    protected function _getNonCopyConfigVars() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getNonCopyConfigVars()
     {
         $nonCopyVars = [
             'aSerials',
@@ -175,13 +182,20 @@ class ShopMain extends \OxidEsales\Eshop\Application\Controller\Admin\AdminDetai
 
         return $nonCopyVars;
     }
+    /**
+     * @deprecated use self::copyConfigVars instead
+     */
+    protected function _copyConfigVars($shop) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->copyConfigVars($shop);
+    }
 
     /**
      * Copies base shop config variables to current
      *
      * @param \OxidEsales\Eshop\Application\Model\Shop $shop new shop object
      */
-    protected function _copyConfigVars($shop) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function copyConfigVars($shop)
     {
         $config = $this->getConfig();
         $utilsObject = \OxidEsales\Eshop\Core\Registry::getUtilsObject();

--- a/source/Application/Controller/Admin/ShopSeo.php
+++ b/source/Application/Controller/Admin/ShopSeo.php
@@ -55,13 +55,20 @@ class ShopSeo extends \OxidEsales\Eshop\Application\Controller\Admin\ShopConfigu
 
         return "shop_seo.tpl";
     }
+    /**
+     * @deprecated use self::loadActiveUrl instead
+     */
+    protected function _loadActiveUrl($iShopId) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->loadActiveUrl($iShopId);
+    }
 
     /**
      * Loads and sets active url info to view
      *
      * @param int $iShopId active shop id
      */
-    protected function _loadActiveUrl($iShopId) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function loadActiveUrl($iShopId)
     {
         $sActObject = null;
         if ($this->_sActSeoObject) {
@@ -111,6 +118,13 @@ class ShopSeo extends \OxidEsales\Eshop\Application\Controller\Admin\ShopConfigu
             }
         }
     }
+    /**
+     * @deprecated use self::processUrls instead
+     */
+    protected function _processUrls($aUrls) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->processUrls($aUrls);
+    }
 
     /**
      * Goes through urls array and prepares them for saving to db
@@ -119,7 +133,7 @@ class ShopSeo extends \OxidEsales\Eshop\Application\Controller\Admin\ShopConfigu
      *
      * @return array
      */
-    protected function _processUrls($aUrls) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function processUrls($aUrls)
     {
         if (isset($aUrls['oxseo__oxstdurl']) && $aUrls['oxseo__oxstdurl']) {
             $aUrls['oxseo__oxstdurl'] = $this->_cleanupUrl($aUrls['oxseo__oxstdurl']);
@@ -133,6 +147,13 @@ class ShopSeo extends \OxidEsales\Eshop\Application\Controller\Admin\ShopConfigu
 
         return $aUrls;
     }
+    /**
+     * @deprecated use self::cleanupUrl instead
+     */
+    protected function _cleanupUrl($sUrl) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->cleanupUrl($sUrl);
+    }
 
     /**
      * processes urls by fixing "&amp;", "&"
@@ -141,7 +162,7 @@ class ShopSeo extends \OxidEsales\Eshop\Application\Controller\Admin\ShopConfigu
      *
      * @return string
      */
-    protected function _cleanupUrl($sUrl) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function cleanupUrl($sUrl)
     {
         // replacing &amp; to & or removing double &&
         while ((stripos($sUrl, '&amp;') !== false) || (stripos($sUrl, '&&') !== false)) {

--- a/source/Application/Controller/Admin/ThemeConfiguration.php
+++ b/source/Application/Controller/Admin/ThemeConfiguration.php
@@ -60,13 +60,20 @@ class ThemeConfiguration extends \OxidEsales\Eshop\Application\Controller\Admin\
 
         return 'theme_config.tpl';
     }
+    /**
+     * @deprecated use self::getModuleForConfigVars instead
+     */
+    protected function _getModuleForConfigVars() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getModuleForConfigVars();
+    }
 
     /**
      * return theme filter for config variables
      *
      * @return string
      */
-    protected function _getModuleForConfigVars() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getModuleForConfigVars()
     {
         if ($this->_sTheme === null) {
             $this->_sTheme = $this->getEditObjectId();

--- a/source/Application/Controller/Admin/ToolsList.php
+++ b/source/Application/Controller/Admin/ToolsList.php
@@ -117,13 +117,20 @@ class ToolsList extends \OxidEsales\Eshop\Application\Controller\Admin\AdminList
             $this->_iDefEdit = 1;
         }
     }
+    /**
+     * @deprecated use self::processFiles instead
+     */
+    protected function _processFiles() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->processFiles();
+    }
 
     /**
      * Processes files containing SQL queries
      *
      * @return mixed
      */
-    protected function _processFiles() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function processFiles()
     {
         if (isset($_FILES['myfile']['name'])) {
             // process all files
@@ -158,6 +165,13 @@ class ToolsList extends \OxidEsales\Eshop\Application\Controller\Admin\AdminList
 
         return;
     }
+    /**
+     * @deprecated use self::prepareSQL instead
+     */
+    protected function _prepareSQL($sSQL, $iSQLlen) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->prepareSQL($sSQL, $iSQLlen);
+    }
 
     /**
      * Method parses givent SQL queries string and returns array on success
@@ -167,7 +181,7 @@ class ToolsList extends \OxidEsales\Eshop\Application\Controller\Admin\AdminList
      *
      * @return mixed
      */
-    protected function _prepareSQL($sSQL, $iSQLlen) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function prepareSQL($sSQL, $iSQLlen)
     {
         $sStrStart = "";
         $blString = false;

--- a/source/Application/Controller/Admin/UserGroupMainAjax.php
+++ b/source/Application/Controller/Admin/UserGroupMainAjax.php
@@ -46,13 +46,20 @@ class UserGroupMainAjax extends \OxidEsales\Eshop\Application\Controller\Admin\L
                                      ['oxid', 'oxobject2group', 0, 0, 1],
                                  ]
     ];
+    /**
+     * @deprecated use self::getQuery instead
+     */
+    protected function _getQuery() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getQuery();
+    }
 
     /**
      * Returns SQL query for data to fetc
      *
      * @return string
      */
-    protected function _getQuery() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getQuery()
     {
         $myConfig = $this->getConfig();
 

--- a/source/Application/Controller/Admin/UserList.php
+++ b/source/Application/Controller/Admin/UserList.php
@@ -79,6 +79,13 @@ class UserList extends \OxidEsales\Eshop\Application\Controller\Admin\AdminListC
             return parent::deleteEntry();
         }
     }
+    /**
+     * @deprecated use self::prepareWhereQuery instead
+     */
+    public function _prepareWhereQuery($whereQuery, $fullQuery) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->prepareWhereQuery($whereQuery, $fullQuery);
+    }
 
     /**
      * Prepares SQL where query according SQL condition array and attaches it to SQL end.
@@ -90,7 +97,7 @@ class UserList extends \OxidEsales\Eshop\Application\Controller\Admin\AdminListC
      *
      * @return string
      */
-    public function _prepareWhereQuery($whereQuery, $fullQuery) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    public function prepareWhereQuery($whereQuery, $fullQuery)
     {
         $nameWhere = null;
         if (isset($whereQuery['oxuser.oxlname']) && ($name = $whereQuery['oxuser.oxlname'])) {
@@ -101,7 +108,7 @@ class UserList extends \OxidEsales\Eshop\Application\Controller\Admin\AdminListC
 
             unset($whereQuery['oxuser.oxlname']);
         }
-        $query = parent::_prepareWhereQuery($whereQuery, $fullQuery);
+        $query = parent::prepareWhereQuery($whereQuery, $fullQuery);
 
         if ($nameWhere) {
             $values = explode(' ', $name);

--- a/source/Application/Controller/Admin/UserMainAjax.php
+++ b/source/Application/Controller/Admin/UserMainAjax.php
@@ -32,13 +32,20 @@ class UserMainAjax extends \OxidEsales\Eshop\Application\Controller\Admin\ListCo
                                      ['oxid', 'oxobject2group', 0, 0, 1],
                                  ]
     ];
+    /**
+     * @deprecated use self::getQuery instead
+     */
+    protected function _getQuery() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getQuery();
+    }
 
     /**
      * Returns SQL query for data to fetc
      *
      * @return string
      */
-    protected function _getQuery() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getQuery()
     {
         // looking for table/view
         $sGroupTable = $this->_getViewName('oxgroups');

--- a/source/Application/Controller/Admin/VendorMainAjax.php
+++ b/source/Application/Controller/Admin/VendorMainAjax.php
@@ -46,13 +46,20 @@ class VendorMainAjax extends \OxidEsales\Eshop\Application\Controller\Admin\List
                                      ['oxid', 'oxarticles', 0, 0, 1]
                                  ]
     ];
+    /**
+     * @deprecated use self::getQuery instead
+     */
+    protected function _getQuery() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getQuery();
+    }
 
     /**
      * Returns SQL query for data to fetc
      *
      * @return string
      */
-    protected function _getQuery() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getQuery()
     {
         // looking for table/view
         $sArtTable = $this->_getViewName('oxarticles');
@@ -81,6 +88,13 @@ class VendorMainAjax extends \OxidEsales\Eshop\Application\Controller\Admin\List
 
         return $sQAdd;
     }
+    /**
+     * @deprecated use self::addFilter instead
+     */
+    protected function _addFilter($sQ) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->addFilter($sQ);
+    }
 
     /**
      * Adds filter SQL to current query
@@ -89,10 +103,10 @@ class VendorMainAjax extends \OxidEsales\Eshop\Application\Controller\Admin\List
      *
      * @return string
      */
-    protected function _addFilter($sQ) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function addFilter($sQ)
     {
         $sArtTable = $this->_getViewName('oxarticles');
-        $sQ = parent::_addFilter($sQ);
+        $sQ = parent::addFilter($sQ);
 
         // display variants or not ?
         $sQ .= $this->getConfig()->getConfigParam('blVariantsSelection') ? ' group by ' . $sArtTable . '.oxid ' : '';

--- a/source/Application/Controller/Admin/VendorSeo.php
+++ b/source/Application/Controller/Admin/VendorSeo.php
@@ -33,13 +33,20 @@ class VendorSeo extends \OxidEsales\Eshop\Application\Controller\Admin\ObjectSeo
 
         return parent::save();
     }
+    /**
+     * @deprecated use self::getEncoder instead
+     */
+    protected function _getEncoder() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getEncoder();
+    }
 
     /**
      * Returns current object type seo encoder object
      *
      * @return oxSeoEncoderVendor
      */
-    protected function _getEncoder() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getEncoder()
     {
         return \OxidEsales\Eshop\Core\Registry::get(\OxidEsales\Eshop\Application\Model\SeoEncoderVendor::class);
     }
@@ -66,13 +73,20 @@ class VendorSeo extends \OxidEsales\Eshop\Application\Controller\Admin\ObjectSeo
             return (bool) $oVendor->oxvendor__oxshowsuffix->value;
         }
     }
+    /**
+     * @deprecated use self::getType instead
+     */
+    protected function _getType() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getType();
+    }
 
     /**
      * Returns url type
      *
      * @return string
      */
-    protected function _getType() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getType()
     {
         return 'oxvendor';
     }

--- a/source/Application/Controller/Admin/VoucherSerieExport.php
+++ b/source/Application/Controller/Admin/VoucherSerieExport.php
@@ -76,13 +76,20 @@ class VoucherSerieExport extends \OxidEsales\Eshop\Application\Controller\Admin\
 
         return $sUrl . '&amp;cl=' . $this->sClassDo . '&amp;fnc=download';
     }
+    /**
+     * @deprecated use self::getExportFileName instead
+     */
+    protected function _getExportFileName() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getExportFileName();
+    }
 
     /**
      * Return export file name
      *
      * @return string
      */
-    protected function _getExportFileName() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getExportFileName()
     {
         $sSessionFileName = \OxidEsales\Eshop\Core\Registry::getSession()->getVariable("sExportFileName");
         if (!$sSessionFileName) {
@@ -92,13 +99,20 @@ class VoucherSerieExport extends \OxidEsales\Eshop\Application\Controller\Admin\
 
         return $sSessionFileName;
     }
+    /**
+     * @deprecated use self::getExportFilePath instead
+     */
+    protected function _getExportFilePath() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getExportFilePath();
+    }
 
     /**
      * Return export file path
      *
      * @return string
      */
-    protected function _getExportFilePath() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getExportFilePath()
     {
         return $this->getConfig()->getConfigParam('sShopDir') . "/export/" . $this->_getExportFileName();
     }

--- a/source/Application/Controller/Admin/VoucherSerieGroupsAjax.php
+++ b/source/Application/Controller/Admin/VoucherSerieGroupsAjax.php
@@ -32,13 +32,20 @@ class VoucherSerieGroupsAjax extends \OxidEsales\Eshop\Application\Controller\Ad
                                      ['oxid', 'oxobject2group', 0, 0, 1],
                                  ]
     ];
+    /**
+     * @deprecated use self::getQuery instead
+     */
+    protected function _getQuery() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getQuery();
+    }
 
     /**
      * Returns SQL query for data to fetc
      *
      * @return string
      */
-    protected function _getQuery() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getQuery()
     {
         // looking for table/view
         $sGroupTable = $this->_getViewName('oxgroups');

--- a/source/Application/Controller/Admin/VoucherSerieMain.php
+++ b/source/Application/Controller/Admin/VoucherSerieMain.php
@@ -126,6 +126,13 @@ class VoucherSerieMain extends \OxidEsales\Eshop\Application\Controller\Admin\Dy
     public function prepareExport()
     {
     }
+    /**
+     * @deprecated use self::getVoucherSerie instead
+     */
+    protected function _getVoucherSerie() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getVoucherSerie();
+    }
 
 
     /**
@@ -133,7 +140,7 @@ class VoucherSerieMain extends \OxidEsales\Eshop\Application\Controller\Admin\Dy
      *
      * @return oxvoucherserie
      */
-    protected function _getVoucherSerie() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getVoucherSerie()
     {
         if ($this->_oVoucherSerie == null) {
             $oVoucherSerie = oxNew(\OxidEsales\Eshop\Application\Model\VoucherSerie::class);

--- a/source/Application/Controller/ArticleDetailsController.php
+++ b/source/Application/Controller/ArticleDetailsController.php
@@ -165,6 +165,13 @@ class ArticleDetailsController extends \OxidEsales\Eshop\Application\Controller\
      * @var bool
      */
     protected $_blShowSorting = true;
+    /**
+     * @deprecated use self::getParentProduct instead
+     */
+    protected function _getParentProduct($parentId) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getParentProduct($parentId);
+    }
 
     /**
      * Returns current product parent article object if it is available
@@ -173,7 +180,7 @@ class ArticleDetailsController extends \OxidEsales\Eshop\Application\Controller\
      *
      * @return \OxidEsales\Eshop\Application\Model\Article
      */
-    protected function _getParentProduct($parentId) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getParentProduct($parentId)
     {
         if ($parentId && $this->_oParentProd === null) {
             $this->_oParentProd = false;
@@ -231,6 +238,13 @@ class ArticleDetailsController extends \OxidEsales\Eshop\Application\Controller\
 
         return $parameters;
     }
+    /**
+     * @deprecated use self::processProduct instead
+     */
+    protected function _processProduct($article) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->processProduct($article);
+    }
 
 
     /**
@@ -238,7 +252,7 @@ class ArticleDetailsController extends \OxidEsales\Eshop\Application\Controller\
      *
      * @param \OxidEsales\Eshop\Application\Model\Article $article Product to process
      */
-    protected function _processProduct($article) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function processProduct($article)
     {
         $article->setLinkType($this->getLinkType());
         if ($dynamicParameters = $this->_getAddUrlParams()) {
@@ -311,6 +325,13 @@ class ArticleDetailsController extends \OxidEsales\Eshop\Application\Controller\
                 return $this->_sThisTemplate;
         }
     }
+    /**
+     * @deprecated use self::prepareMetaDescription instead
+     */
+    protected function _prepareMetaDescription($meta, $length = 200, $descriptionTag = false) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->prepareMetaDescription($meta, $length, $descriptionTag);
+    }
 
     /**
      * Returns current view meta data
@@ -323,7 +344,7 @@ class ArticleDetailsController extends \OxidEsales\Eshop\Application\Controller\
      *
      * @return string
      */
-    protected function _prepareMetaDescription($meta, $length = 200, $descriptionTag = false) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function prepareMetaDescription($meta, $length = 200, $descriptionTag = false)
     {
         if (!$meta) {
             $article = $this->getProduct();
@@ -339,7 +360,14 @@ class ArticleDetailsController extends \OxidEsales\Eshop\Application\Controller\
             $meta = $article->oxarticles__oxtitle->value . ' - ' . $meta;
         }
 
-        return parent::_prepareMetaDescription($meta, $length, $descriptionTag);
+        return parent::prepareMetaDescription($meta, $length, $descriptionTag);
+    }
+    /**
+     * @deprecated use self::prepareMetaKeyword instead
+     */
+    protected function _prepareMetaKeyword($keywords, $removeDuplicatedWords = true) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->prepareMetaKeyword($keywords, $removeDuplicatedWords);
     }
 
     /**
@@ -352,7 +380,7 @@ class ArticleDetailsController extends \OxidEsales\Eshop\Application\Controller\
      *
      * @return string
      */
-    protected function _prepareMetaKeyword($keywords, $removeDuplicatedWords = true) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function prepareMetaKeyword($keywords, $removeDuplicatedWords = true)
     {
         if (!$keywords) {
             $article = $this->getProduct();
@@ -369,7 +397,7 @@ class ArticleDetailsController extends \OxidEsales\Eshop\Application\Controller\
                 $keywords .= ", " . $searchKeys;
             }
 
-            $keywords = parent::_prepareMetaKeyword($keywords, $removeDuplicatedWords);
+            $keywords = parent::prepareMetaKeyword($keywords, $removeDuplicatedWords);
         }
 
         return $keywords;
@@ -448,13 +476,20 @@ class ArticleDetailsController extends \OxidEsales\Eshop\Application\Controller\
             $recommendationList->addArticle($articleId, $recommendationText);
         }
     }
+    /**
+     * @deprecated use self::getSeoObjectId instead
+     */
+    protected function _getSeoObjectId() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getSeoObjectId();
+    }
 
     /**
      * Returns active product id to load its seo meta info
      *
      * @return string
      */
-    protected function _getSeoObjectId() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getSeoObjectId()
     {
         if ($article = $this->getProduct()) {
             return $article->getId();
@@ -500,11 +535,18 @@ class ArticleDetailsController extends \OxidEsales\Eshop\Application\Controller\
 
         return $this->_oProduct;
     }
+    /**
+     * @deprecated use self::additionalChecksForArticle instead
+     */
+    protected function _additionalChecksForArticle() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->additionalChecksForArticle();
+    }
 
     /**
      * Runs additional checks for article.
      */
-    protected function _additionalChecksForArticle() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function additionalChecksForArticle()
     {
         $config = $this->getConfig();
         $utils = Registry::getUtils();
@@ -757,6 +799,13 @@ class ArticleDetailsController extends \OxidEsales\Eshop\Application\Controller\
     {
         return $this->getProduct()->isPriceAlarm();
     }
+    /**
+     * @deprecated use self::getSubject instead
+     */
+    protected function _getSubject($languageId) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getSubject($languageId);
+    }
 
     /**
      * returns object, associated with current view.
@@ -766,7 +815,7 @@ class ArticleDetailsController extends \OxidEsales\Eshop\Application\Controller\
      *
      * @return \OxidEsales\Eshop\Application\Model\Article
      */
-    protected function _getSubject($languageId) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getSubject($languageId)
     {
         return $this->getProduct();
     }
@@ -1247,13 +1296,20 @@ class ArticleDetailsController extends \OxidEsales\Eshop\Application\Controller\
 
         return implode('|', $sorting);
     }
+    /**
+     * @deprecated use self::getVendorBreadCrumb instead
+     */
+    protected function _getVendorBreadCrumb() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getVendorBreadCrumb();
+    }
 
     /**
      * Vendor bread crumb
      *
      * @return array
      */
-    protected function _getVendorBreadCrumb() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getVendorBreadCrumb()
     {
         $paths = [];
         $vendorPath = [];
@@ -1274,6 +1330,13 @@ class ArticleDetailsController extends \OxidEsales\Eshop\Application\Controller\
 
         return $paths;
     }
+    /**
+     * @deprecated use self::getRecommendationListBredCrumb instead
+     */
+    protected function _getRecommendationListBredCrumb() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getRecommendationListBredCrumb();
+    }
 
     /**
      * Recommendation list bread crumb
@@ -1282,7 +1345,7 @@ class ArticleDetailsController extends \OxidEsales\Eshop\Application\Controller\
      *
      * @return array
      */
-    protected function _getRecommendationListBredCrumb() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getRecommendationListBredCrumb()
     {
         $paths = [];
         $recommListPath = [];
@@ -1292,13 +1355,20 @@ class ArticleDetailsController extends \OxidEsales\Eshop\Application\Controller\
 
         return $paths;
     }
+    /**
+     * @deprecated use self::getSearchBreadCrumb instead
+     */
+    protected function _getSearchBreadCrumb() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getSearchBreadCrumb();
+    }
 
     /**
      * Search bread crumb
      *
      * @return array
      */
-    protected function _getSearchBreadCrumb() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getSearchBreadCrumb()
     {
         $paths = [];
         $searchPath = [];
@@ -1316,13 +1386,20 @@ class ArticleDetailsController extends \OxidEsales\Eshop\Application\Controller\
 
         return $paths;
     }
+    /**
+     * @deprecated use self::getCategoryBreadCrumb instead
+     */
+    protected function _getCategoryBreadCrumb() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getCategoryBreadCrumb();
+    }
 
     /**
      * Category bread crumb
      *
      * @return array
      */
-    protected function _getCategoryBreadCrumb() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getCategoryBreadCrumb()
     {
         $paths = [];
 

--- a/source/Application/Controller/ArticleListController.php
+++ b/source/Application/Controller/ArticleListController.php
@@ -231,6 +231,13 @@ class ArticleListController extends \OxidEsales\Eshop\Application\Controller\Fro
 
         return $category;
     }
+    /**
+     * @deprecated use self::checkRequestedPage instead
+     */
+    protected function _checkRequestedPage() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->checkRequestedPage();
+    }
 
     /**
      * Checks if requested page is valid and:
@@ -238,7 +245,7 @@ class ArticleListController extends \OxidEsales\Eshop\Application\Controller\Fro
      * or
      * - displays 404 error if category has no products
      */
-    protected function _checkRequestedPage() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function checkRequestedPage()
     {
         $pageCount = $this->getPageCount();
         $currentPageNumber = $this->getActPage();
@@ -252,12 +259,19 @@ class ArticleListController extends \OxidEsales\Eshop\Application\Controller\Fro
             error_404_handler($this->getActiveCategory()->getLink());
         }
     }
+    /**
+     * @deprecated use self::processListArticles instead
+     */
+    protected function _processListArticles() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->processListArticles();
+    }
 
     /**
      * Iterates through list articles and performs list view specific tasks:
      *  - sets type of link which needs to be generated (Manufacturer link)
      */
-    protected function _processListArticles() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function processListArticles()
     {
         if ($articleList = $this->getArticleList()) {
             $linkType = $this->_getProductLinkType();
@@ -306,6 +320,13 @@ class ArticleListController extends \OxidEsales\Eshop\Application\Controller\Fro
     {
         return '';
     }
+    /**
+     * @deprecated use self::getProductLinkType instead
+     */
+    protected function _getProductLinkType() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getProductLinkType();
+    }
 
     /**
      * Returns product link type:
@@ -314,7 +335,7 @@ class ArticleListController extends \OxidEsales\Eshop\Application\Controller\Fro
      *
      * @return int
      */
-    protected function _getProductLinkType() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getProductLinkType()
     {
         $categoryType = OXARTICLE_LINKTYPE_CATEGORY;
         if (($category = $this->getActiveCategory()) && $category->isPriceCategory()) {
@@ -358,6 +379,13 @@ class ArticleListController extends \OxidEsales\Eshop\Application\Controller\Fro
         unset($sessionFilter[$activeCategory]);
         Registry::getSession()->setVariable('session_attrfilter', $sessionFilter);
     }
+    /**
+     * @deprecated use self::loadArticles instead
+     */
+    protected function _loadArticles($category) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->loadArticles($category);
+    }
 
     /**
      * Loads and returns article list of active category.
@@ -366,7 +394,7 @@ class ArticleListController extends \OxidEsales\Eshop\Application\Controller\Fro
      *
      * @return oxArticleList
      */
-    protected function _loadArticles($category) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function loadArticles($category)
     {
         $config = $this->getConfig();
 
@@ -409,6 +437,13 @@ class ArticleListController extends \OxidEsales\Eshop\Application\Controller\Fro
 
         return $this->_getRequestPageNr();
     }
+    /**
+     * @deprecated use self::getRequestPageNr instead
+     */
+    protected function _getRequestPageNr() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getRequestPageNr();
+    }
 
     /**
      * Calls parent::getActPage();
@@ -418,7 +453,7 @@ class ArticleListController extends \OxidEsales\Eshop\Application\Controller\Fro
      *
      * @return int
      */
-    protected function _getRequestPageNr() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getRequestPageNr()
     {
         return parent::getActPage();
     }
@@ -440,15 +475,30 @@ class ArticleListController extends \OxidEsales\Eshop\Application\Controller\Fro
     }
 
     /**
+     * @deprecated use self::getSeoObjectId instead
+     */
+    protected function _getSeoObjectId() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getSeoObjectId();
+    }
+
+    /**
      * Returns active product id to load its seo meta info
      *
      * @return string
      */
-    protected function _getSeoObjectId() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getSeoObjectId()
     {
         if (($category = $this->getActiveCategory())) {
             return $category->getId();
         }
+    }
+    /**
+     * @deprecated use self::getCatPathString instead
+     */
+    protected function _getCatPathString() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getCatPathString();
     }
 
     /**
@@ -456,7 +506,7 @@ class ArticleListController extends \OxidEsales\Eshop\Application\Controller\Fro
      *
      * @return string
      */
-    protected function _getCatPathString() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getCatPathString()
     {
         if ($this->_sCatPathString === null) {
             // marking as already set
@@ -477,6 +527,13 @@ class ArticleListController extends \OxidEsales\Eshop\Application\Controller\Fro
 
         return $this->_sCatPathString;
     }
+    /**
+     * @deprecated use self::prepareMetaDescription instead
+     */
+    protected function _prepareMetaDescription($meta, $length = 1024, $descriptionTag = false) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->prepareMetaDescription($meta, $length, $descriptionTag);
+    }
 
     /**
      * Returns current view meta description data.
@@ -487,7 +544,7 @@ class ArticleListController extends \OxidEsales\Eshop\Application\Controller\Fro
      *
      * @return  string
      */
-    protected function _prepareMetaDescription($meta, $length = 1024, $descriptionTag = false) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function prepareMetaDescription($meta, $length = 1024, $descriptionTag = false)
     {
         $description = '';
         // appending parent title
@@ -533,6 +590,13 @@ class ArticleListController extends \OxidEsales\Eshop\Application\Controller\Fro
 
         return $meta;
     }
+    /**
+     * @deprecated use self::collectMetaDescription instead
+     */
+    protected function _collectMetaDescription($meta, $length = 1024, $descriptionTag = false) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->collectMetaDescription($meta, $length, $descriptionTag);
+    }
 
     /**
      * Meta tags - description and keywords - generator for search
@@ -546,7 +610,7 @@ class ArticleListController extends \OxidEsales\Eshop\Application\Controller\Fro
      *
      * @return  string
      */
-    protected function _collectMetaDescription($meta, $length = 1024, $descriptionTag = false) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function collectMetaDescription($meta, $length = 1024, $descriptionTag = false)
     {
         //formatting description tag
         $category = $this->getActiveCategory();
@@ -573,7 +637,14 @@ class ArticleListController extends \OxidEsales\Eshop\Application\Controller\Fro
             $meta = $additionalText;
         }
 
-        return parent::_prepareMetaDescription($meta, $length, $descriptionTag);
+        return parent::prepareMetaDescription($meta, $length, $descriptionTag);
+    }
+    /**
+     * @deprecated use self::prepareMetaKeyword instead
+     */
+    protected function _prepareMetaKeyword($keywords, $removeDuplicatedWords = true) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->prepareMetaKeyword($keywords, $removeDuplicatedWords);
     }
 
     /**
@@ -584,7 +655,7 @@ class ArticleListController extends \OxidEsales\Eshop\Application\Controller\Fro
      *
      * @return string
      */
-    protected function _prepareMetaKeyword($keywords, $removeDuplicatedWords = true) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function prepareMetaKeyword($keywords, $removeDuplicatedWords = true)
     {
         $keywords = '';
         if (($activeCategory = $this->getActiveCategory())) {
@@ -608,9 +679,16 @@ class ArticleListController extends \OxidEsales\Eshop\Application\Controller\Fro
             }
         }
 
-        $keywords = parent::_prepareMetaDescription($keywords, -1, $removeDuplicatedWords);
+        $keywords = parent::prepareMetaDescription($keywords, -1, $removeDuplicatedWords);
 
         return trim($keywords);
+    }
+    /**
+     * @deprecated use self::collectMetaKeyword instead
+     */
+    protected function _collectMetaKeyword($keywords) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->collectMetaKeyword($keywords);
     }
 
     /**
@@ -621,7 +699,7 @@ class ArticleListController extends \OxidEsales\Eshop\Application\Controller\Fro
      *
      * @return string
      */
-    protected function _collectMetaKeyword($keywords) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function collectMetaKeyword($keywords)
     {
         $maxTextLength = 60;
         $text = '';
@@ -660,7 +738,7 @@ class ArticleListController extends \OxidEsales\Eshop\Application\Controller\Fro
             $text = "{$keywords}, {$text}";
         }
 
-        return parent::_prepareMetaKeyword($text);
+        return parent::prepareMetaKeyword($text);
     }
 
     /**
@@ -681,6 +759,13 @@ class ArticleListController extends \OxidEsales\Eshop\Application\Controller\Fro
 
         return $this->_sThisTemplate;
     }
+    /**
+     * @deprecated use self::addPageNrParam instead
+     */
+    protected function _addPageNrParam($url, $currentPage, $languageId = null) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->addPageNrParam($url, $currentPage, $languageId);
+    }
 
     /**
      * Adds page number parameter to current Url and returns formatted url
@@ -691,7 +776,7 @@ class ArticleListController extends \OxidEsales\Eshop\Application\Controller\Fro
      *
      * @return string
      */
-    protected function _addPageNrParam($url, $currentPage, $languageId = null) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function addPageNrParam($url, $currentPage, $languageId = null)
     {
         if (Registry::getUtils()->seoIsActive() && ($category = $this->getActiveCategory())) {
             if ($currentPage) {
@@ -699,10 +784,17 @@ class ArticleListController extends \OxidEsales\Eshop\Application\Controller\Fro
                 $url = $category->getBaseSeoLink($languageId, $currentPage);
             }
         } else {
-            $url = parent::_addPageNrParam($url, $currentPage, $languageId);
+            $url = parent::addPageNrParam($url, $currentPage, $languageId);
         }
 
         return $url;
+    }
+    /**
+     * @deprecated use self::isActCategory instead
+     */
+    protected function _isActCategory() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->isActCategory();
     }
 
     /**
@@ -710,7 +802,7 @@ class ArticleListController extends \OxidEsales\Eshop\Application\Controller\Fro
      *
      * @return bool
      */
-    protected function _isActCategory() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function isActCategory()
     {
         return $this->_blIsCat;
     }
@@ -775,6 +867,13 @@ class ArticleListController extends \OxidEsales\Eshop\Application\Controller\Fro
             return Registry::getLang()->translateString('PAGE') . " " . ($activePage + 1);
         }
     }
+    /**
+     * @deprecated use self::getSubject instead
+     */
+    protected function _getSubject($languageId) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getSubject($languageId);
+    }
 
     /**
      * Returns object, associated with current view.
@@ -784,7 +883,7 @@ class ArticleListController extends \OxidEsales\Eshop\Application\Controller\Fro
      *
      * @return object
      */
-    protected function _getSubject($languageId) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getSubject($languageId)
     {
         return $this->getActiveCategory();
     }

--- a/source/Application/Controller/BasketController.php
+++ b/source/Application/Controller/BasketController.php
@@ -395,6 +395,13 @@ class BasketController extends \OxidEsales\Eshop\Application\Controller\Frontend
         /** @var \OxidEsales\Eshop\Application\Model\BasketContentMarkGenerator $oBasketContentMarkGenerator */
         return oxNew('oxBasketContentMarkGenerator', $this->getSession()->getBasket());
     }
+    /**
+     * @deprecated use self::setWrappingInfo instead
+     */
+    protected function _setWrappingInfo($oBasket, $aWrapping) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->setWrappingInfo($oBasket, $aWrapping);
+    }
 
     /**
      * Sets basket wrapping
@@ -402,7 +409,7 @@ class BasketController extends \OxidEsales\Eshop\Application\Controller\Frontend
      * @param \OxidEsales\Eshop\Application\Model\Basket $oBasket
      * @param array                                      $aWrapping
      */
-    protected function _setWrappingInfo($oBasket, $aWrapping) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function setWrappingInfo($oBasket, $aWrapping)
     {
         if (is_array($aWrapping) && count($aWrapping)) {
             foreach ($oBasket->getContents() as $sKey => $oBasketItem) {

--- a/source/Application/Controller/ClearCookiesController.php
+++ b/source/Application/Controller/ClearCookiesController.php
@@ -37,11 +37,18 @@ class ClearCookiesController extends \OxidEsales\Eshop\Application\Controller\Fr
 
         return $this->_sThisTemplate;
     }
+    /**
+     * @deprecated use self::removeCookies instead
+     */
+    protected function _removeCookies() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->removeCookies();
+    }
 
     /**
      * Clears all cookies
      */
-    protected function _removeCookies() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function removeCookies()
     {
         $oUtilsServer = Registry::getUtilsServer();
         if (isset($_SERVER['HTTP_COOKIE'])) {

--- a/source/Application/Controller/CompareController.php
+++ b/source/Application/Controller/CompareController.php
@@ -238,13 +238,20 @@ class CompareController extends \OxidEsales\Eshop\Application\Controller\Fronten
         $this->_aCompItems = $aItems;
         Registry::getSession()->setVariable('aFiltcompproducts', $aItems);
     }
+    /**
+     * @deprecated use self::setArticlesPerPage instead
+     */
+    protected function _setArticlesPerPage($iNumber) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->setArticlesPerPage($iNumber);
+    }
 
     /**
      *  $_iArticlesPerPage setter
      *
      * @param int $iNumber article count in compare page
      */
-    protected function _setArticlesPerPage($iNumber) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function setArticlesPerPage($iNumber)
     {
         $this->_iArticlesPerPage = $iNumber;
     }
@@ -343,6 +350,13 @@ class CompareController extends \OxidEsales\Eshop\Application\Controller\Fronten
 
         return $this->_oPageNavigation;
     }
+    /**
+     * @deprecated use self::removeArticlesFromPage instead
+     */
+    protected function _removeArticlesFromPage($aItems, $oList) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->removeArticlesFromPage($aItems, $oList);
+    }
 
     /**
      * Cuts page articles
@@ -352,7 +366,7 @@ class CompareController extends \OxidEsales\Eshop\Application\Controller\Fronten
      *
      * @return array $aNewItems
      */
-    protected function _removeArticlesFromPage($aItems, $oList) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function removeArticlesFromPage($aItems, $oList)
     {
         //#1106S $aItems changed to $oList.
         //2006-08-10 Alfonsas, compare arrows fixed, array position is very important here, preserve it.
@@ -371,6 +385,13 @@ class CompareController extends \OxidEsales\Eshop\Application\Controller\Fronten
 
         return $aNewItems;
     }
+    /**
+     * @deprecated use self::changeArtListOrder instead
+     */
+    protected function _changeArtListOrder($aItems, $oList) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->changeArtListOrder($aItems, $oList);
+    }
 
     /**
      * Changes order of list elements
@@ -380,7 +401,7 @@ class CompareController extends \OxidEsales\Eshop\Application\Controller\Fronten
      *
      * @return array $oNewList
      */
-    protected function _changeArtListOrder($aItems, $oList) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function changeArtListOrder($aItems, $oList)
     {
         // #777C changing order of list elements, according to $aItems
         $oNewList = [];

--- a/source/Application/Controller/ContentController.php
+++ b/source/Application/Controller/ContentController.php
@@ -158,6 +158,13 @@ class ContentController extends \OxidEsales\Eshop\Application\Controller\Fronten
 
         return $this->_sThisTemplate;
     }
+    /**
+     * @deprecated use self::canShowContent instead
+     */
+    protected function _canShowContent($sContentIdent) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->canShowContent($sContentIdent);
+    }
 
     /**
      * Checks if content can be shown
@@ -166,12 +173,19 @@ class ContentController extends \OxidEsales\Eshop\Application\Controller\Fronten
      *
      * @return bool
      */
-    protected function _canShowContent($sContentIdent) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function canShowContent($sContentIdent)
     {
         return !(
             $this->isEnabledPrivateSales() &&
             !$this->getUser() && !in_array($sContentIdent, $this->_aPsAllowedContents)
         );
+    }
+    /**
+     * @deprecated use self::prepareMetaDescription instead
+     */
+    protected function _prepareMetaDescription($sMeta, $iLength = 200, $blDescTag = false) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->prepareMetaDescription($sMeta, $iLength, $blDescTag);
     }
 
     /**
@@ -184,13 +198,20 @@ class ContentController extends \OxidEsales\Eshop\Application\Controller\Fronten
      *
      * @return string
      */
-    protected function _prepareMetaDescription($sMeta, $iLength = 200, $blDescTag = false) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function prepareMetaDescription($sMeta, $iLength = 200, $blDescTag = false)
     {
         if (!$sMeta) {
             $sMeta = $this->getContent()->oxcontents__oxtitle->value;
         }
 
-        return parent::_prepareMetaDescription($sMeta, $iLength, $blDescTag);
+        return parent::prepareMetaDescription($sMeta, $iLength, $blDescTag);
+    }
+    /**
+     * @deprecated use self::prepareMetaKeyword instead
+     */
+    protected function _prepareMetaKeyword($sKeywords, $blRemoveDuplicatedWords = true) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->prepareMetaKeyword($sKeywords, $blRemoveDuplicatedWords);
     }
 
     /**
@@ -202,13 +223,13 @@ class ContentController extends \OxidEsales\Eshop\Application\Controller\Fronten
      *
      * @return string
      */
-    protected function _prepareMetaKeyword($sKeywords, $blRemoveDuplicatedWords = true) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function prepareMetaKeyword($sKeywords, $blRemoveDuplicatedWords = true)
     {
         if (!$sKeywords) {
             $sKeywords = $this->getContent()->oxcontents__oxtitle->value;
         }
 
-        return parent::_prepareMetaKeyword($sKeywords, $blRemoveDuplicatedWords);
+        return parent::prepareMetaKeyword($sKeywords, $blRemoveDuplicatedWords);
     }
 
     /**
@@ -250,13 +271,20 @@ class ContentController extends \OxidEsales\Eshop\Application\Controller\Fronten
 
         return (bool) $blPlain;
     }
+    /**
+     * @deprecated use self::getSeoObjectId instead
+     */
+    protected function _getSeoObjectId() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getSeoObjectId();
+    }
 
     /**
      * Returns active content id to load its seo meta info
      *
      * @return string
      */
-    protected function _getSeoObjectId() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getSeoObjectId()
     {
         return Registry::getConfig()->getRequestParameter('oxcid');
     }
@@ -310,6 +338,13 @@ class ContentController extends \OxidEsales\Eshop\Application\Controller\Fronten
 
         return $this->_oContent;
     }
+    /**
+     * @deprecated use self::getSubject instead
+     */
+    protected function _getSubject($iLang) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getSubject($iLang);
+    }
 
     /**
      * returns object, assosiated with current view.
@@ -319,9 +354,16 @@ class ContentController extends \OxidEsales\Eshop\Application\Controller\Fronten
      *
      * @return object
      */
-    protected function _getSubject($iLang) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getSubject($iLang)
     {
         return $this->getContent();
+    }
+    /**
+     * @deprecated use self::getTplName instead
+     */
+    protected function _getTplName() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getTplName();
     }
 
     /**
@@ -329,7 +371,7 @@ class ContentController extends \OxidEsales\Eshop\Application\Controller\Fronten
      *
      * @return string
      */
-    protected function _getTplName() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getTplName()
     {
         // assign template name
         $sTplName = Registry::getConfig()->getRequestParameter('tpl');

--- a/source/Application/Controller/CreditsController.php
+++ b/source/Application/Controller/CreditsController.php
@@ -18,13 +18,20 @@ class CreditsController extends \OxidEsales\Eshop\Application\Controller\Content
      * @var string
      */
     protected $_sContentId = "oxcredits";
+    /**
+     * @deprecated use self::getSeoObjectId instead
+     */
+    protected function _getSeoObjectId() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getSeoObjectId();
+    }
 
     /**
      * Returns active content id to load its seo meta info
      *
      * @return string
      */
-    protected function _getSeoObjectId() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getSeoObjectId()
     {
         return $this->getContentId();
     }

--- a/source/Application/Controller/ExceptionErrorController.php
+++ b/source/Application/Controller/ExceptionErrorController.php
@@ -41,13 +41,20 @@ class ExceptionErrorController extends \OxidEsales\Eshop\Application\Controller\
         // resetting errors from session
         \OxidEsales\Eshop\Core\Registry::getSession()->setVariable('Errors', []);
     }
+    /**
+     * @deprecated use self::getErrors instead
+     */
+    protected function _getErrors() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getErrors();
+    }
 
     /**
      * return page errors array
      *
      * @return array
      */
-    protected function _getErrors() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getErrors()
     {
         $aErrors = \OxidEsales\Eshop\Core\Registry::getSession()->getVariable('Errors');
 

--- a/source/Application/Controller/FrontendController.php
+++ b/source/Application/Controller/FrontendController.php
@@ -451,6 +451,13 @@ class FrontendController extends \OxidEsales\Eshop\Core\Controller\BaseControlle
 
         return $count;
     }
+    /**
+     * @deprecated use self::getComponentNames instead
+     */
+    protected function _getComponentNames() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getComponentNames();
+    }
 
     /**
      * Returns component names.
@@ -460,7 +467,7 @@ class FrontendController extends \OxidEsales\Eshop\Core\Controller\BaseControlle
      *
      * @return array
      */
-    protected function _getComponentNames() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getComponentNames()
     {
         if (self::$_aCollectedComponentNames === null) {
             self::$_aCollectedComponentNames = array_merge($this->_aComponentNames, $this->_aUserComponentNames);
@@ -479,6 +486,13 @@ class FrontendController extends \OxidEsales\Eshop\Core\Controller\BaseControlle
 
         return self::$_aCollectedComponentNames;
     }
+    /**
+     * @deprecated use self::processRequest instead
+     */
+    protected function _processRequest() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->processRequest();
+    }
 
     /**
      * In non admin mode checks if request was NOT processed by seo handler.
@@ -486,7 +500,7 @@ class FrontendController extends \OxidEsales\Eshop\Core\Controller\BaseControlle
      * redirects to it. If no alternative path was found - 404 header is emitted
      * and page is rendered
      */
-    protected function _processRequest() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function processRequest()
     {
         $utils = Registry::getUtils();
 
@@ -1018,6 +1032,13 @@ class FrontendController extends \OxidEsales\Eshop\Core\Controller\BaseControlle
     {
         return $this->_sMetaKeywords = $keywords;
     }
+    /**
+     * @deprecated use self::getMetaFromSeo instead
+     */
+    protected function _getMetaFromSeo($dataType) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getMetaFromSeo($dataType);
+    }
 
     /**
      * Fetches meta data (description or keywords) from seo table
@@ -1026,7 +1047,7 @@ class FrontendController extends \OxidEsales\Eshop\Core\Controller\BaseControlle
      *
      * @return string
      */
-    protected function _getMetaFromSeo($dataType) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getMetaFromSeo($dataType)
     {
         $seoObjectId = $this->_getSeoObjectId();
         $baseLanguageId = Registry::getLang()->getBaseLanguage();
@@ -1039,6 +1060,13 @@ class FrontendController extends \OxidEsales\Eshop\Core\Controller\BaseControlle
             return $keywords;
         }
     }
+    /**
+     * @deprecated use self::getMetaFromContent instead
+     */
+    protected function _getMetaFromContent($metaIdent) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getMetaFromContent($metaIdent);
+    }
 
     /**
      * Fetches meta data (description or keywords) from content table
@@ -1047,7 +1075,7 @@ class FrontendController extends \OxidEsales\Eshop\Core\Controller\BaseControlle
      *
      * @return string
      */
-    protected function _getMetaFromContent($metaIdent) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getMetaFromContent($metaIdent)
     {
         if ($metaIdent) {
             $content = oxNew(\OxidEsales\Eshop\Application\Model\Content::class);
@@ -1140,11 +1168,18 @@ class FrontendController extends \OxidEsales\Eshop\Core\Controller\BaseControlle
 
         return $this->_iCompItemsCnt;
     }
+    /**
+     * @deprecated use self::forceNoIndex instead
+     */
+    protected function _forceNoIndex() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->forceNoIndex();
+    }
 
     /**
      * Forces output no index meta data for current view
      */
-    protected function _forceNoIndex() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function forceNoIndex()
     {
         $this->_blForceNoIndex = true;
     }
@@ -1194,11 +1229,18 @@ class FrontendController extends \OxidEsales\Eshop\Core\Controller\BaseControlle
     {
         $this->_aMenueList = $menu;
     }
+    /**
+     * @deprecated use self::setNrOfArtPerPage instead
+     */
+    protected function _setNrOfArtPerPage() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->setNrOfArtPerPage();
+    }
 
     /**
      * Sets number of articles per page to config value
      */
-    protected function _setNrOfArtPerPage() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function setNrOfArtPerPage()
     {
         $config = $this->getConfig();
 
@@ -1249,12 +1291,26 @@ class FrontendController extends \OxidEsales\Eshop\Core\Controller\BaseControlle
         //setting number of articles per page to config value
         $config->setConfigParam('iNrofCatArticles', $numberOfCategoryArticles);
     }
+    /**
+     * @deprecated use self::getSeoObjectId instead
+     */
+    protected function _getSeoObjectId() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getSeoObjectId();
+    }
 
     /**
      * Override this function to return object it which is used to identify its seo meta info
      */
-    protected function _getSeoObjectId() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getSeoObjectId()
     {
+    }
+    /**
+     * @deprecated use self::prepareMetaDescription instead
+     */
+    protected function _prepareMetaDescription($meta, $length = 1024, $removeDuplicatedWords = false) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->prepareMetaDescription($meta, $length, $removeDuplicatedWords);
     }
 
     /**
@@ -1266,7 +1322,7 @@ class FrontendController extends \OxidEsales\Eshop\Core\Controller\BaseControlle
      *
      * @return  string  $string    converted string
      */
-    protected function _prepareMetaDescription($meta, $length = 1024, $removeDuplicatedWords = false) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function prepareMetaDescription($meta, $length = 1024, $removeDuplicatedWords = false)
     {
         if ($meta) {
             $stringModifier = getStr();
@@ -1303,6 +1359,13 @@ class FrontendController extends \OxidEsales\Eshop\Core\Controller\BaseControlle
             return trim($meta);
         }
     }
+    /**
+     * @deprecated use self::prepareMetaKeyword instead
+     */
+    protected function _prepareMetaKeyword($keywords, $removeDuplicatedWords = true) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->prepareMetaKeyword($keywords, $removeDuplicatedWords);
+    }
 
     /**
      * Returns current view keywords separated by comma
@@ -1312,7 +1375,7 @@ class FrontendController extends \OxidEsales\Eshop\Core\Controller\BaseControlle
      *
      * @return string of keywords separated by comma
      */
-    protected function _prepareMetaKeyword($keywords, $removeDuplicatedWords = true) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function prepareMetaKeyword($keywords, $removeDuplicatedWords = true)
     {
         $string = $this->_prepareMetaDescription($keywords, -1, false);
 
@@ -1321,6 +1384,13 @@ class FrontendController extends \OxidEsales\Eshop\Core\Controller\BaseControlle
         }
 
         return trim($string);
+    }
+    /**
+     * @deprecated use self::removeDuplicatedWords instead
+     */
+    protected function _removeDuplicatedWords($input, $skipTags = []) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->removeDuplicatedWords($input, $skipTags);
     }
 
     /**
@@ -1331,7 +1401,7 @@ class FrontendController extends \OxidEsales\Eshop\Core\Controller\BaseControlle
      *
      * @return string of words separated by comma
      */
-    protected function _removeDuplicatedWords($input, $skipTags = []) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function removeDuplicatedWords($input, $skipTags = [])
     {
         $stringModifier = getStr();
         if (is_array($input)) {
@@ -1500,6 +1570,13 @@ class FrontendController extends \OxidEsales\Eshop\Core\Controller\BaseControlle
 
         return implode(' | ', $titleParts);
     }
+    /**
+     * @deprecated use self::getSubject instead
+     */
+    protected function _getSubject($languageId) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getSubject($languageId);
+    }
 
 
     /**
@@ -1510,7 +1587,7 @@ class FrontendController extends \OxidEsales\Eshop\Core\Controller\BaseControlle
      *
      * @return object
      */
-    protected function _getSubject($languageId) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getSubject($languageId)
     {
         return null;
     }
@@ -1624,6 +1701,13 @@ class FrontendController extends \OxidEsales\Eshop\Core\Controller\BaseControlle
     public function getSearchParamForHtml()
     {
     }
+    /**
+     * @deprecated use self::getRequestParams instead
+     */
+    protected function _getRequestParams($addPageNumber = true) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getRequestParams($addPageNumber);
+    }
 
     /**
      * collects _GET parameters used by eShop and returns uri
@@ -1632,7 +1716,7 @@ class FrontendController extends \OxidEsales\Eshop\Core\Controller\BaseControlle
      *
      * @return string
      */
-    protected function _getRequestParams($addPageNumber = true) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getRequestParams($addPageNumber = true)
     {
         $class = $this->getClassName();
         $function = $this->getFncName();
@@ -1715,13 +1799,20 @@ class FrontendController extends \OxidEsales\Eshop\Core\Controller\BaseControlle
 
         return $url;
     }
+    /**
+     * @deprecated use self::getSeoRequestParams instead
+     */
+    protected function _getSeoRequestParams() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getSeoRequestParams();
+    }
 
     /**
      * collects _GET parameters used by eShop SEO and returns uri
      *
      * @return string
      */
-    protected function _getSeoRequestParams() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getSeoRequestParams()
     {
         $class = $this->getClassName();
         $function = $this->getFncName();
@@ -1980,6 +2071,13 @@ class FrontendController extends \OxidEsales\Eshop\Core\Controller\BaseControlle
     {
         return $this->getConfig()->getShopHomeUrl() . $this->_getRequestParams(false);
     }
+    /**
+     * @deprecated use self::addPageNrParam instead
+     */
+    protected function _addPageNrParam($url, $page, $languageId = null) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->addPageNrParam($url, $page, $languageId);
+    }
 
     /**
      * Adds page number parameter to url and returns modified url, if page number 0 drops from url
@@ -1990,7 +2088,7 @@ class FrontendController extends \OxidEsales\Eshop\Core\Controller\BaseControlle
      *
      * @return string
      */
-    protected function _addPageNrParam($url, $page, $languageId = null) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function addPageNrParam($url, $page, $languageId = null)
     {
         if ($page) {
             if ((strpos($url, 'pgNr='))) {
@@ -2404,13 +2502,20 @@ class FrontendController extends \OxidEsales\Eshop\Core\Controller\BaseControlle
     {
         return $this->_iNewsRealStatus;
     }
+    /**
+     * @deprecated use self::canRedirect instead
+     */
+    protected function _canRedirect() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->canRedirect();
+    }
 
     /**
      * Checks if current request parameters does not block SEO redirection process
      *
      * @return bool
      */
-    protected function _canRedirect() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function canRedirect()
     {
         foreach ($this->_aBlockRedirectParams as $param) {
             if ($this->getConfig()->getRequestParameter($param) !== null) {

--- a/source/Application/Controller/ManufacturerListController.php
+++ b/source/Application/Controller/ManufacturerListController.php
@@ -117,15 +117,29 @@ class ManufacturerListController extends \OxidEsales\Eshop\Application\Controlle
 
         return $this->_sThisTemplate;
     }
+    /**
+     * @deprecated use self::getProductLinkType instead
+     */
+    protected function _getProductLinkType() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getProductLinkType();
+    }
 
     /**
      * Returns product link type (OXARTICLE_LINKTYPE_MANUFACTURER)
      *
      * @return int
      */
-    protected function _getProductLinkType() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getProductLinkType()
     {
         return OXARTICLE_LINKTYPE_MANUFACTURER;
+    }
+    /**
+     * @deprecated use self::loadArticles instead
+     */
+    protected function _loadArticles($oManufacturer) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->loadArticles($oManufacturer);
     }
 
     /**
@@ -135,7 +149,7 @@ class ManufacturerListController extends \OxidEsales\Eshop\Application\Controlle
      *
      * @return array
      */
-    protected function _loadArticles($oManufacturer) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function loadArticles($oManufacturer)
     {
         $sManufacturerId = $oManufacturer->getId();
 
@@ -155,17 +169,31 @@ class ManufacturerListController extends \OxidEsales\Eshop\Application\Controlle
 
         return [$oArtList, $this->_iAllArtCnt];
     }
+    /**
+     * @deprecated use self::getSeoObjectId instead
+     */
+    protected function _getSeoObjectId() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getSeoObjectId();
+    }
 
     /**
      * Returns active product id to load its seo meta info
      *
      * @return string
      */
-    protected function _getSeoObjectId() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getSeoObjectId()
     {
         if (($oManufacturer = $this->getActManufacturer())) {
             return $oManufacturer->getId();
         }
+    }
+    /**
+     * @deprecated use self::addPageNrParam instead
+     */
+    protected function _addPageNrParam($sUrl, $iPage, $iLang = null) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->addPageNrParam($sUrl, $iPage, $iLang);
     }
 
     /**
@@ -178,7 +206,7 @@ class ManufacturerListController extends \OxidEsales\Eshop\Application\Controlle
      *
      * @return string
      */
-    protected function _addPageNrParam($sUrl, $iPage, $iLang = null) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function addPageNrParam($sUrl, $iPage, $iLang = null)
     {
         if (Registry::getUtils()->seoIsActive() && ($oManufacturer = $this->getActManufacturer())) {
             if ($iPage) {
@@ -187,7 +215,7 @@ class ManufacturerListController extends \OxidEsales\Eshop\Application\Controlle
             }
         }
 
-        return parent::_addPageNrParam($sUrl, $iPage, $iLang);
+        return parent::addPageNrParam($sUrl, $iPage, $iLang);
     }
 
     /**
@@ -341,6 +369,13 @@ class ManufacturerListController extends \OxidEsales\Eshop\Application\Controlle
             return $this->getConfig()->getActiveShop()->oxshops__oxtitlesuffix->value;
         }
     }
+    /**
+     * @deprecated use self::prepareMetaKeyword instead
+     */
+    protected function _prepareMetaKeyword($aCatPath, $blRemoveDuplicatedWords = true) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->prepareMetaKeyword($aCatPath, $blRemoveDuplicatedWords);
+    }
 
     /**
      * Calls and returns result of parent:: _collectMetaKeyword();
@@ -350,9 +385,16 @@ class ManufacturerListController extends \OxidEsales\Eshop\Application\Controlle
      *
      * @return string
      */
-    protected function _prepareMetaKeyword($aCatPath, $blRemoveDuplicatedWords = true) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function prepareMetaKeyword($aCatPath, $blRemoveDuplicatedWords = true)
     {
-        return parent::_collectMetaKeyword($aCatPath);
+        return parent::collectMetaKeyword($aCatPath);
+    }
+    /**
+     * @deprecated use self::prepareMetaDescription instead
+     */
+    protected function _prepareMetaDescription($aCatPath, $iLength = 1024, $blDescTag = false) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->prepareMetaDescription($aCatPath, $iLength, $blDescTag);
     }
 
     /**
@@ -367,9 +409,16 @@ class ManufacturerListController extends \OxidEsales\Eshop\Application\Controlle
      *
      * @return  string  $sString    converted string
      */
-    protected function _prepareMetaDescription($aCatPath, $iLength = 1024, $blDescTag = false) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function prepareMetaDescription($aCatPath, $iLength = 1024, $blDescTag = false)
     {
-        return parent::_collectMetaDescription($aCatPath, $iLength, $blDescTag);
+        return parent::collectMetaDescription($aCatPath, $iLength, $blDescTag);
+    }
+    /**
+     * @deprecated use self::getSubject instead
+     */
+    protected function _getSubject($iLang) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getSubject($iLang);
     }
 
     /**
@@ -380,7 +429,7 @@ class ManufacturerListController extends \OxidEsales\Eshop\Application\Controlle
      *
      * @return object
      */
-    protected function _getSubject($iLang) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getSubject($iLang)
     {
         return $this->getActManufacturer();
     }

--- a/source/Application/Controller/OrderController.php
+++ b/source/Application/Controller/OrderController.php
@@ -487,6 +487,13 @@ class OrderController extends \OxidEsales\Eshop\Application\Controller\FrontendC
     {
         return oxNew('oxBasketContentMarkGenerator', $this->getBasket());
     }
+    /**
+     * @deprecated use self::getNextStep instead
+     */
+    protected function _getNextStep($iSuccess) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getNextStep($iSuccess);
+    }
 
     /**
      * Returns next order step. If ordering was sucessfull - returns string "thankyou" (possible
@@ -497,7 +504,7 @@ class OrderController extends \OxidEsales\Eshop\Application\Controller\FrontendC
      *
      * @return  string  $sNextStep  partial parameter url for next step
      */
-    protected function _getNextStep($iSuccess) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getNextStep($iSuccess)
     {
         $sNextStep = 'thankyou';
 
@@ -535,13 +542,20 @@ class OrderController extends \OxidEsales\Eshop\Application\Controller\FrontendC
 
         return $sNextStep;
     }
+    /**
+     * @deprecated use self::validateTermsAndConditions instead
+     */
+    protected function _validateTermsAndConditions() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->validateTermsAndConditions();
+    }
 
     /**
      * Validates whether necessary terms and conditions checkboxes were checked.
      *
      * @return bool
      */
-    protected function _validateTermsAndConditions() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function validateTermsAndConditions()
     {
         $blValid = true;
         $oConfig = $this->getConfig();

--- a/source/Application/Controller/OxidStartController.php
+++ b/source/Application/Controller/OxidStartController.php
@@ -100,13 +100,20 @@ class OxidStartController extends \OxidEsales\Eshop\Application\Controller\Front
             'unknown' => 'message/err_unknown.tpl',
         ];
     }
+    /**
+     * @deprecated use self::getSystemEventHandler instead
+     */
+    protected function _getSystemEventHandler() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getSystemEventHandler();
+    }
 
     /**
      * Gets system event handler.
      *
      * @return SystemEventHandler
      */
-    protected function _getSystemEventHandler() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getSystemEventHandler()
     {
         return oxNew(\OxidEsales\Eshop\Core\SystemEventHandler::class);
     }

--- a/source/Application/Controller/PaymentController.php
+++ b/source/Application/Controller/PaymentController.php
@@ -203,13 +203,20 @@ class PaymentController extends \OxidEsales\Eshop\Application\Controller\Fronten
 
         return $this->_sThisTemplate;
     }
+    /**
+     * @deprecated use self::setDefaultEmptyPayment instead
+     */
+    protected function _setDefaultEmptyPayment() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->setDefaultEmptyPayment();
+    }
 
     /**
      * Set default empty payment. If config param 'blOtherCountryOrder' is on,
      * tries to set 'oxempty' payment to aViewData['oxemptypayment'].
      * On error sets aViewData['payerror'] to -2
      */
-    protected function _setDefaultEmptyPayment() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function setDefaultEmptyPayment()
     {
         // no shipping method there !!
         if ($this->getConfig()->getConfigParam('blOtherCountryOrder')) {
@@ -224,11 +231,18 @@ class PaymentController extends \OxidEsales\Eshop\Application\Controller\Fronten
             $this->_sPaymentError = -2;
         }
     }
+    /**
+     * @deprecated use self::unsetPaymentErrors instead
+     */
+    protected function _unsetPaymentErrors() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->unsetPaymentErrors();
+    }
 
     /**
      * Unsets payment errors from session
      */
-    protected function _unsetPaymentErrors() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function unsetPaymentErrors()
     {
         $iPayError = Registry::getConfig()->getRequestParameter('payerror');
         $sPayErrorText = Registry::getConfig()->getRequestParameter('payerrortext');
@@ -412,6 +426,13 @@ class PaymentController extends \OxidEsales\Eshop\Application\Controller\Fronten
 
         return $this->_iAllSetsCnt;
     }
+    /**
+     * @deprecated use self::setValues instead
+     */
+    protected function _setValues(&$aPaymentList, $oBasket = null) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->setValues($aPaymentList, $oBasket);
+    }
 
     /**
      * Calculate payment cost for each payment. Sould be removed later
@@ -419,7 +440,7 @@ class PaymentController extends \OxidEsales\Eshop\Application\Controller\Fronten
      * @param array                                      $aPaymentList payments array
      * @param \OxidEsales\Eshop\Application\Model\Basket $oBasket      basket object
      */
-    protected function _setValues(&$aPaymentList, $oBasket = null) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function setValues(&$aPaymentList, $oBasket = null)
     {
         if (is_array($aPaymentList)) {
             foreach ($aPaymentList as $oPayment) {
@@ -511,12 +532,19 @@ class PaymentController extends \OxidEsales\Eshop\Application\Controller\Fronten
 
         return $this->_aDynValue;
     }
+    /**
+     * @deprecated use self::assignDebitNoteParams instead
+     */
+    protected function _assignDebitNoteParams() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->assignDebitNoteParams();
+    }
 
     /**
      * Assign debit note payment values to view data. Loads user debit note payment
      * if available and assigns payment data to $this->_aDynValue
      */
-    protected function _assignDebitNoteParams() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function assignDebitNoteParams()
     {
         // #701A
         $oUserPayment = oxNew(\OxidEsales\Eshop\Application\Model\UserPayment::class);
@@ -615,6 +643,13 @@ class PaymentController extends \OxidEsales\Eshop\Application\Controller\Fronten
 
         return $this->_aCreditYears;
     }
+    /**
+     * @deprecated use self::checkArrValuesEmpty instead
+     */
+    protected function _checkArrValuesEmpty($aData, $aKeys) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->checkArrValuesEmpty($aData, $aKeys);
+    }
 
     /**
      * Function to check if array values are empty againts given array keys
@@ -624,7 +659,7 @@ class PaymentController extends \OxidEsales\Eshop\Application\Controller\Fronten
      *
      * @return bool
      */
-    protected function _checkArrValuesEmpty($aData, $aKeys) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function checkArrValuesEmpty($aData, $aKeys)
     {
         if (!is_array($aKeys) || count($aKeys) < 1) {
             return false;
@@ -637,6 +672,13 @@ class PaymentController extends \OxidEsales\Eshop\Application\Controller\Fronten
         }
 
         return true;
+    }
+    /**
+     * @deprecated use self::filterDynData instead
+     */
+    protected function _filterDynData() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->filterDynData();
     }
 
 
@@ -652,7 +694,7 @@ class PaymentController extends \OxidEsales\Eshop\Application\Controller\Fronten
      *
      * @return null
      */
-    protected function _filterDynData() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function filterDynData()
     {
         //in case we actually ARE allowed to store the data
         if (Registry::getConfig()->getConfigParam("blStoreCreditCardInfo")) {

--- a/source/Application/Controller/PriceAlarmController.php
+++ b/source/Application/Controller/PriceAlarmController.php
@@ -129,13 +129,20 @@ class PriceAlarmController extends \OxidEsales\Eshop\Application\Controller\Fron
 
         return $this->_oArticle;
     }
+    /**
+     * @deprecated use self::getParams instead
+     */
+    private function _getParams() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getParams();
+    }
 
     /**
      * Returns params (article id, bid price)
      *
      * @return array
      */
-    private function _getParams() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    private function getParams()
     {
         return Registry::getConfig()->getRequestParameter('pa');
     }

--- a/source/Application/Controller/RecommListController.php
+++ b/source/Application/Controller/RecommListController.php
@@ -148,13 +148,20 @@ class RecommListController extends \OxidEsales\Eshop\Application\Controller\Arti
 
         return $this->_sThisTemplate;
     }
+    /**
+     * @deprecated use self::getProductLinkType instead
+     */
+    protected function _getProductLinkType() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getProductLinkType();
+    }
 
     /**
      * Returns product link type (OXARTICLE_LINKTYPE_RECOMM)
      *
      * @return int
      */
-    protected function _getProductLinkType() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getProductLinkType()
     {
         return OXARTICLE_LINKTYPE_RECOMM;
     }
@@ -477,6 +484,13 @@ class RecommListController extends \OxidEsales\Eshop\Application\Controller\Arti
 
         return \OxidEsales\Eshop\Application\Controller\FrontendController::generatePageNavigationUrl();
     }
+    /**
+     * @deprecated use self::addPageNrParam instead
+     */
+    protected function _addPageNrParam($sUrl, $iPage, $iLang = null) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->addPageNrParam($sUrl, $iPage, $iLang);
+    }
 
     /**
      * Adds page number parameter to current Url and returns formatted url
@@ -487,7 +501,7 @@ class RecommListController extends \OxidEsales\Eshop\Application\Controller\Arti
      *
      * @return string
      */
-    protected function _addPageNrParam($sUrl, $iPage, $iLang = null) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function addPageNrParam($sUrl, $iPage, $iLang = null)
     {
         if (Registry::getUtils()->seoIsActive() && ($oRecomm = $this->getActiveRecommList())) {
             if ($iPage) {
@@ -495,7 +509,7 @@ class RecommListController extends \OxidEsales\Eshop\Application\Controller\Arti
                 $sUrl = $oRecomm->getBaseSeoLink($iLang, $iPage);
             }
         } else {
-            $sUrl = \OxidEsales\Eshop\Application\Controller\FrontendController::_addPageNrParam($sUrl, $iPage, $iLang);
+            $sUrl = \OxidEsales\Eshop\Application\Controller\FrontendController::addPageNrParam($sUrl, $iPage, $iLang);
         }
 
         return $sUrl;

--- a/source/Application/Controller/ReviewController.php
+++ b/source/Application/Controller/ReviewController.php
@@ -273,13 +273,20 @@ class ReviewController extends \OxidEsales\Eshop\Application\Controller\ArticleD
     {
         return Registry::getConfig()->getRequestParameter('reviewuserhash');
     }
+    /**
+     * @deprecated use self::getActiveObject instead
+     */
+    protected function _getActiveObject() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getActiveObject();
+    }
 
     /**
      * Template variable getter. Returns active object (oxarticle or oxrecommlist)
      *
      * @return object
      */
-    protected function _getActiveObject() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getActiveObject()
     {
         if ($this->_oActObject === null) {
             $this->_oActObject = false;
@@ -295,13 +302,20 @@ class ReviewController extends \OxidEsales\Eshop\Application\Controller\ArticleD
 
         return $this->_oActObject;
     }
+    /**
+     * @deprecated use self::getActiveType instead
+     */
+    protected function _getActiveType() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getActiveType();
+    }
 
     /**
      * Template variable getter. Returns active type (oxarticle or oxrecommlist)
      *
      * @return string
      */
-    protected function _getActiveType() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getActiveType()
     {
         if ($this->getProduct()) {
             return 'oxarticle';

--- a/source/Application/Controller/RssController.php
+++ b/source/Application/Controller/RssController.php
@@ -43,13 +43,20 @@ class RssController extends \OxidEsales\Eshop\Application\Controller\FrontendCon
      * @var string
      */
     protected $_sThisTemplate = 'widget/rss.tpl';
+    /**
+     * @deprecated use self::getRssFeed instead
+     */
+    protected function _getRssFeed() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getRssFeed();
+    }
 
     /**
      * get RssFeed
      *
      * @return RssFeed
      */
-    protected function _getRssFeed() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getRssFeed()
     {
         if (!$this->_oRss) {
             $this->_oRss = oxNew(RssFeed::class);
@@ -98,6 +105,13 @@ class RssController extends \OxidEsales\Eshop\Application\Controller\FrontendCon
             ->get(TemplateRendererBridgeInterface::class)
             ->getTemplateRenderer();
     }
+    /**
+     * @deprecated use self::processOutput instead
+     */
+    protected function _processOutput($sInput) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->processOutput($sInput);
+    }
 
     /**
      * Processes xml before outputting to user
@@ -106,7 +120,7 @@ class RssController extends \OxidEsales\Eshop\Application\Controller\FrontendCon
      *
      * @return string
      */
-    protected function _processOutput($sInput) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function processOutput($sInput)
     {
         return getStr()->recodeEntities($sInput);
     }

--- a/source/Application/Controller/SearchController.php
+++ b/source/Application/Controller/SearchController.php
@@ -232,12 +232,19 @@ class SearchController extends \OxidEsales\Eshop\Application\Controller\Frontend
 
         return $this->_sThisTemplate;
     }
+    /**
+     * @deprecated use self::processListArticles instead
+     */
+    protected function _processListArticles() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->processListArticles();
+    }
 
     /**
      * Iterates through list articles and performs list view specific tasks:
      *  - sets type of link which needs to be generated (Manufacturer link)
      */
-    protected function _processListArticles() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function processListArticles()
     {
         $sAddDynParams = $this->getAddUrlParams();
         if ($sAddDynParams && ($aArtList = $this->getArticleList())) {
@@ -282,13 +289,20 @@ class SearchController extends \OxidEsales\Eshop\Application\Controller\Frontend
 
         return $sAddParams;
     }
+    /**
+     * @deprecated use self::isSearchClass instead
+     */
+    protected function _isSearchClass() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->isSearchClass();
+    }
 
     /**
      * Template variable getter. Returns similar recommendation lists
      *
      * @return object
      */
-    protected function _isSearchClass() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function isSearchClass()
     {
         if ($this->_blSearchClass === null) {
             $this->_blSearchClass = false;
@@ -482,13 +496,20 @@ class SearchController extends \OxidEsales\Eshop\Application\Controller\Frontend
     {
         return $this->getConfig()->getConfigParam('blShowListDisplayType');
     }
+    /**
+     * @deprecated use self::canRedirect instead
+     */
+    protected function _canRedirect() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->canRedirect();
+    }
 
     /**
      * Checks if current request parameters does not block SEO redirection process
      *
      * @return bool
      */
-    protected function _canRedirect() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function canRedirect()
     {
         return false;
     }

--- a/source/Application/Controller/StartController.php
+++ b/source/Application/Controller/StartController.php
@@ -130,6 +130,13 @@ class StartController extends \OxidEsales\Eshop\Application\Controller\FrontendC
 
         return $this->_sThisTemplate;
     }
+    /**
+     * @deprecated use self::prepareMetaDescription instead
+     */
+    protected function _prepareMetaDescription($sMeta, $iLength = 1024, $blDescTag = false) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->prepareMetaDescription($sMeta, $iLength, $blDescTag);
+    }
 
     /**
      * Returns current view meta data
@@ -142,7 +149,7 @@ class StartController extends \OxidEsales\Eshop\Application\Controller\FrontendC
      *
      * @return string
      */
-    protected function _prepareMetaDescription($sMeta, $iLength = 1024, $blDescTag = false) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function prepareMetaDescription($sMeta, $iLength = 1024, $blDescTag = false)
     {
         if (
             !$sMeta &&
@@ -153,7 +160,14 @@ class StartController extends \OxidEsales\Eshop\Application\Controller\FrontendC
             $sMeta = $oArt->oxarticles__oxtitle->value . ' - ' . $oDescField->value;
         }
 
-        return parent::_prepareMetaDescription($sMeta, $iLength, $blDescTag);
+        return parent::prepareMetaDescription($sMeta, $iLength, $blDescTag);
+    }
+    /**
+     * @deprecated use self::prepareMetaKeyword instead
+     */
+    protected function _prepareMetaKeyword($sKeywords, $blRemoveDuplicatedWords = true) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->prepareMetaKeyword($sKeywords, $blRemoveDuplicatedWords);
     }
 
     /**
@@ -166,7 +180,7 @@ class StartController extends \OxidEsales\Eshop\Application\Controller\FrontendC
      *
      * @return string
      */
-    protected function _prepareMetaKeyword($sKeywords, $blRemoveDuplicatedWords = true) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function prepareMetaKeyword($sKeywords, $blRemoveDuplicatedWords = true)
     {
         if (
             !$sKeywords &&
@@ -177,7 +191,14 @@ class StartController extends \OxidEsales\Eshop\Application\Controller\FrontendC
             $sKeywords = $oDescField->value;
         }
 
-        return parent::_prepareMetaKeyword($sKeywords, $blRemoveDuplicatedWords);
+        return parent::prepareMetaKeyword($sKeywords, $blRemoveDuplicatedWords);
+    }
+    /**
+     * @deprecated use self::getLoadActionsParam instead
+     */
+    protected function _getLoadActionsParam() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getLoadActionsParam();
     }
 
     /**
@@ -185,7 +206,7 @@ class StartController extends \OxidEsales\Eshop\Application\Controller\FrontendC
      *
      * @return string
      */
-    protected function _getLoadActionsParam() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getLoadActionsParam()
     {
         if ($this->_blLoadActions === null) {
             $this->_blLoadActions = false;

--- a/source/Application/Controller/VendorListController.php
+++ b/source/Application/Controller/VendorListController.php
@@ -114,15 +114,29 @@ class VendorListController extends \OxidEsales\Eshop\Application\Controller\Arti
 
         return $this->_sThisTemplate;
     }
+    /**
+     * @deprecated use self::getProductLinkType instead
+     */
+    protected function _getProductLinkType() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getProductLinkType();
+    }
 
     /**
      * Returns product link type (OXARTICLE_LINKTYPE_VENDOR)
      *
      * @return int
      */
-    protected function _getProductLinkType() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getProductLinkType()
     {
         return OXARTICLE_LINKTYPE_VENDOR;
+    }
+    /**
+     * @deprecated use self::loadArticles instead
+     */
+    protected function _loadArticles($oVendor) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->loadArticles($oVendor);
     }
 
     /**
@@ -132,7 +146,7 @@ class VendorListController extends \OxidEsales\Eshop\Application\Controller\Arti
      *
      * @return array
      */
-    protected function _loadArticles($oVendor) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function loadArticles($oVendor)
     {
         $sVendorId = $oVendor->getId();
 
@@ -152,17 +166,31 @@ class VendorListController extends \OxidEsales\Eshop\Application\Controller\Arti
 
         return [$oArtList, $this->_iAllArtCnt];
     }
+    /**
+     * @deprecated use self::getSeoObjectId instead
+     */
+    protected function _getSeoObjectId() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getSeoObjectId();
+    }
 
     /**
      * Returns active product id to load its seo meta info
      *
      * @return string
      */
-    protected function _getSeoObjectId() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getSeoObjectId()
     {
         if (($oVendor = $this->getActVendor())) {
             return $oVendor->getId();
         }
+    }
+    /**
+     * @deprecated use self::addPageNrParam instead
+     */
+    protected function _addPageNrParam($sUrl, $iPage, $iLang = null) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->addPageNrParam($sUrl, $iPage, $iLang);
     }
 
     /**
@@ -175,7 +203,7 @@ class VendorListController extends \OxidEsales\Eshop\Application\Controller\Arti
      *
      * @return string
      */
-    protected function _addPageNrParam($sUrl, $iPage, $iLang = null) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function addPageNrParam($sUrl, $iPage, $iLang = null)
     {
         if (\OxidEsales\Eshop\Core\Registry::getUtils()->seoIsActive() && ($oVendor = $this->getActVendor())) {
             if ($iPage) {
@@ -183,7 +211,7 @@ class VendorListController extends \OxidEsales\Eshop\Application\Controller\Arti
                 $sUrl = $oVendor->getBaseSeoLink($iLang, $iPage);
             }
         } else {
-            $sUrl = \OxidEsales\Eshop\Application\Controller\FrontendController::_addPageNrParam($sUrl, $iPage, $iLang);
+            $sUrl = \OxidEsales\Eshop\Application\Controller\FrontendController::addPageNrParam($sUrl, $iPage, $iLang);
         }
 
         return $sUrl;
@@ -348,24 +376,38 @@ class VendorListController extends \OxidEsales\Eshop\Application\Controller\Arti
             return $this->getConfig()->getActiveShop()->oxshops__oxtitlesuffix->value;
         }
     }
+    /**
+     * @deprecated use self::prepareMetaKeyword instead
+     */
+    protected function _prepareMetaKeyword($sKeywords, $blRemoveDuplicatedWords = true) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->prepareMetaKeyword($sKeywords, $blRemoveDuplicatedWords);
+    }
 
     /**
      * Returns current view keywords separated by comma
-     * (calls parent::_collectMetaKeyword())
+     * (calls parent::collectMetaKeyword())
      *
      * @param string $sKeywords               data to use as keywords
      * @param bool   $blRemoveDuplicatedWords remove duplicated words
      *
      * @return string
      */
-    protected function _prepareMetaKeyword($sKeywords, $blRemoveDuplicatedWords = true) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function prepareMetaKeyword($sKeywords, $blRemoveDuplicatedWords = true)
     {
-        return parent::_collectMetaKeyword($sKeywords);
+        return parent::collectMetaKeyword($sKeywords);
+    }
+    /**
+     * @deprecated use self::prepareMetaDescription instead
+     */
+    protected function _prepareMetaDescription($sMeta, $iLength = 1024, $blDescTag = false) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->prepareMetaDescription($sMeta, $iLength, $blDescTag);
     }
 
     /**
      * Returns current view meta description data
-     * (calls parent::_collectMetaDescription())
+     * (calls parent::collectMetaDescription())
      *
      * @param string $sMeta     category path
      * @param int    $iLength   max length of result, -1 for no truncation
@@ -373,9 +415,16 @@ class VendorListController extends \OxidEsales\Eshop\Application\Controller\Arti
      *
      * @return string
      */
-    protected function _prepareMetaDescription($sMeta, $iLength = 1024, $blDescTag = false) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function prepareMetaDescription($sMeta, $iLength = 1024, $blDescTag = false)
     {
-        return parent::_collectMetaDescription($sMeta, $iLength, $blDescTag);
+        return parent::collectMetaDescription($sMeta, $iLength, $blDescTag);
+    }
+    /**
+     * @deprecated use self::getSubject instead
+     */
+    protected function _getSubject($iLang) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getSubject($iLang);
     }
 
     /**
@@ -386,7 +435,7 @@ class VendorListController extends \OxidEsales\Eshop\Application\Controller\Arti
      *
      * @return object
      */
-    protected function _getSubject($iLang) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getSubject($iLang)
     {
         return $this->getActVendor();
     }

--- a/source/Application/Model/ActionList.php
+++ b/source/Application/Model/ActionList.php
@@ -104,6 +104,13 @@ class ActionList extends \OxidEsales\Eshop\Core\Model\ListModel
                order by oxactiveto, oxactivefrom";
         $this->selectString($sQ);
     }
+    /**
+     * @deprecated use self::getUserGroupFilter instead
+     */
+    protected function _getUserGroupFilter($oUser = null) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getUserGroupFilter($oUser);
+    }
 
     /**
      * Returns part of user group filter query
@@ -112,7 +119,7 @@ class ActionList extends \OxidEsales\Eshop\Core\Model\ListModel
      *
      * @return string
      */
-    protected function _getUserGroupFilter($oUser = null) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getUserGroupFilter($oUser = null)
     {
         $oUser = ($oUser == null) ? $this->getUser() : $oUser;
         $sTable = getViewName('oxactions');

--- a/source/Application/Model/Address.php
+++ b/source/Application/Model/Address.php
@@ -30,13 +30,20 @@ class Address extends \OxidEsales\Eshop\Core\Model\BaseModel
      * @var oxState
      */
     protected $_oStateObject = null;
+    /**
+     * @deprecated use self::getStateObject instead
+     */
+    protected function _getStateObject() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getStateObject();
+    }
 
     /**
      * Returns oxState object
      *
      * @return oxState
      */
-    protected function _getStateObject() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getStateObject()
     {
         if (is_null($this->_oStateObject)) {
             $this->_oStateObject = oxNew(\OxidEsales\Eshop\Application\Model\State::class);
@@ -143,13 +150,20 @@ class Address extends \OxidEsales\Eshop\Core\Model\BaseModel
     {
         $this->_blSelected = true;
     }
+    /**
+     * @deprecated use self::getMergedAddressFields instead
+     */
+    protected function _getMergedAddressFields() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getMergedAddressFields();
+    }
 
     /**
      * Returns merged address fields.
      *
      * @return string
      */
-    protected function _getMergedAddressFields() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getMergedAddressFields()
     {
         $sDelAddress = '';
         $sDelAddress .= $this->oxaddress__oxcompany;

--- a/source/Application/Model/AmountPriceList.php
+++ b/source/Application/Model/AmountPriceList.php
@@ -71,13 +71,20 @@ class AmountPriceList extends \OxidEsales\Eshop\Core\Model\ListModel
 
         $this->assignArray($aData);
     }
+    /**
+     * @deprecated use self::loadFromDb instead
+     */
+    protected function _loadFromDb() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->loadFromDb();
+    }
 
     /**
      * Get data from db
      *
      * @return array
      */
-    protected function _loadFromDb() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function loadFromDb()
     {
         $sArticleId = $this->getArticle()->getId();
         $db = \OxidEsales\Eshop\Core\DatabaseProvider::getDb(\OxidEsales\Eshop\Core\DatabaseProvider::FETCH_MODE_ASSOC);

--- a/source/Application/Model/Article.php
+++ b/source/Application/Model/Article.php
@@ -705,6 +705,13 @@ class Article extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
     {
         return $this->actionType;
     }
+    /**
+     * @deprecated use self::createSqlActiveSnippet instead
+     */
+    protected function _createSqlActiveSnippet($forceCoreTable) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->createSqlActiveSnippet($forceCoreTable);
+    }
 
     /**
      * Returns SQL select string with checks if items are available
@@ -713,7 +720,7 @@ class Article extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
      *
      * @return string
      */
-    protected function _createSqlActiveSnippet($forceCoreTable) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function createSqlActiveSnippet($forceCoreTable)
     {
         // check if article is still active
         $sQ = $this->getActiveCheckQuery($forceCoreTable);
@@ -966,13 +973,20 @@ class Article extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
 
         return $oPrice;
     }
+    /**
+     * @deprecated use self::calculateVarMinPrice instead
+     */
+    protected function _calculateVarMinPrice() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->calculateVarMinPrice();
+    }
 
     /**
      * Calculates lowest price of available article variants.
      *
      * @return double
      */
-    protected function _calculateVarMinPrice() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function calculateVarMinPrice()
     {
         $dPrice = $this->_getVarMinPrice();
 
@@ -1004,13 +1018,20 @@ class Article extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
 
         return $oPrice;
     }
+    /**
+     * @deprecated use self::prepareModifiedPrice instead
+     */
+    protected function _prepareModifiedPrice($dPrice) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->prepareModifiedPrice($dPrice);
+    }
 
     /**
      * @param double $dPrice
      *
      * @return double
      */
-    protected function _prepareModifiedPrice($dPrice) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function prepareModifiedPrice($dPrice)
     {
         $dPrice = $this->_preparePrice($dPrice, $this->getArticleVat());
 
@@ -1134,11 +1155,18 @@ class Article extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
 
         stopProfile('articleAssign');
     }
+    /**
+     * @deprecated use self::setShopValues instead
+     */
+    protected function _setShopValues($article) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->setShopValues($article);
+    }
 
     /**
      * @param \OxidEsales\Eshop\Application\Model\Article $article
      */
-    protected function _setShopValues($article) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function setShopValues($article)
     {
     }
 
@@ -1173,6 +1201,13 @@ class Article extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
 
         return false;
     }
+    /**
+     * @deprecated use self::loadData instead
+     */
+    protected function _loadData($articleId) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->loadData($articleId);
+    }
 
     /**
      * Loads data from database and returns it.
@@ -1181,7 +1216,7 @@ class Article extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
      *
      * @return array
      */
-    protected function _loadData($articleId) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function loadData($articleId)
     {
         return $this->_loadFromDb($articleId);
     }
@@ -1816,11 +1851,18 @@ class Article extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
 
         return null;
     }
+    /**
+     * @deprecated use self::createMultilanguageVendorObject instead
+     */
+    protected function _createMultilanguageVendorObject() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->createMultilanguageVendorObject();
+    }
 
     /**
      * @return oxi18n
      */
-    protected function _createMultilanguageVendorObject() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function createMultilanguageVendorObject()
     {
         $oVendor = oxNew(\OxidEsales\Eshop\Core\Model\MultiLanguageModel::class);
         $oVendor->init('oxvendor');
@@ -2054,6 +2096,13 @@ class Article extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
 
         return $dPrice;
     }
+    /**
+     * @deprecated use self::getModifiedAmountPrice instead
+     */
+    protected function _getModifiedAmountPrice($amount) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getModifiedAmountPrice($amount);
+    }
 
     /**
      * Modifies given amount price.
@@ -2062,7 +2111,7 @@ class Article extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
      *
      * @return double
      */
-    protected function _getModifiedAmountPrice($amount) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getModifiedAmountPrice($amount)
     {
         return $this->_getAmountPrice($amount);
     }
@@ -3550,6 +3599,13 @@ class Article extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
 
         return self::$_blHasAmountPrice;
     }
+    /**
+     * @deprecated use self::loadVariantList instead
+     */
+    protected function _loadVariantList($loadSimpleVariants, $blRemoveNotOrderables = true, $forceCoreTableUsage = null) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->loadVariantList($loadSimpleVariants, $blRemoveNotOrderables, $forceCoreTableUsage);
+    }
 
     /**
      * Loads and returns variants list.
@@ -3560,7 +3616,7 @@ class Article extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
      *
      * @return array | oxsimplevariantlist | oxarticlelist
      */
-    protected function _loadVariantList($loadSimpleVariants, $blRemoveNotOrderables = true, $forceCoreTableUsage = null) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function loadVariantList($loadSimpleVariants, $blRemoveNotOrderables = true, $forceCoreTableUsage = null)
     {
         $variants = [];
         if (($articleId = $this->getId())) {
@@ -3634,6 +3690,13 @@ class Article extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
 
         return $variants;
     }
+    /**
+     * @deprecated use self::selectCategoryIds instead
+     */
+    protected function _selectCategoryIds($query, $field) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->selectCategoryIds($query, $field);
+    }
 
     /**
      * Selects category IDs from given SQL statement and ID field name
@@ -3643,7 +3706,7 @@ class Article extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
      *
      * @return array
      */
-    protected function _selectCategoryIds($query, $field) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function selectCategoryIds($query, $field)
     {
         $oDb = \OxidEsales\Eshop\Core\DatabaseProvider::getDb(\OxidEsales\Eshop\Core\DatabaseProvider::FETCH_MODE_ASSOC);
         $aResult = $oDb->getAll($query);
@@ -3657,6 +3720,13 @@ class Article extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
 
         return $aReturn;
     }
+    /**
+     * @deprecated use self::getCategoryIdsSelect instead
+     */
+    protected function _getCategoryIdsSelect($blActCats = false) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getCategoryIdsSelect($blActCats);
+    }
 
     /**
      * Returns query for article categories select
@@ -3665,7 +3735,7 @@ class Article extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
      *
      * @return string
      */
-    protected function _getCategoryIdsSelect($blActCats = false) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getCategoryIdsSelect($blActCats = false)
     {
         $sO2CView = $this->_getObjectViewName('oxobject2category');
         $sCatView = $this->_getObjectViewName('oxcategories');
@@ -3685,17 +3755,31 @@ class Article extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
 
         return $sSelect;
     }
+    /**
+     * @deprecated use self::getActiveCategorySelectSnippet instead
+     */
+    protected function _getActiveCategorySelectSnippet() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getActiveCategorySelectSnippet();
+    }
 
     /**
      * Returns active category select snippet
      *
      * @return string
      */
-    protected function _getActiveCategorySelectSnippet() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getActiveCategorySelectSnippet()
     {
         $sCatView = $this->_getObjectViewName('oxcategories');
 
         return "and oxcategories.oxhidden = 0 and (select count(cats.oxid) from $sCatView as cats where cats.oxrootid = oxcategories.oxrootid and cats.oxleft < oxcategories.oxleft and cats.oxright > oxcategories.oxright and ( cats.oxhidden = 1 or cats.oxactive = 0 ) ) = 0 ";
+    }
+    /**
+     * @deprecated use self::calculatePrice instead
+     */
+    protected function _calculatePrice($oPrice, $dVat = null) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->calculatePrice($oPrice, $dVat);
     }
 
     /**
@@ -3706,7 +3790,7 @@ class Article extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
      *
      * @return \OxidEsales\Eshop\Core\Price
      */
-    protected function _calculatePrice($oPrice, $dVat = null) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function calculatePrice($oPrice, $dVat = null)
     {
         // apply VAT only if configuration requires it
         if (isset($dVat) || !$this->getConfig()->getConfigParam('bl_perfCalcVatOnlyForBasketOrder')) {
@@ -3729,6 +3813,13 @@ class Article extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
 
         return $oPrice;
     }
+    /**
+     * @deprecated use self::hasAnyVariant instead
+     */
+    protected function _hasAnyVariant($blForceCoreTable = null) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->hasAnyVariant($blForceCoreTable);
+    }
 
     /**
      * Checks if parent has ANY variant assigned
@@ -3737,7 +3828,7 @@ class Article extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
      *
      * @return bool
      */
-    protected function _hasAnyVariant($blForceCoreTable = null) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function hasAnyVariant($blForceCoreTable = null)
     {
         if (($sId = $this->getId())) {
             if ($this->oxarticles__oxshopid->value == $this->getConfig()->getShopId()) {
@@ -3753,15 +3844,29 @@ class Article extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
 
         return false;
     }
+    /**
+     * @deprecated use self::isStockStatusChanged instead
+     */
+    protected function _isStockStatusChanged() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->isStockStatusChanged();
+    }
 
     /**
      * Check if stock status has changed since loading the article
      *
      * @return bool
      */
-    protected function _isStockStatusChanged() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function isStockStatusChanged()
     {
         return $this->_iStockStatus != $this->_iStockStatusOnLoad;
+    }
+    /**
+     * @deprecated use self::isVisibilityChanged instead
+     */
+    protected function _isVisibilityChanged() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->isVisibilityChanged();
     }
 
     /**
@@ -3769,9 +3874,16 @@ class Article extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
      *
      * @return bool
      */
-    protected function _isVisibilityChanged() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function isVisibilityChanged()
     {
         return $this->_isStockStatusChanged() && ($this->_iStockStatus == -1 || $this->_iStockStatusOnLoad == -1);
+    }
+    /**
+     * @deprecated use self::saveArtLongDesc instead
+     */
+    protected function _saveArtLongDesc() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->saveArtLongDesc();
     }
 
     /**
@@ -3779,7 +3891,7 @@ class Article extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
      *
      * @return null
      */
-    protected function _saveArtLongDesc() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function saveArtLongDesc()
     {
         if (in_array("oxlongdesc", $this->_aSkipSaveFields)) {
             return;
@@ -3827,11 +3939,18 @@ class Article extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
             $oArtExt->save();
         }
     }
+    /**
+     * @deprecated use self::skipSaveFields instead
+     */
+    protected function _skipSaveFields() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->skipSaveFields();
+    }
 
     /**
      * Removes object data fields (oxarticles__oxtimestamp, oxarticles__oxparentid, oxarticles__oxinsert).
      */
-    protected function _skipSaveFields() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function skipSaveFields()
     {
         $this->_aSkipSaveFields = [];
 
@@ -3844,6 +3963,13 @@ class Article extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
             $this->_aSkipSaveFields[] = 'oxparentid';
         }
     }
+    /**
+     * @deprecated use self::mergeDiscounts instead
+     */
+    protected function _mergeDiscounts($aDiscounts, $aItemDiscounts) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->mergeDiscounts($aDiscounts, $aItemDiscounts);
+    }
 
     /**
      * Merges two discount arrays. If there are two the same
@@ -3854,7 +3980,7 @@ class Article extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
      *
      * @return array $aDiscounts
      */
-    protected function _mergeDiscounts($aDiscounts, $aItemDiscounts) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function mergeDiscounts($aDiscounts, $aItemDiscounts)
     {
         foreach ($aItemDiscounts as $sKey => $oDiscount) {
             // add prices of the same discounts
@@ -3867,13 +3993,20 @@ class Article extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
 
         return $aDiscounts;
     }
+    /**
+     * @deprecated use self::getGroupPrice instead
+     */
+    protected function _getGroupPrice() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getGroupPrice();
+    }
 
     /**
      * get user Group A, B or C price, returns db price if user is not in groups
      *
      * @return double
      */
-    protected function _getGroupPrice() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getGroupPrice()
     {
         $sPriceSufix = $this->_getUserPriceSufix();
         $sVarName = "oxarticles__oxprice{$sPriceSufix}";
@@ -3886,6 +4019,13 @@ class Article extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
 
         return $dPrice;
     }
+    /**
+     * @deprecated use self::getAmountPrice instead
+     */
+    protected function _getAmountPrice($amount = 1) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getAmountPrice($amount);
+    }
 
     /**
      * Modifies article price depending on given amount.
@@ -3895,7 +4035,7 @@ class Article extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
      *
      * @return double
      */
-    protected function _getAmountPrice($amount = 1) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getAmountPrice($amount = 1)
     {
         startProfile("_getAmountPrice");
 
@@ -3915,6 +4055,13 @@ class Article extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
 
         return $dPrice;
     }
+    /**
+     * @deprecated use self::modifySelectListPrice instead
+     */
+    protected function _modifySelectListPrice($dPrice, $aChosenList = null) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->modifySelectListPrice($dPrice, $aChosenList);
+    }
 
     /**
      * Modifies article price according to selected select list value
@@ -3924,7 +4071,7 @@ class Article extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
      *
      * @return double
      */
-    protected function _modifySelectListPrice($dPrice, $aChosenList = null) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function modifySelectListPrice($dPrice, $aChosenList = null)
     {
         $myConfig = $this->getConfig();
         // #690
@@ -3945,6 +4092,13 @@ class Article extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
 
         return $dPrice;
     }
+    /**
+     * @deprecated use self::fillAmountPriceList instead
+     */
+    protected function _fillAmountPriceList($aAmPriceList) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->fillAmountPriceList($aAmPriceList);
+    }
 
     /**
      * Fills amount price list object and sets amount price for article object
@@ -3953,7 +4107,7 @@ class Article extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
      *
      * @return array
      */
-    protected function _fillAmountPriceList($aAmPriceList) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function fillAmountPriceList($aAmPriceList)
     {
         $oLang = \OxidEsales\Eshop\Core\Registry::getLang();
 
@@ -4034,6 +4188,13 @@ class Article extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
 
         return $this->_dArticleVat;
     }
+    /**
+     * @deprecated use self::applyVAT instead
+     */
+    protected function _applyVAT(\OxidEsales\Eshop\Core\Price $oPrice, $dVat) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->applyVAT($oPrice, $dVat);
+    }
 
     /**
      * Applies VAT to article
@@ -4041,7 +4202,7 @@ class Article extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
      * @param \OxidEsales\Eshop\Core\Price $oPrice Price object
      * @param double                       $dVat   VAT percent
      */
-    protected function _applyVAT(\OxidEsales\Eshop\Core\Price $oPrice, $dVat) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function applyVAT(\OxidEsales\Eshop\Core\Price $oPrice, $dVat)
     {
         startProfile(__FUNCTION__);
         $oPrice->setVAT($dVat);
@@ -4052,6 +4213,13 @@ class Article extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
         }
         stopProfile(__FUNCTION__);
     }
+    /**
+     * @deprecated use self::applyCurrency instead
+     */
+    protected function _applyCurrency(\OxidEsales\Eshop\Core\Price $oPrice, $oCur = null) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->applyCurrency($oPrice, $oCur);
+    }
 
     /**
      * Applies currency factor
@@ -4059,13 +4227,20 @@ class Article extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
      * @param \OxidEsales\Eshop\Core\Price $oPrice Price object
      * @param object                       $oCur   Currency object
      */
-    protected function _applyCurrency(\OxidEsales\Eshop\Core\Price $oPrice, $oCur = null) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function applyCurrency(\OxidEsales\Eshop\Core\Price $oPrice, $oCur = null)
     {
         if (!$oCur) {
             $oCur = $this->getConfig()->getActShopCurrencyObject();
         }
 
         $oPrice->multiply($oCur->rate);
+    }
+    /**
+     * @deprecated use self::getAttribsString instead
+     */
+    protected function _getAttribsString(&$sAttributeSql, &$iCnt) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getAttribsString($sAttributeSql, $iCnt);
     }
 
     /**
@@ -4074,7 +4249,7 @@ class Article extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
      * @param string $sAttributeSql Attribute selection snippet
      * @param int    $iCnt          The number of selected attributes
      */
-    protected function _getAttribsString(&$sAttributeSql, &$iCnt) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getAttribsString(&$sAttributeSql, &$iCnt)
     {
         // we do not use lists here as we don't need this overhead right now
         $oDb = \OxidEsales\Eshop\Core\DatabaseProvider::getDb();
@@ -4094,6 +4269,13 @@ class Article extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
             $sAttributeSql .= 't1.oxattrid IN ( ' . implode(',', $oDb->quoteArray($aAttributeIds)) . ') ';
         }
     }
+    /**
+     * @deprecated use self::getSimList instead
+     */
+    protected function _getSimList($sAttributeSql, $iCnt) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getSimList($sAttributeSql, $iCnt);
+    }
 
     /**
      * Gets similar list.
@@ -4103,7 +4285,7 @@ class Article extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
      *
      * @return array
      */
-    protected function _getSimList($sAttributeSql, $iCnt) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getSimList($sAttributeSql, $iCnt)
     {
         // #523A
         $iAttrPercent = $this->getConfig()->getConfigParam('iAttributesPercent') / 100;
@@ -4130,6 +4312,13 @@ class Article extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
             ':minhit' => $iHitMin
         ]);
     }
+    /**
+     * @deprecated use self::generateSimListSearchStr instead
+     */
+    protected function _generateSimListSearchStr($sArticleTable, $aList) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->generateSimListSearchStr($sArticleTable, $aList);
+    }
 
     /**
      * Generates search string for similar list.
@@ -4139,7 +4328,7 @@ class Article extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
      *
      * @return string
      */
-    protected function _generateSimListSearchStr($sArticleTable, $aList) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function generateSimListSearchStr($sArticleTable, $aList)
     {
         $sFieldList = $this->getSelectFields();
         $aList = array_slice($aList, 0, $this->getConfig()->getConfigParam('iNrofSimilarArticles'));
@@ -4153,6 +4342,13 @@ class Article extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
 
         return $sSearch;
     }
+    /**
+     * @deprecated use self::generateSearchStr instead
+     */
+    protected function _generateSearchStr($sOXID, $blSearchPriceCat = false) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->generateSearchStr($sOXID, $blSearchPriceCat);
+    }
 
     /**
      * Generates SearchString for getCategory()
@@ -4162,7 +4358,7 @@ class Article extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
      *
      * @return string
      */
-    protected function _generateSearchStr($sOXID, $blSearchPriceCat = false) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function generateSearchStr($sOXID, $blSearchPriceCat = false)
     {
         $sCatView = getViewName('oxcategories', $this->getLanguage());
         $sO2CView = getViewName('oxobject2category');
@@ -4177,13 +4373,20 @@ class Article extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
                       '{$this->oxarticles__oxprice->value}' >= {$sCatView}.oxpricefrom and
                       '{$this->oxarticles__oxprice->value}' <= {$sCatView}.oxpriceto ";
     }
+    /**
+     * @deprecated use self::generateSearchStrForCustomerBought instead
+     */
+    protected function _generateSearchStrForCustomerBought() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->generateSearchStrForCustomerBought();
+    }
 
     /**
      * Generates SQL select string for getCustomerAlsoBoughtThisProduct
      *
      * @return string
      */
-    protected function _generateSearchStrForCustomerBought() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function generateSearchStrForCustomerBought()
     {
         $sArtTable = $this->getViewName();
         $sOrderArtTable = getViewName('oxorderarticles');
@@ -4236,6 +4439,13 @@ class Article extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
                and ".$this->getSqlActiveSnippet();
         */
     }
+    /**
+     * @deprecated use self::generateSelectCatStr instead
+     */
+    protected function _generateSelectCatStr($sOXID, $sCatId, $dPriceFromTo = false) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->generateSelectCatStr($sOXID, $sCatId, $dPriceFromTo);
+    }
 
     /**
      * Generates select string for isAssignedToCategory()
@@ -4246,7 +4456,7 @@ class Article extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
      *
      * @return string
      */
-    protected function _generateSelectCatStr($sOXID, $sCatId, $dPriceFromTo = false) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function generateSelectCatStr($sOXID, $sCatId, $dPriceFromTo = false)
     {
         $sCategoryView = getViewName('oxcategories');
         $sO2CView = getViewName('oxobject2category');
@@ -4315,6 +4525,13 @@ class Article extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
 
         return $this->_oAmountPriceList;
     }
+    /**
+     * @deprecated use self::isFieldEmpty instead
+     */
+    protected function _isFieldEmpty($sFieldName) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->isFieldEmpty($sFieldName);
+    }
 
     /**
      * Detects if field is empty.
@@ -4323,7 +4540,7 @@ class Article extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
      *
      * @return bool
      */
-    protected function _isFieldEmpty($sFieldName) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function isFieldEmpty($sFieldName)
     {
         $mValue = $this->$sFieldName->value;
 
@@ -4370,6 +4587,13 @@ class Article extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
 
         return false;
     }
+    /**
+     * @deprecated use self::assignParentFieldValue instead
+     */
+    protected function _assignParentFieldValue($sFieldName) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->assignParentFieldValue($sFieldName);
+    }
 
     /**
      * Assigns parent field values to article
@@ -4378,7 +4602,7 @@ class Article extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
      *
      * @return null;
      */
-    protected function _assignParentFieldValue($sFieldName) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function assignParentFieldValue($sFieldName)
     {
         if (!($oParentArticle = $this->getParentArticle())) {
             return;
@@ -4409,6 +4633,13 @@ class Article extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
             }
         }
     }
+    /**
+     * @deprecated use self::isImageField instead
+     */
+    protected function _isImageField($sFieldName) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->isImageField($sFieldName);
+    }
 
     /**
      * Detects if field is an image field by field name
@@ -4417,18 +4648,25 @@ class Article extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
      *
      * @return bool.
      */
-    protected function _isImageField($sFieldName) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function isImageField($sFieldName)
     {
         return (stristr($sFieldName, '_oxthumb') || stristr($sFieldName, '_oxicon') || stristr(
             $sFieldName,
             '_oxzoom'
         ) || stristr($sFieldName, '_oxpic'));
     }
+    /**
+     * @deprecated use self::assignParentFieldValues instead
+     */
+    protected function _assignParentFieldValues() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->assignParentFieldValues();
+    }
 
     /**
      * Assigns parent field values to article
      */
-    protected function _assignParentFieldValues() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function assignParentFieldValues()
     {
         startProfile('articleAssignParentInternal');
         if ($this->oxarticles__oxparentid->value) {
@@ -4441,11 +4679,18 @@ class Article extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
         }
         stopProfile('articleAssignParentInternal');
     }
+    /**
+     * @deprecated use self::assignNotBuyableParent instead
+     */
+    protected function _assignNotBuyableParent() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->assignNotBuyableParent();
+    }
 
     /**
      * if we have variants then depending on config option the parent may be non buyable
      */
-    protected function _assignNotBuyableParent() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function assignNotBuyableParent()
     {
         if (
             !$this->getConfig()->getConfigParam('blVariantParentBuyable') &&
@@ -4454,11 +4699,18 @@ class Article extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
             $this->_blNotBuyableParent = true;
         }
     }
+    /**
+     * @deprecated use self::assignStock instead
+     */
+    protected function _assignStock() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->assignStock();
+    }
 
     /**
      * Assigns stock status to article
      */
-    protected function _assignStock() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function assignStock()
     {
         $myConfig = $this->getConfig();
         // -----------------------------------
@@ -4525,13 +4777,20 @@ class Article extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
             $this->setBuyableState(false);
         }
     }
+    /**
+     * @deprecated use self::assignPersistentParam instead
+     */
+    protected function _assignPersistentParam() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->assignPersistentParam();
+    }
 
     /**
      * Assigns persistent param to article.
      *
      * @deprecated on b-dev (2015-11-30); Not used anymore. Setting pers params to session was removed since 2.7.
      */
-    protected function _assignPersistentParam() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function assignPersistentParam()
     {
         // Persistent Parameter Handling
         $aPersParam = \OxidEsales\Eshop\Core\Registry::getSession()->getVariable('persparam');
@@ -4539,11 +4798,18 @@ class Article extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
             $this->_aPersistParam = $aPersParam[$this->getId()];
         }
     }
+    /**
+     * @deprecated use self::assignDynImageDir instead
+     */
+    protected function _assignDynImageDir() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->assignDynImageDir();
+    }
 
     /**
      * assigns dynimagedir to article
      */
-    protected function _assignDynImageDir() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function assignDynImageDir()
     {
         $myConfig = $this->getConfig();
 
@@ -4554,11 +4820,18 @@ class Article extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
         $this->nossl_dimagedir = $myConfig->getPictureUrl(null, false, false, null, $sThisShop); //$sThisShop
         $this->ssl_dimagedir = $myConfig->getPictureUrl(null, false, true, null, $sThisShop); //$sThisShop
     }
+    /**
+     * @deprecated use self::assignComparisonListFlag instead
+     */
+    protected function _assignComparisonListFlag() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->assignComparisonListFlag();
+    }
 
     /**
      * Adds a flag if article is on comparisonlist.
      */
-    protected function _assignComparisonListFlag() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function assignComparisonListFlag()
     {
         // #657 add a flag if article is on comparisonlist
 
@@ -4566,6 +4839,13 @@ class Article extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
         if (isset($aItems[$this->getId()])) {
             $this->_blIsOnComparisonList = true;
         }
+    }
+    /**
+     * @deprecated use self::insert instead
+     */
+    protected function _insert() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->insert();
     }
 
     /**
@@ -4575,7 +4855,7 @@ class Article extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
      *
      * @return bool
      */
-    protected function _insert() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function insert()
     {
         // set oxinsert
         $sNow = date('Y-m-d H:i:s', \OxidEsales\Eshop\Core\Registry::getUtilsDate()->getTime());
@@ -4586,13 +4866,20 @@ class Article extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
 
         return parent::_insert();
     }
+    /**
+     * @deprecated use self::update instead
+     */
+    protected function _update() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->update();
+    }
 
     /**
      * Executes \OxidEsales\Eshop\Application\Model\Article::_skipSaveFields() and updates article information
      *
      * @return bool
      */
-    protected function _update() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function update()
     {
         $this->setUpdateSeo(true);
         $this->_setUpdateSeoOnFieldChange('oxtitle');
@@ -4600,6 +4887,13 @@ class Article extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
         $this->_skipSaveFields();
 
         return parent::_update();
+    }
+    /**
+     * @deprecated use self::deleteRecords instead
+     */
+    protected function _deleteRecords($articleId) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->deleteRecords($articleId);
     }
 
     /**
@@ -4609,7 +4903,7 @@ class Article extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
      *
      * @return int
      */
-    protected function _deleteRecords($articleId) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function deleteRecords($articleId)
     {
         $oDb = \OxidEsales\Eshop\Core\DatabaseProvider::getDb();
 
@@ -4683,13 +4977,20 @@ class Article extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
             ':articleId' => $articleId
         ]);
     }
+    /**
+     * @deprecated use self::deleteVariantRecords instead
+     */
+    protected function _deleteVariantRecords($sOXID) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->deleteVariantRecords($sOXID);
+    }
 
     /**
      * Deletes variant records
      *
      * @param string $sOXID Article ID
      */
-    protected function _deleteVariantRecords($sOXID) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function deleteVariantRecords($sOXID)
     {
         if ($sOXID) {
             $database = \OxidEsales\Eshop\Core\DatabaseProvider::getDb();
@@ -4708,11 +5009,18 @@ class Article extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
             }
         }
     }
+    /**
+     * @deprecated use self::deletePics instead
+     */
+    protected function _deletePics() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->deletePics();
+    }
 
     /**
      * Delete pics
      */
-    protected function _deletePics() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function deletePics()
     {
         $myConfig = $this->getConfig();
         $oPictureHandler = \OxidEsales\Eshop\Core\Registry::getPictureHandler();
@@ -4729,6 +5037,13 @@ class Article extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
             $oPictureHandler->deleteArticleMasterPicture($this, $i);
         }
     }
+    /**
+     * @deprecated use self::onChangeResetCounts instead
+     */
+    protected function _onChangeResetCounts($sOxid, $sVendorId = null, $sManufacturerId = null) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->onChangeResetCounts($sOxid, $sVendorId, $sManufacturerId);
+    }
 
     /**
      * Resets category and vendor counts. This method is supposed to be called on article change trigger.
@@ -4737,7 +5052,7 @@ class Article extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
      * @param string $sVendorId       Vendor ID
      * @param string $sManufacturerId Manufacturer ID
      */
-    protected function _onChangeResetCounts($sOxid, $sVendorId = null, $sManufacturerId = null) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function onChangeResetCounts($sOxid, $sVendorId = null, $sManufacturerId = null)
     {
         $myUtilsCount = \OxidEsales\Eshop\Core\Registry::getUtilsCount();
 
@@ -4755,13 +5070,20 @@ class Article extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
             $myUtilsCount->resetCatArticleCount($sCatId);
         }
     }
+    /**
+     * @deprecated use self::onChangeUpdateStock instead
+     */
+    protected function _onChangeUpdateStock($parentId) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->onChangeUpdateStock($parentId);
+    }
 
     /**
      * Updates article stock. This method is supposed to be called on article change trigger.
      *
      * @param string $parentId product parent id
      */
-    protected function _onChangeUpdateStock($parentId) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function onChangeUpdateStock($parentId)
     {
         if ($parentId) {
             $database = \OxidEsales\Eshop\Core\DatabaseProvider::getDb();
@@ -4802,13 +5124,20 @@ class Article extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
             }
         }
     }
+    /**
+     * @deprecated use self::onChangeStockResetCount instead
+     */
+    protected function _onChangeStockResetCount($sOxid) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->onChangeStockResetCount($sOxid);
+    }
 
     /**
      * Resets article count cache when stock value is zero and article goes offline.
      *
      * @param string $sOxid product id
      */
-    protected function _onChangeStockResetCount($sOxid) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function onChangeStockResetCount($sOxid)
     {
         $myConfig = $this->getConfig();
 
@@ -4823,13 +5152,20 @@ class Article extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
             );
         }
     }
+    /**
+     * @deprecated use self::onChangeUpdateVarCount instead
+     */
+    protected function _onChangeUpdateVarCount($parentId) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->onChangeUpdateVarCount($parentId);
+    }
 
     /**
      * Updates variant count. This method is supposed to be called on article change trigger.
      *
      * @param string $parentId Parent ID
      */
-    protected function _onChangeUpdateVarCount($parentId) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function onChangeUpdateVarCount($parentId)
     {
         if ($parentId) {
             $database = \OxidEsales\Eshop\Core\DatabaseProvider::getDb();
@@ -4846,13 +5182,20 @@ class Article extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
             ]);
         }
     }
+    /**
+     * @deprecated use self::setVarMinMaxPrice instead
+     */
+    protected function _setVarMinMaxPrice($sParentId) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->setVarMinMaxPrice($sParentId);
+    }
 
     /**
      * Updates variant min price. This method is supposed to be called on article change trigger.
      *
      * @param string $sParentId Parent ID
      */
-    protected function _setVarMinMaxPrice($sParentId) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function setVarMinMaxPrice($sParentId)
     {
         if ($sParentId) {
             $database = \OxidEsales\Eshop\Core\DatabaseProvider::getDb(\OxidEsales\Eshop\Core\DatabaseProvider::FETCH_MODE_ASSOC);
@@ -4893,6 +5236,13 @@ class Article extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
             $database->execute($sQ, $params);
         }
     }
+    /**
+     * @deprecated use self::hasMasterImage instead
+     */
+    protected function _hasMasterImage($iIndex) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->hasMasterImage($iIndex);
+    }
 
     /**
      * Checks if article has uploaded master image for selected picture
@@ -4901,7 +5251,7 @@ class Article extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
      *
      * @return bool
      */
-    protected function _hasMasterImage($iIndex) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function hasMasterImage($iIndex)
     {
         $sPicName = basename($this->{"oxarticles__oxpic" . $iIndex}->value);
 
@@ -4924,6 +5274,13 @@ class Article extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
 
         return false;
     }
+    /**
+     * @deprecated use self::isPriceViewModeNetto instead
+     */
+    protected function _isPriceViewModeNetto() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->isPriceViewModeNetto();
+    }
 
 
     /**
@@ -4931,7 +5288,7 @@ class Article extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
      *
      * @return bool
      */
-    protected function _isPriceViewModeNetto() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function isPriceViewModeNetto()
     {
         $blResult = (bool) $this->getConfig()->getConfigParam('blShowNetPrice');
         $oUser = $this->getArticleUser();
@@ -4940,6 +5297,13 @@ class Article extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
         }
 
         return $blResult;
+    }
+    /**
+     * @deprecated use self::getPriceObject instead
+     */
+    protected function _getPriceObject($blCalculationModeNetto = null) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getPriceObject($blCalculationModeNetto);
     }
 
 
@@ -4950,7 +5314,7 @@ class Article extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
      *
      * @return oxPice
      */
-    protected function _getPriceObject($blCalculationModeNetto = null) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getPriceObject($blCalculationModeNetto = null)
     {
         /** @var \OxidEsales\Eshop\Core\Price $oPrice */
         $oPrice = oxNew(\OxidEsales\Eshop\Core\Price::class);
@@ -4967,6 +5331,13 @@ class Article extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
 
         return $oPrice;
     }
+    /**
+     * @deprecated use self::getPriceForView instead
+     */
+    protected function _getPriceForView($oPrice) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getPriceForView($oPrice);
+    }
 
     /**
      * Depending on view mode prepare price for viewing
@@ -4975,7 +5346,7 @@ class Article extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
      *
      * @return double
      */
-    protected function _getPriceForView($oPrice) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getPriceForView($oPrice)
     {
         if ($this->_isPriceViewModeNetto()) {
             $dPrice = $oPrice->getNettoPrice();
@@ -4984,6 +5355,13 @@ class Article extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
         }
 
         return $dPrice;
+    }
+    /**
+     * @deprecated use self::preparePrice instead
+     */
+    protected function _preparePrice($dPrice, $dVat, $blCalculationModeNetto = null) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->preparePrice($dPrice, $dVat, $blCalculationModeNetto);
     }
 
 
@@ -4996,7 +5374,7 @@ class Article extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
      *
      * @return double
      */
-    protected function _preparePrice($dPrice, $dVat, $blCalculationModeNetto = null) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function preparePrice($dPrice, $dVat, $blCalculationModeNetto = null)
     {
         if ($blCalculationModeNetto === null) {
             $blCalculationModeNetto = $this->_isPriceViewModeNetto();
@@ -5013,6 +5391,13 @@ class Article extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
 
         return $dPrice;
     }
+    /**
+     * @deprecated use self::getUserPriceSufix instead
+     */
+    protected function _getUserPriceSufix() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getUserPriceSufix();
+    }
 
 
     /**
@@ -5020,7 +5405,7 @@ class Article extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
      *
      * @return null
      */
-    protected function _getUserPriceSufix() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getUserPriceSufix()
     {
         $sPriceSuffix = '';
         $oUser = $this->getArticleUser();
@@ -5096,13 +5481,20 @@ class Article extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
 
         return $this->_dVarMinPrice;
     }
+    /**
+     * @deprecated use self::getVarMaxPrice instead
+     */
+    protected function _getVarMaxPrice() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getVarMaxPrice();
+    }
 
     /**
      * Return variant max price
      *
      * @return null
      */
-    protected function _getVarMaxPrice() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getVarMaxPrice()
     {
         if ($this->_dVarMaxPrice === null) {
             $dPrice = $this->_getShopVarMaxPrice();
@@ -5134,6 +5526,13 @@ class Article extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
 
         return $this->_dVarMaxPrice;
     }
+    /**
+     * @deprecated use self::getShopVarMinPrice instead
+     */
+    protected function _getShopVarMinPrice() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getShopVarMinPrice();
+    }
 
     /**
      * Place to hook to return variant min price if it might be different,
@@ -5141,9 +5540,16 @@ class Article extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
      *
      * @return double|null
      */
-    protected function _getShopVarMinPrice() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getShopVarMinPrice()
     {
         return null;
+    }
+    /**
+     * @deprecated use self::getShopVarMaxPrice instead
+     */
+    protected function _getShopVarMaxPrice() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getShopVarMaxPrice();
     }
 
     /**
@@ -5152,9 +5558,16 @@ class Article extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
      *
      * @return double|null
      */
-    protected function _getShopVarMaxPrice() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getShopVarMaxPrice()
     {
         return null;
+    }
+    /**
+     * @deprecated use self::loadFromDb instead
+     */
+    protected function _loadFromDb($articleId) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->loadFromDb($articleId);
     }
 
     /**
@@ -5164,7 +5577,7 @@ class Article extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
      *
      * @return array
      */
-    protected function _loadFromDb($articleId) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function loadFromDb($articleId)
     {
         $sSelect = $this->buildSelectString([$this->getViewName() . ".oxid" => $articleId]);
 
@@ -5181,13 +5594,20 @@ class Article extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
     public function checkForVpe($amount)
     {
     }
+    /**
+     * @deprecated use self::updateParentDependFields instead
+     */
+    protected function _updateParentDependFields() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->updateParentDependFields();
+    }
 
     /**
      * Set parent field value to child - variants in DB
      *
      * @return bool
      */
-    protected function _updateParentDependFields() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function updateParentDependFields()
     {
         $oDb = \OxidEsales\Eshop\Core\DatabaseProvider::getDb();
 
@@ -5202,21 +5622,35 @@ class Article extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
 
         return $oDb->execute($sSql, [':oxparentid' => $this->getId()]);
     }
+    /**
+     * @deprecated use self::getCopyParentFields instead
+     */
+    protected function _getCopyParentFields() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getCopyParentFields();
+    }
 
     /**
      * Returns array of fields which should not changed in variants
      *
      * @return array
      */
-    protected function _getCopyParentFields() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getCopyParentFields()
     {
         return $this->_aCopyParentField;
+    }
+    /**
+     * @deprecated use self::assignParentDependFields instead
+     */
+    protected function _assignParentDependFields() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->assignParentDependFields();
     }
 
     /**
      * Set parent field value to child - variants
      */
-    protected function _assignParentDependFields() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function assignParentDependFields()
     {
         $sParent = $this->getParentArticle();
         if ($sParent) {
@@ -5225,11 +5659,18 @@ class Article extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
             }
         }
     }
+    /**
+     * @deprecated use self::saveSortingFieldValuesOnLoad instead
+     */
+    protected function _saveSortingFieldValuesOnLoad() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->saveSortingFieldValuesOnLoad();
+    }
 
     /**
      * Saves values of sorting fields on article load.
      */
-    protected function _saveSortingFieldValuesOnLoad() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function saveSortingFieldValuesOnLoad()
     {
         $aSortingFields = \OxidEsales\Eshop\Core\Registry::getConfig()->getConfigParam('aSortCols');
         $aSortingFields = !empty($aSortingFields) ? (array) $aSortingFields : [];

--- a/source/Application/Model/ArticleList.php
+++ b/source/Application/Model/ArticleList.php
@@ -144,6 +144,13 @@ class ArticleList extends \OxidEsales\Eshop\Core\Model\ListModel
         $this->_aOrderMap = array_flip($aIds);
         uksort($this->_aArray, [$this, '_sortByOrderMapCallback']);
     }
+    /**
+     * @deprecated use self::sortByOrderMapCallback instead
+     */
+    protected function _sortByOrderMapCallback($key1, $key2) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->sortByOrderMapCallback($key1, $key2);
+    }
 
     /**
      * callback function only used from sortByIds
@@ -155,7 +162,7 @@ class ArticleList extends \OxidEsales\Eshop\Core\Model\ListModel
      *
      * @return int
      */
-    protected function _sortByOrderMapCallback($key1, $key2) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function sortByOrderMapCallback($key1, $key2)
     {
         if (isset($this->_aOrderMap[$key1])) {
             if (isset($this->_aOrderMap[$key2])) {
@@ -469,6 +476,13 @@ class ArticleList extends \OxidEsales\Eshop\Core\Model\ListModel
 
         $this->_createIdListFromSql($sSelect);
     }
+    /**
+     * @deprecated use self::getArticleSelect instead
+     */
+    protected function _getArticleSelect($sRecommId, $sArticlesFilter = null) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getArticleSelect($sRecommId, $sArticlesFilter);
+    }
 
     /**
      * Returns the appropriate SQL select
@@ -480,7 +494,7 @@ class ArticleList extends \OxidEsales\Eshop\Core\Model\ListModel
      *
      * @return string
      */
-    protected function _getArticleSelect($sRecommId, $sArticlesFilter = null) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getArticleSelect($sRecommId, $sArticlesFilter = null)
     {
         $sRecommId = \OxidEsales\Eshop\Core\DatabaseProvider::getDb()->quote($sRecommId);
 
@@ -827,13 +841,20 @@ class ArticleList extends \OxidEsales\Eshop\Core\Model\ListModel
 
         return $blUpdated;
     }
+    /**
+     * @deprecated use self::createIdListFromSql instead
+     */
+    protected function _createIdListFromSql($sSql) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->createIdListFromSql($sSql);
+    }
 
     /**
      * fills the list simply with keys of the oxid and the position as value for the given sql
      *
      * @param string $sSql SQL select
      */
-    protected function _createIdListFromSql($sSql) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function createIdListFromSql($sSql)
     {
         $rs = \OxidEsales\Eshop\Core\DatabaseProvider::getDb(\OxidEsales\Eshop\Core\DatabaseProvider::FETCH_MODE_ASSOC)->select($sSql);
         if ($rs != false && $rs->count() > 0) {
@@ -844,6 +865,13 @@ class ArticleList extends \OxidEsales\Eshop\Core\Model\ListModel
             }
         }
     }
+    /**
+     * @deprecated use self::getFilterIdsSql instead
+     */
+    protected function _getFilterIdsSql($sCatId, $aFilter) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getFilterIdsSql($sCatId, $aFilter);
+    }
 
     /**
      * Returns sql to fetch ids of articles fitting current filter
@@ -853,7 +881,7 @@ class ArticleList extends \OxidEsales\Eshop\Core\Model\ListModel
      *
      * @return string
      */
-    protected function _getFilterIdsSql($sCatId, $aFilter) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getFilterIdsSql($sCatId, $aFilter)
     {
         $sO2CView = getViewName('oxobject2category');
         $sO2AView = getViewName('oxobject2attribute');
@@ -884,6 +912,13 @@ class ArticleList extends \OxidEsales\Eshop\Core\Model\ListModel
 
         return $sFilterSelect . "{$sFilter} GROUP BY oa.oxobjectid HAVING cnt = $iCnt ";
     }
+    /**
+     * @deprecated use self::getFilterSql instead
+     */
+    protected function _getFilterSql($sCatId, $aFilter) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getFilterSql($sCatId, $aFilter);
+    }
 
     /**
      * Returns filtered articles sql "oxid in (filtered ids)" part
@@ -893,7 +928,7 @@ class ArticleList extends \OxidEsales\Eshop\Core\Model\ListModel
      *
      * @return string
      */
-    protected function _getFilterSql($sCatId, $aFilter) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getFilterSql($sCatId, $aFilter)
     {
         $sArticleTable = getViewName('oxarticles');
         $aIds = \OxidEsales\Eshop\Core\DatabaseProvider::getDb(\OxidEsales\Eshop\Core\DatabaseProvider::FETCH_MODE_ASSOC)->getAll($this->_getFilterIdsSql($sCatId, $aFilter));
@@ -917,6 +952,13 @@ class ArticleList extends \OxidEsales\Eshop\Core\Model\ListModel
 
         return $sFilterSql;
     }
+    /**
+     * @deprecated use self::getCategorySelect instead
+     */
+    protected function _getCategorySelect($sFields, $sCatId, $aSessionFilter) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getCategorySelect($sFields, $sCatId, $aSessionFilter);
+    }
 
     /**
      * Creates SQL Statement to load Articles, etc.
@@ -927,7 +969,7 @@ class ArticleList extends \OxidEsales\Eshop\Core\Model\ListModel
      *
      * @return string SQL
      */
-    protected function _getCategorySelect($sFields, $sCatId, $aSessionFilter) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getCategorySelect($sFields, $sCatId, $aSessionFilter)
     {
         $sArticleTable = getViewName('oxarticles');
         $sO2CView = getViewName('oxobject2category');
@@ -956,6 +998,13 @@ class ArticleList extends \OxidEsales\Eshop\Core\Model\ListModel
 
         return $sSelect;
     }
+    /**
+     * @deprecated use self::getCategoryCountSelect instead
+     */
+    protected function _getCategoryCountSelect($sCatId, $aSessionFilter) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getCategoryCountSelect($sCatId, $aSessionFilter);
+    }
 
     /**
      * Creates SQL Statement to load Articles Count, etc.
@@ -965,7 +1014,7 @@ class ArticleList extends \OxidEsales\Eshop\Core\Model\ListModel
      *
      * @return string SQL
      */
-    protected function _getCategoryCountSelect($sCatId, $aSessionFilter) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getCategoryCountSelect($sCatId, $aSessionFilter)
     {
         $sArticleTable = getViewName('oxarticles');
         $sO2CView = getViewName('oxobject2category');
@@ -988,6 +1037,13 @@ class ArticleList extends \OxidEsales\Eshop\Core\Model\ListModel
 
         return $sSelect;
     }
+    /**
+     * @deprecated use self::getSearchSelect instead
+     */
+    protected function _getSearchSelect($sSearchString) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getSearchSelect($sSearchString);
+    }
 
     /**
      * Forms and returns SQL query string for search in DB.
@@ -996,7 +1052,7 @@ class ArticleList extends \OxidEsales\Eshop\Core\Model\ListModel
      *
      * @return string
      */
-    protected function _getSearchSelect($sSearchString) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getSearchSelect($sSearchString)
     {
         // check if it has string at all
         if (!$sSearchString || !str_replace(' ', '', $sSearchString)) {
@@ -1054,6 +1110,13 @@ class ArticleList extends \OxidEsales\Eshop\Core\Model\ListModel
 
         return $sSearch;
     }
+    /**
+     * @deprecated use self::getPriceSelect instead
+     */
+    protected function _getPriceSelect($dPriceFrom, $dPriceTo) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getPriceSelect($dPriceFrom, $dPriceTo);
+    }
 
     /**
      * Builds SQL for selecting articles by price
@@ -1063,7 +1126,7 @@ class ArticleList extends \OxidEsales\Eshop\Core\Model\ListModel
      *
      * @return string
      */
-    protected function _getPriceSelect($dPriceFrom, $dPriceTo) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getPriceSelect($dPriceFrom, $dPriceTo)
     {
         $oBaseObject = $this->getBaseObject();
         $sArticleTable = $oBaseObject->getViewName();
@@ -1083,6 +1146,13 @@ class ArticleList extends \OxidEsales\Eshop\Core\Model\ListModel
 
         return $sSelect;
     }
+    /**
+     * @deprecated use self::getVendorSelect instead
+     */
+    protected function _getVendorSelect($sVendorId) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getVendorSelect($sVendorId);
+    }
 
     /**
      * Builds vendor select SQL statement
@@ -1091,7 +1161,7 @@ class ArticleList extends \OxidEsales\Eshop\Core\Model\ListModel
      *
      * @return string
      */
-    protected function _getVendorSelect($sVendorId) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getVendorSelect($sVendorId)
     {
         $sArticleTable = getViewName('oxarticles');
         $oBaseObject = $this->getBaseObject();
@@ -1106,6 +1176,13 @@ class ArticleList extends \OxidEsales\Eshop\Core\Model\ListModel
 
         return $sSelect;
     }
+    /**
+     * @deprecated use self::getManufacturerSelect instead
+     */
+    protected function _getManufacturerSelect($sManufacturerId) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getManufacturerSelect($sManufacturerId);
+    }
 
     /**
      * Builds Manufacturer select SQL statement
@@ -1114,7 +1191,7 @@ class ArticleList extends \OxidEsales\Eshop\Core\Model\ListModel
      *
      * @return string
      */
-    protected function _getManufacturerSelect($sManufacturerId) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getManufacturerSelect($sManufacturerId)
     {
         $sArticleTable = getViewName('oxarticles');
         $oBaseObject = $this->getBaseObject();
@@ -1129,13 +1206,20 @@ class ArticleList extends \OxidEsales\Eshop\Core\Model\ListModel
 
         return $sSelect;
     }
+    /**
+     * @deprecated use self::canUpdatePrices instead
+     */
+    protected function _canUpdatePrices() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->canUpdatePrices();
+    }
 
     /**
      * Checks if price update can be executed - current time > next price update time
      *
      * @return bool
      */
-    protected function _canUpdatePrices() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function canUpdatePrices()
     {
         $oConfig = $this->getConfig();
         $blCan = false;

--- a/source/Application/Model/Attribute.php
+++ b/source/Application/Model/Attribute.php
@@ -129,6 +129,13 @@ class Attribute extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel
             }
         }
     }
+    /**
+     * @deprecated use self::getAttrId instead
+     */
+    protected function _getAttrId($sSelTitle) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getAttrId($sSelTitle);
+    }
 
     /**
      * Searches for attribute by oxtitle. If exists returns attribute id
@@ -137,7 +144,7 @@ class Attribute extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel
      *
      * @return mixed attribute id or false
      */
-    protected function _getAttrId($sSelTitle) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getAttrId($sSelTitle)
     {
         $oDb = \OxidEsales\Eshop\Core\DatabaseProvider::getDB();
         $sAttViewName = getViewName('oxattribute');
@@ -145,6 +152,13 @@ class Attribute extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel
         return $oDb->getOne("select oxid from $sAttViewName where LOWER(oxtitle) = :oxtitle ", [
             ':oxtitle' => getStr()->strtolower($sSelTitle)
         ]);
+    }
+    /**
+     * @deprecated use self::createAttribute instead
+     */
+    protected function _createAttribute($aSelTitle) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->createAttribute($aSelTitle);
     }
 
     /**
@@ -154,7 +168,7 @@ class Attribute extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel
      *
      * @return string attribute id
      */
-    protected function _createAttribute($aSelTitle) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function createAttribute($aSelTitle)
     {
         $myLang = \OxidEsales\Eshop\Core\Registry::getLang();
         $aConfLanguages = $myLang->getLanguageIds();

--- a/source/Application/Model/AttributeList.php
+++ b/source/Application/Model/AttributeList.php
@@ -50,6 +50,13 @@ class AttributeList extends \OxidEsales\Eshop\Core\Model\ListModel
 
         return $this->_createAttributeListFromSql($sSelect);
     }
+    /**
+     * @deprecated use self::createAttributeListFromSql instead
+     */
+    protected function _createAttributeListFromSql($sSelect) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->createAttributeListFromSql($sSelect);
+    }
 
     /**
      * Fills array with keys and products with value
@@ -58,7 +65,7 @@ class AttributeList extends \OxidEsales\Eshop\Core\Model\ListModel
      *
      * @return array $aAttributes
      */
-    protected function _createAttributeListFromSql($sSelect) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function createAttributeListFromSql($sSelect)
     {
         $aAttributes = [];
         $rs = \OxidEsales\Eshop\Core\DatabaseProvider::getDb()->select($sSelect);
@@ -210,6 +217,13 @@ class AttributeList extends \OxidEsales\Eshop\Core\Model\ListModel
 
         return $this;
     }
+    /**
+     * @deprecated use self::mergeAttributes instead
+     */
+    protected function _mergeAttributes($aAttributes, $aParentAttributes) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->mergeAttributes($aAttributes, $aParentAttributes);
+    }
 
     /**
      * Merge attribute arrays
@@ -219,7 +233,7 @@ class AttributeList extends \OxidEsales\Eshop\Core\Model\ListModel
      *
      * @return array $aAttributes
      */
-    protected function _mergeAttributes($aAttributes, $aParentAttributes) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function mergeAttributes($aAttributes, $aParentAttributes)
     {
         if (count($aParentAttributes)) {
             $aAttrIds = [];

--- a/source/Application/Model/Basket.php
+++ b/source/Application/Model/Basket.php
@@ -389,6 +389,13 @@ class Basket extends \OxidEsales\Eshop\Core\Base
     {
         return !\OxidEsales\Eshop\Core\Registry::getUtils()->isSearchEngine();
     }
+    /**
+     * @deprecated use self::changeBasketItemKey instead
+     */
+    protected function _changeBasketItemKey($sOldKey, $sNewKey, $value = null) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->changeBasketItemKey($sOldKey, $sNewKey, $value);
+    }
 
     /**
      * change old key to new one but retain key position in array
@@ -397,7 +404,7 @@ class Basket extends \OxidEsales\Eshop\Core\Base
      * @param string $sNewKey new key to place in old one's place
      * @param mixed  $value   (optional)
      */
-    protected function _changeBasketItemKey($sOldKey, $sNewKey, $value = null) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function changeBasketItemKey($sOldKey, $sNewKey, $value = null)
     {
         reset($this->_aBasketContents);
         $iOldKeyPlace = 0;
@@ -620,11 +627,18 @@ class Basket extends \OxidEsales\Eshop\Core\Base
             $this->setBasketRootCatId(null);
         }
     }
+    /**
+     * @deprecated use self::clearBundles instead
+     */
+    protected function _clearBundles() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->clearBundles();
+    }
 
     /**
      * Unsets bundled basket items from basket contents array
      */
-    protected function _clearBundles() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function clearBundles()
     {
         reset($this->_aBasketContents);
         foreach ($this->_aBasketContents as $sItemKey => $oBasketItem) {
@@ -632,6 +646,13 @@ class Basket extends \OxidEsales\Eshop\Core\Base
                 $this->removeItem($sItemKey);
             }
         }
+    }
+    /**
+     * @deprecated use self::getArticleBundles instead
+     */
+    protected function _getArticleBundles($oBasketItem) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getArticleBundles($oBasketItem);
     }
 
     /**
@@ -641,7 +662,7 @@ class Basket extends \OxidEsales\Eshop\Core\Base
      *
      * @return array
      */
-    protected function _getArticleBundles($oBasketItem) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getArticleBundles($oBasketItem)
     {
         $aBundles = [];
 
@@ -656,6 +677,13 @@ class Basket extends \OxidEsales\Eshop\Core\Base
 
         return $aBundles;
     }
+    /**
+     * @deprecated use self::getItemBundles instead
+     */
+    protected function _getItemBundles($oBasketItem, $aBundles = []) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getItemBundles($oBasketItem, $aBundles);
+    }
 
     /**
      * Returns array of bundled discount articles
@@ -665,7 +693,7 @@ class Basket extends \OxidEsales\Eshop\Core\Base
      *
      * @return array
      */
-    protected function _getItemBundles($oBasketItem, $aBundles = []) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getItemBundles($oBasketItem, $aBundles = [])
     {
         if ($oBasketItem->isBundle()) {
             return [];
@@ -694,6 +722,13 @@ class Basket extends \OxidEsales\Eshop\Core\Base
 
         return $aBundles;
     }
+    /**
+     * @deprecated use self::getBasketBundles instead
+     */
+    protected function _getBasketBundles($aBundles = []) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getBasketBundles($aBundles);
+    }
 
     /**
      * Returns array of bundled discount articles for whole basket
@@ -702,7 +737,7 @@ class Basket extends \OxidEsales\Eshop\Core\Base
      *
      * @return array
      */
-    protected function _getBasketBundles($aBundles = []) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getBasketBundles($aBundles = [])
     {
         $aDiscounts = \OxidEsales\Eshop\Core\Registry::get(\OxidEsales\Eshop\Application\Model\DiscountList::class)->getBasketBundleDiscounts($this, $this->getBasketUser());
 
@@ -726,12 +761,19 @@ class Basket extends \OxidEsales\Eshop\Core\Base
 
         return $aBundles;
     }
+    /**
+     * @deprecated use self::addBundles instead
+     */
+    protected function _addBundles() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->addBundles();
+    }
 
     /**
      * Iterates through basket contents and adds bundles to items + adds
      * global basket bundles
      */
-    protected function _addBundles() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function addBundles()
     {
         $aBundles = [];
         // iterating through articles and binding bundles
@@ -765,13 +807,20 @@ class Basket extends \OxidEsales\Eshop\Core\Base
             $this->_addBundlesToBasket($aBundles);
         }
     }
+    /**
+     * @deprecated use self::addBundlesToBasket instead
+     */
+    protected function _addBundlesToBasket($aBundles) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->addBundlesToBasket($aBundles);
+    }
 
     /**
      * Adds bundles to basket
      *
      * @param array $aBundles added bundle articles
      */
-    protected function _addBundlesToBasket($aBundles) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function addBundlesToBasket($aBundles)
     {
         foreach ($aBundles as $sBundleId => $dAmount) {
             if ($dAmount) {
@@ -789,11 +838,18 @@ class Basket extends \OxidEsales\Eshop\Core\Base
             }
         }
     }
+    /**
+     * @deprecated use self::calcItemsPrice instead
+     */
+    protected function _calcItemsPrice() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->calcItemsPrice();
+    }
 
     /**
      * Iterates through basket items and calculates its prices and discounts
      */
-    protected function _calcItemsPrice() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function calcItemsPrice()
     {
         // resetting
         $this->setSkipDiscounts(false);
@@ -869,6 +925,13 @@ class Basket extends \OxidEsales\Eshop\Core\Base
     {
         return $this->_blCalcDiscounts;
     }
+    /**
+     * @deprecated use self::mergeDiscounts instead
+     */
+    protected function _mergeDiscounts($aDiscounts, $aItemDiscounts) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->mergeDiscounts($aDiscounts, $aItemDiscounts);
+    }
 
     /**
      * Merges two discount arrays. If there are two the same
@@ -879,7 +942,7 @@ class Basket extends \OxidEsales\Eshop\Core\Base
      *
      * @return array $aDiscounts
      */
-    protected function _mergeDiscounts($aDiscounts, $aItemDiscounts) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function mergeDiscounts($aDiscounts, $aItemDiscounts)
     {
         foreach ($aItemDiscounts as $sKey => $oDiscount) {
             // add prices of the same discounts
@@ -892,13 +955,20 @@ class Basket extends \OxidEsales\Eshop\Core\Base
 
         return $aDiscounts;
     }
+    /**
+     * @deprecated use self::calcDeliveryCost instead
+     */
+    protected function _calcDeliveryCost() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->calcDeliveryCost();
+    }
 
     /**
      * Iterates through basket items and calculates its delivery costs
      *
      * @return \OxidEsales\Eshop\Core\Price
      */
-    protected function _calcDeliveryCost() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function calcDeliveryCost()
     {
         if ($this->_oDeliveryPrice !== null) {
             return $this->_oDeliveryPrice;
@@ -1010,13 +1080,20 @@ class Basket extends \OxidEsales\Eshop\Core\Base
 
         return false;
     }
+    /**
+     * @deprecated use self::calcTotalPrice instead
+     */
+    protected function _calcTotalPrice() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->calcTotalPrice();
+    }
 
 
     //P
     /**
      * Performs final sum calculation and rounding.
      */
-    protected function _calcTotalPrice() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function calcTotalPrice()
     {
         // 1. add products price
         $dPrice = $this->_dBruttoSum;
@@ -1070,11 +1147,18 @@ class Basket extends \OxidEsales\Eshop\Core\Base
         $this->_oVoucherDiscount->setBruttoPriceMode();
         $this->_oVoucherDiscount->add($dDiscount);
     }
+    /**
+     * @deprecated use self::calcVoucherDiscount instead
+     */
+    protected function _calcVoucherDiscount() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->calcVoucherDiscount();
+    }
 
     /**
      * Calculates voucher discount
      */
-    protected function _calcVoucherDiscount() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function calcVoucherDiscount()
     {
         if ($this->getConfig()->getConfigParam('bl_showVouchers') && ($this->_oVoucherDiscount === null || ($this->_blUpdateNeeded && !$this->isAdmin()))) {
             $this->_oVoucherDiscount = $this->_getPriceObject();
@@ -1134,11 +1218,18 @@ class Basket extends \OxidEsales\Eshop\Core\Base
             }
         }
     }
+    /**
+     * @deprecated use self::applyDiscounts instead
+     */
+    protected function _applyDiscounts() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->applyDiscounts();
+    }
 
     /**
      * Performs netto price and VATs calculations including discounts and vouchers.
      */
-    protected function _applyDiscounts() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function applyDiscounts()
     {
         //apply discounts for brutto price
         $dDiscountedSum = $this->_getDiscountedProductsSum();
@@ -1177,13 +1268,20 @@ class Basket extends \OxidEsales\Eshop\Core\Base
 
         return $blResult;
     }
+    /**
+     * @deprecated use self::getPriceObject instead
+     */
+    protected function _getPriceObject() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getPriceObject();
+    }
 
     /**
      * Returns prepared price object depending on view mode
      *
      * @return \OxidEsales\Eshop\Core\Price
      */
-    protected function _getPriceObject() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getPriceObject()
     {
         $oPrice = oxNew(\OxidEsales\Eshop\Core\Price::class);
 
@@ -1195,11 +1293,18 @@ class Basket extends \OxidEsales\Eshop\Core\Base
 
         return $oPrice;
     }
+    /**
+     * @deprecated use self::calcBasketDiscount instead
+     */
+    protected function _calcBasketDiscount() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->calcBasketDiscount();
+    }
 
     /**
      * Loads basket discounts and calculates discount values.
      */
-    protected function _calcBasketDiscount() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function calcBasketDiscount()
     {
         // resetting
         $this->_aDiscounts = [];
@@ -1258,11 +1363,18 @@ class Basket extends \OxidEsales\Eshop\Core\Base
             }
         }
     }
+    /**
+     * @deprecated use self::calcBasketTotalDiscount instead
+     */
+    protected function _calcBasketTotalDiscount() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->calcBasketTotalDiscount();
+    }
 
     /**
      * Calculates total basket discount value.
      */
-    protected function _calcBasketTotalDiscount() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function calcBasketTotalDiscount()
     {
         if ($this->_oTotalDiscount === null || (!$this->isAdmin())) {
             $this->_oTotalDiscount = $this->_getPriceObject();
@@ -1280,6 +1392,13 @@ class Basket extends \OxidEsales\Eshop\Core\Base
             }
         }
     }
+    /**
+     * @deprecated use self::calcBasketWrapping instead
+     */
+    protected function _calcBasketWrapping() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->calcBasketWrapping();
+    }
 
     /**
      * Adds Gift price info to $this->oBasket (additional field for
@@ -1289,7 +1408,7 @@ class Basket extends \OxidEsales\Eshop\Core\Base
      *
      * @return \OxidEsales\Eshop\Core\Price
      */
-    protected function _calcBasketWrapping() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function calcBasketWrapping()
     {
         $oWrappingPrices = oxNew(\OxidEsales\Eshop\Core\PriceList::class);
 
@@ -1306,6 +1425,13 @@ class Basket extends \OxidEsales\Eshop\Core\Base
 
         return $oWrappingPrices->calculateToPrice();
     }
+    /**
+     * @deprecated use self::calcBasketGiftCard instead
+     */
+    protected function _calcBasketGiftCard() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->calcBasketGiftCard();
+    }
 
     /**
      * Adds Gift price info to $this->oBasket (additional field for
@@ -1315,7 +1441,7 @@ class Basket extends \OxidEsales\Eshop\Core\Base
      *
      * @return \OxidEsales\Eshop\Core\Price
      */
-    protected function _calcBasketGiftCard() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function calcBasketGiftCard()
     {
         $oGiftCardPrice = oxNew(\OxidEsales\Eshop\Core\Price::class);
 
@@ -1339,13 +1465,20 @@ class Basket extends \OxidEsales\Eshop\Core\Base
 
         return $oGiftCardPrice;
     }
+    /**
+     * @deprecated use self::calcPaymentCost instead
+     */
+    protected function _calcPaymentCost() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->calcPaymentCost();
+    }
 
     /**
      * Payment cost calculation, applying payment discount if available.
      *
      * @return \OxidEsales\Eshop\Core\Price
      */
-    protected function _calcPaymentCost() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function calcPaymentCost()
     {
         // resetting values
         $oPaymentPrice = oxNew(\OxidEsales\Eshop\Core\Price::class);
@@ -1651,6 +1784,13 @@ class Basket extends \OxidEsales\Eshop\Core\Base
             }
         }
     }
+    /**
+     * @deprecated use self::canSaveBasket instead
+     */
+    protected function _canSaveBasket() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->canSaveBasket();
+    }
 
     /**
      * Checks whether basket can be saved
@@ -1659,7 +1799,7 @@ class Basket extends \OxidEsales\Eshop\Core\Base
      *
      * @return bool
      */
-    protected function _canSaveBasket() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function canSaveBasket()
     {
         return $this->isSaveToDataBaseEnabled();
     }
@@ -1690,11 +1830,18 @@ class Basket extends \OxidEsales\Eshop\Core\Base
             }
         }
     }
+    /**
+     * @deprecated use self::save instead
+     */
+    protected function _save() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->save();
+    }
 
     /**
      * Saves existing basket to database
      */
-    protected function _save() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function save()
     {
         if ($this->isSaveToDataBaseEnabled()) {
             if ($oUser = $this->getBasketUser()) {
@@ -1714,13 +1861,20 @@ class Basket extends \OxidEsales\Eshop\Core\Base
             }
         }
     }
+    /**
+     * @deprecated use self::deleteSavedBasket instead
+     */
+    protected function _deleteSavedBasket() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->deleteSavedBasket();
+    }
 
     /**
      * Cleans up saved basket data. This method usually is initiated by
      * \OxidEsales\Eshop\Application\Model\Basket::deleteBasket() method which cleans up basket data when
      * user completes order.
      */
-    protected function _deleteSavedBasket() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function deleteSavedBasket()
     {
         // deleting basket if session user available
         if ($oUser = $this->getBasketUser()) {
@@ -1732,13 +1886,20 @@ class Basket extends \OxidEsales\Eshop\Core\Base
             $this->setBasketRootCatId(null);
         }
     }
+    /**
+     * @deprecated use self::findDelivCountry instead
+     */
+    protected function _findDelivCountry() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->findDelivCountry();
+    }
 
     /**
      * Tries to fetch user delivery country ID
      *
      * @return string
      */
-    protected function _findDelivCountry() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function findDelivCountry()
     {
         $myConfig = $this->getConfig();
         $oUser = $this->getBasketUser();
@@ -2694,6 +2855,13 @@ class Basket extends \OxidEsales\Eshop\Core\Base
 
         return $dPrice;
     }
+    /**
+     * @deprecated use self::getDiscountedProductsSum instead
+     */
+    public function _getDiscountedProductsSum() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getDiscountedProductsSum();
+    }
 
 
     /**
@@ -2701,7 +2869,7 @@ class Basket extends \OxidEsales\Eshop\Core\Base
      *
      * @return double
      */
-    public function _getDiscountedProductsSum()  // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    public function getDiscountedProductsSum()
     {
         if ($oProductsPrice = $this->getDiscountProductsPrice()) {
             $dPrice = $oProductsPrice->getSum($this->isCalculationModeNetto());
@@ -2852,6 +3020,13 @@ class Basket extends \OxidEsales\Eshop\Core\Base
 
         return $blCanAdd;
     }
+    /**
+     * @deprecated use self::isProductInRootCategory instead
+     */
+    protected function _isProductInRootCategory($sProductId, $sRootCatId) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->isProductInRootCategory($sProductId, $sRootCatId);
+    }
 
     /**
      * Checks if product is in root category
@@ -2861,7 +3036,7 @@ class Basket extends \OxidEsales\Eshop\Core\Base
      *
      * @return bool
      */
-    protected function _isProductInRootCategory($sProductId, $sRootCatId) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function isProductInRootCategory($sProductId, $sRootCatId)
     {
         $sO2CTable = getViewName('oxobject2category');
         $sCatTable = getViewName('oxcategories');

--- a/source/Application/Model/BasketContentMarkGenerator.php
+++ b/source/Application/Model/BasketContentMarkGenerator.php
@@ -58,15 +58,29 @@ class BasketContentMarkGenerator
 
         return $this->_aMarks[$sMarkIdentification];
     }
+    /**
+     * @deprecated use self::getBasket instead
+     */
+    private function _getBasket() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getBasket();
+    }
 
     /**
      * Basket that is used to get article type(downloadable, intangible etc..).
      *
      * @return \OxidEsales\Eshop\Application\Model\Basket
      */
-    private function _getBasket() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    private function getBasket()
     {
         return $this->_oBasket;
+    }
+    /**
+     * @deprecated use self::formMarks instead
+     */
+    private function _formMarks($sCurrentMark) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->formMarks($sCurrentMark);
     }
 
     /**
@@ -76,7 +90,7 @@ class BasketContentMarkGenerator
      *
      * @return array
      */
-    private function _formMarks($sCurrentMark) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    private function formMarks($sCurrentMark)
     {
         $oBasket = $this->_getBasket();
         $aMarks = [];

--- a/source/Application/Model/BasketItem.php
+++ b/source/Application/Model/BasketItem.php
@@ -700,6 +700,13 @@ class BasketItem extends \OxidEsales\Eshop\Core\Base
 
         return $aRet;
     }
+    /**
+     * @deprecated use self::setArticle instead
+     */
+    protected function _setArticle($sProductId) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->setArticle($sProductId);
+    }
 
     /**
      * Assigns general product parameters to oxbasketitem object :
@@ -716,7 +723,7 @@ class BasketItem extends \OxidEsales\Eshop\Core\Base
      *
      * @throws oxNoArticleException exception
      */
-    protected function _setArticle($sProductId) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function setArticle($sProductId)
     {
         $oConfig = $this->getConfig();
         $oArticle = $this->getArticle(true, $sProductId);
@@ -744,6 +751,13 @@ class BasketItem extends \OxidEsales\Eshop\Core\Base
         $this->_sDimageDirNoSsl = $oArticle->nossl_dimagedir;
         $this->_sDimageDirSsl = $oArticle->ssl_dimagedir;
     }
+    /**
+     * @deprecated use self::setFromOrderArticle instead
+     */
+    protected function _setFromOrderArticle($oOrderArticle) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->setFromOrderArticle($oOrderArticle);
+    }
 
     /**
      * Assigns general product parameters to oxbasketitem object:
@@ -754,7 +768,7 @@ class BasketItem extends \OxidEsales\Eshop\Core\Base
      *
      * @param \OxidEsales\Eshop\Application\Model\OrderArticle $oOrderArticle order article
      */
-    protected function _setFromOrderArticle($oOrderArticle) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function setFromOrderArticle($oOrderArticle)
     {
         // overriding whole article
         $this->_oArticle = $oOrderArticle;
@@ -769,13 +783,20 @@ class BasketItem extends \OxidEsales\Eshop\Core\Base
         $this->_sShopId = $this->getConfig()->getShopId();
         $this->_sNativeShopId = $oOrderArticle->oxarticles__oxshopid->value;
     }
+    /**
+     * @deprecated use self::setSelectList instead
+     */
+    protected function _setSelectList($aSelList) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->setSelectList($aSelList);
+    }
 
     /**
      * Stores item select lists ( oxbasketitem::aSelList )
      *
      * @param array $aSelList item select lists
      */
-    protected function _setSelectList($aSelList) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function setSelectList($aSelList)
     {
         // checking for default select list
         $aSelectLists = $this->getArticle()->getSelectLists();

--- a/source/Application/Model/BasketReservation.php
+++ b/source/Application/Model/BasketReservation.php
@@ -34,13 +34,20 @@ class BasketReservation extends \OxidEsales\Eshop\Core\Base
      * @var array
      */
     protected $_aCurrentlyReserved = null;
+    /**
+     * @deprecated use self::getReservationsId instead
+     */
+    protected function _getReservationsId() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getReservationsId();
+    }
 
     /**
      * return the ID of active resevations user basket
      *
      * @return string
      */
-    protected function _getReservationsId() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getReservationsId()
     {
         $sId = \OxidEsales\Eshop\Core\Registry::getSession()->getVariable('basketReservationToken');
         if (!$sId) {
@@ -51,6 +58,13 @@ class BasketReservation extends \OxidEsales\Eshop\Core\Base
 
         return $sId;
     }
+    /**
+     * @deprecated use self::loadReservations instead
+     */
+    protected function _loadReservations($sBasketId) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->loadReservations($sBasketId);
+    }
 
     /**
      * load reservation or create new reservation user basket
@@ -59,7 +73,7 @@ class BasketReservation extends \OxidEsales\Eshop\Core\Base
      *
      * @return \OxidEsales\EshopCommunity\Application\Model\UserBasket
      */
-    protected function _loadReservations($sBasketId) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function loadReservations($sBasketId)
     {
         $oReservations = oxNew(\OxidEsales\Eshop\Application\Model\UserBasket::class);
         $aWhere = ['oxuserbaskets.oxuserid' => $sBasketId, 'oxuserbaskets.oxtitle' => 'reservations'];
@@ -94,13 +108,20 @@ class BasketReservation extends \OxidEsales\Eshop\Core\Base
 
         return $this->_oReservations;
     }
+    /**
+     * @deprecated use self::getReservedItems instead
+     */
+    protected function _getReservedItems() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getReservedItems();
+    }
 
     /**
      * return currently reserved items in an array format array (artId => amount)
      *
      * @return array
      */
-    protected function _getReservedItems() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getReservedItems()
     {
         if (isset($this->_aCurrentlyReserved)) {
             return $this->_aCurrentlyReserved;
@@ -138,6 +159,13 @@ class BasketReservation extends \OxidEsales\Eshop\Core\Base
 
         return 0;
     }
+    /**
+     * @deprecated use self::basketDifference instead
+     */
+    protected function _basketDifference(\OxidEsales\Eshop\Application\Model\Basket $oBasket) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->basketDifference($oBasket);
+    }
 
     /**
      * compute difference of reserved amounts vs basket items
@@ -146,7 +174,7 @@ class BasketReservation extends \OxidEsales\Eshop\Core\Base
      *
      * @return array
      */
-    protected function _basketDifference(\OxidEsales\Eshop\Application\Model\Basket $oBasket) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function basketDifference(\OxidEsales\Eshop\Application\Model\Basket $oBasket)
     {
         $aDiff = $this->_getReservedItems();
         // refreshing history
@@ -161,6 +189,13 @@ class BasketReservation extends \OxidEsales\Eshop\Core\Base
 
         return $aDiff;
     }
+    /**
+     * @deprecated use self::reserveArticles instead
+     */
+    protected function _reserveArticles($aBasketDiff) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->reserveArticles($aBasketDiff);
+    }
 
     /**
      * reserve articles given the basket difference array
@@ -169,7 +204,7 @@ class BasketReservation extends \OxidEsales\Eshop\Core\Base
      *
      * @see oxBasketReservation::_basketDifference
      */
-    protected function _reserveArticles($aBasketDiff) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function reserveArticles($aBasketDiff)
     {
         $blAllowNegativeStock = $this->getConfig()->getConfigParam('blAllowNegativeStock');
 

--- a/source/Application/Model/Category.php
+++ b/source/Application/Model/Category.php
@@ -204,6 +204,13 @@ class Category extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implement
         }
         return parent::__get($sName);
     }
+    /**
+     * @deprecated use self::loadFromDb instead
+     */
+    protected function _loadFromDb($sOXID) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->loadFromDb($sOXID);
+    }
 
     /**
      * Get data from db
@@ -212,7 +219,7 @@ class Category extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implement
      *
      * @return array
      */
-    protected function _loadFromDb($sOXID) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function loadFromDb($sOXID)
     {
         $sSelect = $this->buildSelectString(["`{$this->getViewName()}`.`oxid`" => $sOXID]);
         $aData = \OxidEsales\Eshop\Core\DatabaseProvider::getDb(\OxidEsales\Eshop\Core\DatabaseProvider::FETCH_MODE_ASSOC)->getRow($sSelect);
@@ -830,13 +837,20 @@ class Category extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implement
 
         return false;
     }
+    /**
+     * @deprecated use self::insert instead
+     */
+    protected function _insert() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->insert();
+    }
 
     /**
      * Inserts new category (and updates existing node oxLeft amd oxRight accordingly). Returns true on success.
      *
      * @return bool
      */
-    protected function _insert() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function insert()
     {
         if ($this->oxcategories__oxparentid->value != "oxrootid") {
             // load parent
@@ -892,13 +906,20 @@ class Category extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implement
             return parent::_insert();
         }
     }
+    /**
+     * @deprecated use self::update instead
+     */
+    protected function _update() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->update();
+    }
 
     /**
      * Updates category tree, returns true on success.
      *
      * @return bool
      */
-    protected function _update() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function update()
     {
         $this->setUpdateSeo(true);
         $this->_setUpdateSeoOnFieldChange('oxtitle');
@@ -1013,6 +1034,13 @@ class Category extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implement
 
         return $blRes;
     }
+    /**
+     * @deprecated use self::setFieldData instead
+     */
+    protected function _setFieldData($fieldName, $value, $dataType = \OxidEsales\Eshop\Core\Field::T_TEXT) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->setFieldData($fieldName, $value, $dataType);
+    }
 
     /**
      * Sets data field value
@@ -1023,7 +1051,7 @@ class Category extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implement
      *
      * @return null
      */
-    protected function _setFieldData($fieldName, $value, $dataType = \OxidEsales\Eshop\Core\Field::T_TEXT) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function setFieldData($fieldName, $value, $dataType = \OxidEsales\Eshop\Core\Field::T_TEXT)
     {
         //preliminary quick check saves 3% of execution time in category lists by avoiding redundant strtolower() call
         $fieldNameIndex2 = $fieldName[2];

--- a/source/Application/Model/CategoryList.php
+++ b/source/Application/Model/CategoryList.php
@@ -122,6 +122,13 @@ class CategoryList extends \OxidEsales\Eshop\Core\Model\ListModel
     {
         return $this->_iForceLevel;
     }
+    /**
+     * @deprecated use self::getSqlSelectFieldsForTree instead
+     */
+    protected function _getSqlSelectFieldsForTree($sTable, $aColumns = null) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getSqlSelectFieldsForTree($sTable, $aColumns);
+    }
 
     /**
      * return fields to select while loading category tree
@@ -131,7 +138,7 @@ class CategoryList extends \OxidEsales\Eshop\Core\Model\ListModel
      *
      * @return string return
      */
-    protected function _getSqlSelectFieldsForTree($sTable, $aColumns = null) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getSqlSelectFieldsForTree($sTable, $aColumns = null)
     {
         if ($aColumns && count($aColumns)) {
             foreach ($aColumns as $key => $val) {
@@ -167,6 +174,13 @@ class CategoryList extends \OxidEsales\Eshop\Core\Model\ListModel
     {
         return ",not $tableName.oxactive as oxppremove";
     }
+    /**
+     * @deprecated use self::getSelectString instead
+     */
+    protected function _getSelectString($blReverse = false, $aColumns = null, $sOrder = null) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getSelectString($blReverse, $aColumns, $sOrder);
+    }
 
     /**
      * constructs the sql string to get the category list
@@ -177,7 +191,7 @@ class CategoryList extends \OxidEsales\Eshop\Core\Model\ListModel
      *
      * @return string
      */
-    protected function _getSelectString($blReverse = false, $aColumns = null, $sOrder = null) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getSelectString($blReverse = false, $aColumns = null, $sOrder = null)
     {
         $sViewName = $this->getBaseObject()->getViewName();
         $sFieldList = $this->_getSqlSelectFieldsForTree($sViewName, $aColumns);
@@ -204,6 +218,13 @@ class CategoryList extends \OxidEsales\Eshop\Core\Model\ListModel
 
         return "select $sFieldList from $sViewName where $sWhere $sUnion order by $sOrder";
     }
+    /**
+     * @deprecated use self::getDepthSqlSnippet instead
+     */
+    protected function _getDepthSqlSnippet($oCat) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getDepthSqlSnippet($oCat);
+    }
 
     /**
      * constructs the sql snippet responsible for depth optimizations,
@@ -213,7 +234,7 @@ class CategoryList extends \OxidEsales\Eshop\Core\Model\ListModel
      *
      * @return string
      */
-    protected function _getDepthSqlSnippet($oCat) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getDepthSqlSnippet($oCat)
     {
         $sViewName = $this->getBaseObject()->getViewName();
         $sDepthSnippet = ' ( 0';
@@ -238,6 +259,13 @@ class CategoryList extends \OxidEsales\Eshop\Core\Model\ListModel
 
         return $sDepthSnippet;
     }
+    /**
+     * @deprecated use self::getDepthSqlUnion instead
+     */
+    protected function _getDepthSqlUnion($oCat, $aColumns = null) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getDepthSqlUnion($oCat, $aColumns);
+    }
 
     /**
      * returns sql snippet for union of select category's and its upper level
@@ -249,7 +277,7 @@ class CategoryList extends \OxidEsales\Eshop\Core\Model\ListModel
      *
      * @return string
      */
-    protected function _getDepthSqlUnion($oCat, $aColumns = null) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getDepthSqlUnion($oCat, $aColumns = null)
     {
         if (!$oCat) {
             return '';
@@ -264,13 +292,20 @@ class CategoryList extends \OxidEsales\Eshop\Core\Model\ListModel
                . " AND subcats.oxleft <= " . (int) $oCat->oxcategories__oxleft->value
                . " AND subcats.oxright >= " . (int) $oCat->oxcategories__oxright->value;
     }
+    /**
+     * @deprecated use self::loadFromDb instead
+     */
+    protected function _loadFromDb() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->loadFromDb();
+    }
 
     /**
      * Get data from db
      *
      * @return array
      */
-    protected function _loadFromDb() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function loadFromDb()
     {
         $sSql = $this->_getSelectString(false, null, 'oxparentid, oxsort, oxtitle');
         $aData = \OxidEsales\Eshop\Core\DatabaseProvider::getDb(\OxidEsales\Eshop\Core\DatabaseProvider::FETCH_MODE_ASSOC)->getAll($sSql);
@@ -321,13 +356,20 @@ class CategoryList extends \OxidEsales\Eshop\Core\Model\ListModel
 
         stopProfile("buildTree");
     }
+    /**
+     * @deprecated use self::ppLoadFullCategory instead
+     */
+    protected function _ppLoadFullCategory($sId) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->ppLoadFullCategory($sId);
+    }
 
     /**
      * set full category object in tree
      *
      * @param string $sId category id
      */
-    protected function _ppLoadFullCategory($sId) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function ppLoadFullCategory($sId)
     {
         if (isset($this->_aArray[$sId])) {
             $oNewCat = oxNew(\OxidEsales\Eshop\Application\Model\Category::class);
@@ -402,11 +444,18 @@ class CategoryList extends \OxidEsales\Eshop\Core\Model\ListModel
             return [reset($this->_aPath)];
         }
     }
+    /**
+     * @deprecated use self::ppRemoveInactiveCategories instead
+     */
+    protected function _ppRemoveInactiveCategories() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->ppRemoveInactiveCategories();
+    }
 
     /**
      * Category list postprocessing routine, responsible for removal of inactive of forbidden categories, and subcategories.
      */
-    protected function _ppRemoveInactiveCategories() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function ppRemoveInactiveCategories()
     {
         // Collect all items which must be remove
         $aRemoveList = [];
@@ -441,13 +490,20 @@ class CategoryList extends \OxidEsales\Eshop\Core\Model\ListModel
             }
         }
     }
+    /**
+     * @deprecated use self::ppAddPathInfo instead
+     */
+    protected function _ppAddPathInfo() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->ppAddPathInfo();
+    }
 
     /**
      * Category list postprocessing routine, responsible for generation of active category path
      *
      * @return null
      */
-    protected function _ppAddPathInfo() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function ppAddPathInfo()
     {
         if (is_null($this->_sActCat)) {
             return;
@@ -465,11 +521,18 @@ class CategoryList extends \OxidEsales\Eshop\Core\Model\ListModel
 
         $this->_aPath = array_reverse($aPath);
     }
+    /**
+     * @deprecated use self::ppAddContentCategories instead
+     */
+    protected function _ppAddContentCategories() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->ppAddContentCategories();
+    }
 
     /**
      * Category list postprocessing routine, responsible adding of content categories
      */
-    protected function _ppAddContentCategories() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function ppAddContentCategories()
     {
         // load content pages for adding them into menu tree
         $oContentList = oxNew(\OxidEsales\Eshop\Application\Model\ContentList::class);
@@ -481,11 +544,18 @@ class CategoryList extends \OxidEsales\Eshop\Core\Model\ListModel
             }
         }
     }
+    /**
+     * @deprecated use self::ppBuildTree instead
+     */
+    protected function _ppBuildTree() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->ppBuildTree();
+    }
 
     /**
      * Category list postprocessing routine, responsible building an sorting of hierarchical category tree
      */
-    protected function _ppBuildTree() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function ppBuildTree()
     {
         $aTree = [];
         foreach ($this->_aArray as $oCat) {
@@ -501,12 +571,19 @@ class CategoryList extends \OxidEsales\Eshop\Core\Model\ListModel
 
         $this->assign($aTree);
     }
+    /**
+     * @deprecated use self::ppAddDepthInformation instead
+     */
+    protected function _ppAddDepthInformation() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->ppAddDepthInformation();
+    }
 
     /**
      * Category list postprocessing routine, responsible for making flat category tree and adding depth information.
      * Requires reversed category list!
      */
-    protected function _ppAddDepthInformation() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function ppAddDepthInformation()
     {
         $aTree = [];
         foreach ($this->_aArray as $oCat) {
@@ -520,6 +597,13 @@ class CategoryList extends \OxidEsales\Eshop\Core\Model\ListModel
         }
         $this->assign($aTree);
     }
+    /**
+     * @deprecated use self::addDepthInfo instead
+     */
+    protected function _addDepthInfo($aTree, $oCat, $sDepth = "") // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->addDepthInfo($aTree, $oCat, $sDepth);
+    }
 
     /**
      * Recursive function to add depth information
@@ -530,7 +614,7 @@ class CategoryList extends \OxidEsales\Eshop\Core\Model\ListModel
      *
      * @return array $aTree
      */
-    protected function _addDepthInfo($aTree, $oCat, $sDepth = "") // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function addDepthInfo($aTree, $oCat, $sDepth = "")
     {
         $sDepth .= "-";
         $oCat->oxcategories__oxtitle->setValue($sDepth . ' ' . $oCat->oxcategories__oxtitle->value);
@@ -614,6 +698,13 @@ class CategoryList extends \OxidEsales\Eshop\Core\Model\ListModel
     {
         return $this->_aUpdateInfo;
     }
+    /**
+     * @deprecated use self::updateNodes instead
+     */
+    protected function _updateNodes($oxRootId, $isRoot, $thisRoot) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->updateNodes($oxRootId, $isRoot, $thisRoot);
+    }
 
     /**
      * Recursively updates root nodes, this method is used (only) in updateCategoryTree()
@@ -622,7 +713,7 @@ class CategoryList extends \OxidEsales\Eshop\Core\Model\ListModel
      * @param bool   $isRoot   is the current node root?
      * @param string $thisRoot the id of the root
      */
-    protected function _updateNodes($oxRootId, $isRoot, $thisRoot) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function updateNodes($oxRootId, $isRoot, $thisRoot)
     {
         // Called from inside a transaction so master is picked automatically (see ESDEV-3804 and ESDEV-3822).
         $database = \OxidEsales\Eshop\Core\DatabaseProvider::getDb();

--- a/source/Application/Model/CompanyVatIn.php
+++ b/source/Application/Model/CompanyVatIn.php
@@ -50,6 +50,13 @@ class CompanyVatIn
     {
         return (string) \OxidEsales\Eshop\Core\Str::getStr()->substr($this->_cleanUp($this->_sCompanyVatNumber), 2);
     }
+    /**
+     * @deprecated use self::cleanUp instead
+     */
+    protected function _cleanUp($sValue) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->cleanUp($sValue);
+    }
 
     /**
      * Removes spaces and symbols: '-',',','.' from string
@@ -58,7 +65,7 @@ class CompanyVatIn
      *
      * @return string
      */
-    protected function _cleanUp($sValue) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function cleanUp($sValue)
     {
         return (string) \OxidEsales\Eshop\Core\Str::getStr()->preg_replace("/\s|-/", '', $sValue);
     }

--- a/source/Application/Model/Content.php
+++ b/source/Application/Model/Content.php
@@ -119,6 +119,13 @@ class Content extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
     {
         return $this->oxcontents__oxcatid->value;
     }
+    /**
+     * @deprecated use self::loadFromDb instead
+     */
+    protected function _loadFromDb($sLoadId) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->loadFromDb($sLoadId);
+    }
 
     /**
      * Get data from db.
@@ -127,7 +134,7 @@ class Content extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
      *
      * @return array
      */
-    protected function _loadFromDb($sLoadId) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function loadFromDb($sLoadId)
     {
         $sTable = $this->getViewName();
         $sShopId = $this->getShopId();
@@ -342,6 +349,13 @@ class Content extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
 
         return \OxidEsales\Eshop\Core\Registry::getUtilsUrl()->processUrl($this->getBaseStdLink($iLang), true, $aParams, $iLang);
     }
+    /**
+     * @deprecated use self::setFieldData instead
+     */
+    protected function _setFieldData($sFieldName, $sValue, $iDataType = \OxidEsales\Eshop\Core\Field::T_TEXT) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->setFieldData($sFieldName, $sValue, $iDataType);
+    }
 
     /**
      * Sets data field value.
@@ -352,7 +366,7 @@ class Content extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
      *
      * @return null
      */
-    protected function _setFieldData($sFieldName, $sValue, $iDataType = \OxidEsales\Eshop\Core\Field::T_TEXT) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function setFieldData($sFieldName, $sValue, $iDataType = \OxidEsales\Eshop\Core\Field::T_TEXT)
     {
         $sLoweredFieldName = strtolower($sFieldName);
         if ('oxcontent' === $sLoweredFieldName || 'oxcontents__oxcontent' === $sLoweredFieldName) {

--- a/source/Application/Model/ContentList.php
+++ b/source/Application/Model/ContentList.php
@@ -108,6 +108,13 @@ class ContentList extends \OxidEsales\Eshop\Core\Model\ListModel
 
         $this->_aArray = $aArray;
     }
+    /**
+     * @deprecated use self::loadFromDb instead
+     */
+    protected function _loadFromDb($iType) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->loadFromDb($iType);
+    }
 
     /**
      * Get data from db
@@ -116,12 +123,19 @@ class ContentList extends \OxidEsales\Eshop\Core\Model\ListModel
      *
      * @return array
      */
-    protected function _loadFromDb($iType) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function loadFromDb($iType)
     {
         $sSql = $this->_getSQLByType($iType);
         $aData = \OxidEsales\Eshop\Core\DatabaseProvider::getDb(\OxidEsales\Eshop\Core\DatabaseProvider::FETCH_MODE_ASSOC)->getAll($sSql);
 
         return $aData;
+    }
+    /**
+     * @deprecated use self::load instead
+     */
+    protected function _load($type) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->load($type);
     }
 
     /**
@@ -129,7 +143,7 @@ class ContentList extends \OxidEsales\Eshop\Core\Model\ListModel
      *
      * @param integer $type - type of content
      */
-    protected function _load($type) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function load($type)
     {
         $data = $this->_loadFromDb($type);
         $this->assignArray($data);
@@ -143,11 +157,18 @@ class ContentList extends \OxidEsales\Eshop\Core\Model\ListModel
         $this->_load(self::TYPE_SERVICE_LIST);
         $this->_extractListToArray();
     }
+    /**
+     * @deprecated use self::extractListToArray instead
+     */
+    protected function _extractListToArray() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->extractListToArray();
+    }
 
     /**
      * Extract oxContentList object to associative array with oxloadid as keys.
      */
-    protected function _extractListToArray() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function extractListToArray()
     {
         $aExtractedContents = [];
         foreach ($this as $oContent) {
@@ -155,6 +176,13 @@ class ContentList extends \OxidEsales\Eshop\Core\Model\ListModel
         }
 
         $this->_aArray = $aExtractedContents;
+    }
+    /**
+     * @deprecated use self::getSQLByType instead
+     */
+    protected function _getSQLByType($iType) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getSQLByType($iType);
     }
 
     /**
@@ -164,7 +192,7 @@ class ContentList extends \OxidEsales\Eshop\Core\Model\ListModel
      *
      * @return string
      */
-    protected function _getSQLByType($iType) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getSQLByType($iType)
     {
         $sSQLAdd = '';
         $oDb = \OxidEsales\Eshop\Core\DatabaseProvider::getDb();

--- a/source/Application/Model/Delivery.php
+++ b/source/Application/Model/Delivery.php
@@ -418,6 +418,13 @@ class Delivery extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel
         return $blForBasket;
     }
     /**
+     * @deprecated use self::isForArticle instead
+     */
+    protected function _isForArticle($content, $artAmount) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->isForArticle($content, $artAmount);
+    }
+    /**
      * Checks if delivery fits for one article
      *
      * @deprecated in b-dev since (2015-07-27), use isDeliveryRuleFitByArticle instead
@@ -427,7 +434,7 @@ class Delivery extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel
      *
      * @return bool
      */
-    protected function _isForArticle($content, $artAmount) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function isForArticle($content, $artAmount)
     {
         return $this->isDeliveryRuleFitByArticle($artAmount);
     }
@@ -449,6 +456,13 @@ class Delivery extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel
     {
         $this->_iProdCnt += 1;
     }
+    /**
+     * @deprecated use self::checkDeliveryAmount instead
+     */
+    protected function _checkDeliveryAmount($iAmount) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->checkDeliveryAmount($iAmount);
+    }
 
     /**
      * checks if amount param is ok for this delivery
@@ -457,7 +471,7 @@ class Delivery extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel
      *
      * @return boolean
      */
-    protected function _checkDeliveryAmount($iAmount) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function checkDeliveryAmount($iAmount)
     {
         $blResult = false;
 
@@ -580,13 +594,20 @@ class Delivery extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel
     {
         return $this->oxdelivery__oxaddsumtype->value;
     }
+    /**
+     * @deprecated use self::getMultiplier instead
+     */
+    protected function _getMultiplier() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getMultiplier();
+    }
 
     /**
      * Calculate multiplier for price calculation
      *
      * @return float|int
      */
-    protected function _getMultiplier() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getMultiplier()
     {
         $dAmount = 0;
 
@@ -600,13 +621,20 @@ class Delivery extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel
 
         return $dAmount;
     }
+    /**
+     * @deprecated use self::getCostSum instead
+     */
+    protected function _getCostSum() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getCostSum();
+    }
 
     /**
      * Calculate cost sum
      *
      * @return float
      */
-    protected function _getCostSum() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getCostSum()
     {
         if ($this->getAddSumType() == 'abs') {
             $oCur = $this->getConfig()->getActShopCurrencyObject();

--- a/source/Application/Model/DeliveryList.php
+++ b/source/Application/Model/DeliveryList.php
@@ -129,6 +129,13 @@ class DeliveryList extends \OxidEsales\Eshop\Core\Model\ListModel
 
         return $this;
     }
+    /**
+     * @deprecated use self::getFilterSelect instead
+     */
+    protected function _getFilterSelect($oUser, $sCountryId, $sDelSet) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getFilterSelect($oUser, $sCountryId, $sDelSet);
+    }
 
     /**
      * Creates delivery list filter SQL to load current state delivery list
@@ -139,7 +146,7 @@ class DeliveryList extends \OxidEsales\Eshop\Core\Model\ListModel
      *
      * @return string
      */
-    protected function _getFilterSelect($oUser, $sCountryId, $sDelSet) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getFilterSelect($oUser, $sCountryId, $sDelSet)
     {
         $oDb = \OxidEsales\Eshop\Core\DatabaseProvider::getDb();
 

--- a/source/Application/Model/DeliverySetList.php
+++ b/source/Application/Model/DeliverySetList.php
@@ -111,6 +111,13 @@ class DeliverySetList extends \OxidEsales\Eshop\Core\Model\ListModel
 
         return $this;
     }
+    /**
+     * @deprecated use self::getFilterSelect instead
+     */
+    protected function _getFilterSelect($oUser, $sCountryId) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getFilterSelect($oUser, $sCountryId);
+    }
 
 
     /**
@@ -121,7 +128,7 @@ class DeliverySetList extends \OxidEsales\Eshop\Core\Model\ListModel
      *
      * @return string
      */
-    protected function _getFilterSelect($oUser, $sCountryId) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getFilterSelect($oUser, $sCountryId)
     {
         $sTable = getViewName('oxdeliveryset');
         $sQ = "select $sTable.* from $sTable ";

--- a/source/Application/Model/Diagnostics.php
+++ b/source/Application/Model/Diagnostics.php
@@ -241,6 +241,13 @@ class Diagnostics
 
         return $aShopDetails;
     }
+    /**
+     * @deprecated use self::countRows instead
+     */
+    protected function _countRows($sTable, $blMode) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->countRows($sTable, $blMode);
+    }
 
     /**
      * counts result Rows
@@ -250,7 +257,7 @@ class Diagnostics
      *
      * @return integer
      */
-    protected function _countRows($sTable, $blMode) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function countRows($sTable, $blMode)
     {
         $oDb = \OxidEsales\Eshop\Core\DatabaseProvider::getDb();
         $sRequest = 'SELECT COUNT(*) FROM ' . $sTable;
@@ -360,13 +367,20 @@ class Diagnostics
 
         return $aServerInfo;
     }
+    /**
+     * @deprecated use self::getApacheVersion instead
+     */
+    protected function _getApacheVersion() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getApacheVersion();
+    }
 
     /**
      * Returns Apache version
      *
      * @return string
      */
-    protected function _getApacheVersion() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getApacheVersion()
     {
         if (function_exists('apache_get_version')) {
             $sReturn = apache_get_version();
@@ -376,13 +390,20 @@ class Diagnostics
 
         return $sReturn;
     }
+    /**
+     * @deprecated use self::getVirtualizationSystem instead
+     */
+    protected function _getVirtualizationSystem() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getVirtualizationSystem();
+    }
 
     /**
      * Tries to find out which VM is used
      *
      * @return string
      */
-    protected function _getVirtualizationSystem() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getVirtualizationSystem()
     {
         $sSystemType = '';
 
@@ -414,6 +435,13 @@ class Diagnostics
     {
         return function_exists('exec');
     }
+    /**
+     * @deprecated use self::getDeviceList instead
+     */
+    protected function _getDeviceList($sSystemType) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getDeviceList($sSystemType);
+    }
 
     /**
      * Finds the list of system devices for given system type
@@ -422,9 +450,16 @@ class Diagnostics
      *
      * @return string
      */
-    protected function _getDeviceList($sSystemType) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getDeviceList($sSystemType)
     {
         return exec('lspci | grep -i ' . $sSystemType);
+    }
+    /**
+     * @deprecated use self::getCpuAmount instead
+     */
+    protected function _getCpuAmount() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getCpuAmount();
     }
 
     /**
@@ -432,10 +467,17 @@ class Diagnostics
      *
      * @return string
      */
-    protected function _getCpuAmount() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getCpuAmount()
     {
         // cat /proc/cpuinfo | grep "processor" | sort -u | cut -d: -f2');
         return exec('cat /proc/cpuinfo | grep "physical id" | sort | uniq | wc -l');
+    }
+    /**
+     * @deprecated use self::getCpuMhz instead
+     */
+    protected function _getCpuMhz() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getCpuMhz();
     }
 
     /**
@@ -443,9 +485,16 @@ class Diagnostics
      *
      * @return float
      */
-    protected function _getCpuMhz() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getCpuMhz()
     {
         return round(exec('cat /proc/cpuinfo | grep "MHz" | sort -u | cut -d: -f2'), 0);
+    }
+    /**
+     * @deprecated use self::getBogoMips instead
+     */
+    protected function _getBogoMips() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getBogoMips();
     }
 
     /**
@@ -453,9 +502,16 @@ class Diagnostics
      *
      * @return string
      */
-    protected function _getBogoMips() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getBogoMips()
     {
         return exec('cat /proc/cpuinfo | grep "bogomips" | sort -u | cut -d: -f2');
+    }
+    /**
+     * @deprecated use self::getMemoryTotal instead
+     */
+    protected function _getMemoryTotal() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getMemoryTotal();
     }
 
     /**
@@ -463,9 +519,16 @@ class Diagnostics
      *
      * @return string
      */
-    protected function _getMemoryTotal() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getMemoryTotal()
     {
         return exec('cat /proc/meminfo | grep "MemTotal" | sort -u | cut -d: -f2');
+    }
+    /**
+     * @deprecated use self::getMemoryFree instead
+     */
+    protected function _getMemoryFree() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getMemoryFree();
     }
 
     /**
@@ -473,9 +536,16 @@ class Diagnostics
      *
      * @return string
      */
-    protected function _getMemoryFree() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getMemoryFree()
     {
         return exec('cat /proc/meminfo | grep "MemFree" | sort -u | cut -d: -f2');
+    }
+    /**
+     * @deprecated use self::getCpuModel instead
+     */
+    protected function _getCpuModel() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getCpuModel();
     }
 
     /**
@@ -483,9 +553,16 @@ class Diagnostics
      *
      * @return string
      */
-    protected function _getCpuModel() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getCpuModel()
     {
         return exec('cat /proc/cpuinfo | grep "model name" | sort -u | cut -d: -f2');
+    }
+    /**
+     * @deprecated use self::getDiskTotalSpace instead
+     */
+    protected function _getDiskTotalSpace() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getDiskTotalSpace();
     }
 
     /**
@@ -493,9 +570,16 @@ class Diagnostics
      *
      * @return string
      */
-    protected function _getDiskTotalSpace() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getDiskTotalSpace()
     {
         return round(disk_total_space('/') / 1024 / 1024, 0) . ' GiB';
+    }
+    /**
+     * @deprecated use self::getDiskFreeSpace instead
+     */
+    protected function _getDiskFreeSpace() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getDiskFreeSpace();
     }
 
     /**
@@ -503,9 +587,16 @@ class Diagnostics
      *
      * @return string
      */
-    protected function _getDiskFreeSpace() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getDiskFreeSpace()
     {
         return round(disk_free_space('/') / 1024 / 1024, 0) . ' GiB';
+    }
+    /**
+     * @deprecated use self::getPhpVersion instead
+     */
+    protected function _getPhpVersion() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getPhpVersion();
     }
 
     /**
@@ -513,9 +604,16 @@ class Diagnostics
      *
      * @return string
      */
-    protected function _getPhpVersion() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getPhpVersion()
     {
         return phpversion();
+    }
+    /**
+     * @deprecated use self::getMySqlServerInfo instead
+     */
+    protected function _getMySqlServerInfo() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getMySqlServerInfo();
     }
 
     /**
@@ -523,7 +621,7 @@ class Diagnostics
      *
      * @return string
      */
-    protected function _getMySqlServerInfo() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getMySqlServerInfo()
     {
         $aResult = \OxidEsales\Eshop\Core\DatabaseProvider::getDb(\OxidEsales\Eshop\Core\DatabaseProvider::FETCH_MODE_ASSOC)->getRow("SHOW VARIABLES LIKE 'version'");
 

--- a/source/Application/Model/Discount.php
+++ b/source/Application/Model/Discount.php
@@ -516,6 +516,13 @@ class Discount extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel
 
         return (int) $nextSort;
     }
+    /**
+     * @deprecated use self::checkForArticleCategories instead
+     */
+    protected function _checkForArticleCategories($oArticle) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->checkForArticleCategories($oArticle);
+    }
 
     /**
      * Checks if discount may be applied according amounts info
@@ -524,7 +531,7 @@ class Discount extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel
      *
      * @return bool
      */
-    protected function _checkForArticleCategories($oArticle) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function checkForArticleCategories($oArticle)
     {
         // check if article is in some assigned category
         $aCatIds = $oArticle->getCategoryIds();
@@ -547,6 +554,13 @@ class Discount extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel
             ':oxtype' => 'oxcategories'
         ]);
     }
+    /**
+     * @deprecated use self::getProductCheckQuery instead
+     */
+    protected function _getProductCheckQuery($oProduct) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getProductCheckQuery($oProduct);
+    }
 
     /**
      * Returns part of query for discount check. If product is variant - query contains both id check e.g.
@@ -556,7 +570,7 @@ class Discount extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel
      *
      * @return string
      */
-    protected function _getProductCheckQuery($oProduct) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getProductCheckQuery($oProduct)
     {
         $oDb = \OxidEsales\Eshop\Core\DatabaseProvider::getDb();
         // check if this article is assigned
@@ -568,6 +582,13 @@ class Discount extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel
 
         return $sArticleId;
     }
+    /**
+     * @deprecated use self::isArticleAssigned instead
+     */
+    protected function _isArticleAssigned($oArticle) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->isArticleAssigned($oArticle);
+    }
 
     /**
      * Checks whether this article is assigned to discount
@@ -576,7 +597,7 @@ class Discount extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel
      *
      * @return bool
      */
-    protected function _isArticleAssigned($oArticle) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function isArticleAssigned($oArticle)
     {
         $oDb = \OxidEsales\Eshop\Core\DatabaseProvider::getDb();
 
@@ -592,6 +613,13 @@ class Discount extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel
 
         return $oDb->getOne($sQ, $params) ? true : false;
     }
+    /**
+     * @deprecated use self::isCategoriesAssigned instead
+     */
+    protected function _isCategoriesAssigned($aCategoryIds) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->isCategoriesAssigned($aCategoryIds);
+    }
 
     /**
      * Checks whether categories are assigned to discount
@@ -600,7 +628,7 @@ class Discount extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel
      *
      * @return bool
      */
-    protected function _isCategoriesAssigned($aCategoryIds) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function isCategoriesAssigned($aCategoryIds)
     {
         if (empty($aCategoryIds)) {
             return false;

--- a/source/Application/Model/DiscountList.php
+++ b/source/Application/Model/DiscountList.php
@@ -98,6 +98,13 @@ class DiscountList extends \OxidEsales\Eshop\Core\Model\ListModel
     {
         $this->_blReload = true;
     }
+    /**
+     * @deprecated use self::getFilterSelect instead
+     */
+    protected function _getFilterSelect($oUser) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getFilterSelect($oUser);
+    }
 
     /**
      * Creates discount list filter SQL to load current state discount list
@@ -106,7 +113,7 @@ class DiscountList extends \OxidEsales\Eshop\Core\Model\ListModel
      *
      * @return string
      */
-    protected function _getFilterSelect($oUser) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getFilterSelect($oUser)
     {
         $oBaseObject = $this->getBaseObject();
 

--- a/source/Application/Model/File.php
+++ b/source/Application/Model/File.php
@@ -105,6 +105,13 @@ class File extends \OxidEsales\Eshop\Core\Model\BaseModel
             throw new \OxidEsales\Eshop\Core\Exception\StandardException('EXCEPTION_COULDNOTWRITETOFILE');
         }
     }
+    /**
+     * @deprecated use self::checkArticleFile instead
+     */
+    protected function _checkArticleFile($aFileInfo) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->checkArticleFile($aFileInfo);
+    }
 
     /**
      * Checks if given file is valid upload file
@@ -113,7 +120,7 @@ class File extends \OxidEsales\Eshop\Core\Model\BaseModel
      *
      * @throws oxException Throws exception if file wasn't uploaded successfully.
      */
-    protected function _checkArticleFile($aFileInfo) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function checkArticleFile($aFileInfo)
     {
         //checking params
         if (!isset($aFileInfo['name']) || !isset($aFileInfo['tmp_name'])) {
@@ -125,13 +132,20 @@ class File extends \OxidEsales\Eshop\Core\Model\BaseModel
             throw new \OxidEsales\Eshop\Core\Exception\StandardException('EXCEPTION_FILEUPLOADERROR_' . ((int) $aFileInfo['error']));
         }
     }
+    /**
+     * @deprecated use self::getBaseDownloadDirPath instead
+     */
+    protected function _getBaseDownloadDirPath() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getBaseDownloadDirPath();
+    }
 
     /**
      * Return full path of root dir where download files are stored
      *
      * @return string
      */
-    protected function _getBaseDownloadDirPath() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getBaseDownloadDirPath()
     {
         $sConfigValue = \OxidEsales\Eshop\Core\Registry::getConfig()->getConfigParam('sDownloadsDir');
 
@@ -186,13 +200,20 @@ class File extends \OxidEsales\Eshop\Core\Model\BaseModel
 
         return strpos($storageLocation, $downloadFolder) !== false;
     }
+    /**
+     * @deprecated use self::getFileLocation instead
+     */
+    protected function _getFileLocation() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getFileLocation();
+    }
 
     /**
      * Returns relative file path from oxConfig 'sDownloadsDir' variable.
      *
      * @return string
      */
-    protected function _getFileLocation() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getFileLocation()
     {
         $this->_sRelativeFilePath = '';
         $sFileHash = $this->oxfiles__oxstorehash->value;
@@ -212,6 +233,13 @@ class File extends \OxidEsales\Eshop\Core\Model\BaseModel
 
         return $this->_sRelativeFilePath;
     }
+    /**
+     * @deprecated use self::getHashedFileDir instead
+     */
+    protected function _getHashedFileDir($sFileHash) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getHashedFileDir($sFileHash);
+    }
 
     /**
      * Returns relative sub dir of oxconfig 'sDownloadsDir' of
@@ -222,7 +250,7 @@ class File extends \OxidEsales\Eshop\Core\Model\BaseModel
      *
      * @return string
      */
-    protected function _getHashedFileDir($sFileHash) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getHashedFileDir($sFileHash)
     {
         $sDir = substr($sFileHash, 0, 2);
         $sAbsDir = $this->_getBaseDownloadDirPath() . DIRECTORY_SEPARATOR . $sDir;
@@ -233,6 +261,13 @@ class File extends \OxidEsales\Eshop\Core\Model\BaseModel
 
         return $sDir;
     }
+    /**
+     * @deprecated use self::getFileHash instead
+     */
+    protected function _getFileHash($sFileName) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getFileHash($sFileName);
+    }
 
     /**
      * Calculates file hash.
@@ -242,9 +277,16 @@ class File extends \OxidEsales\Eshop\Core\Model\BaseModel
      *
      * @return string
      */
-    protected function _getFileHash($sFileName) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getFileHash($sFileName)
     {
         return md5_file($sFileName);
+    }
+    /**
+     * @deprecated use self::uploadFile instead
+     */
+    protected function _uploadFile($sSource, $sTarget) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->uploadFile($sSource, $sTarget);
     }
 
     /**
@@ -256,7 +298,7 @@ class File extends \OxidEsales\Eshop\Core\Model\BaseModel
      *
      * @return bool
      */
-    protected function _uploadFile($sSource, $sTarget) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function uploadFile($sSource, $sTarget)
     {
         $blDone = move_uploaded_file($sSource, $sTarget);
 
@@ -304,6 +346,13 @@ class File extends \OxidEsales\Eshop\Core\Model\BaseModel
 
         return $blDeleted;
     }
+    /**
+     * @deprecated use self::deleteFile instead
+     */
+    protected function _deleteFile() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->deleteFile();
+    }
 
     /**
      * Checks if file is not used for  other objects.
@@ -311,7 +360,7 @@ class File extends \OxidEsales\Eshop\Core\Model\BaseModel
      *
      * @return null|false
      */
-    protected function _deleteFile() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function deleteFile()
     {
         if (!$this->isUploaded()) {
             return false;
@@ -328,6 +377,13 @@ class File extends \OxidEsales\Eshop\Core\Model\BaseModel
             unlink($sPath);
         }
     }
+    /**
+     * @deprecated use self::getFilenameForUrl instead
+     */
+    protected function _getFilenameForUrl() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getFilenameForUrl();
+    }
 
     /**
      * returns oxfile__oxfilename for URL usage
@@ -335,7 +391,7 @@ class File extends \OxidEsales\Eshop\Core\Model\BaseModel
      *
      * @return string
      */
-    protected function _getFilenameForUrl() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getFilenameForUrl()
     {
         return rawurlencode($this->oxfiles__oxfilename->value);
     }

--- a/source/Application/Model/FileChecker.php
+++ b/source/Application/Model/FileChecker.php
@@ -244,13 +244,20 @@ class FileChecker
     {
         return $this->_isWebServiceOnline() && $this->_isShopVersionIsKnown();
     }
+    /**
+     * @deprecated use self::isWebServiceOnline instead
+     */
+    protected function _isWebServiceOnline() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->isWebServiceOnline();
+    }
 
     /**
      * in case if a general error is thrown by webservice
      *
      * @return string error
      */
-    protected function _isWebServiceOnline() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function isWebServiceOnline()
     {
         $oXML = null;
         $aParams = [
@@ -282,6 +289,13 @@ class FileChecker
 
         return !$this->_blError;
     }
+    /**
+     * @deprecated use self::isShopVersionIsKnown instead
+     */
+    protected function _isShopVersionIsKnown() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->isShopVersionIsKnown();
+    }
 
 
     /**
@@ -289,7 +303,7 @@ class FileChecker
      *
      * @return boolean
      */
-    protected function _isShopVersionIsKnown() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function isShopVersionIsKnown()
     {
         $aParams = [
             'job' => 'existsversion',
@@ -393,6 +407,13 @@ class FileChecker
 
         return $aResult;
     }
+    /**
+     * @deprecated use self::getFileVersion instead
+     */
+    protected function _getFileVersion($sMD5, $sFile) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getFileVersion($sMD5, $sFile);
+    }
 
     /**
      * Queries checksum-webservice according to md5, version, revision, edition and filename
@@ -402,7 +423,7 @@ class FileChecker
      *
      * @return \SimpleXMLElement
      */
-    protected function _getFileVersion($sMD5, $sFile) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getFileVersion($sMD5, $sFile)
     {
         $aParams = [
             'job' => 'md5check',

--- a/source/Application/Model/Links.php
+++ b/source/Application/Model/Links.php
@@ -32,6 +32,13 @@ class Links extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel
         parent::__construct();
         $this->init('oxlinks');
     }
+    /**
+     * @deprecated use self::setFieldData instead
+     */
+    protected function _setFieldData($sFieldName, $sValue, $iDataType = \OxidEsales\Eshop\Core\Field::T_TEXT) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->setFieldData($sFieldName, $sValue, $iDataType);
+    }
 
     /**
      * Sets data field value
@@ -42,7 +49,7 @@ class Links extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel
      *
      * @return null
      */
-    protected function _setFieldData($sFieldName, $sValue, $iDataType = \OxidEsales\Eshop\Core\Field::T_TEXT) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function setFieldData($sFieldName, $sValue, $iDataType = \OxidEsales\Eshop\Core\Field::T_TEXT)
     {
         if ('oxurldesc' === strtolower($sFieldName) || 'oxlinks__oxurldesc' === strtolower($sFieldName)) {
             $iDataType = \OxidEsales\Eshop\Core\Field::T_RAW;

--- a/source/Application/Model/Manufacturer.php
+++ b/source/Application/Model/Manufacturer.php
@@ -150,13 +150,20 @@ class Manufacturer extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel imple
 
         return parent::load($sOxid);
     }
+    /**
+     * @deprecated use self::setRootObjectData instead
+     */
+    protected function _setRootObjectData() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->setRootObjectData();
+    }
 
     /**
      * Sets root manufacturer data. Returns true
      *
      * @return bool
      */
-    protected function _setRootObjectData() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function setRootObjectData()
     {
         $this->setId('root');
         $this->oxmanufacturers__oxicon = new \OxidEsales\Eshop\Core\Field('', \OxidEsales\Eshop\Core\Field::T_RAW);

--- a/source/Application/Model/ManufacturerList.php
+++ b/source/Application/Model/ManufacturerList.php
@@ -141,13 +141,20 @@ class ManufacturerList extends \OxidEsales\Eshop\Core\Model\ListModel
     {
         return $this->_aPath;
     }
+    /**
+     * @deprecated use self::addCategoryFields instead
+     */
+    protected function _addCategoryFields($oManufacturer) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->addCategoryFields($oManufacturer);
+    }
 
     /**
      * Adds category specific fields to manufacturer object
      *
      * @param object $oManufacturer manufacturer object
      */
-    protected function _addCategoryFields($oManufacturer) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function addCategoryFields($oManufacturer)
     {
         $oManufacturer->oxcategories__oxid = new \OxidEsales\Eshop\Core\Field($oManufacturer->oxmanufacturers__oxid->value);
         $oManufacturer->oxcategories__oxicon = $oManufacturer->oxmanufacturers__oxicon;
@@ -177,11 +184,18 @@ class ManufacturerList extends \OxidEsales\Eshop\Core\Model\ListModel
     {
         return $this->_oClickedManufacturer;
     }
+    /**
+     * @deprecated use self::seoSetManufacturerData instead
+     */
+    protected function _seoSetManufacturerData() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->seoSetManufacturerData();
+    }
 
     /**
      * Processes manufacturer category URLs
      */
-    protected function _seoSetManufacturerData() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function seoSetManufacturerData()
     {
         // only when SEO id on and in front end
         if (\OxidEsales\Eshop\Core\Registry::getUtils()->seoIsActive() && !$this->isAdmin()) {

--- a/source/Application/Model/MdVariant.php
+++ b/source/Application/Model/MdVariant.php
@@ -356,15 +356,29 @@ class MdVariant extends \OxidEsales\Eshop\Core\Base
 
         return false;
     }
+    /**
+     * @deprecated use self::addMdSubvariant instead
+     */
+    protected function _addMdSubvariant($oSubvariant) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->addMdSubvariant($oSubvariant);
+    }
 
     /**
      * Adds one subvariant to subvariant set
      *
      * @param \OxidEsales\Eshop\Application\Model\MdVariant $oSubvariant Subvariant
      */
-    protected function _addMdSubvariant($oSubvariant) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function addMdSubvariant($oSubvariant)
     {
         $this->_aSubvariants[$oSubvariant->getId()] = $oSubvariant;
+    }
+    /**
+     * @deprecated use self::isFixedPrice instead
+     */
+    protected function _isFixedPrice() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->isFixedPrice();
     }
 
     /**
@@ -372,7 +386,7 @@ class MdVariant extends \OxidEsales\Eshop\Core\Base
      *
      * @return bool
      */
-    protected function _isFixedPrice() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function isFixedPrice()
     {
         $dPrice = $this->getDPrice();
         $aVariants = $this->getMdSubvariants();

--- a/source/Application/Model/MediaUrl.php
+++ b/source/Application/Model/MediaUrl.php
@@ -112,13 +112,20 @@ class MediaUrl extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel
 
         return parent::delete($sOXID);
     }
+    /**
+     * @deprecated use self::getYoutubeHtml instead
+     */
+    protected function _getYoutubeHtml() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getYoutubeHtml();
+    }
 
     /**
      * Transforms the link to YouTube object, and returns it.
      *
      * @return string
      */
-    protected function _getYoutubeHtml() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getYoutubeHtml()
     {
         $sUrl = $this->oxmediaurls__oxurl->value;
         $sDesc = $this->oxmediaurls__oxdesc->value;

--- a/source/Application/Model/News.php
+++ b/source/Application/Model/News.php
@@ -128,15 +128,29 @@ class News extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel
 
         return $blDelete;
     }
+    /**
+     * @deprecated use self::update instead
+     */
+    protected function _update() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->update();
+    }
 
     /**
      * Updates object information in DB.
      */
-    protected function _update() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function update()
     {
         $this->oxnews__oxdate->setValue(\OxidEsales\Eshop\Core\Registry::getUtilsDate()->formatDBDate($this->oxnews__oxdate->value, true));
 
         parent::_update();
+    }
+    /**
+     * @deprecated use self::insert instead
+     */
+    protected function _insert() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->insert();
     }
 
     /**
@@ -144,7 +158,7 @@ class News extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel
      *
      * @return bool
      */
-    protected function _insert() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function insert()
     {
         if (!$this->oxnews__oxdate || \OxidEsales\Eshop\Core\Registry::getUtilsDate()->isEmptyDate($this->oxnews__oxdate->value)) {
             // if date field is empty, assigning current date
@@ -154,6 +168,13 @@ class News extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel
         }
 
         return parent::_insert();
+    }
+    /**
+     * @deprecated use self::setFieldData instead
+     */
+    protected function _setFieldData($sFieldName, $sValue, $iDataType = \OxidEsales\Eshop\Core\Field::T_TEXT) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->setFieldData($sFieldName, $sValue, $iDataType);
     }
 
     /**
@@ -165,7 +186,7 @@ class News extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel
      *
      * @return null
      */
-    protected function _setFieldData($sFieldName, $sValue, $iDataType = \OxidEsales\Eshop\Core\Field::T_TEXT) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function setFieldData($sFieldName, $sValue, $iDataType = \OxidEsales\Eshop\Core\Field::T_TEXT)
     {
         switch (strtolower($sFieldName)) {
             case 'oxlongdesc':

--- a/source/Application/Model/NewsSubscribed.php
+++ b/source/Application/Model/NewsSubscribed.php
@@ -122,18 +122,32 @@ class NewsSubscribed extends \OxidEsales\Eshop\Core\Model\BaseModel
 
         return $this->load($sOxId);
     }
+    /**
+     * @deprecated use self::insert instead
+     */
+    protected function _insert() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->insert();
+    }
 
     /**
      * Inserts nbews object data to DB. Returns true on success.
      *
      * @return mixed oxid on success or false on failure
      */
-    protected function _insert() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function insert()
     {
         // set subscription date
         $this->oxnewssubscribed__oxsubscribed = new \OxidEsales\Eshop\Core\Field(date('Y-m-d H:i:s'), \OxidEsales\Eshop\Core\Field::T_RAW);
 
         return parent::_insert();
+    }
+    /**
+     * @deprecated use self::update instead
+     */
+    protected function _update() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->update();
     }
 
     /**
@@ -141,7 +155,7 @@ class NewsSubscribed extends \OxidEsales\Eshop\Core\Model\BaseModel
      *
      * @return mixed oxid on success or false on failure
      */
-    protected function _update() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function update()
     {
         if (($this->_blWasSubscribed || $this->_blWasPreSubscribed) && !$this->oxnewssubscribed__oxdboptin->value) {
             // set unsubscription date

--- a/source/Application/Model/Newsletter.php
+++ b/source/Application/Model/Newsletter.php
@@ -175,6 +175,13 @@ class Newsletter extends \OxidEsales\Eshop\Core\Model\BaseModel
 
         return $blSend;
     }
+    /**
+     * @deprecated use self::setParams instead
+     */
+    protected function _setParams($blPerfLoadAktion = false) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->setParams($blPerfLoadAktion);
+    }
 
     /**
      * Assigns to Smarty oxuser object, add newsletter products,
@@ -183,7 +190,7 @@ class Newsletter extends \OxidEsales\Eshop\Core\Model\BaseModel
      *
      * @param bool $blPerfLoadAktion perform option load actions
      */
-    protected function _setParams($blPerfLoadAktion = false) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function setParams($blPerfLoadAktion = false)
     {
         $myConfig = $this->getConfig();
 
@@ -228,13 +235,21 @@ class Newsletter extends \OxidEsales\Eshop\Core\Model\BaseModel
     }
 
     /**
+     * @deprecated use self::assignProducts instead
+     */
+    protected function _assignProducts($oView, $blPerfLoadAktion = false) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->assignProducts($oView, $blPerfLoadAktion);
+    }
+
+    /**
      * Add newsletter products (#559 only if we have user we can assign this info),
      * adds products which fit to the last order of assigned user.
      *
      * @param \OxidEsales\Eshop\Core\Controller\BaseController $oView            view object to store view data
      * @param bool                                             $blPerfLoadAktion perform option load actions
      */
-    protected function _assignProducts($oView, $blPerfLoadAktion = false) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function assignProducts($oView, $blPerfLoadAktion = false)
     {
         if ($blPerfLoadAktion) {
             $oArtList = oxNew(\OxidEsales\Eshop\Application\Model\ArticleList::class);
@@ -265,6 +280,13 @@ class Newsletter extends \OxidEsales\Eshop\Core\Model\BaseModel
             }
         }
     }
+    /**
+     * @deprecated use self::setFieldData instead
+     */
+    protected function _setFieldData($sFieldName, $sValue, $iDataType = \OxidEsales\Eshop\Core\Field::T_TEXT) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->setFieldData($sFieldName, $sValue, $iDataType);
+    }
 
     /**
      * Sets data field value
@@ -275,7 +297,7 @@ class Newsletter extends \OxidEsales\Eshop\Core\Model\BaseModel
      *
      * @return null
      */
-    protected function _setFieldData($sFieldName, $sValue, $iDataType = \OxidEsales\Eshop\Core\Field::T_TEXT) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function setFieldData($sFieldName, $sValue, $iDataType = \OxidEsales\Eshop\Core\Field::T_TEXT)
     {
         if ('oxtemplate' === $sFieldName || 'oxplaintemplate' === $sFieldName) {
             $iDataType = \OxidEsales\Eshop\Core\Field::T_RAW;

--- a/source/Application/Model/Order.php
+++ b/source/Application/Model/Order.php
@@ -291,6 +291,13 @@ class Order extends \OxidEsales\Eshop\Core\Model\BaseModel
         $this->oxorder__oxorderdate = new \OxidEsales\Eshop\Core\Field($oUtilsDate->formatDBDate($this->oxorder__oxorderdate->value));
         $this->oxorder__oxsenddate = new \OxidEsales\Eshop\Core\Field($oUtilsDate->formatDBDate($this->oxorder__oxsenddate->value));
     }
+    /**
+     * @deprecated use self::getCountryTitle instead
+     */
+    protected function _getCountryTitle($sCountryId) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getCountryTitle($sCountryId);
+    }
 
     /**
      * Gets country title by country id.
@@ -299,7 +306,7 @@ class Order extends \OxidEsales\Eshop\Core\Model\BaseModel
      *
      * @return string
      */
-    protected function _getCountryTitle($sCountryId) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getCountryTitle($sCountryId)
     {
         $sTitle = null;
         if ($sCountryId && $sCountryId != '-1') {
@@ -310,6 +317,13 @@ class Order extends \OxidEsales\Eshop\Core\Model\BaseModel
 
         return $sTitle;
     }
+    /**
+     * @deprecated use self::getArticles instead
+     */
+    protected function _getArticles($blExcludeCanceled = false) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getArticles($blExcludeCanceled);
+    }
 
     /**
      * returned assigned orderarticles from order
@@ -318,7 +332,7 @@ class Order extends \OxidEsales\Eshop\Core\Model\BaseModel
      *
      * @return \oxlist
      */
-    protected function _getArticles($blExcludeCanceled = false) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getArticles($blExcludeCanceled = false)
     {
         $sSelect = "SELECT `oxorderarticles`.* FROM `oxorderarticles`
                         WHERE `oxorderarticles`.`oxorderid` = :oxorderid" .
@@ -577,6 +591,13 @@ class Order extends \OxidEsales\Eshop\Core\Model\BaseModel
     {
         return (bool) $this->oxorder__oxisnettomode->value;
     }
+    /**
+     * @deprecated use self::setOrderStatus instead
+     */
+    protected function _setOrderStatus($sStatus) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->setOrderStatus($sStatus);
+    }
 
 
     /**
@@ -584,7 +605,7 @@ class Order extends \OxidEsales\Eshop\Core\Model\BaseModel
      *
      * @param string $sStatus order transaction status
      */
-    protected function _setOrderStatus($sStatus) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function setOrderStatus($sStatus)
     {
         $oDb = \OxidEsales\Eshop\Core\DatabaseProvider::getDb();
         $sQ = 'update oxorder set oxtransstatus = :oxtransstatus where oxid = :oxid';
@@ -596,6 +617,13 @@ class Order extends \OxidEsales\Eshop\Core\Model\BaseModel
         //updating order object
         $this->oxorder__oxtransstatus = new \OxidEsales\Eshop\Core\Field($sStatus, \OxidEsales\Eshop\Core\Field::T_RAW);
     }
+    /**
+     * @deprecated use self::convertVat instead
+     */
+    protected function _convertVat($sVat) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->convertVat($sVat);
+    }
 
     /**
      * Converts string VAT representation into float e.g. 7,6 to 7.6
@@ -604,7 +632,7 @@ class Order extends \OxidEsales\Eshop\Core\Model\BaseModel
      *
      * @return float
      */
-    protected function _convertVat($sVat) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function convertVat($sVat)
     {
         if (strpos($sVat, '.') < strpos($sVat, ',')) {
             $sVat = str_replace(['.', ','], ['', '.'], $sVat);
@@ -614,16 +642,30 @@ class Order extends \OxidEsales\Eshop\Core\Model\BaseModel
 
         return (float) $sVat;
     }
+    /**
+     * @deprecated use self::resetVats instead
+     */
+    protected function _resetVats() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->resetVats();
+    }
 
     /**
      * Reset Vat info
      */
-    protected function _resetVats() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function resetVats()
     {
         $this->oxorder__oxartvat1 = new \OxidEsales\Eshop\Core\Field(null);
         $this->oxorder__oxartvatprice1 = new \OxidEsales\Eshop\Core\Field(null);
         $this->oxorder__oxartvat2 = new \OxidEsales\Eshop\Core\Field(null);
         $this->oxorder__oxartvatprice2 = new \OxidEsales\Eshop\Core\Field(null);
+    }
+    /**
+     * @deprecated use self::loadFromBasket instead
+     */
+    protected function _loadFromBasket(\OxidEsales\Eshop\Application\Model\Basket $oBasket) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->loadFromBasket($oBasket);
     }
 
     /**
@@ -634,7 +676,7 @@ class Order extends \OxidEsales\Eshop\Core\Model\BaseModel
      *
      * @param \OxidEsales\Eshop\Application\Model\Basket $oBasket Shopping basket object
      */
-    protected function _loadFromBasket(\OxidEsales\Eshop\Application\Model\Basket $oBasket) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function loadFromBasket(\OxidEsales\Eshop\Application\Model\Basket $oBasket)
     {
         $myConfig = $this->getConfig();
 
@@ -779,13 +821,20 @@ class Order extends \OxidEsales\Eshop\Core\Model\BaseModel
             $this->oxorder__oxdelsal = clone $oDelAdress->oxaddress__oxsal;
         }
     }
+    /**
+     * @deprecated use self::setWrapping instead
+     */
+    protected function _setWrapping(\OxidEsales\Eshop\Application\Model\Basket $oBasket) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->setWrapping($oBasket);
+    }
 
     /**
      * Assigns wrapping VAT and card price + card message info
      *
      * @param \OxidEsales\Eshop\Application\Model\Basket $oBasket basket object
      */
-    protected function _setWrapping(\OxidEsales\Eshop\Application\Model\Basket $oBasket) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function setWrapping(\OxidEsales\Eshop\Application\Model\Basket $oBasket)
     {
         // wrapping price
         if (($oWrappingCost = $oBasket->getCosts('oxwrapping'))) {
@@ -805,6 +854,13 @@ class Order extends \OxidEsales\Eshop\Core\Model\BaseModel
         // card text will be stored in database
         $this->oxorder__oxcardtext = new \OxidEsales\Eshop\Core\Field($oBasket->getCardMessage(), \OxidEsales\Eshop\Core\Field::T_RAW);
     }
+    /**
+     * @deprecated use self::setOrderArticles instead
+     */
+    protected function _setOrderArticles($aArticleList) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->setOrderArticles($aArticleList);
+    }
 
     /**
      * Creates OrderArticle objects and assigns to them basket articles.
@@ -812,7 +868,7 @@ class Order extends \OxidEsales\Eshop\Core\Model\BaseModel
      *
      * @param array $aArticleList article list
      */
-    protected function _setOrderArticles($aArticleList) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function setOrderArticles($aArticleList)
     {
         // reset articles list
         $this->_oArticles = oxNew(\OxidEsales\Eshop\Core\Model\ListModel::class);
@@ -903,6 +959,13 @@ class Order extends \OxidEsales\Eshop\Core\Model\BaseModel
             $this->_oArticles->offsetSet($oOrderArticle->getId(), $oOrderArticle);
         }
     }
+    /**
+     * @deprecated use self::executePayment instead
+     */
+    protected function _executePayment(\OxidEsales\Eshop\Application\Model\Basket $oBasket, $oUserpayment) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->executePayment($oBasket, $oUserpayment);
+    }
 
     /**
      * Executes payment. Additionally loads oxPaymentGateway object, initiates
@@ -915,7 +978,7 @@ class Order extends \OxidEsales\Eshop\Core\Model\BaseModel
      *
      * @return  integer 2 or an error code
      */
-    protected function _executePayment(\OxidEsales\Eshop\Application\Model\Basket $oBasket, $oUserpayment) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function executePayment(\OxidEsales\Eshop\Application\Model\Basket $oBasket, $oUserpayment)
     {
         $oPayTransaction = $this->_getGateway();
         $oPayTransaction->setPaymentParams($oUserpayment);
@@ -942,6 +1005,13 @@ class Order extends \OxidEsales\Eshop\Core\Model\BaseModel
 
         return true; // everything fine
     }
+    /**
+     * @deprecated use self::getGateway instead
+     */
+    protected function _getGateway() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getGateway();
+    }
 
     /**
      * Returns the correct gateway. At the moment only switch between default
@@ -949,9 +1019,16 @@ class Order extends \OxidEsales\Eshop\Core\Model\BaseModel
      *
      * @return object $oPayTransaction payment gateway object
      */
-    protected function _getGateway() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getGateway()
     {
         return oxNew(\OxidEsales\Eshop\Application\Model\PaymentGateway::class);
+    }
+    /**
+     * @deprecated use self::setPayment instead
+     */
+    protected function _setPayment($sPaymentid) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->setPayment($sPaymentid);
     }
 
     /**
@@ -961,7 +1038,7 @@ class Order extends \OxidEsales\Eshop\Core\Model\BaseModel
      *
      * @return \OxidEsales\Eshop\Application\Model\UserPayment
      */
-    protected function _setPayment($sPaymentid) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function setPayment($sPaymentid)
     {
         $oPayment = oxNew(\OxidEsales\Eshop\Application\Model\Payment::class);
 
@@ -1007,14 +1084,28 @@ class Order extends \OxidEsales\Eshop\Core\Model\BaseModel
         // returning user payment object which will be used later in code ...
         return $oUserpayment;
     }
+    /**
+     * @deprecated use self::setFolder instead
+     */
+    protected function _setFolder() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->setFolder();
+    }
 
     /**
      * Assigns oxfolder as new
      */
-    protected function _setFolder() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function setFolder()
     {
         $myConfig = $this->getConfig();
         $this->oxorder__oxfolder = new \OxidEsales\Eshop\Core\Field(key($myConfig->getShopConfVar('aOrderfolder', $myConfig->getShopId())), \OxidEsales\Eshop\Core\Field::T_RAW);
+    }
+    /**
+     * @deprecated use self::updateWishlist instead
+     */
+    protected function _updateWishlist($aArticleList, $oUser) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->updateWishlist($aArticleList, $oUser);
     }
 
     /**
@@ -1024,7 +1115,7 @@ class Order extends \OxidEsales\Eshop\Core\Model\BaseModel
      * @param array  $aArticleList basket products
      * @param object $oUser        user object
      */
-    protected function _updateWishlist($aArticleList, $oUser) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function updateWishlist($aArticleList, $oUser)
     {
         foreach ($aArticleList as $oContent) {
             if (($sWishId = $oContent->getWishId())) {
@@ -1052,6 +1143,13 @@ class Order extends \OxidEsales\Eshop\Core\Model\BaseModel
             }
         }
     }
+    /**
+     * @deprecated use self::updateNoticeList instead
+     */
+    protected function _updateNoticeList($aArticleList, $oUser) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->updateNoticeList($aArticleList, $oUser);
+    }
 
     /**
      * After order is finished this method cleans up users notice list, by
@@ -1062,7 +1160,7 @@ class Order extends \OxidEsales\Eshop\Core\Model\BaseModel
      *
      * @return null
      */
-    protected function _updateNoticeList($aArticleList, $oUser) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function updateNoticeList($aArticleList, $oUser)
     {
         /*
          * #6141
@@ -1092,11 +1190,18 @@ class Order extends \OxidEsales\Eshop\Core\Model\BaseModel
             }
         }
     }
+    /**
+     * @deprecated use self::updateOrderDate instead
+     */
+    protected function _updateOrderDate() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->updateOrderDate();
+    }
 
     /**
      * Updates order date to current date
      */
-    protected function _updateOrderDate() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function updateOrderDate()
     {
         $oDb = \OxidEsales\Eshop\Core\DatabaseProvider::getDb();
         $sDate = date('Y-m-d H:i:s', \OxidEsales\Eshop\Core\Registry::getUtilsDate()->getTime());
@@ -1107,6 +1212,13 @@ class Order extends \OxidEsales\Eshop\Core\Model\BaseModel
             ':oxid' => $this->getId()
         ]);
     }
+    /**
+     * @deprecated use self::markVouchers instead
+     */
+    protected function _markVouchers($oBasket, $oUser) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->markVouchers($oBasket, $oUser);
+    }
 
     /**
      * Marks voucher as used (oxvoucher::markAsUsed())
@@ -1115,7 +1227,7 @@ class Order extends \OxidEsales\Eshop\Core\Model\BaseModel
      * @param \OxidEsales\Eshop\Application\Model\Basket $oBasket basket object
      * @param \OxidEsales\Eshop\Application\Model\User   $oUser   user object
      */
-    protected function _markVouchers($oBasket, $oUser) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function markVouchers($oBasket, $oUser)
     {
         $this->_aVoucherList = $oBasket->getVouchers();
 
@@ -1219,13 +1331,20 @@ class Order extends \OxidEsales\Eshop\Core\Model\BaseModel
             }
         }
     }
+    /**
+     * @deprecated use self::insert instead
+     */
+    protected function _insert() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->insert();
+    }
 
     /**
      * Inserts order object information in DB. Returns true on success.
      *
      * @return bool
      */
-    protected function _insert() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function insert()
     {
         $myConfig = $this->getConfig();
         $oUtilsDate = \OxidEsales\Eshop\Core\Registry::getUtilsDate();
@@ -1254,17 +1373,31 @@ class Order extends \OxidEsales\Eshop\Core\Model\BaseModel
 
         return $blInsert;
     }
+    /**
+     * @deprecated use self::getCounterIdent instead
+     */
+    protected function _getCounterIdent() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getCounterIdent();
+    }
 
     /**
      * creates counter ident
      *
      * @return String
      */
-    protected function _getCounterIdent() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getCounterIdent()
     {
         $sCounterIdent = ($this->_blSeparateNumbering) ? 'oxOrder_' . $this->getConfig()->getShopId() : 'oxOrder';
 
         return $sCounterIdent;
+    }
+    /**
+     * @deprecated use self::setNumber instead
+     */
+    protected function _setNumber() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->setNumber();
     }
 
 
@@ -1273,7 +1406,7 @@ class Order extends \OxidEsales\Eshop\Core\Model\BaseModel
      *
      * @return bool
      */
-    protected function _setNumber() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function setNumber()
     {
         $oDb = \OxidEsales\Eshop\Core\DatabaseProvider::getDb();
 
@@ -1290,13 +1423,20 @@ class Order extends \OxidEsales\Eshop\Core\Model\BaseModel
 
         return $blUpdate;
     }
+    /**
+     * @deprecated use self::update instead
+     */
+    protected function _update() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->update();
+    }
 
     /**
      * Updates object parameters to DB.
      *
      * @return null
      */
-    protected function _update() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function update()
     {
         $this->_aSkipSaveFields = ['oxtimestamp', 'oxorderdate'];
         $this->oxorder__oxsenddate = new \OxidEsales\Eshop\Core\Field(\OxidEsales\Eshop\Core\Registry::getUtilsDate()->formatDBDate($this->oxorder__oxsenddate->value, true));
@@ -1381,6 +1521,13 @@ class Order extends \OxidEsales\Eshop\Core\Model\BaseModel
             throw $exception;
         }
     }
+    /**
+     * @deprecated use self::getOrderBasket instead
+     */
+    protected function _getOrderBasket($blStockCheck = true) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getOrderBasket($blStockCheck);
+    }
 
     /**
      * Returns basket object filled up with discount, delivery, wrapping and all other info
@@ -1389,7 +1536,7 @@ class Order extends \OxidEsales\Eshop\Core\Model\BaseModel
      *
      * @return \OxidEsales\Eshop\Application\Model\Basket
      */
-    protected function _getOrderBasket($blStockCheck = true) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getOrderBasket($blStockCheck = true)
     {
         $this->_oOrderBasket = oxNew(\OxidEsales\Eshop\Application\Model\Basket::class);
         $this->_oOrderBasket->enableSaveToDataBase(false);
@@ -1679,6 +1826,13 @@ class Order extends \OxidEsales\Eshop\Core\Model\BaseModel
         // We force reading from master to prevent issues with slow replications or open transactions (see ESDEV-3804).
         return (int) \OxidEsales\Eshop\Core\DatabaseProvider::getMaster()->getOne($sSelect, $params);
     }
+    /**
+     * @deprecated use self::checkOrderExist instead
+     */
+    protected function _checkOrderExist($sOxId = null) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->checkOrderExist($sOxId);
+    }
 
 
     /**
@@ -1688,7 +1842,7 @@ class Order extends \OxidEsales\Eshop\Core\Model\BaseModel
      *
      * @return bool
      */
-    protected function _checkOrderExist($sOxId = null) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function checkOrderExist($sOxId = null)
     {
         if (!$sOxId) {
             return false;
@@ -1705,6 +1859,13 @@ class Order extends \OxidEsales\Eshop\Core\Model\BaseModel
 
         return false;
     }
+    /**
+     * @deprecated use self::sendOrderByEmail instead
+     */
+    protected function _sendOrderByEmail($oUser = null, $oBasket = null, $oPayment = null) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->sendOrderByEmail($oUser, $oBasket, $oPayment);
+    }
 
     /**
      * Send order to shop owner and user
@@ -1715,7 +1876,7 @@ class Order extends \OxidEsales\Eshop\Core\Model\BaseModel
      *
      * @return bool
      */
-    protected function _sendOrderByEmail($oUser = null, $oBasket = null, $oPayment = null) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function sendOrderByEmail($oUser = null, $oBasket = null, $oPayment = null)
     {
         $iRet = self::ORDER_STATE_MAILINGERROR;
 
@@ -1850,6 +2011,13 @@ class Order extends \OxidEsales\Eshop\Core\Model\BaseModel
 
         return $sLastPaymentId;
     }
+    /**
+     * @deprecated use self::addOrderArticlesToBasket instead
+     */
+    protected function _addOrderArticlesToBasket($oBasket, $aOrderArticles) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->addOrderArticlesToBasket($oBasket, $aOrderArticles);
+    }
 
     /**
      * Adds order articles back to virtual basket. Needed for recalculating order.
@@ -1857,7 +2025,7 @@ class Order extends \OxidEsales\Eshop\Core\Model\BaseModel
      * @param \OxidEsales\Eshop\Application\Model\Basket $oBasket        basket object
      * @param array                                      $aOrderArticles order articles
      */
-    protected function _addOrderArticlesToBasket($oBasket, $aOrderArticles) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function addOrderArticlesToBasket($oBasket, $aOrderArticles)
     {
         // if no order articles, return empty basket
         if (count($aOrderArticles) > 0) {
@@ -1867,6 +2035,13 @@ class Order extends \OxidEsales\Eshop\Core\Model\BaseModel
             }
         }
     }
+    /**
+     * @deprecated use self::addArticlesToBasket instead
+     */
+    protected function _addArticlesToBasket($oBasket, $aArticles) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->addArticlesToBasket($oBasket, $aArticles);
+    }
 
     /**
      * Adds new products to basket/order
@@ -1874,7 +2049,7 @@ class Order extends \OxidEsales\Eshop\Core\Model\BaseModel
      * @param \OxidEsales\Eshop\Application\Model\Basket $oBasket   basket to add articles
      * @param array                                      $aArticles article array
      */
-    protected function _addArticlesToBasket($oBasket, $aArticles) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function addArticlesToBasket($oBasket, $aArticles)
     {
         // if no order articles
         if (count($aArticles) > 0) {

--- a/source/Application/Model/OrderArticle.php
+++ b/source/Application/Model/OrderArticle.php
@@ -155,6 +155,13 @@ class OrderArticle extends \OxidEsales\Eshop\Core\Model\BaseModel implements Art
         //update article sold amount
         $oArticle->updateSoldAmount($dAddAmount * (-1));
     }
+    /**
+     * @deprecated use self::getArtStock instead
+     */
+    protected function _getArtStock($dAddAmount = 0, $blAllowNegativeStock = false) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getArtStock($dAddAmount, $blAllowNegativeStock);
+    }
 
     /**
      * Adds or substracts defined amount passed by param from arcticle stock
@@ -164,7 +171,7 @@ class OrderArticle extends \OxidEsales\Eshop\Core\Model\BaseModel implements Art
      *
      * @return double
      */
-    protected function _getArtStock($dAddAmount = 0, $blAllowNegativeStock = false) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getArtStock($dAddAmount = 0, $blAllowNegativeStock = false)
     {
         // We force reading from master to prevent issues with slow replications or open transactions (see ESDEV-3804).
         $masterDb = \OxidEsales\Eshop\Core\DatabaseProvider::getMaster();
@@ -216,6 +223,13 @@ class OrderArticle extends \OxidEsales\Eshop\Core\Model\BaseModel implements Art
         // serializing persisten info stored while ordering
         $this->oxorderarticles__oxpersparam = new \OxidEsales\Eshop\Core\Field(serialize($aParams), \OxidEsales\Eshop\Core\Field::T_RAW);
     }
+    /**
+     * @deprecated use self::setFieldData instead
+     */
+    protected function _setFieldData($sFieldName, $sValue, $iDataType = \OxidEsales\Eshop\Core\Field::T_TEXT) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->setFieldData($sFieldName, $sValue, $iDataType);
+    }
 
     /**
      * Sets data field value
@@ -226,7 +240,7 @@ class OrderArticle extends \OxidEsales\Eshop\Core\Model\BaseModel implements Art
      *
      * @return null
      */
-    protected function _setFieldData($sFieldName, $sValue, $iDataType = \OxidEsales\Eshop\Core\Field::T_TEXT) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function setFieldData($sFieldName, $sValue, $iDataType = \OxidEsales\Eshop\Core\Field::T_TEXT)
     {
         $sFieldName = strtolower($sFieldName);
         switch ($sFieldName) {
@@ -288,11 +302,18 @@ class OrderArticle extends \OxidEsales\Eshop\Core\Model\BaseModel implements Art
 
         return $this->oxarticles__oxparentid->value;
     }
+    /**
+     * @deprecated use self::setArticleParams instead
+     */
+    protected function _setArticleParams() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->setArticleParams();
+    }
 
     /**
      * Sets article parameters to current object, so this object can be used for basket calculation
      */
-    protected function _setArticleParams() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function setArticleParams()
     {
         // creating needed fields
         $this->oxarticles__oxstock = $this->oxorderarticles__oxamount;
@@ -341,6 +362,13 @@ class OrderArticle extends \OxidEsales\Eshop\Core\Model\BaseModel implements Art
     {
         return true;
     }
+    /**
+     * @deprecated use self::getOrderArticle instead
+     */
+    protected function _getOrderArticle($sArticleId = null) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getOrderArticle($sArticleId);
+    }
 
     /**
      * Loads, caches and returns real order article instance. If article is not
@@ -350,7 +378,7 @@ class OrderArticle extends \OxidEsales\Eshop\Core\Model\BaseModel implements Art
      *
      * @return \OxidEsales\Eshop\Application\Model\Article | false
      */
-    protected function _getOrderArticle($sArticleId = null) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getOrderArticle($sArticleId = null)
     {
         if ($this->_oOrderArticle === null) {
             $this->_oOrderArticle = false;
@@ -757,6 +785,13 @@ class OrderArticle extends \OxidEsales\Eshop\Core\Model\BaseModel implements Art
 
         return null;
     }
+    /**
+     * @deprecated use self::insert instead
+     */
+    protected function _insert() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->insert();
+    }
 
     /**
      * Sets article creation date
@@ -765,7 +800,7 @@ class OrderArticle extends \OxidEsales\Eshop\Core\Model\BaseModel implements Art
      *
      * @return bool
      */
-    protected function _insert() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function insert()
     {
         $iInsertTime = time();
         $now = date('Y-m-d H:i:s', $iInsertTime);
@@ -800,12 +835,19 @@ class OrderArticle extends \OxidEsales\Eshop\Core\Model\BaseModel implements Art
 
         return $this->_oArticle;
     }
+    /**
+     * @deprecated use self::setOrderFiles instead
+     */
+    public function _setOrderFiles() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->setOrderFiles();
+    }
 
 
     /**
      * Set order files
      */
-    public function _setOrderFiles() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    public function setOrderFiles()
     {
         $oArticle = $this->getArticle();
 

--- a/source/Application/Model/OrderFile.php
+++ b/source/Application/Model/OrderFile.php
@@ -125,6 +125,13 @@ class OrderFile extends \OxidEsales\Eshop\Core\Model\BaseModel
 
         return $oFile->getSize();
     }
+    /**
+     * @deprecated use self::getFieldLongName instead
+     */
+    protected function _getFieldLongName($sFieldName) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getFieldLongName($sFieldName);
+    }
 
     /**
      * returns long name
@@ -133,7 +140,7 @@ class OrderFile extends \OxidEsales\Eshop\Core\Model\BaseModel
      *
      * @return string
      */
-    protected function _getFieldLongName($sFieldName) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getFieldLongName($sFieldName)
     {
         $aFieldNames = [
             'oxorderfiles__oxarticletitle',

--- a/source/Application/Model/PaymentGateway.php
+++ b/source/Application/Model/PaymentGateway.php
@@ -100,13 +100,20 @@ class PaymentGateway extends \OxidEsales\Eshop\Core\Base
     {
         return $this->_sLastError;
     }
+    /**
+     * @deprecated use self::isActive instead
+     */
+    protected function _isActive() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->isActive();
+    }
 
     /**
      * Returns true is payment active.
      *
      * @return bool
      */
-    protected function _isActive() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function isActive()
     {
         return $this->_blActive;
     }

--- a/source/Application/Model/PaymentList.php
+++ b/source/Application/Model/PaymentList.php
@@ -44,6 +44,13 @@ class PaymentList extends \OxidEsales\Eshop\Core\Model\ListModel
             $this->_sHomeCountry = $sHomeCountry;
         }
     }
+    /**
+     * @deprecated use self::getFilterSelect instead
+     */
+    protected function _getFilterSelect($sShipSetId, $dPrice, $oUser) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getFilterSelect($sShipSetId, $dPrice, $oUser);
+    }
 
     /**
      * Creates payment list filter SQL to load current state payment list
@@ -54,7 +61,7 @@ class PaymentList extends \OxidEsales\Eshop\Core\Model\ListModel
      *
      * @return string
      */
-    protected function _getFilterSelect($sShipSetId, $dPrice, $oUser) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getFilterSelect($sShipSetId, $dPrice, $oUser)
     {
         $oDb = \OxidEsales\Eshop\Core\DatabaseProvider::getDb();
         $sBoni = ($oUser && $oUser->oxuser__oxboni->value) ? $oUser->oxuser__oxboni->value : 0;

--- a/source/Application/Model/PriceAlarm.php
+++ b/source/Application/Model/PriceAlarm.php
@@ -82,13 +82,20 @@ class PriceAlarm extends \OxidEsales\Eshop\Core\Model\BaseModel
         parent::__construct();
         $this->init('oxpricealarm');
     }
+    /**
+     * @deprecated use self::insert instead
+     */
+    protected function _insert() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->insert();
+    }
 
     /**
      * Inserts object data into DB, returns true on success.
      *
      * @return bool
      */
-    protected function _insert() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function insert()
     {
         // set oxinsert value
         $this->oxpricealarm__oxinsert = new \OxidEsales\Eshop\Core\Field(date('Y-m-d', \OxidEsales\Eshop\Core\Registry::getUtilsDate()->getTime()));

--- a/source/Application/Model/RecommendationList.php
+++ b/source/Application/Model/RecommendationList.php
@@ -101,13 +101,20 @@ class RecommendationList extends \OxidEsales\Eshop\Core\Model\BaseModel implemen
 
         return $iCnt;
     }
+    /**
+     * @deprecated use self::getArticleSelect instead
+     */
+    protected function _getArticleSelect() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getArticleSelect();
+    }
 
     /**
      * Returns the appropriate SQL select
      *
      * @return string
      */
-    protected function _getArticleSelect() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getArticleSelect()
     {
         $sArtView = getViewName('oxarticles');
         $sSelect = "select count(distinct $sArtView.oxid) from oxobject2list ";
@@ -293,6 +300,13 @@ class RecommendationList extends \OxidEsales\Eshop\Core\Model\BaseModel implemen
             }
         }
     }
+    /**
+     * @deprecated use self::loadFirstArticles instead
+     */
+    protected function _loadFirstArticles(\OxidEsales\Eshop\Core\Model\ListModel $oRecommList, $aIds) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->loadFirstArticles($oRecommList, $aIds);
+    }
 
     /**
      * loads first articles to recomm list also ordering them and clearing not usable list objects
@@ -303,7 +317,7 @@ class RecommendationList extends \OxidEsales\Eshop\Core\Model\BaseModel implemen
      * @param \OxidEsales\Eshop\Core\Model\ListModel $oRecommList recommendation list
      * @param array                                  $aIds        article ids
      */
-    protected function _loadFirstArticles(\OxidEsales\Eshop\Core\Model\ListModel $oRecommList, $aIds) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function loadFirstArticles(\OxidEsales\Eshop\Core\Model\ListModel $oRecommList, $aIds)
     {
         $aIds = \OxidEsales\Eshop\Core\DatabaseProvider::getDb()->quoteArray($aIds);
         $sIds = implode(", ", $aIds);
@@ -382,6 +396,13 @@ class RecommendationList extends \OxidEsales\Eshop\Core\Model\BaseModel implemen
 
         return $iCnt;
     }
+    /**
+     * @deprecated use self::getSearchSelect instead
+     */
+    protected function _getSearchSelect($sSearchStr) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getSearchSelect($sSearchStr);
+    }
 
     /**
      * Returns the appropriate SQL select according to search parameters
@@ -390,7 +411,7 @@ class RecommendationList extends \OxidEsales\Eshop\Core\Model\BaseModel implemen
      *
      * @return string
      */
-    protected function _getSearchSelect($sSearchStr) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getSearchSelect($sSearchStr)
     {
         $iShopId = $this->getConfig()->getShopId();
         $sSearchStrQuoted = \OxidEsales\Eshop\Core\DatabaseProvider::getDb()->quote("%$sSearchStr%");

--- a/source/Application/Model/Remark.php
+++ b/source/Application/Model/Remark.php
@@ -55,13 +55,20 @@ class Remark extends \OxidEsales\Eshop\Core\Model\BaseModel
 
         return $blRet;
     }
+    /**
+     * @deprecated use self::insert instead
+     */
+    protected function _insert() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->insert();
+    }
 
     /**
      * Inserts object data fields in DB. Returns true on success.
      *
      * @return bool
      */
-    protected function _insert() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function insert()
     {
         // set oxcreate
         $sNow = date('Y-m-d H:i:s', \OxidEsales\Eshop\Core\Registry::getUtilsDate()->getTime());

--- a/source/Application/Model/RequiredAddressFields.php
+++ b/source/Application/Model/RequiredAddressFields.php
@@ -92,6 +92,13 @@ class RequiredAddressFields
 
         return $this->_filterFields($aRequiredFields, 'oxaddress__');
     }
+    /**
+     * @deprecated use self::filterFields instead
+     */
+    private function _filterFields($aFields, $sPrefix) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->filterFields($aFields, $sPrefix);
+    }
 
     /**
      * Removes delivery fields from fields list.
@@ -101,7 +108,7 @@ class RequiredAddressFields
      *
      * @return mixed
      */
-    private function _filterFields($aFields, $sPrefix) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    private function filterFields($aFields, $sPrefix)
     {
         $aAllowed = [];
         foreach ($aFields as $sKey => $sValue) {

--- a/source/Application/Model/RequiredFieldValidator.php
+++ b/source/Application/Model/RequiredFieldValidator.php
@@ -33,6 +33,13 @@ class RequiredFieldValidator
 
         return $blValid;
     }
+    /**
+     * @deprecated use self::validateFieldValueArray instead
+     */
+    private function _validateFieldValueArray($aFieldValues) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->validateFieldValueArray($aFieldValues);
+    }
 
     /**
      * Checks if all values are filled up
@@ -41,7 +48,7 @@ class RequiredFieldValidator
      *
      * @return bool
      */
-    private function _validateFieldValueArray($aFieldValues) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    private function validateFieldValueArray($aFieldValues)
     {
         $blValid = true;
         foreach ($aFieldValues as $sValue) {

--- a/source/Application/Model/RequiredFieldsValidator.php
+++ b/source/Application/Model/RequiredFieldsValidator.php
@@ -120,13 +120,20 @@ class RequiredFieldsValidator
 
         return empty($aInvalidFields);
     }
+    /**
+     * @deprecated use self::setInvalidFields instead
+     */
+    private function _setInvalidFields($aFields) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->setInvalidFields($aFields);
+    }
 
     /**
      * Add fields to invalid fields array.
      *
      * @param array $aFields Invalid field name.
      */
-    private function _setInvalidFields($aFields) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    private function setInvalidFields($aFields)
     {
         $this->_aInvalidFields = $aFields;
     }

--- a/source/Application/Model/Review.php
+++ b/source/Application/Model/Review.php
@@ -82,13 +82,20 @@ class Review extends \OxidEsales\Eshop\Core\Model\BaseModel
 
         return $blRet;
     }
+    /**
+     * @deprecated use self::insert instead
+     */
+    protected function _insert() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->insert();
+    }
 
     /**
      * Inserts object data fiels in DB. Returns true on success.
      *
      * @return bool
      */
-    protected function _insert() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function insert()
     {
         // set oxcreate
         $this->oxreviews__oxcreate = new \OxidEsales\Eshop\Core\Field(date('Y-m-d H:i:s', \OxidEsales\Eshop\Core\Registry::getUtilsDate()->getTime()));

--- a/source/Application/Model/RssFeed.php
+++ b/source/Application/Model/RssFeed.php
@@ -90,13 +90,20 @@ class RssFeed extends \OxidEsales\Eshop\Core\Base
 
         $this->_deleteFile($sFilePath);
     }
+    /**
+     * @deprecated use self::loadBaseChannel instead
+     */
+    protected function _loadBaseChannel() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->loadBaseChannel();
+    }
 
     /**
      * _loadBaseChannel loads basic channel data
      *
      * @access protected
      */
-    protected function _loadBaseChannel() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function loadBaseChannel()
     {
         $oShop = $this->getConfig()->getActiveShop();
         $this->_aChannel['title'] = $oShop->oxshops__oxname->value;
@@ -123,6 +130,13 @@ class RssFeed extends \OxidEsales\Eshop\Core\Base
         $this->_aChannel['image']['title'] = $this->_aChannel['title'];
         $this->_aChannel['image']['link'] = $this->_aChannel['link'];
     }
+    /**
+     * @deprecated use self::getCacheId instead
+     */
+    protected function _getCacheId($name) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getCacheId($name);
+    }
 
     /**
      * _getCacheId retrieve cache id
@@ -132,11 +146,18 @@ class RssFeed extends \OxidEsales\Eshop\Core\Base
      * @access protected
      * @return string
      */
-    protected function _getCacheId($name) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getCacheId($name)
     {
         $oConfig = $this->getConfig();
 
         return $name . '_' . $oConfig->getShopId() . '_' . Registry::getLang()->getBaseLanguage() . '_' . (int) $oConfig->getShopCurrency();
+    }
+    /**
+     * @deprecated use self::loadFromCache instead
+     */
+    protected function _loadFromCache($name) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->loadFromCache($name);
     }
 
     /**
@@ -147,7 +168,7 @@ class RssFeed extends \OxidEsales\Eshop\Core\Base
      * @access protected
      * @return array
      */
-    protected function _loadFromCache($name) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function loadFromCache($name)
     {
         if ($aRes = Registry::getUtils()->fromFileCache($this->_getCacheId($name))) {
             if ($aRes['timestamp'] > time() - self::CACHE_TTL) {
@@ -156,6 +177,13 @@ class RssFeed extends \OxidEsales\Eshop\Core\Base
         }
 
         return false;
+    }
+    /**
+     * @deprecated use self::getLastBuildDate instead
+     */
+    protected function _getLastBuildDate($name, $aData) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getLastBuildDate($name, $aData);
     }
 
 
@@ -169,7 +197,7 @@ class RssFeed extends \OxidEsales\Eshop\Core\Base
      * @access protected
      * @return string
      */
-    protected function _getLastBuildDate($name, $aData) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getLastBuildDate($name, $aData)
     {
         if ($aData2 = Registry::getUtils()->fromFileCache($this->_getCacheId($name))) {
             $sLastBuildDate = $aData2['content']['lastBuildDate'];
@@ -181,6 +209,13 @@ class RssFeed extends \OxidEsales\Eshop\Core\Base
         }
 
         return date('D, d M Y H:i:s O');
+    }
+    /**
+     * @deprecated use self::saveToCache instead
+     */
+    protected function _saveToCache($name, $aContent) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->saveToCache($name, $aContent);
     }
 
     /**
@@ -195,11 +230,18 @@ class RssFeed extends \OxidEsales\Eshop\Core\Base
      * @access protected
      * @return void
      */
-    protected function _saveToCache($name, $aContent) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function saveToCache($name, $aContent)
     {
         $aData = ['timestamp' => time(), 'content' => $aContent];
 
         return Registry::getUtils()->toFileCache($this->_getCacheId($name), $aData);
+    }
+    /**
+     * @deprecated use self::getArticleItems instead
+     */
+    protected function _getArticleItems(\OxidEsales\Eshop\Application\Model\ArticleList $oList) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getArticleItems($oList);
     }
 
 
@@ -211,7 +253,7 @@ class RssFeed extends \OxidEsales\Eshop\Core\Base
      * @access protected
      * @return array
      */
-    protected function _getArticleItems(\OxidEsales\Eshop\Application\Model\ArticleList $oList) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getArticleItems(\OxidEsales\Eshop\Application\Model\ArticleList $oList)
     {
         $myUtilsUrl = Registry::getUtilsUrl();
         $aItems = [];
@@ -270,6 +312,13 @@ class RssFeed extends \OxidEsales\Eshop\Core\Base
 
         return $aItems;
     }
+    /**
+     * @deprecated use self::prepareUrl instead
+     */
+    protected function _prepareUrl($sUri, $sTitle) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->prepareUrl($sUri, $sTitle);
+    }
 
     /**
      * _prepareUrl make url from uri
@@ -281,7 +330,7 @@ class RssFeed extends \OxidEsales\Eshop\Core\Base
      *
      * @return string
      */
-    protected function _prepareUrl($sUri, $sTitle) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function prepareUrl($sUri, $sTitle)
     {
         $iLang = Registry::getLang()->getBaseLanguage();
         $sUrl = $this->_getShopUrl();
@@ -294,6 +343,13 @@ class RssFeed extends \OxidEsales\Eshop\Core\Base
 
         return Registry::getUtilsUrl()->prepareUrlForNoSession($sUrl);
     }
+    /**
+     * @deprecated use self::prepareFeedName instead
+     */
+    protected function _prepareFeedName($sTitle) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->prepareFeedName($sTitle);
+    }
 
     /**
      * _prepareFeedName adds shop name to feed title
@@ -304,11 +360,18 @@ class RssFeed extends \OxidEsales\Eshop\Core\Base
      *
      * @return string
      */
-    protected function _prepareFeedName($sTitle) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function prepareFeedName($sTitle)
     {
         $oShop = $this->getConfig()->getActiveShop();
 
         return $oShop->oxshops__oxname->value . "/" . $sTitle;
+    }
+    /**
+     * @deprecated use self::getShopUrl instead
+     */
+    protected function _getShopUrl() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getShopUrl();
     }
 
     /**
@@ -317,7 +380,7 @@ class RssFeed extends \OxidEsales\Eshop\Core\Base
      * @access protected
      * @return string
      */
-    protected function _getShopUrl() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getShopUrl()
     {
         $sUrl = $this->getConfig()->getShopUrl();
         $oStr = getStr();
@@ -330,6 +393,13 @@ class RssFeed extends \OxidEsales\Eshop\Core\Base
         }
 
         return $sUrl;
+    }
+    /**
+     * @deprecated use self::loadData instead
+     */
+    protected function _loadData($sTag, $sTitle, $sDesc, $aItems, $sRssUrl, $sTargetUrl = null) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->loadData($sTag, $sTitle, $sDesc, $aItems, $sRssUrl, $sTargetUrl);
     }
 
     /**
@@ -344,7 +414,7 @@ class RssFeed extends \OxidEsales\Eshop\Core\Base
      *
      * @access protected
      */
-    protected function _loadData($sTag, $sTitle, $sDesc, $aItems, $sRssUrl, $sTargetUrl = null) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function loadData($sTag, $sTitle, $sDesc, $aItems, $sRssUrl, $sTargetUrl = null)
     {
         $this->_loadBaseChannel();
 
@@ -491,6 +561,13 @@ class RssFeed extends \OxidEsales\Eshop\Core\Base
 
         return $this->_prepareFeedName($sTitle . $oLang->translateString('PRODUCTS', $iLang));
     }
+    /**
+     * @deprecated use self::getCatPath instead
+     */
+    protected function _getCatPath($oCat) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getCatPath($oCat);
+    }
 
     /**
      * Returns string built from category titles
@@ -499,7 +576,7 @@ class RssFeed extends \OxidEsales\Eshop\Core\Base
      *
      * @return string
      */
-    protected function _getCatPath($oCat) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getCatPath($oCat)
     {
         $sCatPathString = '';
         $sSep = '';
@@ -581,6 +658,13 @@ class RssFeed extends \OxidEsales\Eshop\Core\Base
     {
         return $this->_prepareFeedName(getStr()->htmlspecialchars($this->_getSearchParamsTranslation('SEARCH_FOR_PRODUCTS_CATEGORY_VENDOR_MANUFACTURER', $sSearch, $sCatId, $sVendorId, $sManufacturerId)));
     }
+    /**
+     * @deprecated use self::getSearchParamsUrl instead
+     */
+    protected function _getSearchParamsUrl($sSearch, $sCatId, $sVendorId, $sManufacturerId) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getSearchParamsUrl($sSearch, $sCatId, $sVendorId, $sManufacturerId);
+    }
 
     /**
      * _getSearchParamsUrl return search parameters for url
@@ -594,7 +678,7 @@ class RssFeed extends \OxidEsales\Eshop\Core\Base
      *
      * @return string
      */
-    protected function _getSearchParamsUrl($sSearch, $sCatId, $sVendorId, $sManufacturerId) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getSearchParamsUrl($sSearch, $sCatId, $sVendorId, $sManufacturerId)
     {
         $sParams = "searchparam=" . urlencode($sSearch);
         if ($sCatId) {
@@ -611,6 +695,13 @@ class RssFeed extends \OxidEsales\Eshop\Core\Base
 
         return $sParams;
     }
+    /**
+     * @deprecated use self::getObjectField instead
+     */
+    protected function _getObjectField($sId, $sObject, $sField) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getObjectField($sId, $sObject, $sField);
+    }
 
     /**
      * loads object and returns specified field
@@ -622,7 +713,7 @@ class RssFeed extends \OxidEsales\Eshop\Core\Base
      * @access protected
      * @return string
      */
-    protected function _getObjectField($sId, $sObject, $sField) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getObjectField($sId, $sObject, $sField)
     {
         if (!$sId) {
             return '';
@@ -633,6 +724,13 @@ class RssFeed extends \OxidEsales\Eshop\Core\Base
         }
 
         return '';
+    }
+    /**
+     * @deprecated use self::getSearchParamsTranslation instead
+     */
+    protected function _getSearchParamsTranslation($sSearch, $sId, $sCatId, $sVendorId, $sManufacturerId) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getSearchParamsTranslation($sSearch, $sId, $sCatId, $sVendorId, $sManufacturerId);
     }
 
     /**
@@ -648,7 +746,7 @@ class RssFeed extends \OxidEsales\Eshop\Core\Base
      * @access protected
      * @return string
      */
-    protected function _getSearchParamsTranslation($sSearch, $sId, $sCatId, $sVendorId, $sManufacturerId) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getSearchParamsTranslation($sSearch, $sId, $sCatId, $sVendorId, $sManufacturerId)
     {
         $oLang = Registry::getLang();
         $sCatTitle = '';
@@ -768,6 +866,13 @@ class RssFeed extends \OxidEsales\Eshop\Core\Base
             $oLang->translateString("LISTMANIA", $iLang) . "/" . $oArticle->oxarticles__oxtitle->value
         );
     }
+    /**
+     * @deprecated use self::getRecommListItems instead
+     */
+    protected function _getRecommListItems($oList) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getRecommListItems($oList);
+    }
 
     /**
      * make rss data array from given oxlist
@@ -778,7 +883,7 @@ class RssFeed extends \OxidEsales\Eshop\Core\Base
      *
      * @return array
      */
-    protected function _getRecommListItems($oList) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getRecommListItems($oList)
     {
         $myUtilsUrl = Registry::getUtilsUrl();
         $aItems = [];
@@ -957,6 +1062,13 @@ class RssFeed extends \OxidEsales\Eshop\Core\Base
     {
         return self::CACHE_TTL;
     }
+    /**
+     * @deprecated use self::deleteFile instead
+     */
+    protected function _deleteFile($sFilePath) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->deleteFile($sFilePath);
+    }
 
     /**
      * Delete the file, given by its path.
@@ -965,7 +1077,7 @@ class RssFeed extends \OxidEsales\Eshop\Core\Base
      *
      * @return bool Went everything well?
      */
-    protected function _deleteFile($sFilePath) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function deleteFile($sFilePath)
     {
         return @unlink($sFilePath);
     }

--- a/source/Application/Model/Search.php
+++ b/source/Application/Model/Search.php
@@ -101,6 +101,13 @@ class Search extends \OxidEsales\Eshop\Core\Base
 
         return $iCnt;
     }
+    /**
+     * @deprecated use self::getSearchSelect instead
+     */
+    protected function _getSearchSelect($sSearchParamForQuery = false, $sInitialSearchCat = false, $sInitialSearchVendor = false, $sInitialSearchManufacturer = false, $sSortBy = false) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getSearchSelect($sSearchParamForQuery, $sInitialSearchCat, $sInitialSearchVendor, $sInitialSearchManufacturer, $sSortBy);
+    }
 
     /**
      * Returns the appropriate SQL select for a search according to search parameters
@@ -113,7 +120,7 @@ class Search extends \OxidEsales\Eshop\Core\Base
      *
      * @return string
      */
-    protected function _getSearchSelect($sSearchParamForQuery = false, $sInitialSearchCat = false, $sInitialSearchVendor = false, $sInitialSearchManufacturer = false, $sSortBy = false) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getSearchSelect($sSearchParamForQuery = false, $sInitialSearchCat = false, $sInitialSearchVendor = false, $sInitialSearchManufacturer = false, $sSortBy = false)
     {
         if (!$sSearchParamForQuery && !$sInitialSearchCat && !$sInitialSearchVendor && !$sInitialSearchManufacturer) {
             //no search string
@@ -232,6 +239,13 @@ class Search extends \OxidEsales\Eshop\Core\Base
 
         return $sSelect;
     }
+    /**
+     * @deprecated use self::getWhere instead
+     */
+    protected function _getWhere($sSearchString) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getWhere($sSearchString);
+    }
 
     /**
      * Forms and returns SQL query string for search in DB.
@@ -240,7 +254,7 @@ class Search extends \OxidEsales\Eshop\Core\Base
      *
      * @return string
      */
-    protected function _getWhere($sSearchString) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getWhere($sSearchString)
     {
         $oDb = \OxidEsales\Eshop\Core\DatabaseProvider::getDb();
         $myConfig = $this->getConfig();

--- a/source/Application/Model/SeoEncoderArticle.php
+++ b/source/Application/Model/SeoEncoderArticle.php
@@ -25,15 +25,29 @@ class SeoEncoderArticle extends \OxidEsales\Eshop\Core\SeoEncoder
      * @var array
      */
     protected static $_aTitleCache = [];
+    /**
+     * @deprecated use self::getUrlExtension instead
+     */
+    protected function _getUrlExtension() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getUrlExtension();
+    }
 
     /**
      * Returns target "extension" (.html)
      *
      * @return string
      */
-    protected function _getUrlExtension() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getUrlExtension()
     {
         return '.html';
+    }
+    /**
+     * @deprecated use self::getProductForLang instead
+     */
+    protected function _getProductForLang($oArticle, $iLang) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getProductForLang($oArticle, $iLang);
     }
 
     /**
@@ -45,7 +59,7 @@ class SeoEncoderArticle extends \OxidEsales\Eshop\Core\SeoEncoder
      *
      * @return \OxidEsales\Eshop\Application\Model\Article
      */
-    protected function _getProductForLang($oArticle, $iLang) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getProductForLang($oArticle, $iLang)
     {
         if (isset($iLang) && $iLang != $oArticle->getLanguage()) {
             $sId = $oArticle->getId();
@@ -101,6 +115,13 @@ class SeoEncoderArticle extends \OxidEsales\Eshop\Core\SeoEncoder
 
         return $sSeoUri;
     }
+    /**
+     * @deprecated use self::getRecomm instead
+     */
+    protected function _getRecomm($oArticle, $iLang) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getRecomm($oArticle, $iLang);
+    }
 
     /**
      * Returns active recommendation list object if available
@@ -112,7 +133,7 @@ class SeoEncoderArticle extends \OxidEsales\Eshop\Core\SeoEncoder
      *
      * @return \OxidEsales\Eshop\Application\Model\RecommendationList | null
      */
-    protected function _getRecomm($oArticle, $iLang) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getRecomm($oArticle, $iLang)
     {
         $oList = null;
         $oView = $this->getConfig()->getActiveView();
@@ -122,15 +143,29 @@ class SeoEncoderArticle extends \OxidEsales\Eshop\Core\SeoEncoder
 
         return $oList;
     }
+    /**
+     * @deprecated use self::getListType instead
+     */
+    protected function _getListType() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getListType();
+    }
 
     /**
      * Returns active list type
      *
      * @return string
      */
-    protected function _getListType() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getListType()
     {
         return $this->getConfig()->getActiveView()->getListType();
+    }
+    /**
+     * @deprecated use self::createArticleCategoryUri instead
+     */
+    protected function _createArticleCategoryUri($oArticle, $oCategory, $iLang) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->createArticleCategoryUri($oArticle, $oCategory, $iLang);
     }
 
     /**
@@ -142,7 +177,7 @@ class SeoEncoderArticle extends \OxidEsales\Eshop\Core\SeoEncoder
      *
      * @return string
      */
-    protected function _createArticleCategoryUri($oArticle, $oCategory, $iLang) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function createArticleCategoryUri($oArticle, $oCategory, $iLang)
     {
         startProfile(__FUNCTION__);
         $oArticle = $this->_getProductForLang($oArticle, $iLang);
@@ -216,6 +251,13 @@ class SeoEncoderArticle extends \OxidEsales\Eshop\Core\SeoEncoder
 
         return $sSeoUri;
     }
+    /**
+     * @deprecated use self::getCategory instead
+     */
+    protected function _getCategory($oArticle, $iLang) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getCategory($oArticle, $iLang);
+    }
 
     /**
      * Returns active category if available
@@ -225,7 +267,7 @@ class SeoEncoderArticle extends \OxidEsales\Eshop\Core\SeoEncoder
      *
      * @return \OxidEsales\Eshop\Application\Model\Category | null
      */
-    protected function _getCategory($oArticle, $iLang) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getCategory($oArticle, $iLang)
     {
         $oCat = null;
         $oView = $this->getConfig()->getActiveView();
@@ -237,6 +279,13 @@ class SeoEncoderArticle extends \OxidEsales\Eshop\Core\SeoEncoder
 
         return $oCat;
     }
+    /**
+     * @deprecated use self::getMainCategory instead
+     */
+    protected function _getMainCategory($oArticle) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getMainCategory($oArticle);
+    }
 
     /**
      * Returns products main category id
@@ -245,7 +294,7 @@ class SeoEncoderArticle extends \OxidEsales\Eshop\Core\SeoEncoder
      *
      * @return string
      */
-    protected function _getMainCategory($oArticle) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getMainCategory($oArticle)
     {
         $oMainCat = null;
 
@@ -323,6 +372,13 @@ class SeoEncoderArticle extends \OxidEsales\Eshop\Core\SeoEncoder
 
         return $sSeoUri;
     }
+    /**
+     * @deprecated use self::prepareArticleTitle instead
+     */
+    protected function _prepareArticleTitle($oArticle) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->prepareArticleTitle($oArticle);
+    }
 
     /**
      * Returns seo title for current article (if oxTitle field is empty, oxArtnum is used).
@@ -332,7 +388,7 @@ class SeoEncoderArticle extends \OxidEsales\Eshop\Core\SeoEncoder
      *
      * @return string
      */
-    protected function _prepareArticleTitle($oArticle) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function prepareArticleTitle($oArticle)
     {
         // create title part for uri
         if (!($sTitle = $oArticle->oxarticles__oxtitle->value)) {
@@ -408,6 +464,13 @@ class SeoEncoderArticle extends \OxidEsales\Eshop\Core\SeoEncoder
 
         return $sSeoUri;
     }
+    /**
+     * @deprecated use self::getVendor instead
+     */
+    protected function _getVendor($oArticle, $iLang) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getVendor($oArticle, $iLang);
+    }
 
     /**
      * Returns active vendor if available
@@ -417,7 +480,7 @@ class SeoEncoderArticle extends \OxidEsales\Eshop\Core\SeoEncoder
      *
      * @return \OxidEsales\Eshop\Application\Model\Vendor | null
      */
-    protected function _getVendor($oArticle, $iLang) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getVendor($oArticle, $iLang)
     {
         $oView = $this->getConfig()->getActiveView();
 
@@ -485,6 +548,13 @@ class SeoEncoderArticle extends \OxidEsales\Eshop\Core\SeoEncoder
 
         return $sSeoUri;
     }
+    /**
+     * @deprecated use self::getManufacturer instead
+     */
+    protected function _getManufacturer($oArticle, $iLang) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getManufacturer($oArticle, $iLang);
+    }
 
     /**
      * Returns active manufacturer if available
@@ -494,7 +564,7 @@ class SeoEncoderArticle extends \OxidEsales\Eshop\Core\SeoEncoder
      *
      * @return \OxidEsales\Eshop\Application\Model\Manufacturer | null
      */
-    protected function _getManufacturer($oArticle, $iLang) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getManufacturer($oArticle, $iLang)
     {
         $oManufacturer = null;
         if ($sActManufacturerId = $oArticle->oxarticles__oxmanufacturerid->value) {
@@ -594,6 +664,13 @@ class SeoEncoderArticle extends \OxidEsales\Eshop\Core\SeoEncoder
             ':oxobjectid' => $oArticle->getId()
         ]);
     }
+    /**
+     * @deprecated use self::getAltUri instead
+     */
+    protected function _getAltUri($sObjectId, $iLang) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getAltUri($sObjectId, $iLang);
+    }
 
     /**
      * Returns alternative uri used while updating seo
@@ -603,7 +680,7 @@ class SeoEncoderArticle extends \OxidEsales\Eshop\Core\SeoEncoder
      *
      * @return string
      */
-    protected function _getAltUri($sObjectId, $iLang) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getAltUri($sObjectId, $iLang)
     {
         $sSeoUrl = null;
         $oArticle = oxNew(\OxidEsales\Eshop\Application\Model\Article::class);

--- a/source/Application/Model/SeoEncoderCategory.php
+++ b/source/Application/Model/SeoEncoderCategory.php
@@ -16,15 +16,29 @@ class SeoEncoderCategory extends \OxidEsales\Eshop\Core\SeoEncoder
 {
     /** @var array _aCatCache cache for categories. */
     protected $_aCatCache = [];
+    /**
+     * @deprecated use self::getUrlExtension instead
+     */
+    protected function _getUrlExtension() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getUrlExtension();
+    }
 
     /**
      * Returns target "extension" (/)
      *
      * @return string
      */
-    protected function _getUrlExtension() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getUrlExtension()
     {
         return '/';
+    }
+    /**
+     * @deprecated use self::categoryUrlLoader instead
+     */
+    protected function _categoryUrlLoader($oCat, $iLang) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->categoryUrlLoader($oCat, $iLang);
     }
 
     /**
@@ -38,7 +52,7 @@ class SeoEncoderCategory extends \OxidEsales\Eshop\Core\SeoEncoder
      *
      * @return boolean
      */
-    protected function _categoryUrlLoader($oCat, $iLang) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function categoryUrlLoader($oCat, $iLang)
     {
         $sCacheId = $this->_getCategoryCacheId($oCat, $iLang);
         if (isset($this->_aCatCache[$sCacheId])) {
@@ -49,6 +63,13 @@ class SeoEncoderCategory extends \OxidEsales\Eshop\Core\SeoEncoder
         }
 
         return $sSeoUrl;
+    }
+    /**
+     * @deprecated use self::getCategoryCacheId instead
+     */
+    private function _getCategoryCacheId($oCat, $iLang) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getCategoryCacheId($oCat, $iLang);
     }
 
     /**
@@ -61,7 +82,7 @@ class SeoEncoderCategory extends \OxidEsales\Eshop\Core\SeoEncoder
      *
      * @return string
      */
-    private function _getCategoryCacheId($oCat, $iLang) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    private function getCategoryCacheId($oCat, $iLang)
     {
         return $oCat->getId() . '_' . ((int) $iLang);
     }
@@ -246,6 +267,13 @@ class SeoEncoderCategory extends \OxidEsales\Eshop\Core\SeoEncoder
             ':oxobjectid' => $oCategory->getId()
         ]);
     }
+    /**
+     * @deprecated use self::getAltUri instead
+     */
+    protected function _getAltUri($sObjectId, $iLang) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getAltUri($sObjectId, $iLang);
+    }
 
     /**
      * Returns alternative uri used while updating seo
@@ -255,7 +283,7 @@ class SeoEncoderCategory extends \OxidEsales\Eshop\Core\SeoEncoder
      *
      * @return string
      */
-    protected function _getAltUri($sObjectId, $iLang) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getAltUri($sObjectId, $iLang)
     {
         $sSeoUrl = null;
         $oCat = oxNew(\OxidEsales\Eshop\Application\Model\Category::class);

--- a/source/Application/Model/SeoEncoderContent.php
+++ b/source/Application/Model/SeoEncoderContent.php
@@ -16,11 +16,18 @@ use oxDb;
 class SeoEncoderContent extends \OxidEsales\Eshop\Core\SeoEncoder
 {
     /**
+     * @deprecated use self::getUrlExtension instead
+     */
+    protected function _getUrlExtension() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getUrlExtension();
+    }
+    /**
      * Returns target "extension" (/)
      *
      * @return string
      */
-    protected function _getUrlExtension() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getUrlExtension()
     {
         return '/';
     }
@@ -106,6 +113,13 @@ class SeoEncoderContent extends \OxidEsales\Eshop\Core\SeoEncoder
             ':oxobjectid' => $sId
         ]);
     }
+    /**
+     * @deprecated use self::getAltUri instead
+     */
+    protected function _getAltUri($sObjectId, $iLang) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getAltUri($sObjectId, $iLang);
+    }
 
     /**
      * Returns alternative uri used while updating seo
@@ -115,7 +129,7 @@ class SeoEncoderContent extends \OxidEsales\Eshop\Core\SeoEncoder
      *
      * @return string
      */
-    protected function _getAltUri($sObjectId, $iLang) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getAltUri($sObjectId, $iLang)
     {
         $sSeoUrl = null;
         $oCont = oxNew(\OxidEsales\Eshop\Application\Model\Content::class);

--- a/source/Application/Model/SeoEncoderManufacturer.php
+++ b/source/Application/Model/SeoEncoderManufacturer.php
@@ -20,13 +20,20 @@ class SeoEncoderManufacturer extends \OxidEsales\Eshop\Core\SeoEncoder
      * @var array
      */
     protected $_aRootManufacturerUri = null;
+    /**
+     * @deprecated use self::getUrlExtension instead
+     */
+    protected function _getUrlExtension() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getUrlExtension();
+    }
 
     /**
      * Returns target "extension" (/)
      *
      * @return string
      */
-    protected function _getUrlExtension() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getUrlExtension()
     {
         return '/';
     }
@@ -136,6 +143,13 @@ class SeoEncoderManufacturer extends \OxidEsales\Eshop\Core\SeoEncoder
             ':oxobjectid' => $oManufacturer->getId()
         ]);
     }
+    /**
+     * @deprecated use self::getAltUri instead
+     */
+    protected function _getAltUri($sObjectId, $iLang) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getAltUri($sObjectId, $iLang);
+    }
 
     /**
      * Returns alternative uri used while updating seo
@@ -145,7 +159,7 @@ class SeoEncoderManufacturer extends \OxidEsales\Eshop\Core\SeoEncoder
      *
      * @return string
      */
-    protected function _getAltUri($sObjectId, $iLang) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getAltUri($sObjectId, $iLang)
     {
         $sSeoUrl = null;
         $oManufacturer = oxNew(\OxidEsales\Eshop\Application\Model\Manufacturer::class);

--- a/source/Application/Model/SeoEncoderVendor.php
+++ b/source/Application/Model/SeoEncoderVendor.php
@@ -21,13 +21,20 @@ class SeoEncoderVendor extends \OxidEsales\Eshop\Core\SeoEncoder
      * @var string
      */
     protected $_aRootVendorUri = null;
+    /**
+     * @deprecated use self::getUrlExtension instead
+     */
+    protected function _getUrlExtension() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getUrlExtension();
+    }
 
     /**
      * Returns target "extension" (/)
      *
      * @return string
      */
-    protected function _getUrlExtension() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getUrlExtension()
     {
         return '/';
     }
@@ -138,6 +145,13 @@ class SeoEncoderVendor extends \OxidEsales\Eshop\Core\SeoEncoder
             ':oxobjectid' => $vendorId
         ]);
     }
+    /**
+     * @deprecated use self::getAltUri instead
+     */
+    protected function _getAltUri($vendorId, $languageId) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getAltUri($vendorId, $languageId);
+    }
 
     /**
      * Returns alternative uri used while updating seo.
@@ -147,7 +161,7 @@ class SeoEncoderVendor extends \OxidEsales\Eshop\Core\SeoEncoder
      *
      * @return string
      */
-    protected function _getAltUri($vendorId, $languageId) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getAltUri($vendorId, $languageId)
     {
         $seoUrl = null;
         $vendor = oxNew(\OxidEsales\Eshop\Application\Model\Vendor::class);

--- a/source/Application/Model/Shop.php
+++ b/source/Application/Model/Shop.php
@@ -184,6 +184,13 @@ class Shop extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel
             $this->addViewLanguageQuery($sStart, $sTable, $iLang, $sLang);
         }
     }
+    /**
+     * @deprecated use self::getViewSelect instead
+     */
+    protected function _getViewSelect($sTable, $iLang) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getViewSelect($sTable, $iLang);
+    }
 
     /**
      * Returns table field name mapping sql section for single language views
@@ -193,7 +200,7 @@ class Shop extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel
      *
      * @return string
      */
-    protected function _getViewSelect($sTable, $iLang) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getViewSelect($sTable, $iLang)
     {
         $oMetaData = oxNew(\OxidEsales\Eshop\Core\DbMetaDataHandler::class);
         $aFields = $oMetaData->getSinglelangFields($sTable, $iLang);
@@ -205,6 +212,13 @@ class Shop extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel
 
         return implode(',', $aFields);
     }
+    /**
+     * @deprecated use self::getViewSelectMultilang instead
+     */
+    protected function _getViewSelectMultilang($sTable) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getViewSelectMultilang($sTable);
+    }
 
     /**
      * Returns table fields sql section for multiple language views
@@ -213,7 +227,7 @@ class Shop extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel
      *
      * @return string
      */
-    protected function _getViewSelectMultilang($sTable) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getViewSelectMultilang($sTable)
     {
         $aFields = [];
 
@@ -230,6 +244,13 @@ class Shop extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel
 
         return implode(',', $aFields);
     }
+    /**
+     * @deprecated use self::getViewJoinAll instead
+     */
+    protected function _getViewJoinAll($sTable) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getViewJoinAll($sTable);
+    }
 
     /**
      * Returns all language table view JOIN section
@@ -238,7 +259,7 @@ class Shop extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel
      *
      * @return string $sSQL
      */
-    protected function _getViewJoinAll($sTable) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getViewJoinAll($sTable)
     {
         $sJoin = ' ';
         $oMetaData = oxNew(\OxidEsales\Eshop\Core\DbMetaDataHandler::class);
@@ -251,6 +272,13 @@ class Shop extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel
 
         return $sJoin;
     }
+    /**
+     * @deprecated use self::getViewJoinLang instead
+     */
+    protected function _getViewJoinLang($sTable, $iLang) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getViewJoinLang($sTable, $iLang);
+    }
 
     /**
      * Returns language table view JOIN section
@@ -260,7 +288,7 @@ class Shop extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel
      *
      * @return string $sSQL
      */
-    protected function _getViewJoinLang($sTable, $iLang) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getViewJoinLang($sTable, $iLang)
     {
         $sJoin = ' ';
         $sLangTable = getLangTableName($sTable, $iLang);
@@ -270,11 +298,18 @@ class Shop extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel
 
         return $sJoin;
     }
+    /**
+     * @deprecated use self::cleanInvalidViews instead
+     */
+    protected function _cleanInvalidViews() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->cleanInvalidViews();
+    }
 
     /**
      * Gets all invalid views and drops them from database
      */
-    protected function _cleanInvalidViews() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function cleanInvalidViews()
     {
         $oDb = \OxidEsales\Eshop\Core\DatabaseProvider::getDb();
         $oLang = \OxidEsales\Eshop\Core\Registry::getLang();
@@ -300,11 +335,18 @@ class Shop extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel
             $oDb->execute('DROP VIEW IF EXISTS `' . $sView . '`');
         }
     }
+    /**
+     * @deprecated use self::prepareViewsQueries instead
+     */
+    protected function _prepareViewsQueries() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->prepareViewsQueries();
+    }
 
     /**
      * Creates all view queries and adds them in query array
      */
-    protected function _prepareViewsQueries() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function prepareViewsQueries()
     {
         $oLang = \OxidEsales\Eshop\Core\Registry::getLang();
         $aLanguages = $oLang->getLanguageIds($this->getId());
@@ -344,6 +386,13 @@ class Shop extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel
         $sQuery = "{$queryStart} `{$sViewTable}` AS SELECT {$sFields} FROM {$table}{$sJoin}";
         $this->addQuery($sQuery);
     }
+    /**
+     * @deprecated use self::runQueries instead
+     */
+    protected function _runQueries() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->runQueries();
+    }
 
     /**
      * Runs stored queries
@@ -351,7 +400,7 @@ class Shop extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel
      *
      * @return bool
      */
-    protected function _runQueries() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function runQueries()
     {
         $oDb = \OxidEsales\Eshop\Core\DatabaseProvider::getDb();
         $aQueries = $this->getQueries();

--- a/source/Application/Model/ShopViewValidator.php
+++ b/source/Application/Model/ShopViewValidator.php
@@ -133,19 +133,33 @@ class ShopViewValidator
     {
         return $this->_iShopId;
     }
+    /**
+     * @deprecated use self::getAllViews instead
+     */
+    protected function _getAllViews() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getAllViews();
+    }
 
     /**
      * Returns list of all shop views
      *
      * @return array
      */
-    protected function _getAllViews() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getAllViews()
     {
         if (empty($this->_aAllViews)) {
             $this->_aAllViews = \OxidEsales\Eshop\Core\DatabaseProvider::getDb()->getCol("SHOW TABLES LIKE  'oxv\_%'");
         }
 
         return $this->_aAllViews;
+    }
+    /**
+     * @deprecated use self::isCurrentShopView instead
+     */
+    protected function _isCurrentShopView($sViewName) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->isCurrentShopView($sViewName);
     }
 
     /**
@@ -155,7 +169,7 @@ class ShopViewValidator
      *
      * @return bool
      */
-    protected function _isCurrentShopView($sViewName) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function isCurrentShopView($sViewName)
     {
         $blResult = false;
 
@@ -172,6 +186,13 @@ class ShopViewValidator
 
         return $blResult;
     }
+    /**
+     * @deprecated use self::getShopViews instead
+     */
+    protected function _getShopViews() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getShopViews();
+    }
 
 
     /**
@@ -179,7 +200,7 @@ class ShopViewValidator
      *
      * @return array
      */
-    protected function _getShopViews() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getShopViews()
     {
         if (empty($this->_aShopViews)) {
             $this->_aShopViews = [];
@@ -194,13 +215,20 @@ class ShopViewValidator
 
         return $this->_aShopViews;
     }
+    /**
+     * @deprecated use self::getValidShopViews instead
+     */
+    protected function _getValidShopViews() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getValidShopViews();
+    }
 
     /**
      * Returns list of valid shop views
      *
      * @return array
      */
-    protected function _getValidShopViews() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getValidShopViews()
     {
         if (empty($this->_aValidShopViews)) {
             $aTables = $this->getShopTables();
@@ -241,6 +269,13 @@ class ShopViewValidator
             }
         }
     }
+    /**
+     * @deprecated use self::isViewValid instead
+     */
+    protected function _isViewValid($sViewName) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->isViewValid($sViewName);
+    }
 
     /**
      * Checks if view name is valid according to current config
@@ -249,7 +284,7 @@ class ShopViewValidator
      *
      * @return bool
      */
-    protected function _isViewValid($sViewName) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function isViewValid($sViewName)
     {
         return in_array($sViewName, $this->_getValidShopViews());
     }

--- a/source/Application/Model/SimpleVariant.php
+++ b/source/Application/Model/SimpleVariant.php
@@ -100,13 +100,20 @@ class SimpleVariant extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel impl
 
         return $this->_oUser;
     }
+    /**
+     * @deprecated use self::getGroupPrice instead
+     */
+    protected function _getGroupPrice() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getGroupPrice();
+    }
 
     /**
      * get user Group A, B or C price, returns db price if user is not in groups
      *
      * @return double
      */
-    protected function _getGroupPrice() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getGroupPrice()
     {
         $dPrice = $this->oxarticles__oxprice->value;
         if ($oUser = $this->getArticleUser()) {
@@ -168,6 +175,13 @@ class SimpleVariant extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel impl
     {
         return $price;
     }
+    /**
+     * @deprecated use self::applyCurrency instead
+     */
+    protected function _applyCurrency(\OxidEsales\Eshop\Core\Price $oPrice, $oCur = null) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->applyCurrency($oPrice, $oCur);
+    }
 
     /**
      * Applies currency factor
@@ -175,7 +189,7 @@ class SimpleVariant extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel impl
      * @param \OxidEsales\Eshop\Core\Price $oPrice Price object
      * @param object                       $oCur   Currency object
      */
-    protected function _applyCurrency(\OxidEsales\Eshop\Core\Price $oPrice, $oCur = null) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function applyCurrency(\OxidEsales\Eshop\Core\Price $oPrice, $oCur = null)
     {
         if (!$oCur) {
             $oCur = $this->getConfig()->getActShopCurrencyObject();
@@ -183,17 +197,31 @@ class SimpleVariant extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel impl
 
         $oPrice->multiply($oCur->rate);
     }
+    /**
+     * @deprecated use self::applyParentDiscounts instead
+     */
+    protected function _applyParentDiscounts($oPrice) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->applyParentDiscounts($oPrice);
+    }
 
     /**
      * Applies discounts which should be applied in general case (for 0 amount)
      *
      * @param \OxidEsales\Eshop\Core\Price $oPrice Price object
      */
-    protected function _applyParentDiscounts($oPrice) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function applyParentDiscounts($oPrice)
     {
         if (($oParent = $this->getParent())) {
             $oParent->applyDiscountsForVariant($oPrice);
         }
+    }
+    /**
+     * @deprecated use self::applyParentVat instead
+     */
+    protected function _applyParentVat($oPrice) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->applyParentVat($oPrice);
     }
 
     /**
@@ -201,7 +229,7 @@ class SimpleVariant extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel impl
      *
      * @param \OxidEsales\Eshop\Core\Price $oPrice price object
      */
-    protected function _applyParentVat($oPrice) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function applyParentVat($oPrice)
     {
         if (($oParent = $this->getParent()) && !$this->getConfig()->getConfigParam('bl_perfCalcVatOnlyForBasketOrder')) {
             $oParent->applyVats($oPrice);

--- a/source/Application/Model/SimpleVariantList.php
+++ b/source/Application/Model/SimpleVariantList.php
@@ -34,6 +34,13 @@ class SimpleVariantList extends \OxidEsales\Eshop\Core\Model\ListModel
     {
         $this->_oParent = $oParent;
     }
+    /**
+     * @deprecated use self::assignElement instead
+     */
+    protected function _assignElement($oListObject, $aDbFields) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->assignElement($oListObject, $aDbFields);
+    }
 
     /**
      * Sets parent for variant. This method is invoked for each element in oxList::assign() loop.
@@ -41,7 +48,7 @@ class SimpleVariantList extends \OxidEsales\Eshop\Core\Model\ListModel
      * @param oxSimleVariant $oListObject Simple variant
      * @param array          $aDbFields   Array of available
      */
-    protected function _assignElement($oListObject, $aDbFields) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function assignElement($oListObject, $aDbFields)
     {
         $oListObject->setParent($this->_oParent);
         parent::_assignElement($oListObject, $aDbFields);

--- a/source/Application/Model/User.php
+++ b/source/Application/Model/User.php
@@ -176,13 +176,20 @@ class User extends \OxidEsales\Eshop\Core\Model\BaseModel
      *                                        was added as the new default for hashing passwords.
      */
     private $isOutdatedPasswordHashAlgorithmUsed = false;
+    /**
+     * @deprecated use self::getStateObject instead
+     */
+    protected function _getStateObject() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getStateObject();
+    }
 
     /**
      * Gets state object.
      *
      * @return oxState
      */
-    protected function _getStateObject() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getStateObject()
     {
         if (is_null($this->_oStateObject)) {
             $this->_oStateObject = oxNew(\OxidEsales\Eshop\Application\Model\State::class);
@@ -418,13 +425,20 @@ class User extends \OxidEsales\Eshop\Core\Model\BaseModel
 
         return $sAddressId;
     }
+    /**
+     * @deprecated use self::getWishListId instead
+     */
+    protected function _getWishListId() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getWishListId();
+    }
 
     /**
      * Checks if product from wishlist is added
      *
      * @return $sWishId
      */
-    protected function _getWishListId() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getWishListId()
     {
         $this->_sWishId = null;
         // check if we have to set it here
@@ -1229,13 +1243,20 @@ class User extends \OxidEsales\Eshop\Core\Model\BaseModel
             $this->_setAutoGroups($sCountryId);
         }
     }
+    /**
+     * @deprecated use self::getMergedAddressFields instead
+     */
+    protected function _getMergedAddressFields() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getMergedAddressFields();
+    }
 
     /**
      * Returns merged delivery address fields.
      *
      * @return string
      */
-    protected function _getMergedAddressFields() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getMergedAddressFields()
     {
         $sDelAddress = '';
         $sDelAddress .= $this->oxuser__oxcompany;
@@ -1256,13 +1277,20 @@ class User extends \OxidEsales\Eshop\Core\Model\BaseModel
 
         return $sDelAddress;
     }
+    /**
+     * @deprecated use self::assignAddress instead
+     */
+    protected function _assignAddress($aDelAddress) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->assignAddress($aDelAddress);
+    }
 
     /**
      * creates new address entry or updates existing
      *
      * @param array $aDelAddress address data array
      */
-    protected function _assignAddress($aDelAddress) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function assignAddress($aDelAddress)
     {
         if (is_array($aDelAddress) && count($aDelAddress)) {
             $sAddressId = $this->getConfig()->getRequestParameter('oxaddressid');
@@ -1286,6 +1314,13 @@ class User extends \OxidEsales\Eshop\Core\Model\BaseModel
             Registry::getSession()->setVariable('deladrid', null);
         }
     }
+    /**
+     * @deprecated use self::getLoginQueryHashedWithMD5 instead
+     */
+    protected function _getLoginQueryHashedWithMD5($userName, $password, $shopId, $isAdmin) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getLoginQueryHashedWithMD5($userName, $password, $shopId, $isAdmin);
+    }
 
     /**
      * Builds and returns user login query.
@@ -1306,7 +1341,7 @@ class User extends \OxidEsales\Eshop\Core\Model\BaseModel
      *
      * @return string
      */
-    protected function _getLoginQueryHashedWithMD5($userName, $password, $shopId, $isAdmin) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getLoginQueryHashedWithMD5($userName, $password, $shopId, $isAdmin)
     {
         $database = \OxidEsales\Eshop\Core\DatabaseProvider::getDb();
 
@@ -1326,6 +1361,13 @@ class User extends \OxidEsales\Eshop\Core\Model\BaseModel
 
         return $query;
     }
+    /**
+     * @deprecated use self::getLoginQuery instead
+     */
+    protected function _getLoginQuery($userName, $password, $shopId, $isAdmin) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getLoginQuery($userName, $password, $shopId, $isAdmin);
+    }
 
     /**
      * Builds and returns user login query
@@ -1343,7 +1385,7 @@ class User extends \OxidEsales\Eshop\Core\Model\BaseModel
      *
      * @return string
      */
-    protected function _getLoginQuery($userName, $password, $shopId, $isAdmin) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getLoginQuery($userName, $password, $shopId, $isAdmin)
     {
         $database = DatabaseProvider::getDb();
         $userNameCondition = $this->formQueryPartForUserName($userName, $database);
@@ -1363,6 +1405,13 @@ class User extends \OxidEsales\Eshop\Core\Model\BaseModel
 
         return $query;
     }
+    /**
+     * @deprecated use self::getShopSelect instead
+     */
+    protected function _getShopSelect($myConfig, $sShopID, $blAdmin) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getShopSelect($myConfig, $sShopID, $blAdmin);
+    }
 
     /**
      * Returns shopselect part of login query sql
@@ -1373,7 +1422,7 @@ class User extends \OxidEsales\Eshop\Core\Model\BaseModel
      *
      * @return string
      */
-    protected function _getShopSelect($myConfig, $sShopID, $blAdmin) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getShopSelect($myConfig, $sShopID, $blAdmin)
     {
         $sShopSelect = $this->formQueryPartForAdminView($sShopID, $blAdmin);
 
@@ -1594,13 +1643,20 @@ class User extends \OxidEsales\Eshop\Core\Model\BaseModel
             return false;
         }
     }
+    /**
+     * @deprecated use self::getCookieUserId instead
+     */
+    protected function _getCookieUserId() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getCookieUserId();
+    }
 
     /**
      * Checks if user is connected via cookies and if so, returns user id.
      *
      * @return string
      */
-    protected function _getCookieUserId() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getCookieUserId()
     {
         $sUserID = null;
         $oConfig = $this->getConfig();
@@ -1632,6 +1688,13 @@ class User extends \OxidEsales\Eshop\Core\Model\BaseModel
 
         return $sUserID;
     }
+    /**
+     * @deprecated use self::ldapLogin instead
+     */
+    protected function _ldapLogin($sUser, $sPassword, $sShopID, $sShopSelect) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->ldapLogin($sUser, $sPassword, $sShopID, $sShopSelect);
+    }
 
     /**
      * Login for Ldap
@@ -1645,7 +1708,7 @@ class User extends \OxidEsales\Eshop\Core\Model\BaseModel
      *
      * @throws $oEx if user is wrong
      */
-    protected function _ldapLogin($sUser, $sPassword, $sShopID, $sShopSelect) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function ldapLogin($sUser, $sPassword, $sShopID, $sShopSelect)
     {
         $aLDAPParams = $this->getConfig()->getConfigParam('aLDAPParams');
         $oLDAP = oxNew(\OxidEsales\Eshop\Core\LDAP::class, $aLDAPParams['HOST'], $aLDAPParams['PORT']);
@@ -1705,6 +1768,13 @@ class User extends \OxidEsales\Eshop\Core\Model\BaseModel
             throw $oEx;
         }
     }
+    /**
+     * @deprecated use self::getUserRights instead
+     */
+    protected function _getUserRights() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getUserRights();
+    }
 
     /**
      * Returns user rights index. Index cannot be higher than current session
@@ -1712,7 +1782,7 @@ class User extends \OxidEsales\Eshop\Core\Model\BaseModel
      *
      * @return string
      */
-    protected function _getUserRights() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getUserRights()
     {
         // previously user had no rights defined
         if (!$this->oxuser__oxrights instanceof \OxidEsales\Eshop\Core\Field || !$this->oxuser__oxrights->value) {
@@ -1758,13 +1828,20 @@ class User extends \OxidEsales\Eshop\Core\Model\BaseModel
         // leaving as it was set ...
         return $this->oxuser__oxrights->value;
     }
+    /**
+     * @deprecated use self::insert instead
+     */
+    protected function _insert() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->insert();
+    }
 
     /**
      * Inserts user object data to DB. Returns true on success.
      *
      * @return bool
      */
-    protected function _insert() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function insert()
     {
 
         // set oxcreate date
@@ -1776,13 +1853,20 @@ class User extends \OxidEsales\Eshop\Core\Model\BaseModel
 
         return parent::_insert();
     }
+    /**
+     * @deprecated use self::update instead
+     */
+    protected function _update() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->update();
+    }
 
     /**
      * Updates changed user object data to DB. Returns true on success.
      *
      * @return bool
      */
-    protected function _update() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function update()
     {
         //V #M418: for not registered users, don't change boni during update
         if (!$this->oxuser__oxpassword->value && $this->oxuser__oxregister->value < 1) {
@@ -1924,6 +2008,13 @@ class User extends \OxidEsales\Eshop\Core\Model\BaseModel
 
         return $this->_iCntRecommLists;
     }
+    /**
+     * @deprecated use self::setAutoGroups instead
+     */
+    protected function _setAutoGroups($sCountryId) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->setAutoGroups($sCountryId);
+    }
 
     /**
      * Automatically assigns user to specific groups
@@ -1931,7 +2022,7 @@ class User extends \OxidEsales\Eshop\Core\Model\BaseModel
      *
      * @param string $sCountryId users country id
      */
-    protected function _setAutoGroups($sCountryId) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function setAutoGroups($sCountryId)
     {
         // assigning automatically to specific groups
         $blForeigner = true;
@@ -2364,6 +2455,13 @@ class User extends \OxidEsales\Eshop\Core\Model\BaseModel
     {
         return 'malladmin' === $this->oxuser__oxrights->value;
     }
+    /**
+     * @deprecated use self::dbLogin instead
+     */
+    protected function _dbLogin(string $userName, $password, $shopID) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->dbLogin($userName, $password, $shopID);
+    }
 
     /**
      * Initiates user login against data in DB.
@@ -2382,7 +2480,7 @@ class User extends \OxidEsales\Eshop\Core\Model\BaseModel
      *
      * @return void
      */
-    protected function _dbLogin(string $userName, $password, $shopID) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function dbLogin(string $userName, $password, $shopID)
     {
         $database = \OxidEsales\Eshop\Core\DatabaseProvider::getDb();
         $userId = $database->getOne($this->_getLoginQuery($userName, $password, $shopID, $this->isAdmin()));
@@ -2424,13 +2522,20 @@ class User extends \OxidEsales\Eshop\Core\Model\BaseModel
 
         return $database->getOne($query);
     }
+    /**
+     * @deprecated use self::isDemoShop instead
+     */
+    protected function _isDemoShop() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->isDemoShop();
+    }
 
     /**
      * Return true - if shop is in demo mode
      *
      * @return bool
      */
-    protected function _isDemoShop() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function isDemoShop()
     {
         $blDemoMode = false;
 
@@ -2439,6 +2544,13 @@ class User extends \OxidEsales\Eshop\Core\Model\BaseModel
         }
 
         return $blDemoMode;
+    }
+    /**
+     * @deprecated use self::getDemoShopLoginQuery instead
+     */
+    protected function _getDemoShopLoginQuery($sUser, $sPassword) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getDemoShopLoginQuery($sUser, $sPassword);
     }
 
     /**
@@ -2451,7 +2563,7 @@ class User extends \OxidEsales\Eshop\Core\Model\BaseModel
      *
      * @return string
      */
-    protected function _getDemoShopLoginQuery($sUser, $sPassword) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getDemoShopLoginQuery($sUser, $sPassword)
     {
         if ($sPassword == "admin" && $sUser == "admin") {
             $sSelect = "SELECT `oxid` FROM `oxuser` WHERE `oxrights` = 'malladmin' ";

--- a/source/Application/Model/UserBasket.php
+++ b/source/Application/Model/UserBasket.php
@@ -57,13 +57,20 @@ class UserBasket extends \OxidEsales\Eshop\Core\Model\BaseModel
         parent::__construct();
         $this->init('oxuserbaskets');
     }
+    /**
+     * @deprecated use self::insert instead
+     */
+    protected function _insert() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->insert();
+    }
 
     /**
      * Inserts object data to DB, returns true on success.
      *
      * @return mixed
      */
-    protected function _insert() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function insert()
     {
         // marking basket as not new any more
         $this->_blNewBasket = false;
@@ -176,6 +183,13 @@ class UserBasket extends \OxidEsales\Eshop\Core\Model\BaseModel
 
         return $this->_aBasketItems;
     }
+    /**
+     * @deprecated use self::createItem instead
+     */
+    protected function _createItem($sProductId, $aSelList = null, $aPersParams = null) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->createItem($sProductId, $aSelList, $aPersParams);
+    }
 
     /**
      * Creates and returns  oxuserbasketitem object
@@ -186,7 +200,7 @@ class UserBasket extends \OxidEsales\Eshop\Core\Model\BaseModel
      *
      * @return oxUserBasketItem
      */
-    protected function _createItem($sProductId, $aSelList = null, $aPersParams = null) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function createItem($sProductId, $aSelList = null, $aPersParams = null)
     {
         $oNewItem = oxNew(\OxidEsales\Eshop\Application\Model\UserBasketItem::class);
         $oNewItem->oxuserbasketitems__oxartid = new \OxidEsales\Eshop\Core\Field($sProductId, \OxidEsales\Eshop\Core\Field::T_RAW);
@@ -237,6 +251,13 @@ class UserBasket extends \OxidEsales\Eshop\Core\Model\BaseModel
 
         return $oItem;
     }
+    /**
+     * @deprecated use self::getItemKey instead
+     */
+    protected function _getItemKey($sProductId, $aSel = null, $aPersParam = null) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getItemKey($sProductId, $aSel, $aPersParam);
+    }
 
     /**
      * Returns unique item key according to its ID and user chosen select
@@ -247,7 +268,7 @@ class UserBasket extends \OxidEsales\Eshop\Core\Model\BaseModel
      *
      * @return string
      */
-    protected function _getItemKey($sProductId, $aSel = null, $aPersParam = null) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getItemKey($sProductId, $aSel = null, $aPersParam = null)
     {
         $aSel = ($aSel != null) ? $aSel : [0 => '0'];
 

--- a/source/Application/Model/UserBasketItem.php
+++ b/source/Application/Model/UserBasketItem.php
@@ -186,6 +186,13 @@ class UserBasketItem extends \OxidEsales\Eshop\Core\Model\BaseModel
     {
         $this->oxuserbasketitems__oxpersparam = new \OxidEsales\Eshop\Core\Field(serialize($sPersParams), \OxidEsales\Eshop\Core\Field::T_RAW);
     }
+    /**
+     * @deprecated use self::setFieldData instead
+     */
+    protected function _setFieldData($sFieldName, $sValue, $iDataType = \OxidEsales\Eshop\Core\Field::T_TEXT) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->setFieldData($sFieldName, $sValue, $iDataType);
+    }
 
     /**
      * Sets data field value
@@ -196,7 +203,7 @@ class UserBasketItem extends \OxidEsales\Eshop\Core\Model\BaseModel
      *
      * @return null
      */
-    protected function _setFieldData($sFieldName, $sValue, $iDataType = \OxidEsales\Eshop\Core\Field::T_TEXT) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function setFieldData($sFieldName, $sValue, $iDataType = \OxidEsales\Eshop\Core\Field::T_TEXT)
     {
         if (
             'oxsellist' === strtolower($sFieldName) || 'oxuserbasketitems__oxsellist' === strtolower($sFieldName)

--- a/source/Application/Model/UserPayment.php
+++ b/source/Application/Model/UserPayment.php
@@ -129,6 +129,13 @@ class UserPayment extends \OxidEsales\Eshop\Core\Model\BaseModel
 
         return $this->assignRecord($sSelect);
     }
+    /**
+     * @deprecated use self::insert instead
+     */
+    protected function _insert() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->insert();
+    }
 
 
     /**
@@ -136,7 +143,7 @@ class UserPayment extends \OxidEsales\Eshop\Core\Model\BaseModel
      *
      * @return bool
      */
-    protected function _insert() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function insert()
     {
         // @deprecated since v6.5.1 (2019-02-07); credit card payment method will be no longer supported
         // we do not store credit card information
@@ -165,13 +172,20 @@ class UserPayment extends \OxidEsales\Eshop\Core\Model\BaseModel
 
         return $blRet;
     }
+    /**
+     * @deprecated use self::update instead
+     */
+    protected function _update() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->update();
+    }
 
     /**
      * Updates payment record in DB. Returns update status.
      *
      * @return bool
      */
-    protected function _update() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function update()
     {
 
         //encode sensitive data

--- a/source/Application/Model/VariantHandler.php
+++ b/source/Application/Model/VariantHandler.php
@@ -118,6 +118,13 @@ class VariantHandler extends \OxidEsales\Eshop\Core\Base
             $this->_updateArticleVarName($sVarNameUpdate, $oArticle->oxarticles__oxid->value);
         }
     }
+    /**
+     * @deprecated use self::assignValues instead
+     */
+    protected function _assignValues($aValues, $oVariants, $oArticle, $aConfLanguages) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->assignValues($aValues, $oVariants, $oArticle, $aConfLanguages);
+    }
 
     /**
      * Assigns values of selection list to variants
@@ -129,7 +136,7 @@ class VariantHandler extends \OxidEsales\Eshop\Core\Base
      *
      * @return mixed
      */
-    protected function _assignValues($aValues, $oVariants, $oArticle, $aConfLanguages) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function assignValues($aValues, $oVariants, $oArticle, $aConfLanguages)
     {
         $myConfig = $this->getConfig();
         $myLang = \OxidEsales\Eshop\Core\Registry::getLang();
@@ -206,6 +213,13 @@ class VariantHandler extends \OxidEsales\Eshop\Core\Base
 
         return $aMDVariants;
     }
+    /**
+     * @deprecated use self::getValuePrice instead
+     */
+    protected function _getValuePrice($oValue, $dParentPrice) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getValuePrice($oValue, $dParentPrice);
+    }
 
     /**
      * Returns article price
@@ -215,7 +229,7 @@ class VariantHandler extends \OxidEsales\Eshop\Core\Base
      *
      * @return double
      */
-    protected function _getValuePrice($oValue, $dParentPrice) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getValuePrice($oValue, $dParentPrice)
     {
         $myConfig = $this->getConfig();
         $dPriceMod = 0;
@@ -234,6 +248,13 @@ class VariantHandler extends \OxidEsales\Eshop\Core\Base
 
         return $dPriceMod;
     }
+    /**
+     * @deprecated use self::createNewVariant instead
+     */
+    protected function _createNewVariant($aParams = null, $sParentId = null) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->createNewVariant($aParams, $sParentId);
+    }
 
     /**
      * Creates new article variant.
@@ -243,7 +264,7 @@ class VariantHandler extends \OxidEsales\Eshop\Core\Base
      *
      * @return null
      */
-    protected function _createNewVariant($aParams = null, $sParentId = null) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function createNewVariant($aParams = null, $sParentId = null)
     {
         // checkbox handling
         $aParams['oxarticles__oxactive'] = 0;
@@ -262,6 +283,13 @@ class VariantHandler extends \OxidEsales\Eshop\Core\Base
 
         return $oArticle->getId();
     }
+    /**
+     * @deprecated use self::updateArticleVarName instead
+     */
+    protected function _updateArticleVarName($sUpdate, $sArtId) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->updateArticleVarName($sUpdate, $sArtId);
+    }
 
     /**
      * Inserts article variant name for all languages
@@ -269,7 +297,7 @@ class VariantHandler extends \OxidEsales\Eshop\Core\Base
      * @param string $sUpdate query for update variant name
      * @param string $sArtId  parent article id
      */
-    protected function _updateArticleVarName($sUpdate, $sArtId) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function updateArticleVarName($sUpdate, $sArtId)
     {
         $oDb = \OxidEsales\Eshop\Core\DatabaseProvider::getDb();
         $sUpdate = "update oxarticles set " . $sUpdate . " where oxid = :oxid";
@@ -293,6 +321,13 @@ class VariantHandler extends \OxidEsales\Eshop\Core\Base
 
         return false;
     }
+    /**
+     * @deprecated use self::fillVariantSelections instead
+     */
+    protected function _fillVariantSelections($oVariantList, $iVarSelCnt, &$aFilter, $sActVariantId) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->fillVariantSelections($oVariantList, $iVarSelCnt, $aFilter, $sActVariantId);
+    }
 
     /**
      * Creates array/matrix with variant selections
@@ -304,7 +339,7 @@ class VariantHandler extends \OxidEsales\Eshop\Core\Base
      *
      * @return array
      */
-    protected function _fillVariantSelections($oVariantList, $iVarSelCnt, &$aFilter, $sActVariantId) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function fillVariantSelections($oVariantList, $iVarSelCnt, &$aFilter, $sActVariantId)
     {
         $aSelections = [];
 
@@ -329,6 +364,13 @@ class VariantHandler extends \OxidEsales\Eshop\Core\Base
 
         return $aSelections;
     }
+    /**
+     * @deprecated use self::cleanFilter instead
+     */
+    protected function _cleanFilter($aFilter) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->cleanFilter($aFilter);
+    }
 
     /**
      * Cleans up user given filter. If filter was empty - returns false
@@ -337,7 +379,7 @@ class VariantHandler extends \OxidEsales\Eshop\Core\Base
      *
      * @return array | bool
      */
-    protected function _cleanFilter($aFilter) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function cleanFilter($aFilter)
     {
         $aCleanFilter = false;
         if (is_array($aFilter) && count($aFilter)) {
@@ -350,6 +392,13 @@ class VariantHandler extends \OxidEsales\Eshop\Core\Base
 
         return $aCleanFilter;
     }
+    /**
+     * @deprecated use self::applyVariantSelectionsFilter instead
+     */
+    protected function _applyVariantSelectionsFilter($aSelections, $aFilter) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->applyVariantSelectionsFilter($aSelections, $aFilter);
+    }
 
     /**
      * Applies filter on variant selection array
@@ -359,7 +408,7 @@ class VariantHandler extends \OxidEsales\Eshop\Core\Base
      *
      * @return array
      */
-    protected function _applyVariantSelectionsFilter($aSelections, $aFilter) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function applyVariantSelectionsFilter($aSelections, $aFilter)
     {
         $iMaxActiveCount = 0;
         $sMostSuitableVariantId = null;
@@ -401,6 +450,13 @@ class VariantHandler extends \OxidEsales\Eshop\Core\Base
 
         return [$aSelections, $sMostSuitableVariantId, $blPerfectFit];
     }
+    /**
+     * @deprecated use self::buildVariantSelectionsList instead
+     */
+    protected function _buildVariantSelectionsList($aVarSelects, $aSelections) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->buildVariantSelectionsList($aVarSelects, $aSelections);
+    }
 
     /**
      * Builds variant selections list - array containing oxVariantSelectList
@@ -410,7 +466,7 @@ class VariantHandler extends \OxidEsales\Eshop\Core\Base
      *
      * @return array
      */
-    protected function _buildVariantSelectionsList($aVarSelects, $aSelections) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function buildVariantSelectionsList($aVarSelects, $aSelections)
     {
         // creating selection lists
         foreach ($aVarSelects as $iKey => $sLabel) {
@@ -426,6 +482,13 @@ class VariantHandler extends \OxidEsales\Eshop\Core\Base
 
         return $aVariantSelections;
     }
+    /**
+     * @deprecated use self::getSelections instead
+     */
+    protected function _getSelections($sTitle) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getSelections($sTitle);
+    }
 
     /**
      * In case multidimentional variants ON explodes title by _sMdSeparator
@@ -435,7 +498,7 @@ class VariantHandler extends \OxidEsales\Eshop\Core\Base
      *
      * @return array
      */
-    protected function _getSelections($sTitle) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getSelections($sTitle)
     {
         if ($this->getConfig()->getConfigParam('blUseMultidimensionVariants')) {
             $aSelections = explode($this->_sMdSeparator, $sTitle);

--- a/source/Application/Model/VatSelector.php
+++ b/source/Application/Model/VatSelector.php
@@ -70,6 +70,13 @@ class VatSelector extends \OxidEsales\Eshop\Core\Base
 
         return $ret;
     }
+    /**
+     * @deprecated use self::getForeignCountryUserVat instead
+     */
+    protected function _getForeignCountryUserVat(\OxidEsales\Eshop\Application\Model\User $oUser, \OxidEsales\Eshop\Application\Model\Country $oCountry) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getForeignCountryUserVat($oUser, $oCountry);
+    }
 
     /**
      * get vat for user of a foreign country
@@ -79,7 +86,7 @@ class VatSelector extends \OxidEsales\Eshop\Core\Base
      *
      * @return mixed
      */
-    protected function _getForeignCountryUserVat(\OxidEsales\Eshop\Application\Model\User $oUser, \OxidEsales\Eshop\Application\Model\Country $oCountry) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getForeignCountryUserVat(\OxidEsales\Eshop\Application\Model\User $oUser, \OxidEsales\Eshop\Application\Model\Country $oCountry)
     {
         if ($oCountry->isInEU()) {
             if ($oUser->oxuser__oxustid->value) {
@@ -91,6 +98,13 @@ class VatSelector extends \OxidEsales\Eshop\Core\Base
 
         return 0;
     }
+    /**
+     * @deprecated use self::getVatForArticleCategory instead
+     */
+    protected function _getVatForArticleCategory(\OxidEsales\Eshop\Application\Model\Article $oArticle) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getVatForArticleCategory($oArticle);
+    }
 
     /**
      * return Vat value for category type assignment only
@@ -99,7 +113,7 @@ class VatSelector extends \OxidEsales\Eshop\Core\Base
      *
      * @return float | false
      */
-    protected function _getVatForArticleCategory(\OxidEsales\Eshop\Application\Model\Article $oArticle) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getVatForArticleCategory(\OxidEsales\Eshop\Application\Model\Article $oArticle)
     {
         $oDb = \OxidEsales\Eshop\Core\DatabaseProvider::getDb();
         $sCatT = getViewName('oxcategories');
@@ -192,6 +206,13 @@ class VatSelector extends \OxidEsales\Eshop\Core\Base
 
         return false;
     }
+    /**
+     * @deprecated use self::getVatCountry instead
+     */
+    protected function _getVatCountry(\OxidEsales\Eshop\Application\Model\User $oUser) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getVatCountry($oUser);
+    }
 
 
     /**
@@ -202,7 +223,7 @@ class VatSelector extends \OxidEsales\Eshop\Core\Base
      *
      * @return string
      */
-    protected function _getVatCountry(\OxidEsales\Eshop\Application\Model\User $oUser) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getVatCountry(\OxidEsales\Eshop\Application\Model\User $oUser)
     {
         $blUseShippingCountry = $this->getConfig()->getConfigParam("blShippingCountryVat");
 

--- a/source/Application/Model/Vendor.php
+++ b/source/Application/Model/Vendor.php
@@ -118,13 +118,20 @@ class Vendor extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements 
 
         return parent::load($sOxid);
     }
+    /**
+     * @deprecated use self::setRootObjectData instead
+     */
+    protected function _setRootObjectData() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->setRootObjectData();
+    }
 
     /**
      * Sets root vendor data. Returns true
      *
      * @return bool
      */
-    protected function _setRootObjectData() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function setRootObjectData()
     {
         $this->setId('root');
         $this->oxvendor__oxicon = new \OxidEsales\Eshop\Core\Field('', \OxidEsales\Eshop\Core\Field::T_RAW);

--- a/source/Application/Model/VendorList.php
+++ b/source/Application/Model/VendorList.php
@@ -142,13 +142,20 @@ class VendorList extends \OxidEsales\Eshop\Core\Model\ListModel
     {
         return $this->_aPath;
     }
+    /**
+     * @deprecated use self::addCategoryFields instead
+     */
+    protected function _addCategoryFields($oVendor) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->addCategoryFields($oVendor);
+    }
 
     /**
      * Adds category specific fields to vendor object
      *
      * @param object $oVendor vendor object
      */
-    protected function _addCategoryFields($oVendor) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function addCategoryFields($oVendor)
     {
         $oVendor->oxcategories__oxid = new \OxidEsales\Eshop\Core\Field("v_" . $oVendor->oxvendor__oxid->value);
         $oVendor->oxcategories__oxicon = $oVendor->oxvendor__oxicon;
@@ -178,11 +185,18 @@ class VendorList extends \OxidEsales\Eshop\Core\Model\ListModel
     {
         return $this->_oClickedVendor;
     }
+    /**
+     * @deprecated use self::seoSetVendorData instead
+     */
+    protected function _seoSetVendorData() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->seoSetVendorData();
+    }
 
     /**
      * Processes vendor category URLs
      */
-    protected function _seoSetVendorData() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function seoSetVendorData()
     {
         // only when SEO id on and in front end
         if (\OxidEsales\Eshop\Core\Registry::getUtils()->seoIsActive() && !$this->isAdmin()) {

--- a/source/Application/Model/Voucher.php
+++ b/source/Application/Model/Voucher.php
@@ -210,6 +210,13 @@ class Voucher extends \OxidEsales\Eshop\Core\Model\BaseModel
         // returning true - no exception was thrown
         return true;
     }
+    /**
+     * @deprecated use self::isAvailablePrice instead
+     */
+    protected function _isAvailablePrice($dPrice) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->isAvailablePrice($dPrice);
+    }
 
     /**
      * Checks availability about price. Returns error array.
@@ -220,7 +227,7 @@ class Voucher extends \OxidEsales\Eshop\Core\Model\BaseModel
      *
      * @return array
      */
-    protected function _isAvailablePrice($dPrice) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function isAvailablePrice($dPrice)
     {
         $oSeries = $this->getSerie();
         $oCur = $this->getConfig()->getActShopCurrencyObject();
@@ -232,6 +239,13 @@ class Voucher extends \OxidEsales\Eshop\Core\Model\BaseModel
         }
 
         return true;
+    }
+    /**
+     * @deprecated use self::isAvailableWithSameSeries instead
+     */
+    protected function _isAvailableWithSameSeries($aVouchers) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->isAvailableWithSameSeries($aVouchers);
     }
 
     /**
@@ -245,7 +259,7 @@ class Voucher extends \OxidEsales\Eshop\Core\Model\BaseModel
      * @return bool
      *
      */
-    protected function _isAvailableWithSameSeries($aVouchers) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function isAvailableWithSameSeries($aVouchers)
     {
         if (is_array($aVouchers)) {
             $sId = $this->getId();
@@ -269,6 +283,13 @@ class Voucher extends \OxidEsales\Eshop\Core\Model\BaseModel
 
         return true;
     }
+    /**
+     * @deprecated use self::isAvailableWithOtherSeries instead
+     */
+    protected function _isAvailableWithOtherSeries($aVouchers) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->isAvailableWithOtherSeries($aVouchers);
+    }
 
     /**
      * Checks if calculation with vouchers from the other series possible.
@@ -280,7 +301,7 @@ class Voucher extends \OxidEsales\Eshop\Core\Model\BaseModel
      *
      * @return bool
      */
-    protected function _isAvailableWithOtherSeries($aVouchers) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function isAvailableWithOtherSeries($aVouchers)
     {
         if (is_array($aVouchers) && count($aVouchers)) {
             $oSeries = $this->getSerie();
@@ -313,6 +334,13 @@ class Voucher extends \OxidEsales\Eshop\Core\Model\BaseModel
 
         return true;
     }
+    /**
+     * @deprecated use self::isValidDate instead
+     */
+    protected function _isValidDate() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->isValidDate();
+    }
 
     /**
      * Checks if voucher is in valid time period. Returns true on success.
@@ -321,7 +349,7 @@ class Voucher extends \OxidEsales\Eshop\Core\Model\BaseModel
      *
      * @return bool
      */
-    protected function _isValidDate() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function isValidDate()
     {
         $oSeries = $this->getSerie();
         $iTime = time();
@@ -350,6 +378,13 @@ class Voucher extends \OxidEsales\Eshop\Core\Model\BaseModel
         $oEx->setVoucherNr($this->oxvouchers__oxvouchernr->value);
         throw $oEx;
     }
+    /**
+     * @deprecated use self::isNotReserved instead
+     */
+    protected function _isNotReserved() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->isNotReserved();
+    }
 
     /**
      * Checks if voucher is not yet reserved before.
@@ -358,7 +393,7 @@ class Voucher extends \OxidEsales\Eshop\Core\Model\BaseModel
      *
      * @return bool
      */
-    protected function _isNotReserved() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function isNotReserved()
     {
         if ($this->oxvouchers__oxreserved->value < time() - $this->_getVoucherTimeout()) {
             return true;
@@ -388,6 +423,13 @@ class Voucher extends \OxidEsales\Eshop\Core\Model\BaseModel
         // returning true if no exception was thrown
         return true;
     }
+    /**
+     * @deprecated use self::isAvailableInOtherOrder instead
+     */
+    protected function _isAvailableInOtherOrder($oUser) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->isAvailableInOtherOrder($oUser);
+    }
 
     /**
      * Checks if user already used vouchers from this series and can he use it again.
@@ -398,7 +440,7 @@ class Voucher extends \OxidEsales\Eshop\Core\Model\BaseModel
      *
      * @return boolean
      */
-    protected function _isAvailableInOtherOrder($oUser) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function isAvailableInOtherOrder($oUser)
     {
         $oSeries = $this->getSerie();
         if (!$oSeries->oxvoucherseries__oxallowuseanother->value) {
@@ -423,6 +465,13 @@ class Voucher extends \OxidEsales\Eshop\Core\Model\BaseModel
 
         return true;
     }
+    /**
+     * @deprecated use self::isValidUserGroup instead
+     */
+    protected function _isValidUserGroup($oUser) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->isValidUserGroup($oUser);
+    }
 
     /**
      * Checks if user belongs to the same group as the voucher. Returns true on sucess.
@@ -433,7 +482,7 @@ class Voucher extends \OxidEsales\Eshop\Core\Model\BaseModel
      *
      * @return bool
      */
-    protected function _isValidUserGroup($oUser) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function isValidUserGroup($oUser)
     {
         $oVoucherSeries = $this->getSerie();
         $oUserGroups = $oVoucherSeries->setUserGroups();
@@ -495,13 +544,20 @@ class Voucher extends \OxidEsales\Eshop\Core\Model\BaseModel
 
         return $oSerie;
     }
+    /**
+     * @deprecated use self::isProductVoucher instead
+     */
+    protected function _isProductVoucher() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->isProductVoucher();
+    }
 
     /**
      * Returns true if voucher is product specific, otherwise false
      *
      * @return boolean
      */
-    protected function _isProductVoucher() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function isProductVoucher()
     {
         $oDb = \OxidEsales\Eshop\Core\DatabaseProvider::getDb();
         $oSeries = $this->getSerie();
@@ -514,13 +570,20 @@ class Voucher extends \OxidEsales\Eshop\Core\Model\BaseModel
 
         return $blOk;
     }
+    /**
+     * @deprecated use self::isCategoryVoucher instead
+     */
+    protected function _isCategoryVoucher() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->isCategoryVoucher();
+    }
 
     /**
      * Returns true if voucher is category specific, otherwise false
      *
      * @return boolean
      */
-    protected function _isCategoryVoucher() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function isCategoryVoucher()
     {
         $oDb = \OxidEsales\Eshop\Core\DatabaseProvider::getDb();
         $oSeries = $this->getSerie();
@@ -533,13 +596,20 @@ class Voucher extends \OxidEsales\Eshop\Core\Model\BaseModel
 
         return $blOk;
     }
+    /**
+     * @deprecated use self::getSerieDiscount instead
+     */
+    protected function _getSerieDiscount() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getSerieDiscount();
+    }
 
     /**
      * Returns the discount object created from voucher serie data
      *
      * @return object
      */
-    protected function _getSerieDiscount() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getSerieDiscount()
     {
         $oSeries = $this->getSerie();
         $oDiscount = oxNew(\OxidEsales\Eshop\Application\Model\Discount::class);
@@ -562,6 +632,13 @@ class Voucher extends \OxidEsales\Eshop\Core\Model\BaseModel
 
         return $oDiscount;
     }
+    /**
+     * @deprecated use self::getBasketItems instead
+     */
+    protected function _getBasketItems($oDiscount = null) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getBasketItems($oDiscount);
+    }
 
     /**
      * Returns basket item information array from session or order.
@@ -570,7 +647,7 @@ class Voucher extends \OxidEsales\Eshop\Core\Model\BaseModel
      *
      * @return array
      */
-    protected function _getBasketItems($oDiscount = null) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getBasketItems($oDiscount = null)
     {
         if ($this->oxvouchers__oxorderid->value) {
             return $this->_getOrderBasketItems($oDiscount);
@@ -580,6 +657,13 @@ class Voucher extends \OxidEsales\Eshop\Core\Model\BaseModel
             return [];
         }
     }
+    /**
+     * @deprecated use self::getOrderBasketItems instead
+     */
+    protected function _getOrderBasketItems($oDiscount = null) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getOrderBasketItems($oDiscount);
+    }
 
     /**
      * Returns basket item information (id,amount,price) array takig item list from order.
@@ -588,7 +672,7 @@ class Voucher extends \OxidEsales\Eshop\Core\Model\BaseModel
      *
      * @return array
      */
-    protected function _getOrderBasketItems($oDiscount = null) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getOrderBasketItems($oDiscount = null)
     {
         if (is_null($oDiscount)) {
             $oDiscount = $this->_getSerieDiscount();
@@ -614,6 +698,13 @@ class Voucher extends \OxidEsales\Eshop\Core\Model\BaseModel
 
         return $aItems;
     }
+    /**
+     * @deprecated use self::getSessionBasketItems instead
+     */
+    protected function _getSessionBasketItems($oDiscount = null) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getSessionBasketItems($oDiscount);
+    }
 
     /**
      * Returns basket item information (id,amount,price) array taking item list from session.
@@ -622,7 +713,7 @@ class Voucher extends \OxidEsales\Eshop\Core\Model\BaseModel
      *
      * @return array
      */
-    protected function _getSessionBasketItems($oDiscount = null) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getSessionBasketItems($oDiscount = null)
     {
         if (is_null($oDiscount)) {
             $oDiscount = $this->_getSerieDiscount();
@@ -647,6 +738,13 @@ class Voucher extends \OxidEsales\Eshop\Core\Model\BaseModel
 
         return $aItems;
     }
+    /**
+     * @deprecated use self::getGenericDiscoutValue instead
+     */
+    protected function _getGenericDiscoutValue($dPrice) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getGenericDiscoutValue($dPrice);
+    }
 
     /**
      * Returns the discount value used.
@@ -655,13 +753,20 @@ class Voucher extends \OxidEsales\Eshop\Core\Model\BaseModel
      *
      * @throws oxVoucherException exception
      *
-     * @deprecated on b-dev (2015-03-31); Use function _getGenericDiscountValue()
+     * @deprecated on b-dev (2015-03-31); Use function _getGenericDiscountValue() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
      *
      * @return double
      */
-    protected function _getGenericDiscoutValue($dPrice) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getGenericDiscoutValue($dPrice)
     {
         return $this->_getGenericDiscountValue($dPrice);
+    }
+    /**
+     * @deprecated use self::getGenericDiscountValue instead
+     */
+    protected function _getGenericDiscountValue($dPrice) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getGenericDiscountValue($dPrice);
     }
 
     /**
@@ -673,7 +778,7 @@ class Voucher extends \OxidEsales\Eshop\Core\Model\BaseModel
      *
      * @return double
      */
-    protected function _getGenericDiscountValue($dPrice) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getGenericDiscountValue($dPrice)
     {
         $oSeries = $this->getSerie();
         if ($oSeries->oxvoucherseries__oxdiscounttype->value == 'absolute') {
@@ -714,6 +819,13 @@ class Voucher extends \OxidEsales\Eshop\Core\Model\BaseModel
 
         return $oSeries->oxvoucherseries__oxdiscounttype->value;
     }
+    /**
+     * @deprecated use self::getProductDiscoutValue instead
+     */
+    protected function _getProductDiscoutValue($dPrice) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getProductDiscoutValue($dPrice);
+    }
 
     /**
      * Returns the discount value used, if voucher is aplied only for specific products.
@@ -722,13 +834,20 @@ class Voucher extends \OxidEsales\Eshop\Core\Model\BaseModel
      *
      * @throws oxVoucherException exception
      *
-     * @deprecated on b-dev (2015-03-31); Use function _getProductDiscountValue()
+     * @deprecated on b-dev (2015-03-31); Use function _getProductDiscountValue() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
      *
      * @return double
      */
-    protected function _getProductDiscoutValue($dPrice) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getProductDiscoutValue($dPrice)
     {
         return $this->_getProductDiscountValue($dPrice);
+    }
+    /**
+     * @deprecated use self::getProductDiscountValue instead
+     */
+    protected function _getProductDiscountValue($dPrice) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getProductDiscountValue($dPrice);
     }
 
     /**
@@ -740,7 +859,7 @@ class Voucher extends \OxidEsales\Eshop\Core\Model\BaseModel
      *
      * @return double
      */
-    protected function _getProductDiscountValue($dPrice) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getProductDiscountValue($dPrice)
     {
         $oDiscount = $this->_getSerieDiscount();
         $aBasketItems = $this->_getBasketItems($oDiscount);
@@ -795,6 +914,13 @@ class Voucher extends \OxidEsales\Eshop\Core\Model\BaseModel
 
         return $dVoucher;
     }
+    /**
+     * @deprecated use self::getCategoryDiscoutValue instead
+     */
+    protected function _getCategoryDiscoutValue($dPrice) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getCategoryDiscoutValue($dPrice);
+    }
 
     /**
      * Returns the discount value used, if voucher is applied only for specific categories.
@@ -803,13 +929,20 @@ class Voucher extends \OxidEsales\Eshop\Core\Model\BaseModel
      *
      * @throws oxVoucherException exception
      *
-     * @deprecated on b-dev (2015-03-31); Use function _getCategoryDiscountValue()
+     * @deprecated on b-dev (2015-03-31); Use function _getCategoryDiscountValue() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
      *
      * @return double
      */
-    protected function _getCategoryDiscoutValue($dPrice) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getCategoryDiscoutValue($dPrice)
     {
         return $this->_getCategoryDiscountValue($dPrice);
+    }
+    /**
+     * @deprecated use self::getCategoryDiscountValue instead
+     */
+    protected function _getCategoryDiscountValue($dPrice) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getCategoryDiscountValue($dPrice);
     }
 
     /**
@@ -821,7 +954,7 @@ class Voucher extends \OxidEsales\Eshop\Core\Model\BaseModel
      *
      * @return double
      */
-    protected function _getCategoryDiscountValue($dPrice) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getCategoryDiscountValue($dPrice)
     {
         $oDiscount = $this->_getSerieDiscount();
         $aBasketItems = $this->_getBasketItems($oDiscount);
@@ -872,6 +1005,13 @@ class Voucher extends \OxidEsales\Eshop\Core\Model\BaseModel
         }
         return parent::__get($sName);
     }
+    /**
+     * @deprecated use self::getVoucherTimeout instead
+     */
+    protected function _getVoucherTimeout() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->getVoucherTimeout();
+    }
 
     /**
      * Returns a configured value for voucher timeouts or a default
@@ -879,7 +1019,7 @@ class Voucher extends \OxidEsales\Eshop\Core\Model\BaseModel
      *
      * @return integer Seconds a voucher can stay in status reserved
      */
-    protected function _getVoucherTimeout() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function getVoucherTimeout()
     {
         $iVoucherTimeout = (int) \OxidEsales\Eshop\Core\Registry::getConfig()->getConfigParam('iVoucherTimeout') ?:
             3 * 3600;

--- a/source/Application/Model/Wrapping.php
+++ b/source/Application/Model/Wrapping.php
@@ -148,13 +148,20 @@ class Wrapping extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel
             ':oxtype' => $sWrapType
         ]);
     }
+    /**
+     * @deprecated use self::isPriceViewModeNetto instead
+     */
+    protected function _isPriceViewModeNetto() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        return $this->isPriceViewModeNetto();
+    }
 
     /**
      * Checks and return true if price view mode is netto
      *
      * @return bool
      */
-    protected function _isPriceViewModeNetto() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function isPriceViewModeNetto()
     {
         $blResult = (bool) $this->getConfig()->getConfigParam('blShowNetPrice');
         $oUser = $this->getUser();

--- a/tests/Integration/Application/Component/UserComponentTest.php
+++ b/tests/Integration/Application/Component/UserComponentTest.php
@@ -31,7 +31,7 @@ class modcmp_user extends oxcmp_user
 {
     protected $_oParent;
 
-    public function getLogoutLink()
+    public function PUBLICgetLogoutLink()
     {
         $this->_oParent = new modcmp_user_parent();
 
@@ -359,7 +359,7 @@ class UserComponentTest extends \OxidTestCase
         $this->setRequestParameter('tpl', 'test');
         $this->setRequestParameter('oxloadid', 'test');
         $this->setRequestParameter('recommid', 'recommid');
-        $sLink = $oView->getLogoutLink();
+        $sLink = $oView->PUBLICgetLogoutLink();
         $sExpLink = "shopurl/?cl=testclass&amp;searchparam=a&amp;anid=artid&amp;cnid=catid&amp;mnid=manId" .
                     "&amp;tpl=test&amp;oxloadid=test&amp;recommid=recommid&amp;fnc=logout";
 
@@ -379,7 +379,7 @@ class UserComponentTest extends \OxidTestCase
         $this->setRequestParameter('mnid', 'manId');
         $this->setRequestParameter('anid', 'artid');
         $this->setRequestParameter('tpl', 'test');
-        $sLink = $oView->getLogoutLink();
+        $sLink = $oView->PUBLICgetLogoutLink();
         $sExpLink = "sslshopurl/?cl=testclass&amp;searchparam=a&amp;anid=artid&amp;cnid=catid&amp;mnid=manId" .
                     "&amp;tpl=test&amp;fnc=logout";
 

--- a/tests/Unit/Application/Controller/Admin/DynExportBaseTest.php
+++ b/tests/Unit/Application/Controller/Admin/DynExportBaseTest.php
@@ -19,7 +19,7 @@ use stdClass;
  */
 class _DynExportBase extends DynExportBase
 {
-    public function initArticle($heapTable, $count, & $continue)
+    public function PUBLICinitArticle($heapTable, $count, & $continue)
     {
         try {
             return $this->_initArticle($heapTable, $count, $continue);
@@ -733,7 +733,7 @@ class DynExportBaseTest extends \OxidTestCase
         $oDb->execute("INSERT INTO `{$sHeapTable}` values ( '{$sProdId}' )");
 
         $oView = new _DynExportBase();
-        $oArticle = $oView->initArticle("testdynexportbasetable", 0, $blContinue);
+        $oArticle = $oView->PUBLICinitArticle("testdynexportbasetable", 0, $blContinue);
         $this->assertNotNull($oArticle);
         $this->assertTrue($oArticle instanceof \OxidEsales\EshopCommunity\Application\Model\Article);
         $this->assertEquals($oParent->oxarticles__oxtitle->value . " " . $sTitle, $oArticle->oxarticles__oxtitle->value);

--- a/tests/Unit/Application/Model/VarianthandlerTest.php
+++ b/tests/Unit/Application/Model/VarianthandlerTest.php
@@ -13,7 +13,7 @@ use \oxDb;
 
 class oxVariantHandlerForOxvarianthandlerTest extends oxVariantHandler
 {
-    public function fillVariantSelections($oVariantList, $iVarSelCnt, &$aFilter, $sActVariantId)
+    public function PUBLICfillVariantSelections($oVariantList, $iVarSelCnt, &$aFilter, $sActVariantId)
     {
         return parent::_fillVariantSelections($oVariantList, $iVarSelCnt, $aFilter, $sActVariantId);
     }
@@ -247,7 +247,7 @@ class VarianthandlerTest extends \OxidTestCase
 
         // empty variant list
         $oHandler = new oxVariantHandlerForOxvarianthandlerTest();
-        $this->assertEquals(array(), $oHandler->fillVariantSelections(array(), 100, $aFilter, ""));
+        $this->assertEquals(array(), $oHandler->PUBLICfillVariantSelections(array(), 100, $aFilter, ""));
 
         // filled variant list
         $oVariant1 = oxNew('oxbase');
@@ -272,7 +272,7 @@ class VarianthandlerTest extends \OxidTestCase
 
         // checking
         $oHandler = new oxVariantHandlerForOxvarianthandlerTest();
-        $this->assertEquals($aArray, $oHandler->fillVariantSelections(array($oVariant1, $oVariant2, $oVariant3), 2, $aFilter, "test1"));
+        $this->assertEquals($aArray, $oHandler->PUBLICfillVariantSelections(array($oVariant1, $oVariant2, $oVariant3), 2, $aFilter, "test1"));
         $this->assertEquals(array("0cc175b9c0f1b6a831c399e269772661", "92eb5ffee6ae2fec3ad71c777531578f"), $aFilter);
     }
 


### PR DESCRIPTION
Hello there :open_hands:,

this pull request deprecates most methods that start with an `_` as stated in OXDEV-3281. There are some methods with preceding `_` that are not easy to cleanup in an automated way. So I only cleaned up all methods that I was able to do in an automated fashion.
All methods that are left with a preceding `_` need to be converted manually.

/Flo