### PR TITLE
OXDEV-3281 deprecate all underscore methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
         - `RECOMMENDED_PRODUCTS`
         - `SHOP_CONFIG_ALLOW_SUGGEST_ARTICLE`
         - `HELP_SHOP_CONFIG_ALLOW_SUGGEST_ARTICLE`
+- Methods starting with underscore have been deprecated, these methods will be renamed
+
 ### Fixed
 - Change visibility of Session::setSessionCookie to protected for overwriting possibility [PR-785](https://github.com/OXID-eSales/oxideshop_ce/pull/785)
 - Use cache directory from config file for the container cache: [#0007111](https://bugs.oxid-esales.com/view.php?id=7111)

--- a/source/Application/Component/BasketComponent.php
+++ b/source/Application/Component/BasketComponent.php
@@ -263,6 +263,7 @@ class BasketComponent extends \OxidEsales\Eshop\Core\Controller\BaseController
      * storing something to basket
      *
      * @return string   $sClass.$sPosition  redirection URL
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getRedirectUrl" in next major
      */
     protected function _getRedirectUrl() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -326,6 +327,7 @@ class BasketComponent extends \OxidEsales\Eshop\Core\Controller\BaseController
      * @param bool   $blOverride amount override status
      *
      * @return mixed
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getItems" in next major
      */
     protected function _getItems( // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
         $sProductId = null,
@@ -386,6 +388,7 @@ class BasketComponent extends \OxidEsales\Eshop\Core\Controller\BaseController
      * @param array $products products to add array
      *
      * @return  object  $oBasketItem    last added basket item
+     * @deprecated underscore prefix violates PSR12, will be renamed to "addItems" in next major
      */
     protected function _addItems($products) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -447,6 +450,7 @@ class BasketComponent extends \OxidEsales\Eshop\Core\Controller\BaseController
      * @param string $sCallName    name of action ('tobasket', 'changebasket')
      * @param array  $aProductInfo data which comes from request when you press button "to basket"
      * @param array  $aBasketInfo  array returned by \OxidEsales\Eshop\Application\Model\Basket::getBasketSummary()
+     * @deprecated underscore prefix violates PSR12, will be renamed to "setLastCall" in next major
      */
     protected function _setLastCall($sCallName, $aProductInfo, $aBasketInfo) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -457,6 +461,7 @@ class BasketComponent extends \OxidEsales\Eshop\Core\Controller\BaseController
      * Setting last call function name (data used by econda)
      *
      * @param string $sCallName name of action ('tobasket', 'changebasket')
+     * @deprecated underscore prefix violates PSR12, will be renamed to "setLastCallFnc" in next major
      */
     protected function _setLastCallFnc($sCallName) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -467,6 +472,7 @@ class BasketComponent extends \OxidEsales\Eshop\Core\Controller\BaseController
      * Getting last call function name (data used by econda)
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getLastCallFnc" in next major
      */
     protected function _getLastCallFnc() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {

--- a/source/Application/Component/CategoriesComponent.php
+++ b/source/Application/Component/CategoriesComponent.php
@@ -105,6 +105,7 @@ class CategoriesComponent extends \OxidEsales\Eshop\Core\Controller\BaseControll
      * get active category id
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getActCat" in next major
      */
     protected function _getActCat() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -141,6 +142,7 @@ class CategoriesComponent extends \OxidEsales\Eshop\Core\Controller\BaseControll
      * Category tree loader
      *
      * @param string $sActCat active category id
+     * @deprecated underscore prefix violates PSR12, will be renamed to "loadCategoryTree" in next major
      */
     protected function _loadCategoryTree($sActCat) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -162,6 +164,7 @@ class CategoriesComponent extends \OxidEsales\Eshop\Core\Controller\BaseControll
      * Manufacturer tree loader
      *
      * @param string $sActManufacturer active Manufacturer id
+     * @deprecated underscore prefix violates PSR12, will be renamed to "loadManufacturerTree" in next major
      */
     protected function _loadManufacturerTree($sActManufacturer) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -217,6 +220,7 @@ class CategoriesComponent extends \OxidEsales\Eshop\Core\Controller\BaseControll
      * @param string                                      $sActVendor       active vendor
      *
      * @return string $sActCat
+     * @deprecated underscore prefix violates PSR12, will be renamed to "addAdditionalParams" in next major
      */
     protected function _addAdditionalParams($oProduct, $sActCat, $sActManufacturer, $sActVendor) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -261,6 +265,7 @@ class CategoriesComponent extends \OxidEsales\Eshop\Core\Controller\BaseControll
      * @param \OxidEsales\Eshop\Application\Model\Article $oProduct current product object
      *
      * @return array
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getDefaultParams" in next major
      */
     protected function _getDefaultParams($oProduct) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {

--- a/source/Application/Component/Locator.php
+++ b/source/Application/Component/Locator.php
@@ -87,6 +87,7 @@ class Locator extends \OxidEsales\Eshop\Core\Base
      *
      * @param FrontendController $oLocatorTarget view object
      * @param Article            $oCurrArticle   current article
+     * @deprecated underscore prefix violates PSR12, will be renamed to "setListLocatorData" in next major
      */
     protected function _setListLocatorData($oLocatorTarget, $oCurrArticle) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -130,6 +131,7 @@ class Locator extends \OxidEsales\Eshop\Core\Base
      *
      * @param FrontendController $oLocatorTarget FrontendController object
      * @param Article            $oCurrArticle   current article
+     * @deprecated underscore prefix violates PSR12, will be renamed to "setVendorLocatorData" in next major
      */
     protected function _setVendorLocatorData($oLocatorTarget, $oCurrArticle) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -174,6 +176,7 @@ class Locator extends \OxidEsales\Eshop\Core\Base
      *
      * @param FrontendController $oLocatorTarget FrontendController object
      * @param Article            $oCurrArticle   current article
+     * @deprecated underscore prefix violates PSR12, will be renamed to "setManufacturerLocatorData" in next major
      */
     protected function _setManufacturerLocatorData($oLocatorTarget, $oCurrArticle) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -228,6 +231,7 @@ class Locator extends \OxidEsales\Eshop\Core\Base
      *
      * @param FrontendController $oLocatorTarget FrontendController object
      * @param Article            $oCurrArticle   current article
+     * @deprecated underscore prefix violates PSR12, will be renamed to "setSearchLocatorData" in next major
      */
     protected function _setSearchLocatorData($oLocatorTarget, $oCurrArticle) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -358,6 +362,7 @@ class Locator extends \OxidEsales\Eshop\Core\Base
      * @param string                                       $sOrderBy     order by fields
      *
      * @return object
+     * @deprecated underscore prefix violates PSR12, will be renamed to "loadIdsInList" in next major
      */
     protected function _loadIdsInList($oCategory, $oCurrArticle, $sOrderBy = null) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -389,6 +394,7 @@ class Locator extends \OxidEsales\Eshop\Core\Base
      * @param string $sParams parameters to add to url
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "makeLink" in next major
      */
     protected function _makeLink($sLink, $sParams) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -408,6 +414,7 @@ class Locator extends \OxidEsales\Eshop\Core\Base
      * @param Article   $oArticle active article id (optional)
      *
      * @return int
+     * @deprecated underscore prefix violates PSR12, will be renamed to "findActPageNumber" in next major
      */
     protected function _findActPageNumber($iPageNr, $oIdList = null, $oArticle = null) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -433,6 +440,7 @@ class Locator extends \OxidEsales\Eshop\Core\Base
      * @param int $iPageNr page number
      *
      * @return string $sPageNum
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getPageNumber" in next major
      */
     protected function _getPageNumber($iPageNr) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -450,6 +458,7 @@ class Locator extends \OxidEsales\Eshop\Core\Base
      * @param FrontendController $oLocatorTarget FrontendController object
      *
      * @return integer
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getProductPos" in next major
      */
     protected function _getProductPos($oArticle, $oIdList, $oLocatorTarget) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {

--- a/source/Application/Component/UserComponent.php
+++ b/source/Application/Component/UserComponent.php
@@ -125,6 +125,7 @@ class UserComponent extends \OxidEsales\Eshop\Core\Controller\BaseController
      * In case any condition is not satisfied redirects user to:
      *  (1) login page;
      *  (2) terms agreement page;
+     * @deprecated underscore prefix violates PSR12, will be renamed to "checkPsState" in next major
      */
     protected function _checkPsState() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -149,6 +150,7 @@ class UserComponent extends \OxidEsales\Eshop\Core\Controller\BaseController
      * Tries to load user ID from session.
      *
      * @return null
+     * @deprecated underscore prefix violates PSR12, will be renamed to "loadSessionUser" in next major
      */
     protected function _loadSessionUser() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -232,6 +234,7 @@ class UserComponent extends \OxidEsales\Eshop\Core\Controller\BaseController
      * @param \OxidEsales\Eshop\Application\Model\User $oUser user object
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "afterLogin" in next major
      */
     protected function _afterLogin($oUser) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -287,6 +290,7 @@ class UserComponent extends \OxidEsales\Eshop\Core\Controller\BaseController
      * oxcmp_user::logout is called. Currently it unsets such
      * session parameters as user chosen payment id, delivery
      * address id, active delivery set.
+     * @deprecated underscore prefix violates PSR12, will be renamed to "afterLogout" in next major
      */
     protected function _afterLogout() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -606,6 +610,7 @@ class UserComponent extends \OxidEsales\Eshop\Core\Controller\BaseController
 
     /**
      * Saves invitor ID
+     * @deprecated underscore prefix violates PSR12, will be renamed to "saveInvitor" in next major
      */
     protected function _saveInvitor() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -617,6 +622,7 @@ class UserComponent extends \OxidEsales\Eshop\Core\Controller\BaseController
 
     /**
      * Saving show/hide delivery address state
+     * @deprecated underscore prefix violates PSR12, will be renamed to "saveDeliveryAddressState" in next major
      */
     protected function _saveDeliveryAddressState() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -751,6 +757,7 @@ class UserComponent extends \OxidEsales\Eshop\Core\Controller\BaseController
      * all needed data is there
      *
      * @return array
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getDelAddressData" in next major
      */
     protected function _getDelAddressData() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -779,6 +786,7 @@ class UserComponent extends \OxidEsales\Eshop\Core\Controller\BaseController
      * Returns logout link with additional params
      *
      * @return string $sLogoutLink
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getLogoutLink" in next major
      */
     protected function _getLogoutLink() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {

--- a/source/Application/Component/UtilsComponent.php
+++ b/source/Application/Component/UtilsComponent.php
@@ -133,6 +133,7 @@ class UtilsComponent extends \OxidEsales\Eshop\Core\Controller\BaseController
      * @param string $sProductId product id
      * @param double $dAmount    product amount
      * @param array  $aSel       product selection list
+     * @deprecated underscore prefix violates PSR12, will be renamed to "toList" in next major
      */
     protected function _toList($sListType, $sProductId, $dAmount, $aSel) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {

--- a/source/Application/Component/Widget/Actions.php
+++ b/source/Application/Component/Widget/Actions.php
@@ -48,6 +48,7 @@ class Actions extends \OxidEsales\Eshop\Application\Component\Widget\WidgetContr
      * Returns if actions are ON
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getLoadActionsParam" in next major
      */
     protected function _getLoadActionsParam() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {

--- a/source/Application/Component/Widget/ArticleBox.php
+++ b/source/Application/Component/Widget/ArticleBox.php
@@ -248,6 +248,7 @@ class ArticleBox extends \OxidEsales\Eshop\Application\Component\Widget\WidgetCo
      * @param \OxidEsales\Eshop\Application\Model\Article $oArticle      Article
      *
      * @return bool
+     * @deprecated underscore prefix violates PSR12, will be renamed to "addDynParamsToLink" in next major
      */
     protected function _addDynParamsToLink($sAddDynParams, $oArticle) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -271,6 +272,7 @@ class ArticleBox extends \OxidEsales\Eshop\Application\Component\Widget\WidgetCo
      * @param string $sArticleId Article id
      *
      * @return \OxidEsales\Eshop\Application\Model\Article
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getArticleById" in next major
      */
     protected function _getArticleById($sArticleId) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {

--- a/source/Application/Component/Widget/ArticleDetails.php
+++ b/source/Application/Component/Widget/ArticleDetails.php
@@ -225,6 +225,7 @@ class ArticleDetails extends \OxidEsales\Eshop\Application\Component\Widget\Widg
      * @param string $sParentId parent product id
      *
      * @return Article
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getParentProduct" in next major
      */
     protected function _getParentProduct($sParentId) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -244,6 +245,7 @@ class ArticleDetails extends \OxidEsales\Eshop\Application\Component\Widget\Widg
      * In case list type is "search" returns search parameters which will be added to product details link.
      *
      * @return string|null
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getAddUrlParams" in next major
      */
     protected function _getAddUrlParams() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -256,6 +258,7 @@ class ArticleDetails extends \OxidEsales\Eshop\Application\Component\Widget\Widg
      * Processes product by setting link type and in case list type is search adds search parameters to details link.
      *
      * @param object $oProduct Product to process.
+     * @deprecated underscore prefix violates PSR12, will be renamed to "processProduct" in next major
      */
     protected function _processProduct($oProduct) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -697,6 +700,7 @@ class ArticleDetails extends \OxidEsales\Eshop\Application\Component\Widget\Widg
      * @param int $iLang language id
      *
      * @return object
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getSubject" in next major
      */
     protected function _getSubject($iLang) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -898,6 +902,7 @@ class ArticleDetails extends \OxidEsales\Eshop\Application\Component\Widget\Widg
 
     /**
      * Set item sorting for widget based of retrieved parameters.
+     * @deprecated underscore prefix violates PSR12, will be renamed to "setSortingParameters" in next major
      */
     protected function _setSortingParameters() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -968,6 +973,7 @@ class ArticleDetails extends \OxidEsales\Eshop\Application\Component\Widget\Widg
      *
      * @param Utils  $myUtils  General utils.
      * @param Config $myConfig Main shop configuration.
+     * @deprecated underscore prefix violates PSR12, will be renamed to "additionalChecksForArticle" in next major
      */
     protected function _additionalChecksForArticle($myUtils, $myConfig) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {

--- a/source/Application/Component/Widget/Information.php
+++ b/source/Application/Component/Widget/Information.php
@@ -54,6 +54,7 @@ class Information extends \OxidEsales\Eshop\Application\Component\Widget\WidgetC
      * Returns content list object.
      *
      * @return object|oxContentList
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getContentList" in next major
      */
     protected function _getContentList() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {

--- a/source/Application/Component/Widget/WidgetController.php
+++ b/source/Application/Component/Widget/WidgetController.php
@@ -59,6 +59,7 @@ class WidgetController extends \OxidEsales\Eshop\Application\Controller\Frontend
     /**
      * In widgets we do not need to parse seo and do any work related to that
      * Shop main control is responsible for that, and that has to be done once
+     * @deprecated underscore prefix violates PSR12, will be renamed to "processRequest" in next major
      */
     protected function _processRequest() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {

--- a/source/Application/Controller/AccountController.php
+++ b/source/Application/Controller/AccountController.php
@@ -141,6 +141,7 @@ class AccountController extends \OxidEsales\Eshop\Application\Controller\Fronten
      *  - else returns $this->_sThisLoginTemplate
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getLoginTemplate" in next major
      */
     protected function _getLoginTemplate() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {

--- a/source/Application/Controller/AccountDownloadsController.php
+++ b/source/Application/Controller/AccountDownloadsController.php
@@ -86,6 +86,7 @@ class AccountDownloadsController extends \OxidEsales\Eshop\Application\Controlle
      * @param \OxidEsales\Eshop\Application\Model\OrderFileList $oOrderFileList - list or orderfiles
      *
      * @return array
+     * @deprecated underscore prefix violates PSR12, will be renamed to "prepareForTemplate" in next major
      */
     protected function _prepareForTemplate($oOrderFileList) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {

--- a/source/Application/Controller/Admin/ActionsArticleAjax.php
+++ b/source/Application/Controller/Admin/ActionsArticleAjax.php
@@ -43,6 +43,7 @@ class ActionsArticleAjax extends \OxidEsales\Eshop\Application\Controller\Admin\
      * Returns SQL query for data to fetc
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getQuery" in next major
      */
     protected function _getQuery() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -85,6 +86,7 @@ class ActionsArticleAjax extends \OxidEsales\Eshop\Application\Controller\Admin\
      * @param string $sQ query to add filter condition
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "addFilter" in next major
      */
     protected function _addFilter($sQ) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {

--- a/source/Application/Controller/Admin/ActionsGroupsAjax.php
+++ b/source/Application/Controller/Admin/ActionsGroupsAjax.php
@@ -39,6 +39,7 @@ class ActionsGroupsAjax extends \OxidEsales\Eshop\Application\Controller\Admin\L
      * Returns SQL query for data to fetc
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getQuery" in next major
      */
     protected function _getQuery() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {

--- a/source/Application/Controller/Admin/ActionsList.php
+++ b/source/Application/Controller/Admin/ActionsList.php
@@ -60,6 +60,7 @@ class ActionsList extends \OxidEsales\Eshop\Application\Controller\Admin\AdminLi
      * @param string $sqlFull SQL query string
      *
      * @return $sQ
+     * @deprecated underscore prefix violates PSR12, will be renamed to "prepareWhereQuery" in next major
      */
     protected function _prepareWhereQuery($aWhere, $sqlFull) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {

--- a/source/Application/Controller/Admin/ActionsMainAjax.php
+++ b/source/Application/Controller/Admin/ActionsMainAjax.php
@@ -54,6 +54,7 @@ class ActionsMainAjax extends \OxidEsales\Eshop\Application\Controller\Admin\Lis
      * Returns SQL query for data to fetc
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getQuery" in next major
      */
     protected function _getQuery() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -103,6 +104,7 @@ class ActionsMainAjax extends \OxidEsales\Eshop\Application\Controller\Admin\Lis
      * @param string $sQ query to add filter condition
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "addFilter" in next major
      */
     protected function _addFilter($sQ) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -125,6 +127,7 @@ class ActionsMainAjax extends \OxidEsales\Eshop\Application\Controller\Admin\Lis
      * Returns SQL query addon for sorting
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getSorting" in next major
      */
     protected function _getSorting() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -273,6 +276,7 @@ class ActionsMainAjax extends \OxidEsales\Eshop\Application\Controller\Admin\Lis
      * Getter for the rss feed handler.
      *
      * @return \OxidEsales\Eshop\Application\Model\RssFeed The rss feed handler.
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getOxRssFeed" in next major
      */
     protected function _getOxRssFeed() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {

--- a/source/Application/Controller/Admin/ActionsOrderAjax.php
+++ b/source/Application/Controller/Admin/ActionsOrderAjax.php
@@ -33,6 +33,7 @@ class ActionsOrderAjax extends \OxidEsales\Eshop\Application\Controller\Admin\Li
      * Returns SQL query for data to fetc
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getQuery" in next major
      */
     protected function _getQuery() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -47,6 +48,7 @@ class ActionsOrderAjax extends \OxidEsales\Eshop\Application\Controller\Admin\Li
      * Returns SQL query addon for sorting
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getSorting" in next major
      */
     protected function _getSorting() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {

--- a/source/Application/Controller/Admin/AdminController.php
+++ b/source/Application/Controller/Admin/AdminController.php
@@ -133,6 +133,7 @@ class AdminController extends \OxidEsales\Eshop\Core\Controller\BaseController
      * @param object $sShopId shop id
      *
      * @return oxshop
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getEditShop" in next major
      */
     protected function _getEditShop($sShopId) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -216,6 +217,7 @@ class AdminController extends \OxidEsales\Eshop\Core\Controller\BaseController
      * Returns service url protocol: "https" is admin works in ssl mode, "http" if no ssl
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getServiceProtocol" in next major
      */
     protected function _getServiceProtocol() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -272,6 +274,7 @@ class AdminController extends \OxidEsales\Eshop\Core\Controller\BaseController
      * Sets-up navigation parameters
      *
      * @param string $sNode active view id
+     * @deprecated underscore prefix violates PSR12, will be renamed to "setupNavigation" in next major
      */
     protected function _setupNavigation($sNode) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -300,6 +303,7 @@ class AdminController extends \OxidEsales\Eshop\Core\Controller\BaseController
      * Store navigation history parameters to cookie
      *
      * @param string $sNode active view id
+     * @deprecated underscore prefix violates PSR12, will be renamed to "addNavigationHistory" in next major
      */
     protected function _addNavigationHistory($sNode) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -373,6 +377,7 @@ class AdminController extends \OxidEsales\Eshop\Core\Controller\BaseController
      * @param bool $blFormatted  Return formated
      *
      * @return array
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getMaxUploadFileInfo" in next major
      */
     protected function _getMaxUploadFileInfo($iMaxFileSize, $blFormatted = false) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -460,6 +465,7 @@ class AdminController extends \OxidEsales\Eshop\Core\Controller\BaseController
 
     /**
      * Resets cache.
+     * @deprecated underscore prefix violates PSR12, will be renamed to "resetContentCache" in next major
      */
     protected function _resetContentCache() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -472,6 +478,7 @@ class AdminController extends \OxidEsales\Eshop\Core\Controller\BaseController
      * @param string $sUserId user id
      *
      * @return bool
+     * @deprecated underscore prefix violates PSR12, will be renamed to "allowAdminEdit" in next major
      */
     protected function _allowAdminEdit($sUserId) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -484,6 +491,7 @@ class AdminController extends \OxidEsales\Eshop\Core\Controller\BaseController
      * @param string $sCountryCode Country code
      *
      * @return boolean
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getCountryByCode" in next major
      */
     protected function _getCountryByCode($sCountryCode) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -521,6 +529,7 @@ class AdminController extends \OxidEsales\Eshop\Core\Controller\BaseController
      * performs authorization of admin user
      *
      * @return boolean
+     * @deprecated underscore prefix violates PSR12, will be renamed to "authorize" in next major
      */
     protected function _authorize() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {

--- a/source/Application/Controller/Admin/AdminController.php
+++ b/source/Application/Controller/Admin/AdminController.php
@@ -380,7 +380,7 @@ class AdminController extends \OxidEsales\Eshop\Core\Controller\BaseController
 
         // processing config
         $iMaxFileSize = trim($iMaxFileSize);
-        $sParam = strtolower($iMaxFileSize{strlen($iMaxFileSize) - 1});
+        $sParam = strtolower($iMaxFileSize[strlen($iMaxFileSize) - 1]);
         switch ($sParam) {
             case 'g':
                 $iMaxFileSize *= 1024;

--- a/source/Application/Controller/Admin/AdminDetailsController.php
+++ b/source/Application/Controller/Admin/AdminDetailsController.php
@@ -68,6 +68,7 @@ class AdminDetailsController extends \OxidEsales\Eshop\Application\Controller\Ad
      * @param string                                 $sField  name of editable field
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getEditValue" in next major
      */
     protected function _getEditValue($oObject, $sField) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -92,6 +93,7 @@ class AdminDetailsController extends \OxidEsales\Eshop\Application\Controller\Ad
      * @param string $sValue string to process
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "processEditValue" in next major
      */
     protected function _processEditValue($sValue) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -202,6 +204,7 @@ class AdminDetailsController extends \OxidEsales\Eshop\Application\Controller\Ad
      * @param int    $iTreeShopId     tree shop id
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "createCategoryTree" in next major
      */
     protected function _createCategoryTree($sTplVarName, $sEditCatId = '', $blForceNonCache = false, $iTreeShopId = null) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -247,6 +250,7 @@ class AdminDetailsController extends \OxidEsales\Eshop\Application\Controller\Ad
      * @param int    $iTreeShopId     tree shop id
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getCategoryTree" in next major
      */
     protected function _getCategoryTree( // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
         $sTplVarName,
@@ -304,6 +308,7 @@ class AdminDetailsController extends \OxidEsales\Eshop\Application\Controller\Ad
      * Sets-up navigation parameters.
      *
      * @param string $sNode active view id
+     * @deprecated underscore prefix violates PSR12, will be renamed to "setupNavigation" in next major
      */
     protected function _setupNavigation($sNode) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -323,6 +328,7 @@ class AdminDetailsController extends \OxidEsales\Eshop\Application\Controller\Ad
      * Resets count of vendor/manufacturer category items.
      *
      * @param array $aIds to reset type => id
+     * @deprecated underscore prefix violates PSR12, will be renamed to "resetCounts" in next major
      */
     protected function _resetCounts($aIds) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {

--- a/source/Application/Controller/Admin/AdminListController.php
+++ b/source/Application/Controller/Admin/AdminListController.php
@@ -154,6 +154,7 @@ class AdminListController extends \OxidEsales\Eshop\Application\Controller\Admin
      * Viewable list size getter
      *
      * @return int
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getViewListSize" in next major
      */
     protected function _getViewListSize() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -189,6 +190,7 @@ class AdminListController extends \OxidEsales\Eshop\Application\Controller\Admin
      * Viewable list size getter (used in list_*.php views)
      *
      * @return int
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getUserDefListSize" in next major
      */
     protected function _getUserDefListSize() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -250,6 +252,7 @@ class AdminListController extends \OxidEsales\Eshop\Application\Controller\Admin
      * Calculates list items count
      *
      * @param string $sql SQL query used co select list items
+     * @deprecated underscore prefix violates PSR12, will be renamed to "calcListItemsCount" in next major
      */
     protected function _calcListItemsCount($sql) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -273,6 +276,7 @@ class AdminListController extends \OxidEsales\Eshop\Application\Controller\Admin
      * Set current list position
      *
      * @param string $page jump page string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "setCurrentListPosition" in next major
      */
     protected function _setCurrentListPosition($page = null) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -297,6 +301,7 @@ class AdminListController extends \OxidEsales\Eshop\Application\Controller\Admin
      * @param string $query sql string
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "prepareOrderByQuery" in next major
      */
     protected function _prepareOrderByQuery($query = null) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -341,6 +346,7 @@ class AdminListController extends \OxidEsales\Eshop\Application\Controller\Admin
      * @param object $listObject list main object
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "buildSelectString" in next major
      */
     protected function _buildSelectString($listObject = null) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -356,6 +362,7 @@ class AdminListController extends \OxidEsales\Eshop\Application\Controller\Admin
      * @param string $fieldValue Filters
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "processFilter" in next major
      */
     protected function _processFilter($fieldValue) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -374,6 +381,7 @@ class AdminListController extends \OxidEsales\Eshop\Application\Controller\Admin
      * @param bool   $isSearchValue filter value type, true means surrount search key with '%'
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "buildFilter" in next major
      */
     protected function _buildFilter($value, $isSearchValue) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -394,6 +402,7 @@ class AdminListController extends \OxidEsales\Eshop\Application\Controller\Admin
      * @param string $fieldValue filter value
      *
      * @return bool
+     * @deprecated underscore prefix violates PSR12, will be renamed to "isSearchValue" in next major
      */
     protected function _isSearchValue($fieldValue) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -409,6 +418,7 @@ class AdminListController extends \OxidEsales\Eshop\Application\Controller\Admin
      * @param string $fullQuery  SQL query string
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "prepareWhereQuery" in next major
      */
     protected function _prepareWhereQuery($whereQuery, $fullQuery) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -468,6 +478,7 @@ class AdminListController extends \OxidEsales\Eshop\Application\Controller\Admin
      * @param string $query SQL select to change
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "changeselect" in next major
      */
     protected function _changeselect($query) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -522,6 +533,7 @@ class AdminListController extends \OxidEsales\Eshop\Application\Controller\Admin
      * @param string $fieldType Field type
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "convertToDBDate" in next major
      */
     protected function _convertToDBDate($value, $fieldType) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -554,6 +566,7 @@ class AdminListController extends \OxidEsales\Eshop\Application\Controller\Admin
      * @param string $date searched date
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "convertDate" in next major
      */
     protected function _convertDate($date) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -592,6 +605,7 @@ class AdminListController extends \OxidEsales\Eshop\Application\Controller\Admin
      * @param string $fullDate searched date
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "convertTime" in next major
      */
     protected function _convertTime($fullDate) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -630,6 +644,7 @@ class AdminListController extends \OxidEsales\Eshop\Application\Controller\Admin
 
     /**
      * Set parameters needed for list navigation
+     * @deprecated underscore prefix violates PSR12, will be renamed to "setListNavigationParams" in next major
      */
     protected function _setListNavigationParams() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -715,6 +730,7 @@ class AdminListController extends \OxidEsales\Eshop\Application\Controller\Admin
      * Sets-up navigation parameters
      *
      * @param string $node active view id
+     * @deprecated underscore prefix violates PSR12, will be renamed to "setupNavigation" in next major
      */
     protected function _setupNavigation($node) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {

--- a/source/Application/Controller/Admin/ArticleAccessoriesAjax.php
+++ b/source/Application/Controller/Admin/ArticleAccessoriesAjax.php
@@ -63,6 +63,7 @@ class ArticleAccessoriesAjax extends \OxidEsales\Eshop\Application\Controller\Ad
      *
      * @return string
      * @throws DatabaseConnectionException
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getQuery" in next major
      */
     protected function _getQuery() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -117,6 +118,7 @@ class ArticleAccessoriesAjax extends \OxidEsales\Eshop\Application\Controller\Ad
      * overide default sorting and replace it with OXSORT field
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getSorting" in next major
      */
     protected function _getSorting() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {

--- a/source/Application/Controller/Admin/ArticleAttributeAjax.php
+++ b/source/Application/Controller/Admin/ArticleAttributeAjax.php
@@ -37,6 +37,7 @@ class ArticleAttributeAjax extends \OxidEsales\Eshop\Application\Controller\Admi
      * Returns SQL query for data to fetc
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getQuery" in next major
      */
     protected function _getQuery() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {

--- a/source/Application/Controller/Admin/ArticleBundleAjax.php
+++ b/source/Application/Controller/Admin/ArticleBundleAjax.php
@@ -42,6 +42,7 @@ class ArticleBundleAjax extends \OxidEsales\Eshop\Application\Controller\Admin\L
      * Returns SQL query for data to fetc
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getQuery" in next major
      */
     protected function _getQuery() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -85,6 +86,7 @@ class ArticleBundleAjax extends \OxidEsales\Eshop\Application\Controller\Admin\L
      * @param string $sQ query to add filter condition
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "addFilter" in next major
      */
     protected function _addFilter($sQ) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {

--- a/source/Application/Controller/Admin/ArticleCrosssellingAjax.php
+++ b/source/Application/Controller/Admin/ArticleCrosssellingAjax.php
@@ -52,6 +52,7 @@ class ArticleCrosssellingAjax extends \OxidEsales\Eshop\Application\Controller\A
      * Returns SQL query for data to fetc
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getQuery" in next major
      */
     protected function _getQuery() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {

--- a/source/Application/Controller/Admin/ArticleExtendAjax.php
+++ b/source/Application/Controller/Admin/ArticleExtendAjax.php
@@ -42,6 +42,7 @@ class ArticleExtendAjax extends \OxidEsales\Eshop\Application\Controller\Admin\L
      * Returns SQL query for data to fetc
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getQuery" in next major
      */
     protected function _getQuery() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -74,6 +75,7 @@ class ArticleExtendAjax extends \OxidEsales\Eshop\Application\Controller\Admin\L
      * @param string $sQ SQL query
      *
      * @return array
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getDataFields" in next major
      */
     protected function _getDataFields($sQ) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -196,6 +198,7 @@ class ArticleExtendAjax extends \OxidEsales\Eshop\Application\Controller\Admin\L
      * Updates oxtime value for product
      *
      * @param string $oxId product id
+     * @deprecated underscore prefix violates PSR12, will be renamed to "updateOxTime" in next major
      */
     protected function _updateOxTime($oxId) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {

--- a/source/Application/Controller/Admin/ArticleFiles.php
+++ b/source/Application/Controller/Admin/ArticleFiles.php
@@ -203,6 +203,7 @@ class ArticleFiles extends \OxidEsales\Eshop\Application\Controller\Admin\AdminD
      * @param array $aParams params
      *
      * @return array
+     * @deprecated underscore prefix violates PSR12, will be renamed to "processOptions" in next major
      */
     protected function _processOptions($aParams) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {

--- a/source/Application/Controller/Admin/ArticleList.php
+++ b/source/Application/Controller/Admin/ArticleList.php
@@ -240,6 +240,7 @@ class ArticleList extends \OxidEsales\Eshop\Application\Controller\Admin\AdminLi
      * @param object $oListObject list main object
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "buildSelectString" in next major
      */
     protected function _buildSelectString($oListObject = null) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {

--- a/source/Application/Controller/Admin/ArticleMain.php
+++ b/source/Application/Controller/Admin/ArticleMain.php
@@ -111,6 +111,7 @@ class ArticleMain extends \OxidEsales\Eshop\Application\Controller\Admin\AdminDe
      * @param string                                 $sField  name of editable field
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getEditValue" in next major
      */
     protected function _getEditValue($oObject, $sField) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -214,6 +215,7 @@ class ArticleMain extends \OxidEsales\Eshop\Application\Controller\Admin\AdminDe
      * @param string $sValue value to fix
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "processLongDesc" in next major
      */
     protected function _processLongDesc($sValue) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -233,6 +235,7 @@ class ArticleMain extends \OxidEsales\Eshop\Application\Controller\Admin\AdminDe
      * Resets article categories counters
      *
      * @param string $sArticleId Article id
+     * @deprecated underscore prefix violates PSR12, will be renamed to "resetCategoriesCounter" in next major
      */
     protected function _resetCategoriesCounter($sArticleId) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -376,6 +379,7 @@ class ArticleMain extends \OxidEsales\Eshop\Application\Controller\Admin\AdminDe
      *
      * @param string $sOldId       Id from old article
      * @param string $newArticleId Id from new article
+     * @deprecated underscore prefix violates PSR12, will be renamed to "copyCategories" in next major
      */
     protected function _copyCategories($sOldId, $newArticleId) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -404,6 +408,7 @@ class ArticleMain extends \OxidEsales\Eshop\Application\Controller\Admin\AdminDe
      *
      * @param string $sOldId Id from old article
      * @param string $sNewId Id from new article
+     * @deprecated underscore prefix violates PSR12, will be renamed to "copyAttributes" in next major
      */
     protected function _copyAttributes($sOldId, $sNewId) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -433,6 +438,7 @@ class ArticleMain extends \OxidEsales\Eshop\Application\Controller\Admin\AdminDe
      *
      * @param string $sOldId Id from old article
      * @param string $sNewId Id from new article
+     * @deprecated underscore prefix violates PSR12, will be renamed to "copyFiles" in next major
      */
     protected function _copyFiles($sOldId, $sNewId) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -463,6 +469,7 @@ class ArticleMain extends \OxidEsales\Eshop\Application\Controller\Admin\AdminDe
      *
      * @param string $sOldId Id from old article
      * @param string $sNewId Id from new article
+     * @deprecated underscore prefix violates PSR12, will be renamed to "copySelectlists" in next major
      */
     protected function _copySelectlists($sOldId, $sNewId) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -494,6 +501,7 @@ class ArticleMain extends \OxidEsales\Eshop\Application\Controller\Admin\AdminDe
      *
      * @param string $sOldId Id from old article
      * @param string $sNewId Id from new article
+     * @deprecated underscore prefix violates PSR12, will be renamed to "copyCrossseling" in next major
      */
     protected function _copyCrossseling($sOldId, $sNewId) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -525,6 +533,7 @@ class ArticleMain extends \OxidEsales\Eshop\Application\Controller\Admin\AdminDe
      *
      * @param string $sOldId Id from old article
      * @param string $sNewId Id from new article
+     * @deprecated underscore prefix violates PSR12, will be renamed to "copyAccessoires" in next major
      */
     protected function _copyAccessoires($sOldId, $sNewId) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -556,6 +565,7 @@ class ArticleMain extends \OxidEsales\Eshop\Application\Controller\Admin\AdminDe
      *
      * @param string $sOldId Id from old article
      * @param string $sNewId Id from new article
+     * @deprecated underscore prefix violates PSR12, will be renamed to "copyStaffelpreis" in next major
      */
     protected function _copyStaffelpreis($sOldId, $sNewId) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -582,6 +592,7 @@ class ArticleMain extends \OxidEsales\Eshop\Application\Controller\Admin\AdminDe
      *
      * @param string $sOldId Id from old article
      * @param string $sNewId Id from new article
+     * @deprecated underscore prefix violates PSR12, will be renamed to "copyArtExtends" in next major
      */
     protected function _copyArtExtends($sOldId, $sNewId) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -618,6 +629,7 @@ class ArticleMain extends \OxidEsales\Eshop\Application\Controller\Admin\AdminDe
      *
      * @param object $oArticle       article object
      * @param object $oParentArticle article parent object
+     * @deprecated underscore prefix violates PSR12, will be renamed to "formJumpList" in next major
      */
     protected function _formJumpList($oArticle, $oParentArticle) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -662,6 +674,7 @@ class ArticleMain extends \OxidEsales\Eshop\Application\Controller\Admin\AdminDe
      * @param object $oObj product object
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getTitle" in next major
      */
     protected function _getTitle($oObj) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {

--- a/source/Application/Controller/Admin/ArticlePictures.php
+++ b/source/Application/Controller/Admin/ArticlePictures.php
@@ -136,6 +136,7 @@ class ArticlePictures extends \OxidEsales\Eshop\Application\Controller\Admin\Adm
      * @param \OxidEsales\Eshop\Application\Model\Article $oArticle       article object
      * @param int                                         $iIndex         master picture index
      * @param bool                                        $blDeleteMaster if TRUE - deletes and unsets master image file
+     * @deprecated underscore prefix violates PSR12, will be renamed to "resetMasterPicture" in next major
      */
     protected function _resetMasterPicture($oArticle, $iIndex, $blDeleteMaster = false) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -165,6 +166,7 @@ class ArticlePictures extends \OxidEsales\Eshop\Application\Controller\Admin\Adm
      * Deletes main icon file
      *
      * @param \OxidEsales\Eshop\Application\Model\Article $oArticle article object
+     * @deprecated underscore prefix violates PSR12, will be renamed to "deleteMainIcon" in next major
      */
     protected function _deleteMainIcon($oArticle) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -183,6 +185,7 @@ class ArticlePictures extends \OxidEsales\Eshop\Application\Controller\Admin\Adm
      * Deletes thumbnail file
      *
      * @param \OxidEsales\Eshop\Application\Model\Article $oArticle article object
+     * @deprecated underscore prefix violates PSR12, will be renamed to "deleteThumbnail" in next major
      */
     protected function _deleteThumbnail($oArticle) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -202,6 +205,7 @@ class ArticlePictures extends \OxidEsales\Eshop\Application\Controller\Admin\Adm
      * icon or thumb picture, leaves records untouched.
      *
      * @param \OxidEsales\Eshop\Application\Model\Article $oArticle article object
+     * @deprecated underscore prefix violates PSR12, will be renamed to "cleanupCustomFields" in next major
      */
     protected function _cleanupCustomFields($oArticle) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {

--- a/source/Application/Controller/Admin/ArticleReview.php
+++ b/source/Application/Controller/Admin/ArticleReview.php
@@ -76,6 +76,7 @@ class ArticleReview extends \OxidEsales\Eshop\Application\Controller\Admin\Admin
      * @param \OxidEsales\Eshop\Application\Model\Article $article Article object
      *
      * @return oxList
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getReviewList" in next major
      */
     protected function _getReviewList($article) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {

--- a/source/Application/Controller/Admin/ArticleSelectionAjax.php
+++ b/source/Application/Controller/Admin/ArticleSelectionAjax.php
@@ -40,6 +40,7 @@ class ArticleSelectionAjax extends \OxidEsales\Eshop\Application\Controller\Admi
      * Returns SQL query for data to fetc
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getQuery" in next major
      */
     protected function _getQuery() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {

--- a/source/Application/Controller/Admin/ArticleSeo.php
+++ b/source/Application/Controller/Admin/ArticleSeo.php
@@ -137,6 +137,7 @@ class ArticleSeo extends \OxidEsales\Eshop\Application\Controller\Admin\ObjectSe
      * @param \OxidEsales\Eshop\Application\Model\Article $oArticle Article object
      *
      * @return array
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getCategoryList" in next major
      */
     protected function _getCategoryList($oArticle) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -183,6 +184,7 @@ class ArticleSeo extends \OxidEsales\Eshop\Application\Controller\Admin\ObjectSe
      * @param \OxidEsales\Eshop\Application\Model\Article $oArticle Article object
      *
      * @return array
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getVendorList" in next major
      */
     protected function _getVendorList($oArticle) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -200,6 +202,7 @@ class ArticleSeo extends \OxidEsales\Eshop\Application\Controller\Admin\ObjectSe
      * @param \OxidEsales\Eshop\Application\Model\Article $oArticle Article object
      *
      * @return array
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getManufacturerList" in next major
      */
     protected function _getManufacturerList($oArticle) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -277,6 +280,7 @@ class ArticleSeo extends \OxidEsales\Eshop\Application\Controller\Admin\ObjectSe
      * Returns alternative seo entry id
      *
      * @return null
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getAltSeoEntryId" in next major
      */
     protected function _getAltSeoEntryId() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -287,6 +291,7 @@ class ArticleSeo extends \OxidEsales\Eshop\Application\Controller\Admin\ObjectSe
      * Returns url type
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getType" in next major
      */
     protected function _getType() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -309,6 +314,7 @@ class ArticleSeo extends \OxidEsales\Eshop\Application\Controller\Admin\ObjectSe
      * Returns current object type seo encoder object
      *
      * @return oxSeoEncoderCategory
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getEncoder" in next major
      */
     protected function _getEncoder() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {

--- a/source/Application/Controller/Admin/ArticleVariant.php
+++ b/source/Application/Controller/Admin/ArticleVariant.php
@@ -164,6 +164,7 @@ class ArticleVariant extends \OxidEsales\Eshop\Application\Controller\Admin\Admi
      * @param array                                       $aData    Data provided for check.
      *
      * @return bool
+     * @deprecated underscore prefix violates PSR12, will be renamed to "isAnythingChanged" in next major
      */
     protected function _isAnythingChanged($oProduct, $aData) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -185,6 +186,7 @@ class ArticleVariant extends \OxidEsales\Eshop\Application\Controller\Admin\Admi
      * @param string $sParentId parent product id
      *
      * @return \OxidEsales\Eshop\Application\Model\Article
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getProductParent" in next major
      */
     protected function _getProductParent($sParentId) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {

--- a/source/Application/Controller/Admin/AttributeCategoryAjax.php
+++ b/source/Application/Controller/Admin/AttributeCategoryAjax.php
@@ -46,6 +46,7 @@ class AttributeCategoryAjax extends \OxidEsales\Eshop\Application\Controller\Adm
      * Returns SQL query for data to fetc
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getQuery" in next major
      */
     protected function _getQuery() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {

--- a/source/Application/Controller/Admin/AttributeMainAjax.php
+++ b/source/Application/Controller/Admin/AttributeMainAjax.php
@@ -52,6 +52,7 @@ class AttributeMainAjax extends \OxidEsales\Eshop\Application\Controller\Admin\L
      * Returns SQL query for data to fetc
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getQuery" in next major
      */
     protected function _getQuery() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -100,6 +101,7 @@ class AttributeMainAjax extends \OxidEsales\Eshop\Application\Controller\Admin\L
      * @param string $sQ query to add filter condition
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "addFilter" in next major
      */
     protected function _addFilter($sQ) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {

--- a/source/Application/Controller/Admin/AttributeOrderAjax.php
+++ b/source/Application/Controller/Admin/AttributeOrderAjax.php
@@ -31,6 +31,7 @@ class AttributeOrderAjax extends \OxidEsales\Eshop\Application\Controller\Admin\
      * Returns SQL query for data to fetc
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getQuery" in next major
      */
     protected function _getQuery() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -45,6 +46,7 @@ class AttributeOrderAjax extends \OxidEsales\Eshop\Application\Controller\Admin\
      * Returns SQL query addon for sorting
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getSorting" in next major
      */
     protected function _getSorting() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {

--- a/source/Application/Controller/Admin/CategoryMain.php
+++ b/source/Application/Controller/Admin/CategoryMain.php
@@ -174,6 +174,7 @@ class CategoryMain extends \OxidEsales\Eshop\Application\Controller\Admin\AdminD
      * @param string $sValue value to fix
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "processLongDesc" in next major
      */
     protected function _processLongDesc($sValue) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -230,6 +231,7 @@ class CategoryMain extends \OxidEsales\Eshop\Application\Controller\Admin\AdminD
      * @param string                                       $field picture field name
      *
      * @return null
+     * @deprecated underscore prefix violates PSR12, will be renamed to "deleteCatPicture" in next major
      */
     protected function _deleteCatPicture($item, $field) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -277,6 +279,7 @@ class CategoryMain extends \OxidEsales\Eshop\Application\Controller\Admin\AdminD
      * @param array $aReqParams Request parameters.
      *
      * @return array
+     * @deprecated underscore prefix violates PSR12, will be renamed to "parseRequestParametersForSave" in next major
      */
     protected function _parseRequestParametersForSave($aReqParams) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {

--- a/source/Application/Controller/Admin/CategoryMainAjax.php
+++ b/source/Application/Controller/Admin/CategoryMainAjax.php
@@ -51,6 +51,7 @@ class CategoryMainAjax extends \OxidEsales\Eshop\Application\Controller\Admin\Li
      * Returns SQL query for data to fetc
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getQuery" in next major
      */
     protected function _getQuery() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -93,6 +94,7 @@ class CategoryMainAjax extends \OxidEsales\Eshop\Application\Controller\Admin\Li
      * @param string $sQ query to add filter condition
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "addFilter" in next major
      */
     protected function _addFilter($sQ) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -176,6 +178,7 @@ class CategoryMainAjax extends \OxidEsales\Eshop\Application\Controller\Admin\Li
      * Updates oxtime value for products
      *
      * @param string $sProdIds product ids: "id1", "id2", "id3"
+     * @deprecated underscore prefix violates PSR12, will be renamed to "updateOxTime" in next major
      */
     protected function _updateOxTime($sProdIds) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {

--- a/source/Application/Controller/Admin/CategoryOrderAjax.php
+++ b/source/Application/Controller/Admin/CategoryOrderAjax.php
@@ -46,6 +46,7 @@ class CategoryOrderAjax extends \OxidEsales\Eshop\Application\Controller\Admin\L
      * Returns SQL query for data to fetc
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getQuery" in next major
      */
     protected function _getQuery() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -77,6 +78,7 @@ class CategoryOrderAjax extends \OxidEsales\Eshop\Application\Controller\Admin\L
      * Returns SQL query addon for sorting
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getSorting" in next major
      */
     protected function _getSorting() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {

--- a/source/Application/Controller/Admin/CategorySeo.php
+++ b/source/Application/Controller/Admin/CategorySeo.php
@@ -40,6 +40,7 @@ class CategorySeo extends \OxidEsales\Eshop\Application\Controller\Admin\ObjectS
      * Returns current object type seo encoder object
      *
      * @return oxSeoEncoderCategory
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getEncoder" in next major
      */
     protected function _getEncoder() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -60,6 +61,7 @@ class CategorySeo extends \OxidEsales\Eshop\Application\Controller\Admin\ObjectS
      * Returns url type
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getType" in next major
      */
     protected function _getType() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {

--- a/source/Application/Controller/Admin/CategoryUpdate.php
+++ b/source/Application/Controller/Admin/CategoryUpdate.php
@@ -30,6 +30,7 @@ class CategoryUpdate extends \OxidEsales\Eshop\Application\Controller\Admin\Admi
      * Returns category list object
      *
      * @return oxCategoryList
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getCategoryList" in next major
      */
     protected function _getCategoryList() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {

--- a/source/Application/Controller/Admin/ContentList.php
+++ b/source/Application/Controller/Admin/ContentList.php
@@ -65,6 +65,7 @@ class ContentList extends \OxidEsales\Eshop\Application\Controller\Admin\AdminLi
      * @param string $sqlFull SQL query string
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "prepareWhereQuery" in next major
      */
     protected function _prepareWhereQuery($aWhere, $sqlFull) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {

--- a/source/Application/Controller/Admin/ContentMain.php
+++ b/source/Application/Controller/Admin/ContentMain.php
@@ -196,6 +196,7 @@ class ContentMain extends \OxidEsales\Eshop\Application\Controller\Admin\AdminDe
      * @param string $sIdent ident to filter
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "prepareIdent" in next major
      */
     protected function _prepareIdent($sIdent) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -211,6 +212,7 @@ class ContentMain extends \OxidEsales\Eshop\Application\Controller\Admin\AdminDe
      * @param string $sOxId  Object id
      *
      * @return null
+     * @deprecated underscore prefix violates PSR12, will be renamed to "checkIdent" in next major
      */
     protected function _checkIdent($sIdent, $sOxId) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {

--- a/source/Application/Controller/Admin/ContentSeo.php
+++ b/source/Application/Controller/Admin/ContentSeo.php
@@ -18,6 +18,7 @@ class ContentSeo extends \OxidEsales\Eshop\Application\Controller\Admin\ObjectSe
      * Returns url type
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getType" in next major
      */
     protected function _getType() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -28,6 +29,7 @@ class ContentSeo extends \OxidEsales\Eshop\Application\Controller\Admin\ObjectSe
      * Returns current object type seo encoder object
      *
      * @return oxSeoEncoderContent
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getEncoder" in next major
      */
     protected function _getEncoder() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {

--- a/source/Application/Controller/Admin/CountryList.php
+++ b/source/Application/Controller/Admin/CountryList.php
@@ -74,6 +74,7 @@ class CountryList extends \OxidEsales\Eshop\Application\Controller\Admin\AdminLi
      * Getter for the second sort field name (for getting the expected oreder out of the databse).
      *
      * @return string The name of the field we want to be the second order by argument.
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getSecondSortFieldName" in next major
      */
     protected function _getSecondSortFieldName() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {

--- a/source/Application/Controller/Admin/DeliveryArticlesAjax.php
+++ b/source/Application/Controller/Admin/DeliveryArticlesAjax.php
@@ -51,6 +51,7 @@ class DeliveryArticlesAjax extends \OxidEsales\Eshop\Application\Controller\Admi
      * Returns SQL query for data to fetc
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getQuery" in next major
      */
     protected function _getQuery() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {

--- a/source/Application/Controller/Admin/DeliveryCategoriesAjax.php
+++ b/source/Application/Controller/Admin/DeliveryCategoriesAjax.php
@@ -39,6 +39,7 @@ class DeliveryCategoriesAjax extends \OxidEsales\Eshop\Application\Controller\Ad
      * Returns SQL query for data to fetc
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getQuery" in next major
      */
     protected function _getQuery() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {

--- a/source/Application/Controller/Admin/DeliveryGroupsAjax.php
+++ b/source/Application/Controller/Admin/DeliveryGroupsAjax.php
@@ -36,6 +36,7 @@ class DeliveryGroupsAjax extends \OxidEsales\Eshop\Application\Controller\Admin\
      * Returns SQL query for data to fetc
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getQuery" in next major
      */
     protected function _getQuery() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {

--- a/source/Application/Controller/Admin/DeliveryMainAjax.php
+++ b/source/Application/Controller/Admin/DeliveryMainAjax.php
@@ -40,6 +40,7 @@ class DeliveryMainAjax extends \OxidEsales\Eshop\Application\Controller\Admin\Li
      * Returns SQL query for data to fetc
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getQuery" in next major
      */
     protected function _getQuery() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {

--- a/source/Application/Controller/Admin/DeliverySetCountryAjax.php
+++ b/source/Application/Controller/Admin/DeliverySetCountryAjax.php
@@ -40,6 +40,7 @@ class DeliverySetCountryAjax extends \OxidEsales\Eshop\Application\Controller\Ad
      * Returns SQL query for data to fetc
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getQuery" in next major
      */
     protected function _getQuery() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {

--- a/source/Application/Controller/Admin/DeliverySetGroupsAjax.php
+++ b/source/Application/Controller/Admin/DeliverySetGroupsAjax.php
@@ -36,6 +36,7 @@ class DeliverySetGroupsAjax extends \OxidEsales\Eshop\Application\Controller\Adm
      * Returns SQL query for data to fetc
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getQuery" in next major
      */
     protected function _getQuery() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {

--- a/source/Application/Controller/Admin/DeliverySetMainAjax.php
+++ b/source/Application/Controller/Admin/DeliverySetMainAjax.php
@@ -40,6 +40,7 @@ class DeliverySetMainAjax extends \OxidEsales\Eshop\Application\Controller\Admin
      * Returns SQL query for data to fetc
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getQuery" in next major
      */
     protected function _getQuery() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {

--- a/source/Application/Controller/Admin/DeliverySetPaymentAjax.php
+++ b/source/Application/Controller/Admin/DeliverySetPaymentAjax.php
@@ -39,6 +39,7 @@ class DeliverySetPaymentAjax extends \OxidEsales\Eshop\Application\Controller\Ad
      * Returns SQL query for data to fetc
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getQuery" in next major
      */
     protected function _getQuery() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {

--- a/source/Application/Controller/Admin/DeliverySetUsersAjax.php
+++ b/source/Application/Controller/Admin/DeliverySetUsersAjax.php
@@ -52,6 +52,7 @@ class DeliverySetUsersAjax extends \OxidEsales\Eshop\Application\Controller\Admi
      * Returns SQL query for data to fetc
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getQuery" in next major
      */
     protected function _getQuery() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {

--- a/source/Application/Controller/Admin/DeliveryUsersAjax.php
+++ b/source/Application/Controller/Admin/DeliveryUsersAjax.php
@@ -50,6 +50,7 @@ class DeliveryUsersAjax extends \OxidEsales\Eshop\Application\Controller\Admin\L
      * Returns SQL query for data to fetc
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getQuery" in next major
      */
     protected function _getQuery() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {

--- a/source/Application/Controller/Admin/DiagnosticsMain.php
+++ b/source/Application/Controller/Admin/DiagnosticsMain.php
@@ -64,6 +64,7 @@ class DiagnosticsMain extends \OxidEsales\Eshop\Application\Controller\Admin\Adm
      * Error status getter
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "hasError" in next major
      */
     protected function _hasError() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -74,6 +75,7 @@ class DiagnosticsMain extends \OxidEsales\Eshop\Application\Controller\Admin\Adm
      * Error status getter
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getErrorMessage" in next major
      */
     protected function _getErrorMessage() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -233,6 +235,7 @@ class DiagnosticsMain extends \OxidEsales\Eshop\Application\Controller\Admin\Adm
      * Shop and module details, database health, php parameters, server information
      *
      * @return array
+     * @deprecated underscore prefix violates PSR12, will be renamed to "runBasicDiagnostics" in next major
      */
     protected function _runBasicDiagnostics() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {

--- a/source/Application/Controller/Admin/DiscountArticlesAjax.php
+++ b/source/Application/Controller/Admin/DiscountArticlesAjax.php
@@ -56,6 +56,7 @@ class DiscountArticlesAjax extends \OxidEsales\Eshop\Application\Controller\Admi
      * Returns SQL query for data to fetc
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getQuery" in next major
      */
     protected function _getQuery() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {

--- a/source/Application/Controller/Admin/DiscountCategoriesAjax.php
+++ b/source/Application/Controller/Admin/DiscountCategoriesAjax.php
@@ -44,6 +44,7 @@ class DiscountCategoriesAjax extends \OxidEsales\Eshop\Application\Controller\Ad
      * Returns SQL query for data to fetc
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getQuery" in next major
      */
     protected function _getQuery() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {

--- a/source/Application/Controller/Admin/DiscountGroupsAjax.php
+++ b/source/Application/Controller/Admin/DiscountGroupsAjax.php
@@ -41,6 +41,7 @@ class DiscountGroupsAjax extends \OxidEsales\Eshop\Application\Controller\Admin\
      * Returns SQL query for data to fetc
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getQuery" in next major
      */
     protected function _getQuery() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {

--- a/source/Application/Controller/Admin/DiscountItemAjax.php
+++ b/source/Application/Controller/Admin/DiscountItemAjax.php
@@ -46,6 +46,7 @@ class DiscountItemAjax extends \OxidEsales\Eshop\Application\Controller\Admin\Li
      * Returns SQL query for data to fetc
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getQuery" in next major
      */
     protected function _getQuery() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -137,6 +138,7 @@ class DiscountItemAjax extends \OxidEsales\Eshop\Application\Controller\Admin\Li
      * fields to load from DB. Adds subselect to get variant title from parent article
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getQueryCols" in next major
      */
     protected function _getQueryCols() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {

--- a/source/Application/Controller/Admin/DiscountMainAjax.php
+++ b/source/Application/Controller/Admin/DiscountMainAjax.php
@@ -40,6 +40,7 @@ class DiscountMainAjax extends \OxidEsales\Eshop\Application\Controller\Admin\Li
      * Returns SQL query for data to fetc
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getQuery" in next major
      */
     protected function _getQuery() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {

--- a/source/Application/Controller/Admin/DiscountUsersAjax.php
+++ b/source/Application/Controller/Admin/DiscountUsersAjax.php
@@ -50,6 +50,7 @@ class DiscountUsersAjax extends \OxidEsales\Eshop\Application\Controller\Admin\L
      * Returns SQL query for data to fetc
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getQuery" in next major
      */
     protected function _getQuery() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {

--- a/source/Application/Controller/Admin/DynamicExportBaseController.php
+++ b/source/Application/Controller/Admin/DynamicExportBaseController.php
@@ -545,6 +545,7 @@ class DynamicExportBaseController extends \OxidEsales\Eshop\Application\Controll
      * @param string $sInput string to replace
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "unHtmlEntities" in next major
      */
     protected function _unHtmlEntities($sInput) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -557,6 +558,7 @@ class DynamicExportBaseController extends \OxidEsales\Eshop\Application\Controll
      * Create valid Heap table name
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getHeapTableName" in next major
      */
     protected function _getHeapTableName() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -570,6 +572,7 @@ class DynamicExportBaseController extends \OxidEsales\Eshop\Application\Controll
      * @param string $sMysqlVersion MySql version
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "generateTableCharSet" in next major
      */
     protected function _generateTableCharSet($sMysqlVersion) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -597,6 +600,7 @@ class DynamicExportBaseController extends \OxidEsales\Eshop\Application\Controll
      * @param string $sTableCharset table charset
      *
      * @return bool
+     * @deprecated underscore prefix violates PSR12, will be renamed to "createHeapTable" in next major
      */
     protected function _createHeapTable($sHeapTable, $sTableCharset) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -617,6 +621,7 @@ class DynamicExportBaseController extends \OxidEsales\Eshop\Application\Controll
      * @param array $aChosenCat Selected category array
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getCatAdd" in next major
      */
     protected function _getCatAdd($aChosenCat) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -645,6 +650,7 @@ class DynamicExportBaseController extends \OxidEsales\Eshop\Application\Controll
      * @param string $sCatAdd    category id filter (part of sql)
      *
      * @return bool
+     * @deprecated underscore prefix violates PSR12, will be renamed to "insertArticles" in next major
      */
     protected function _insertArticles($sHeapTable, $sCatAdd) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -696,6 +702,7 @@ class DynamicExportBaseController extends \OxidEsales\Eshop\Application\Controll
      * removes parent articles so that we only have variants itself
      *
      * @param string $sHeapTable table name
+     * @deprecated underscore prefix violates PSR12, will be renamed to "removeParentArticles" in next major
      */
     protected function _removeParentArticles($sHeapTable) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -727,6 +734,7 @@ class DynamicExportBaseController extends \OxidEsales\Eshop\Application\Controll
 
     /**
      * stores some info in session
+     * @deprecated underscore prefix violates PSR12, will be renamed to "setSessionParams" in next major
      */
     protected function _setSessionParams() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -775,6 +783,7 @@ class DynamicExportBaseController extends \OxidEsales\Eshop\Application\Controll
      * Load all root cat's == all trees
      *
      * @return null
+     * @deprecated underscore prefix violates PSR12, will be renamed to "loadRootCats" in next major
      */
     protected function _loadRootCats() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -826,6 +835,7 @@ class DynamicExportBaseController extends \OxidEsales\Eshop\Application\Controll
      * @param \OxidEsales\Eshop\Application\Model\Article $oArticle article object
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "findDeepestCatPath" in next major
      */
     protected function _findDeepestCatPath($oArticle) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -867,6 +877,7 @@ class DynamicExportBaseController extends \OxidEsales\Eshop\Application\Controll
      * @param bool   $blContinue false is used to stop exporting
      *
      * @return object
+     * @deprecated underscore prefix violates PSR12, will be renamed to "initArticle" in next major
      */
     protected function _initArticle($sHeapTable, $iCnt, &$blContinue) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -901,6 +912,7 @@ class DynamicExportBaseController extends \OxidEsales\Eshop\Application\Controll
      * @param \OxidEsales\Eshop\Application\Model\Article $oArticle article object
      *
      * @return \OxidEsales\Eshop\Application\Model\Article
+     * @deprecated underscore prefix violates PSR12, will be renamed to "setCampaignDetailLink" in next major
      */
     protected function _setCampaignDetailLink($oArticle) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {

--- a/source/Application/Controller/Admin/DynamicScreenController.php
+++ b/source/Application/Controller/Admin/DynamicScreenController.php
@@ -32,6 +32,7 @@ class DynamicScreenController extends \OxidEsales\Eshop\Application\Controller\A
      * Sets up navigation for current view
      *
      * @param string $sNode None name
+     * @deprecated underscore prefix violates PSR12, will be renamed to "setupNavigation" in next major
      */
     protected function _setupNavigation($sNode) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {

--- a/source/Application/Controller/Admin/GenericImportMain.php
+++ b/source/Application/Controller/Admin/GenericImportMain.php
@@ -165,6 +165,7 @@ class GenericImportMain extends \OxidEsales\Eshop\Application\Controller\Admin\A
 
     /**
      * Deletes uploaded csv file from temp directory
+     * @deprecated underscore prefix violates PSR12, will be renamed to "deleteCsvFile" in next major
      */
     protected function _deleteCsvFile() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -179,6 +180,7 @@ class GenericImportMain extends \OxidEsales\Eshop\Application\Controller\Admin\A
      * returns default columns names Column 1, Column 2..
      *
      * @return array
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getCsvFieldsNames" in next major
      */
     protected function _getCsvFieldsNames() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -208,6 +210,7 @@ class GenericImportMain extends \OxidEsales\Eshop\Application\Controller\Admin\A
      * Get first row from uploaded CSV file
      *
      * @return array
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getCsvFirstRow" in next major
      */
     protected function _getCsvFirstRow() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -225,6 +228,7 @@ class GenericImportMain extends \OxidEsales\Eshop\Application\Controller\Admin\A
 
     /**
      * Resets CSV parameters stored in session
+     * @deprecated underscore prefix violates PSR12, will be renamed to "resetUploadedCsvData" in next major
      */
     protected function _resetUploadedCsvData() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -240,6 +244,7 @@ class GenericImportMain extends \OxidEsales\Eshop\Application\Controller\Admin\A
      * @param int $iNavStep Navigation step id
      *
      * @return int
+     * @deprecated underscore prefix violates PSR12, will be renamed to "checkErrors" in next major
      */
     protected function _checkErrors($iNavStep) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -280,6 +285,7 @@ class GenericImportMain extends \OxidEsales\Eshop\Application\Controller\Admin\A
      * and stores path to file in session. Return path to uploaded file.
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getUploadedCsvFilePath" in next major
      */
     protected function _getUploadedCsvFilePath() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -305,6 +311,7 @@ class GenericImportMain extends \OxidEsales\Eshop\Application\Controller\Admin\A
      * Checks if any error occured during import and displays them
      *
      * @param object $oErpImport Import object
+     * @deprecated underscore prefix violates PSR12, will be renamed to "checkImportErrors" in next major
      */
     protected function _checkImportErrors($oErpImport) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -321,6 +328,7 @@ class GenericImportMain extends \OxidEsales\Eshop\Application\Controller\Admin\A
      * Get csv field terminator symbol
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getCsvFieldsTerminator" in next major
      */
     protected function _getCsvFieldsTerminator() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -338,6 +346,7 @@ class GenericImportMain extends \OxidEsales\Eshop\Application\Controller\Admin\A
      * Get csv field encloser symbol
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getCsvFieldsEncolser" in next major
      */
     protected function _getCsvFieldsEncolser() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {

--- a/source/Application/Controller/Admin/LanguageList.php
+++ b/source/Application/Controller/Admin/LanguageList.php
@@ -92,6 +92,7 @@ class LanguageList extends \OxidEsales\Eshop\Application\Controller\Admin\AdminL
      * Collects shop languages list.
      *
      * @return array
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getLanguagesList" in next major
      */
     protected function _getLanguagesList() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -138,6 +139,7 @@ class LanguageList extends \OxidEsales\Eshop\Application\Controller\Admin\AdminL
      * @param object $oLang2 language object
      *
      * @return bool
+     * @deprecated underscore prefix violates PSR12, will be renamed to "sortLanguagesCallback" in next major
      */
     protected function _sortLanguagesCallback($oLang1, $oLang2) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -157,6 +159,7 @@ class LanguageList extends \OxidEsales\Eshop\Application\Controller\Admin\AdminL
      * to default value in all tables.
      *
      * @param string $iLangId language ID
+     * @deprecated underscore prefix violates PSR12, will be renamed to "resetMultiLangDbFields" in next major
      */
     protected function _resetMultiLangDbFields($iLangId) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {

--- a/source/Application/Controller/Admin/LanguageMain.php
+++ b/source/Application/Controller/Admin/LanguageMain.php
@@ -183,6 +183,7 @@ class LanguageMain extends \OxidEsales\Eshop\Application\Controller\Admin\AdminD
      * @param string $sOxId language abbervation
      *
      * @return array
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getLanguageInfo" in next major
      */
     protected function _getLanguageInfo($sOxId) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -202,6 +203,7 @@ class LanguageMain extends \OxidEsales\Eshop\Application\Controller\Admin\AdminD
      * Languages array setter
      *
      * @param array $aLangData languages parameters array
+     * @deprecated underscore prefix violates PSR12, will be renamed to "setLanguages" in next major
      */
     protected function _setLanguages($aLangData) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -214,6 +216,7 @@ class LanguageMain extends \OxidEsales\Eshop\Application\Controller\Admin\AdminD
      * Returns collected languages parameters array.
      *
      * @return array
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getLanguages" in next major
      */
     protected function _getLanguages() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -235,6 +238,7 @@ class LanguageMain extends \OxidEsales\Eshop\Application\Controller\Admin\AdminD
      *
      * @param string $sOldId old ID
      * @param string $sNewId new ID
+     * @deprecated underscore prefix violates PSR12, will be renamed to "updateAbbervation" in next major
      */
     protected function _updateAbbervation($sOldId, $sNewId) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -258,6 +262,7 @@ class LanguageMain extends \OxidEsales\Eshop\Application\Controller\Admin\AdminD
     /**
      * Sort languages, languages parameters, urls, ssl urls arrays according
      * base land ID
+     * @deprecated underscore prefix violates PSR12, will be renamed to "sortLangArraysByBaseId" in next major
      */
     protected function _sortLangArraysByBaseId() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -285,6 +290,7 @@ class LanguageMain extends \OxidEsales\Eshop\Application\Controller\Admin\AdminD
      * @param array $aLanguages language array
      *
      * @return array
+     * @deprecated underscore prefix violates PSR12, will be renamed to "assignDefaultLangParams" in next major
      */
     protected function _assignDefaultLangParams($aLanguages) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -306,6 +312,7 @@ class LanguageMain extends \OxidEsales\Eshop\Application\Controller\Admin\AdminD
      * Sets default language base ID to config var 'sDefaultLang'
      *
      * @param string $sOxId language abbervation
+     * @deprecated underscore prefix violates PSR12, will be renamed to "setDefaultLang" in next major
      */
     protected function _setDefaultLang($sOxId) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -317,6 +324,7 @@ class LanguageMain extends \OxidEsales\Eshop\Application\Controller\Admin\AdminD
      * Get availabale language base ID
      *
      * @return int
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getAvailableLangBaseId" in next major
      */
     protected function _getAvailableLangBaseId() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -345,6 +353,7 @@ class LanguageMain extends \OxidEsales\Eshop\Application\Controller\Admin\AdminD
      * If not - displays warning
      *
      * @param string $sOxId language abbervation
+     * @deprecated underscore prefix violates PSR12, will be renamed to "checkLangTranslations" in next major
      */
     protected function _checkLangTranslations($sOxId) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -365,6 +374,7 @@ class LanguageMain extends \OxidEsales\Eshop\Application\Controller\Admin\AdminD
      * @param string $sOxId language abbervation
      *
      * @return bool
+     * @deprecated underscore prefix violates PSR12, will be renamed to "checkMultilangFieldsExistsInDb" in next major
      */
     protected function _checkMultilangFieldsExistsInDb($sOxId) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -382,6 +392,7 @@ class LanguageMain extends \OxidEsales\Eshop\Application\Controller\Admin\AdminD
      * language ID (e.g. oxtitle_4)
      *
      * @return null
+     * @deprecated underscore prefix violates PSR12, will be renamed to "addNewMultilangFieldsToDb" in next major
      */
     protected function _addNewMultilangFieldsToDb() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -411,6 +422,7 @@ class LanguageMain extends \OxidEsales\Eshop\Application\Controller\Admin\AdminD
      * @param string $sAbbr language abbervation
      *
      * @return bool
+     * @deprecated underscore prefix violates PSR12, will be renamed to "checkLangExists" in next major
      */
     protected function _checkLangExists($sAbbr) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -427,6 +439,7 @@ class LanguageMain extends \OxidEsales\Eshop\Application\Controller\Admin\AdminD
      * @param object $oLang2 language array
      *
      * @return bool
+     * @deprecated underscore prefix violates PSR12, will be renamed to "sortLangParamsByBaseIdCallback" in next major
      */
     protected function _sortLangParamsByBaseIdCallback($oLang1, $oLang2) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -437,6 +450,7 @@ class LanguageMain extends \OxidEsales\Eshop\Application\Controller\Admin\AdminD
      * Check language input errors
      *
      * @return bool
+     * @deprecated underscore prefix violates PSR12, will be renamed to "validateInput" in next major
      */
     protected function _validateInput() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {

--- a/source/Application/Controller/Admin/ListComponentAjax.php
+++ b/source/Application/Controller/Admin/ListComponentAjax.php
@@ -78,6 +78,7 @@ class ListComponentAjax extends \OxidEsales\Eshop\Core\Base
      * @param string $sId "table_name.col_name"
      *
      * @return array
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getActionIds" in next major
      */
     protected function _getActionIds($sId) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -103,6 +104,7 @@ class ListComponentAjax extends \OxidEsales\Eshop\Core\Base
      * Empty function, developer should override this method according requirements
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getQuery" in next major
      */
     protected function _getQuery() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -115,6 +117,7 @@ class ListComponentAjax extends \OxidEsales\Eshop\Core\Base
      * @param string $sQ part of initial query
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getDataQuery" in next major
      */
     protected function _getDataQuery($sQ) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -127,6 +130,7 @@ class ListComponentAjax extends \OxidEsales\Eshop\Core\Base
      * @param string $sQ part of initial query
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getCountQuery" in next major
      */
     protected function _getCountQuery($sQ) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -158,6 +162,7 @@ class ListComponentAjax extends \OxidEsales\Eshop\Core\Base
      * Returns column id to sort
      *
      * @return int
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getSortCol" in next major
      */
     protected function _getSortCol() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -177,6 +182,7 @@ class ListComponentAjax extends \OxidEsales\Eshop\Core\Base
      * @param string $sId container id (optional)
      *
      * @return array
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getColNames" in next major
      */
     protected function _getColNames($sId = null) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -196,6 +202,7 @@ class ListComponentAjax extends \OxidEsales\Eshop\Core\Base
      * in AJAX and further in this processor class
      *
      * @return array
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getIdentColNames" in next major
      */
     protected function _getIdentColNames() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -215,6 +222,7 @@ class ListComponentAjax extends \OxidEsales\Eshop\Core\Base
      * Returns array of col names which are requested by AJAX call and will be fetched from DB
      *
      * @return array
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getVisibleColNames" in next major
      */
     protected function _getVisibleColNames() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -250,6 +258,7 @@ class ListComponentAjax extends \OxidEsales\Eshop\Core\Base
      * fields to load from DB
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getQueryCols" in next major
      */
     protected function _getQueryCols() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -266,6 +275,7 @@ class ListComponentAjax extends \OxidEsales\Eshop\Core\Base
      * @param bool  $blIdentCols if true, means ident columns part is build
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "buildColsQuery" in next major
      */
     protected function _buildColsQuery($aIdentCols, $blIdentCols = true) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -293,6 +303,7 @@ class ListComponentAjax extends \OxidEsales\Eshop\Core\Base
      * @param string $sColumn column name
      *
      * @return bool
+     * @deprecated underscore prefix violates PSR12, will be renamed to "isExtendedColumn" in next major
      */
     protected function _isExtendedColumn($sColumn) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -310,6 +321,7 @@ class ListComponentAjax extends \OxidEsales\Eshop\Core\Base
      * @param int    $iCnt       column count
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getExtendedColQuery" in next major
      */
     protected function _getExtendedColQuery($sViewTable, $sColumn, $iCnt) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -325,6 +337,7 @@ class ListComponentAjax extends \OxidEsales\Eshop\Core\Base
      * Formats and returns part of SQL query for sorting
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getSorting" in next major
      */
     protected function _getSorting() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -337,6 +350,7 @@ class ListComponentAjax extends \OxidEsales\Eshop\Core\Base
      * @param int $iStart start position
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getLimit" in next major
      */
     protected function _getLimit($iStart) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -350,6 +364,7 @@ class ListComponentAjax extends \OxidEsales\Eshop\Core\Base
      * Returns part of SQL query for filtering DB data
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getFilter" in next major
      */
     protected function _getFilter() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -394,6 +409,7 @@ class ListComponentAjax extends \OxidEsales\Eshop\Core\Base
      * @param string $sQ query to add filter condition
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "addFilter" in next major
      */
     protected function _addFilter($sQ) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -410,6 +426,7 @@ class ListComponentAjax extends \OxidEsales\Eshop\Core\Base
      * @param string $sQ SQL query
      *
      * @return array
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getAll" in next major
      */
     protected function _getAll($sQ) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -429,6 +446,7 @@ class ListComponentAjax extends \OxidEsales\Eshop\Core\Base
      * Checks user input and returns SQL sorting direction key
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getSortDir" in next major
      */
     protected function _getSortDir() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -444,6 +462,7 @@ class ListComponentAjax extends \OxidEsales\Eshop\Core\Base
      * Returns position from where data must be loaded
      *
      * @return int
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getStartIndex" in next major
      */
     protected function _getStartIndex() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -456,6 +475,7 @@ class ListComponentAjax extends \OxidEsales\Eshop\Core\Base
      * @param string $sQ SQL query
      *
      * @return int
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getTotalCount" in next major
      */
     protected function _getTotalCount($sQ) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -475,6 +495,7 @@ class ListComponentAjax extends \OxidEsales\Eshop\Core\Base
      * @param string $sQ SQL query
      *
      * @return array
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getDataFields" in next major
      */
     protected function _getDataFields($sQ) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -486,6 +507,7 @@ class ListComponentAjax extends \OxidEsales\Eshop\Core\Base
      * Outputs JSON encoded data
      *
      * @param array $aData data to output
+     * @deprecated underscore prefix violates PSR12, will be renamed to "outputResponse" in next major
      */
     protected function _outputResponse($aData) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -496,6 +518,7 @@ class ListComponentAjax extends \OxidEsales\Eshop\Core\Base
      * Echoes given string
      *
      * @param string $sOut string to echo
+     * @deprecated underscore prefix violates PSR12, will be renamed to "output" in next major
      */
     protected function _output($sOut) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -508,6 +531,7 @@ class ListComponentAjax extends \OxidEsales\Eshop\Core\Base
      * @param string $sTable table name
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getViewName" in next major
      */
     protected function _getViewName($sTable) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -521,6 +545,7 @@ class ListComponentAjax extends \OxidEsales\Eshop\Core\Base
      * @param string $sQ      data load query
      *
      * @return array
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getData" in next major
      */
     protected function _getData($sCountQ, $sQ) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -628,6 +653,7 @@ class ListComponentAjax extends \OxidEsales\Eshop\Core\Base
 
     /**
      * Resets content cache.
+     * @deprecated underscore prefix violates PSR12, will be renamed to "resetContentCache" in next major
      */
     protected function _resetContentCache() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -635,6 +661,7 @@ class ListComponentAjax extends \OxidEsales\Eshop\Core\Base
 
     /**
      * Resets output caches
+     * @deprecated underscore prefix violates PSR12, will be renamed to "resetCaches" in next major
      */
     protected function _resetCaches() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {

--- a/source/Application/Controller/Admin/ListReview.php
+++ b/source/Application/Controller/Admin/ListReview.php
@@ -32,6 +32,7 @@ class ListReview extends \OxidEsales\Eshop\Application\Controller\Admin\ArticleL
      * Viewable list size getter
      *
      * @return int
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getViewListSize" in next major
      */
     protected function _getViewListSize() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -60,6 +61,7 @@ class ListReview extends \OxidEsales\Eshop\Application\Controller\Admin\ArticleL
      * @param object $oObject list item object
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "buildSelectString" in next major
      */
     protected function _buildSelectString($oObject = null) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -86,6 +88,7 @@ class ListReview extends \OxidEsales\Eshop\Application\Controller\Admin\ArticleL
      * @param string $sSql   query string
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "prepareWhereQuery" in next major
      */
     protected function _prepareWhereQuery($aWhere, $sSql) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {

--- a/source/Application/Controller/Admin/ListUser.php
+++ b/source/Application/Controller/Admin/ListUser.php
@@ -18,6 +18,7 @@ class ListUser extends \OxidEsales\Eshop\Application\Controller\Admin\UserList
      * Viewable list size getter
      *
      * @return int
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getViewListSize" in next major
      */
     protected function _getViewListSize() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {

--- a/source/Application/Controller/Admin/LoginController.php
+++ b/source/Application/Controller/Admin/LoginController.php
@@ -177,6 +177,7 @@ class LoginController extends \OxidEsales\Eshop\Application\Controller\Admin\Adm
      * Rewrites authorization method.
      *
      * @return boolean
+     * @deprecated underscore prefix violates PSR12, will be renamed to "authorize" in next major
      */
     protected function _authorize() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -197,6 +198,7 @@ class LoginController extends \OxidEsales\Eshop\Application\Controller\Admin\Adm
      * Get available admin interface languages
      *
      * @return array
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getAvailableLanguages" in next major
      */
     protected function _getAvailableLanguages() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -215,6 +217,7 @@ class LoginController extends \OxidEsales\Eshop\Application\Controller\Admin\Adm
      * Get detected user browser language abbervation
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getBrowserLanguage" in next major
      */
     protected function _getBrowserLanguage() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {

--- a/source/Application/Controller/Admin/ManufacturerMainAjax.php
+++ b/source/Application/Controller/Admin/ManufacturerMainAjax.php
@@ -52,6 +52,7 @@ class ManufacturerMainAjax extends \OxidEsales\Eshop\Application\Controller\Admi
      * Returns SQL query for data to fetc
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getQuery" in next major
      */
     protected function _getQuery() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -90,6 +91,7 @@ class ManufacturerMainAjax extends \OxidEsales\Eshop\Application\Controller\Admi
      * @param string $query query to add filter condition
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "addFilter" in next major
      */
     protected function _addFilter($query) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {

--- a/source/Application/Controller/Admin/ManufacturerSeo.php
+++ b/source/Application/Controller/Admin/ManufacturerSeo.php
@@ -38,6 +38,7 @@ class ManufacturerSeo extends \OxidEsales\Eshop\Application\Controller\Admin\Obj
      * Returns current object type seo encoder object
      *
      * @return oxSeoEncoderManufacturer
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getEncoder" in next major
      */
     protected function _getEncoder() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -58,6 +59,7 @@ class ManufacturerSeo extends \OxidEsales\Eshop\Application\Controller\Admin\Obj
      * Returns url type
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getType" in next major
      */
     protected function _getType() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {

--- a/source/Application/Controller/Admin/ModuleConfiguration.php
+++ b/source/Application/Controller/Admin/ModuleConfiguration.php
@@ -331,6 +331,7 @@ class ModuleConfiguration extends \OxidEsales\Eshop\Application\Controller\Admin
      * @param string $type Metadata type.
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getDbConfigTypeName" in next major
      */
     private function _getDbConfigTypeName($type) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {

--- a/source/Application/Controller/Admin/NavigationController.php
+++ b/source/Application/Controller/Admin/NavigationController.php
@@ -151,6 +151,7 @@ class NavigationController extends \OxidEsales\Eshop\Application\Controller\Admi
      * returns some messages if there is something to display
      *
      * @return array
+     * @deprecated underscore prefix violates PSR12, will be renamed to "doStartUpChecks" in next major
      */
     protected function _doStartUpChecks() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -202,6 +203,7 @@ class NavigationController extends \OxidEsales\Eshop\Application\Controller\Admi
      * Checks if newer shop version available. If true - returns message
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "checkVersion" in next major
      */
     protected function _checkVersion() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {

--- a/source/Application/Controller/Admin/NavigationTree.php
+++ b/source/Application/Controller/Admin/NavigationTree.php
@@ -51,6 +51,7 @@ class NavigationTree extends \OxidEsales\Eshop\Core\Base
      * @param object $dom         dom object
      * @param string $parentXPath parent xpath
      * @param string $childXPath  child xpath from parent
+     * @deprecated underscore prefix violates PSR12, will be renamed to "cleanEmptyParents" in next major
      */
     protected function _cleanEmptyParents($dom, $parentXPath, $childXPath) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -70,6 +71,7 @@ class NavigationTree extends \OxidEsales\Eshop\Core\Base
      * Adds links to xml nodes to resolve paths
      *
      * @param DomDocument $dom where to add links
+     * @deprecated underscore prefix violates PSR12, will be renamed to "addLinks" in next major
      */
     protected function _addLinks($dom) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -97,6 +99,7 @@ class NavigationTree extends \OxidEsales\Eshop\Core\Base
      *
      * @param string      $menuFile which file to load
      * @param DomDocument $dom      where to load
+     * @deprecated underscore prefix violates PSR12, will be renamed to "loadFromFile" in next major
      */
     protected function _loadFromFile($menuFile, $dom) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -203,6 +206,7 @@ class NavigationTree extends \OxidEsales\Eshop\Core\Base
      * add session parameters to local urls
      *
      * @param object $dom dom element to add links
+     * @deprecated underscore prefix violates PSR12, will be renamed to "sessionizeLocalUrls" in next major
      */
     protected function _sessionizeLocalUrls($dom) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -224,6 +228,7 @@ class NavigationTree extends \OxidEsales\Eshop\Core\Base
      * Removes form tree elements which does not have required user rights
      *
      * @param object $dom DOMDocument
+     * @deprecated underscore prefix violates PSR12, will be renamed to "checkRights" in next major
      */
     protected function _checkRights($dom) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -255,6 +260,7 @@ class NavigationTree extends \OxidEsales\Eshop\Core\Base
      * Removes from tree elements which don't have required groups
      *
      * @param DOMDocument $dom document to check group
+     * @deprecated underscore prefix violates PSR12, will be renamed to "checkGroups" in next major
      */
     protected function _checkGroups($dom) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -288,6 +294,7 @@ class NavigationTree extends \OxidEsales\Eshop\Core\Base
      * @param DOMDocument $dom document to check group
      *
      * @return null
+     * @deprecated underscore prefix violates PSR12, will be renamed to "checkDemoShopDenials" in next major
      */
     protected function _checkDemoShopDenials($dom) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -326,6 +333,7 @@ class NavigationTree extends \OxidEsales\Eshop\Core\Base
      *
      * @param object $domElemTo   DOMElement
      * @param object $domElemFrom DOMElement
+     * @deprecated underscore prefix violates PSR12, will be renamed to "copyAttributes" in next major
      */
     protected function _copyAttributes($domElemTo, $domElemFrom) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -342,6 +350,7 @@ class NavigationTree extends \OxidEsales\Eshop\Core\Base
      * @param object $xPathTo     node path
      * @param object $domDocTo    node to append child
      * @param string $queryStart  node query
+     * @deprecated underscore prefix violates PSR12, will be renamed to "mergeNodes" in next major
      */
     protected function _mergeNodes($domElemTo, $domElemFrom, $xPathTo, $domDocTo, $queryStart) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -376,6 +385,7 @@ class NavigationTree extends \OxidEsales\Eshop\Core\Base
      *
      * @param DomDocument $domNew what to merge
      * @param DomDocument $dom    where to merge
+     * @deprecated underscore prefix violates PSR12, will be renamed to "merge" in next major
      */
     protected function _merge($domNew, $dom) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -456,6 +466,7 @@ class NavigationTree extends \OxidEsales\Eshop\Core\Base
      * Returns array with paths + names ox menu xml files. Paths are checked
      *
      * @return array
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getMenuFiles" in next major
      */
     protected function _getMenuFiles() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -522,6 +533,7 @@ class NavigationTree extends \OxidEsales\Eshop\Core\Base
      * @param string $cacheContents
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "processCachedFile" in next major
      */
     protected function _processCachedFile($cacheContents) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -532,6 +544,7 @@ class NavigationTree extends \OxidEsales\Eshop\Core\Base
      * get initial dom, not modified by init method
      *
      * @return DOMDocument
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getInitialDom" in next major
      */
     protected function _getInitialDom() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -709,6 +722,7 @@ class NavigationTree extends \OxidEsales\Eshop\Core\Base
      * Admin url getter
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getAdminUrl" in next major
      */
     protected function _getAdminUrl() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -729,6 +743,7 @@ class NavigationTree extends \OxidEsales\Eshop\Core\Base
      * @param string $rights session user rights
      *
      * @return bool
+     * @deprecated underscore prefix violates PSR12, will be renamed to "hasRights" in next major
      */
     protected function _hasRights($rights) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -741,6 +756,7 @@ class NavigationTree extends \OxidEsales\Eshop\Core\Base
      * @param string $groupId active group id
      *
      * @return bool
+     * @deprecated underscore prefix violates PSR12, will be renamed to "hasGroup" in next major
      */
     protected function _hasGroup($groupId) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {

--- a/source/Application/Controller/Admin/NewsMainAjax.php
+++ b/source/Application/Controller/Admin/NewsMainAjax.php
@@ -41,6 +41,7 @@ class NewsMainAjax extends \OxidEsales\Eshop\Application\Controller\Admin\ListCo
      * Returns SQL query for data to fetc
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getQuery" in next major
      */
     protected function _getQuery() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {

--- a/source/Application/Controller/Admin/NewsletterSelectionAjax.php
+++ b/source/Application/Controller/Admin/NewsletterSelectionAjax.php
@@ -36,6 +36,7 @@ class NewsletterSelectionAjax extends \OxidEsales\Eshop\Application\Controller\A
      * Returns SQL query for data to fetc
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getQuery" in next major
      */
     protected function _getQuery() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {

--- a/source/Application/Controller/Admin/NewsletterSend.php
+++ b/source/Application/Controller/Admin/NewsletterSend.php
@@ -182,6 +182,7 @@ class NewsletterSend extends \OxidEsales\Eshop\Application\Controller\Admin\News
      * Overrides parent method to pass referred id
      *
      * @param string $sNode referred id
+     * @deprecated underscore prefix violates PSR12, will be renamed to "setupNavigation" in next major
      */
     protected function _setupNavigation($sNode) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {

--- a/source/Application/Controller/Admin/ObjectSeo.php
+++ b/source/Application/Controller/Admin/ObjectSeo.php
@@ -100,6 +100,7 @@ class ObjectSeo extends \OxidEsales\Eshop\Application\Controller\Admin\AdminDeta
      * @param array $aSeoData Seo data array
      *
      * @return null|string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getAdditionalParams" in next major
      */
     protected function _getAdditionalParams($aSeoData) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -117,6 +118,7 @@ class ObjectSeo extends \OxidEsales\Eshop\Application\Controller\Admin\AdminDeta
      * Returns id of object which must be saved
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getSaveObjectId" in next major
      */
     protected function _getSaveObjectId() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -159,6 +161,7 @@ class ObjectSeo extends \OxidEsales\Eshop\Application\Controller\Admin\AdminDeta
 
     /**
      * Returns url type
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getType" in next major
      */
     protected function _getType() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -170,6 +173,7 @@ class ObjectSeo extends \OxidEsales\Eshop\Application\Controller\Admin\AdminDeta
      * @param string $sOxid object id
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getStdUrl" in next major
      */
     protected function _getStdUrl($sOxid) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -193,6 +197,7 @@ class ObjectSeo extends \OxidEsales\Eshop\Application\Controller\Admin\AdminDeta
 
     /**
      * Returns alternative seo entry id
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getAltSeoEntryId" in next major
      */
     protected function _getAltSeoEntryId() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -202,6 +207,7 @@ class ObjectSeo extends \OxidEsales\Eshop\Application\Controller\Admin\AdminDeta
      * Returns seo entry type
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getSeoEntryType" in next major
      */
     protected function _getSeoEntryType() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -222,6 +228,7 @@ class ObjectSeo extends \OxidEsales\Eshop\Application\Controller\Admin\AdminDeta
 
     /**
      * Returns current object type seo encoder object
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getEncoder" in next major
      */
     protected function _getEncoder() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {

--- a/source/Application/Controller/Admin/OrderAddress.php
+++ b/source/Application/Controller/Admin/OrderAddress.php
@@ -53,6 +53,7 @@ class OrderAddress extends \OxidEsales\Eshop\Application\Controller\Admin\AdminD
      * @param array  $aIgnore        fields which must be ignored while processing
      *
      * @return null
+     * @deprecated underscore prefix violates PSR12, will be renamed to "processAddress" in next major
      */
     protected function _processAddress($aData, $sTypeToProcess, $aIgnore) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {

--- a/source/Application/Controller/Admin/OrderList.php
+++ b/source/Application/Controller/Admin/OrderList.php
@@ -117,6 +117,7 @@ class OrderList extends \OxidEsales\Eshop\Application\Controller\Admin\AdminList
      * @param string $fullQuery  SQL query string
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "prepareWhereQuery" in next major
      */
     protected function _prepareWhereQuery($whereQuery, $fullQuery) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -142,6 +143,7 @@ class OrderList extends \OxidEsales\Eshop\Application\Controller\Admin\AdminList
      * @param object $listObject list main object
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "buildSelectString" in next major
      */
     protected function _buildSelectString($listObject = null) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {

--- a/source/Application/Controller/Admin/OrderOverview.php
+++ b/source/Application/Controller/Admin/OrderOverview.php
@@ -75,6 +75,7 @@ class OrderOverview extends \OxidEsales\Eshop\Application\Controller\Admin\Admin
      * @param object $oOrder Order object
      *
      * @return oxUserPayment
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getPaymentType" in next major
      */
     protected function _getPaymentType($oOrder) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {

--- a/source/Application/Controller/Admin/PaymentCountryAjax.php
+++ b/source/Application/Controller/Admin/PaymentCountryAjax.php
@@ -40,6 +40,7 @@ class PaymentCountryAjax extends \OxidEsales\Eshop\Application\Controller\Admin\
      * Returns SQL query for data to fetc
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getQuery" in next major
      */
     protected function _getQuery() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {

--- a/source/Application/Controller/Admin/PaymentMainAjax.php
+++ b/source/Application/Controller/Admin/PaymentMainAjax.php
@@ -38,6 +38,7 @@ class PaymentMainAjax extends \OxidEsales\Eshop\Application\Controller\Admin\Lis
      * Returns SQL query for data to fetc
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getQuery" in next major
      */
     protected function _getQuery() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {

--- a/source/Application/Controller/Admin/PriceAlarmList.php
+++ b/source/Application/Controller/Admin/PriceAlarmList.php
@@ -41,6 +41,7 @@ class PriceAlarmList extends \OxidEsales\Eshop\Application\Controller\Admin\Admi
      * @param object $oListObject list main object
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "buildSelectString" in next major
      */
     protected function _buildSelectString($oListObject = null) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {

--- a/source/Application/Controller/Admin/PriceAlarmSend.php
+++ b/source/Application/Controller/Admin/PriceAlarmSend.php
@@ -68,6 +68,7 @@ class PriceAlarmSend extends \OxidEsales\Eshop\Application\Controller\Admin\Admi
      * Overrides parent method to pass referred id.
      *
      * @param string $sId Class name
+     * @deprecated underscore prefix violates PSR12, will be renamed to "setupNavigation" in next major
      */
     protected function _setupNavigation($sId) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {

--- a/source/Application/Controller/Admin/SelectListMain.php
+++ b/source/Application/Controller/Admin/SelectListMain.php
@@ -319,6 +319,7 @@ class SelectListMain extends \OxidEsales\Eshop\Application\Controller\Admin\Admi
      * @param integer $iPos   new pos of the field
      *
      * @return bool - true if failed.
+     * @deprecated underscore prefix violates PSR12, will be renamed to "rearrangeFields" in next major
      */
     protected function _rearrangeFields($oField, $iPos) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {

--- a/source/Application/Controller/Admin/SelectListMainAjax.php
+++ b/source/Application/Controller/Admin/SelectListMainAjax.php
@@ -61,6 +61,7 @@ class SelectListMainAjax extends \OxidEsales\Eshop\Application\Controller\Admin\
      * Returns SQL query for data to fetc
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getQuery" in next major
      */
     protected function _getQuery() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {

--- a/source/Application/Controller/Admin/SelectListOrderAjax.php
+++ b/source/Application/Controller/Admin/SelectListOrderAjax.php
@@ -33,6 +33,7 @@ class SelectListOrderAjax extends \OxidEsales\Eshop\Application\Controller\Admin
      * Returns SQL query for data to fetc
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getQuery" in next major
      */
     protected function _getQuery() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -47,6 +48,7 @@ class SelectListOrderAjax extends \OxidEsales\Eshop\Application\Controller\Admin
      * Returns SQL query addon for sorting
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getSorting" in next major
      */
     protected function _getSorting() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {

--- a/source/Application/Controller/Admin/ShopConfiguration.php
+++ b/source/Application/Controller/Admin/ShopConfiguration.php
@@ -122,6 +122,7 @@ class ShopConfiguration extends \OxidEsales\Eshop\Application\Controller\Admin\A
      * return theme filter for config variables
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getModuleForConfigVars" in next major
      */
     protected function _getModuleForConfigVars() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -266,6 +267,7 @@ class ShopConfiguration extends \OxidEsales\Eshop\Application\Controller\Admin\A
      * @param string $constraint serialized constraint
      *
      * @return mixed
+     * @deprecated underscore prefix violates PSR12, will be renamed to "parseConstraint" in next major
      */
     protected function _parseConstraint($type, $constraint) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -284,6 +286,7 @@ class ShopConfiguration extends \OxidEsales\Eshop\Application\Controller\Admin\A
      * @param mixed  $constraint constraint value
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "serializeConstraint" in next major
      */
     protected function _serializeConstraint($type, $constraint) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -303,6 +306,7 @@ class ShopConfiguration extends \OxidEsales\Eshop\Application\Controller\Admin\A
      * @param string $value var value
      *
      * @return mixed
+     * @deprecated underscore prefix violates PSR12, will be renamed to "unserializeConfVar" in next major
      */
     public function _unserializeConfVar($type, $name, $value) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -353,6 +357,7 @@ class ShopConfiguration extends \OxidEsales\Eshop\Application\Controller\Admin\A
      * @param mixed  $value var value
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "serializeConfVar" in next major
      */
     public function _serializeConfVar($type, $name, $value) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -390,6 +395,7 @@ class ShopConfiguration extends \OxidEsales\Eshop\Application\Controller\Admin\A
      * @param array $input Array with text
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "arrayToMultiline" in next major
      */
     protected function _arrayToMultiline($input) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -402,6 +408,7 @@ class ShopConfiguration extends \OxidEsales\Eshop\Application\Controller\Admin\A
      * @param string $multiline Multiline text
      *
      * @return array
+     * @deprecated underscore prefix violates PSR12, will be renamed to "multilineToArray" in next major
      */
     protected function _multilineToArray($multiline) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -424,6 +431,7 @@ class ShopConfiguration extends \OxidEsales\Eshop\Application\Controller\Admin\A
      * @param array $input Array to convert
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "aarrayToMultiline" in next major
      */
     protected function _aarrayToMultiline($input) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -446,6 +454,7 @@ class ShopConfiguration extends \OxidEsales\Eshop\Application\Controller\Admin\A
      * @param string $multiline Multiline text
      *
      * @return array
+     * @deprecated underscore prefix violates PSR12, will be renamed to "multilineToAarray" in next major
      */
     protected function _multilineToAarray($multiline) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {

--- a/source/Application/Controller/Admin/ShopDefaultCategoryAjax.php
+++ b/source/Application/Controller/Admin/ShopDefaultCategoryAjax.php
@@ -32,6 +32,7 @@ class ShopDefaultCategoryAjax extends \OxidEsales\Eshop\Application\Controller\A
      * Returns SQL query for data to fetc
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getQuery" in next major
      */
     protected function _getQuery() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {

--- a/source/Application/Controller/Admin/ShopLicense.php
+++ b/source/Application/Controller/Admin/ShopLicense.php
@@ -66,6 +66,7 @@ class ShopLicense extends \OxidEsales\Eshop\Application\Controller\Admin\ShopCon
      * Checks if the license key update is allowed.
      *
      * @return bool
+     * @deprecated underscore prefix violates PSR12, will be renamed to "canUpdate" in next major
      */
     protected function _canUpdate() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -86,6 +87,7 @@ class ShopLicense extends \OxidEsales\Eshop\Application\Controller\Admin\ShopCon
      * Fetch current shop version information from url
      * @param string $sUrl current version info fetching url by edition
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "fetchCurVersionInfo" in next major
      */
     protected function _fetchCurVersionInfo($sUrl) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {

--- a/source/Application/Controller/Admin/ShopMain.php
+++ b/source/Application/Controller/Admin/ShopMain.php
@@ -145,6 +145,7 @@ class ShopMain extends \OxidEsales\Eshop\Application\Controller\Admin\AdminDetai
      * Returns array of config variables which cannot be copied
      *
      * @return array
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getNonCopyConfigVars" in next major
      */
     protected function _getNonCopyConfigVars() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -180,6 +181,7 @@ class ShopMain extends \OxidEsales\Eshop\Application\Controller\Admin\AdminDetai
      * Copies base shop config variables to current
      *
      * @param \OxidEsales\Eshop\Application\Model\Shop $shop new shop object
+     * @deprecated underscore prefix violates PSR12, will be renamed to "copyConfigVars" in next major
      */
     protected function _copyConfigVars($shop) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {

--- a/source/Application/Controller/Admin/ShopSeo.php
+++ b/source/Application/Controller/Admin/ShopSeo.php
@@ -60,6 +60,7 @@ class ShopSeo extends \OxidEsales\Eshop\Application\Controller\Admin\ShopConfigu
      * Loads and sets active url info to view
      *
      * @param int $iShopId active shop id
+     * @deprecated underscore prefix violates PSR12, will be renamed to "loadActiveUrl" in next major
      */
     protected function _loadActiveUrl($iShopId) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -118,6 +119,7 @@ class ShopSeo extends \OxidEsales\Eshop\Application\Controller\Admin\ShopConfigu
      * @param array $aUrls urls to process
      *
      * @return array
+     * @deprecated underscore prefix violates PSR12, will be renamed to "processUrls" in next major
      */
     protected function _processUrls($aUrls) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -140,6 +142,7 @@ class ShopSeo extends \OxidEsales\Eshop\Application\Controller\Admin\ShopConfigu
      * @param string $sUrl processable url
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "cleanupUrl" in next major
      */
     protected function _cleanupUrl($sUrl) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {

--- a/source/Application/Controller/Admin/ThemeConfiguration.php
+++ b/source/Application/Controller/Admin/ThemeConfiguration.php
@@ -65,6 +65,7 @@ class ThemeConfiguration extends \OxidEsales\Eshop\Application\Controller\Admin\
      * return theme filter for config variables
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getModuleForConfigVars" in next major
      */
     protected function _getModuleForConfigVars() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {

--- a/source/Application/Controller/Admin/ToolsList.php
+++ b/source/Application/Controller/Admin/ToolsList.php
@@ -122,6 +122,7 @@ class ToolsList extends \OxidEsales\Eshop\Application\Controller\Admin\AdminList
      * Processes files containing SQL queries
      *
      * @return mixed
+     * @deprecated underscore prefix violates PSR12, will be renamed to "processFiles" in next major
      */
     protected function _processFiles() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -166,6 +167,7 @@ class ToolsList extends \OxidEsales\Eshop\Application\Controller\Admin\AdminList
      * @param integer $iSQLlen query lenght
      *
      * @return mixed
+     * @deprecated underscore prefix violates PSR12, will be renamed to "prepareSQL" in next major
      */
     protected function _prepareSQL($sSQL, $iSQLlen) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {

--- a/source/Application/Controller/Admin/UserGroupMainAjax.php
+++ b/source/Application/Controller/Admin/UserGroupMainAjax.php
@@ -51,6 +51,7 @@ class UserGroupMainAjax extends \OxidEsales\Eshop\Application\Controller\Admin\L
      * Returns SQL query for data to fetc
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getQuery" in next major
      */
     protected function _getQuery() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {

--- a/source/Application/Controller/Admin/UserList.php
+++ b/source/Application/Controller/Admin/UserList.php
@@ -89,6 +89,7 @@ class UserList extends \OxidEsales\Eshop\Application\Controller\Admin\AdminListC
      * @param string $fullQuery  SQL query string
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "prepareWhereQuery" in next major
      */
     public function _prepareWhereQuery($whereQuery, $fullQuery) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {

--- a/source/Application/Controller/Admin/UserMainAjax.php
+++ b/source/Application/Controller/Admin/UserMainAjax.php
@@ -37,6 +37,7 @@ class UserMainAjax extends \OxidEsales\Eshop\Application\Controller\Admin\ListCo
      * Returns SQL query for data to fetc
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getQuery" in next major
      */
     protected function _getQuery() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {

--- a/source/Application/Controller/Admin/VendorMainAjax.php
+++ b/source/Application/Controller/Admin/VendorMainAjax.php
@@ -51,6 +51,7 @@ class VendorMainAjax extends \OxidEsales\Eshop\Application\Controller\Admin\List
      * Returns SQL query for data to fetc
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getQuery" in next major
      */
     protected function _getQuery() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -88,6 +89,7 @@ class VendorMainAjax extends \OxidEsales\Eshop\Application\Controller\Admin\List
      * @param string $sQ query to add filter condition
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "addFilter" in next major
      */
     protected function _addFilter($sQ) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {

--- a/source/Application/Controller/Admin/VendorSeo.php
+++ b/source/Application/Controller/Admin/VendorSeo.php
@@ -38,6 +38,7 @@ class VendorSeo extends \OxidEsales\Eshop\Application\Controller\Admin\ObjectSeo
      * Returns current object type seo encoder object
      *
      * @return oxSeoEncoderVendor
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getEncoder" in next major
      */
     protected function _getEncoder() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -71,6 +72,7 @@ class VendorSeo extends \OxidEsales\Eshop\Application\Controller\Admin\ObjectSeo
      * Returns url type
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getType" in next major
      */
     protected function _getType() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {

--- a/source/Application/Controller/Admin/VoucherSerieExport.php
+++ b/source/Application/Controller/Admin/VoucherSerieExport.php
@@ -81,6 +81,7 @@ class VoucherSerieExport extends \OxidEsales\Eshop\Application\Controller\Admin\
      * Return export file name
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getExportFileName" in next major
      */
     protected function _getExportFileName() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -97,6 +98,7 @@ class VoucherSerieExport extends \OxidEsales\Eshop\Application\Controller\Admin\
      * Return export file path
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getExportFilePath" in next major
      */
     protected function _getExportFilePath() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {

--- a/source/Application/Controller/Admin/VoucherSerieGroupsAjax.php
+++ b/source/Application/Controller/Admin/VoucherSerieGroupsAjax.php
@@ -37,6 +37,7 @@ class VoucherSerieGroupsAjax extends \OxidEsales\Eshop\Application\Controller\Ad
      * Returns SQL query for data to fetc
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getQuery" in next major
      */
     protected function _getQuery() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {

--- a/source/Application/Controller/Admin/VoucherSerieMain.php
+++ b/source/Application/Controller/Admin/VoucherSerieMain.php
@@ -132,6 +132,7 @@ class VoucherSerieMain extends \OxidEsales\Eshop\Application\Controller\Admin\Dy
      * Returns voucher serie object
      *
      * @return oxvoucherserie
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getVoucherSerie" in next major
      */
     protected function _getVoucherSerie() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {

--- a/source/Application/Controller/ArticleDetailsController.php
+++ b/source/Application/Controller/ArticleDetailsController.php
@@ -172,6 +172,7 @@ class ArticleDetailsController extends \OxidEsales\Eshop\Application\Controller\
      * @param string $parentId parent product id
      *
      * @return \OxidEsales\Eshop\Application\Model\Article
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getParentProduct" in next major
      */
     protected function _getParentProduct($parentId) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -190,7 +191,8 @@ class ArticleDetailsController extends \OxidEsales\Eshop\Application\Controller\
     /**
      * In case list type is "search" returns search parameters which will be added to product details link
      *
-     * @return string | null
+     * @return string|null
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getAddUrlParams" in next major
      */
     protected function _getAddUrlParams() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -237,6 +239,7 @@ class ArticleDetailsController extends \OxidEsales\Eshop\Application\Controller\
      * Processes product by setting link type and in case list type is search adds search parameters to details link
      *
      * @param \OxidEsales\Eshop\Application\Model\Article $article Product to process
+     * @deprecated underscore prefix violates PSR12, will be renamed to "processProduct" in next major
      */
     protected function _processProduct($article) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -322,6 +325,7 @@ class ArticleDetailsController extends \OxidEsales\Eshop\Application\Controller\
      * @param bool   $descriptionTag If true - performs additional duplicate cleaning
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "prepareMetaDescription" in next major
      */
     protected function _prepareMetaDescription($meta, $length = 200, $descriptionTag = false) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -351,6 +355,7 @@ class ArticleDetailsController extends \OxidEsales\Eshop\Application\Controller\
      * @param bool   $removeDuplicatedWords Remove duplicated words
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "prepareMetaKeyword" in next major
      */
     protected function _prepareMetaKeyword($keywords, $removeDuplicatedWords = true) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -453,6 +458,7 @@ class ArticleDetailsController extends \OxidEsales\Eshop\Application\Controller\
      * Returns active product id to load its seo meta info
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getSeoObjectId" in next major
      */
     protected function _getSeoObjectId() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -503,6 +509,7 @@ class ArticleDetailsController extends \OxidEsales\Eshop\Application\Controller\
 
     /**
      * Runs additional checks for article.
+     * @deprecated underscore prefix violates PSR12, will be renamed to "additionalChecksForArticle" in next major
      */
     protected function _additionalChecksForArticle() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -765,6 +772,7 @@ class ArticleDetailsController extends \OxidEsales\Eshop\Application\Controller\
      * @param int $languageId language id
      *
      * @return \OxidEsales\Eshop\Application\Model\Article
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getSubject" in next major
      */
     protected function _getSubject($languageId) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -1252,6 +1260,7 @@ class ArticleDetailsController extends \OxidEsales\Eshop\Application\Controller\
      * Vendor bread crumb
      *
      * @return array
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getVendorBreadCrumb" in next major
      */
     protected function _getVendorBreadCrumb() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -1297,6 +1306,7 @@ class ArticleDetailsController extends \OxidEsales\Eshop\Application\Controller\
      * Search bread crumb
      *
      * @return array
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getSearchBreadCrumb" in next major
      */
     protected function _getSearchBreadCrumb() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -1321,6 +1331,7 @@ class ArticleDetailsController extends \OxidEsales\Eshop\Application\Controller\
      * Category bread crumb
      *
      * @return array
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getCategoryBreadCrumb" in next major
      */
     protected function _getCategoryBreadCrumb() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {

--- a/source/Application/Controller/ArticleListController.php
+++ b/source/Application/Controller/ArticleListController.php
@@ -237,6 +237,7 @@ class ArticleListController extends \OxidEsales\Eshop\Application\Controller\Fro
      * - redirecting to first page in case requested page does not exist
      * or
      * - displays 404 error if category has no products
+     * @deprecated underscore prefix violates PSR12, will be renamed to "checkRequestedPage" in next major
      */
     protected function _checkRequestedPage() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -256,6 +257,7 @@ class ArticleListController extends \OxidEsales\Eshop\Application\Controller\Fro
     /**
      * Iterates through list articles and performs list view specific tasks:
      *  - sets type of link which needs to be generated (Manufacturer link)
+     * @deprecated underscore prefix violates PSR12, will be renamed to "processListArticles" in next major
      */
     protected function _processListArticles() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -313,6 +315,7 @@ class ArticleListController extends \OxidEsales\Eshop\Application\Controller\Fro
      *  - OXARTICLE_LINKTYPE_CATEGORY - when active category is regular category
      *
      * @return int
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getProductLinkType" in next major
      */
     protected function _getProductLinkType() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -365,6 +368,7 @@ class ArticleListController extends \OxidEsales\Eshop\Application\Controller\Fro
      * @param Category $category category object
      *
      * @return oxArticleList
+     * @deprecated underscore prefix violates PSR12, will be renamed to "loadArticles" in next major
      */
     protected function _loadArticles($category) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -417,6 +421,7 @@ class ArticleListController extends \OxidEsales\Eshop\Application\Controller\Fro
      * soon product list loading is refactored
      *
      * @return int
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getRequestPageNr" in next major
      */
     protected function _getRequestPageNr() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -427,6 +432,7 @@ class ArticleListController extends \OxidEsales\Eshop\Application\Controller\Fro
      * Get list display type
      *
      * @return null|string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getListDisplayType" in next major
      */
     protected function _getListDisplayType() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -443,6 +449,7 @@ class ArticleListController extends \OxidEsales\Eshop\Application\Controller\Fro
      * Returns active product id to load its seo meta info
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getSeoObjectId" in next major
      */
     protected function _getSeoObjectId() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -455,6 +462,7 @@ class ArticleListController extends \OxidEsales\Eshop\Application\Controller\Fro
      * Returns string built from category titles
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getCatPathString" in next major
      */
     protected function _getCatPathString() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -486,6 +494,7 @@ class ArticleListController extends \OxidEsales\Eshop\Application\Controller\Fro
      * @param bool   $descriptionTag If true - performs additional duplicate cleaning.
      *
      * @return  string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "prepareMetaDescription" in next major
      */
     protected function _prepareMetaDescription($meta, $length = 1024, $descriptionTag = false) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -545,6 +554,7 @@ class ArticleListController extends \OxidEsales\Eshop\Application\Controller\Fro
      * @param bool   $descriptionTag If true - performs additional duplicate cleaning
      *
      * @return  string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "collectMetaDescription" in next major
      */
     protected function _collectMetaDescription($meta, $length = 1024, $descriptionTag = false) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -583,6 +593,7 @@ class ArticleListController extends \OxidEsales\Eshop\Application\Controller\Fro
      * @param bool   $removeDuplicatedWords Remove duplicated words
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "prepareMetaKeyword" in next major
      */
     protected function _prepareMetaKeyword($keywords, $removeDuplicatedWords = true) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -620,6 +631,7 @@ class ArticleListController extends \OxidEsales\Eshop\Application\Controller\Fro
      * @param string $keywords category path
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "collectMetaKeyword" in next major
      */
     protected function _collectMetaKeyword($keywords) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -690,6 +702,7 @@ class ArticleListController extends \OxidEsales\Eshop\Application\Controller\Fro
      * @param int    $languageId  Requested language
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "addPageNrParam" in next major
      */
     protected function _addPageNrParam($url, $currentPage, $languageId = null) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -709,6 +722,7 @@ class ArticleListController extends \OxidEsales\Eshop\Application\Controller\Fro
      * Returns true if we have category
      *
      * @return bool
+     * @deprecated underscore prefix violates PSR12, will be renamed to "isActCategory" in next major
      */
     protected function _isActCategory() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -783,6 +797,7 @@ class ArticleListController extends \OxidEsales\Eshop\Application\Controller\Fro
      * @param int $languageId Language id
      *
      * @return object
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getSubject" in next major
      */
     protected function _getSubject($languageId) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {

--- a/source/Application/Controller/BasketController.php
+++ b/source/Application/Controller/BasketController.php
@@ -401,6 +401,7 @@ class BasketController extends \OxidEsales\Eshop\Application\Controller\Frontend
      *
      * @param \OxidEsales\Eshop\Application\Model\Basket $oBasket
      * @param array                                      $aWrapping
+     * @deprecated underscore prefix violates PSR12, will be renamed to "setWrappingInfo" in next major
      */
     protected function _setWrappingInfo($oBasket, $aWrapping) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {

--- a/source/Application/Controller/ClearCookiesController.php
+++ b/source/Application/Controller/ClearCookiesController.php
@@ -40,6 +40,7 @@ class ClearCookiesController extends \OxidEsales\Eshop\Application\Controller\Fr
 
     /**
      * Clears all cookies
+     * @deprecated underscore prefix violates PSR12, will be renamed to "removeCookies" in next major
      */
     protected function _removeCookies() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {

--- a/source/Application/Controller/CompareController.php
+++ b/source/Application/Controller/CompareController.php
@@ -243,6 +243,7 @@ class CompareController extends \OxidEsales\Eshop\Application\Controller\Fronten
      *  $_iArticlesPerPage setter
      *
      * @param int $iNumber article count in compare page
+     * @deprecated underscore prefix violates PSR12, will be renamed to "setArticlesPerPage" in next major
      */
     protected function _setArticlesPerPage($iNumber) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -351,6 +352,7 @@ class CompareController extends \OxidEsales\Eshop\Application\Controller\Fronten
      * @param object $oList  article list array
      *
      * @return array $aNewItems
+     * @deprecated underscore prefix violates PSR12, will be renamed to "removeArticlesFromPage" in next major
      */
     protected function _removeArticlesFromPage($aItems, $oList) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -379,6 +381,7 @@ class CompareController extends \OxidEsales\Eshop\Application\Controller\Fronten
      * @param object $oList  article list array
      *
      * @return array $oNewList
+     * @deprecated underscore prefix violates PSR12, will be renamed to "changeArtListOrder" in next major
      */
     protected function _changeArtListOrder($aItems, $oList) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {

--- a/source/Application/Controller/ContentController.php
+++ b/source/Application/Controller/ContentController.php
@@ -165,6 +165,7 @@ class ContentController extends \OxidEsales\Eshop\Application\Controller\Fronten
      * @param string $sContentIdent ident of content to display
      *
      * @return bool
+     * @deprecated underscore prefix violates PSR12, will be renamed to "canShowContent" in next major
      */
     protected function _canShowContent($sContentIdent) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -183,6 +184,7 @@ class ContentController extends \OxidEsales\Eshop\Application\Controller\Fronten
      * @param bool   $blDescTag if true - performs additional duplicate cleaning
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "prepareMetaDescription" in next major
      */
     protected function _prepareMetaDescription($sMeta, $iLength = 200, $blDescTag = false) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -201,6 +203,7 @@ class ContentController extends \OxidEsales\Eshop\Application\Controller\Fronten
      * @param bool   $blRemoveDuplicatedWords remove duplicated words
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "prepareMetaKeyword" in next major
      */
     protected function _prepareMetaKeyword($sKeywords, $blRemoveDuplicatedWords = true) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -255,6 +258,7 @@ class ContentController extends \OxidEsales\Eshop\Application\Controller\Fronten
      * Returns active content id to load its seo meta info
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getSeoObjectId" in next major
      */
     protected function _getSeoObjectId() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -318,6 +322,7 @@ class ContentController extends \OxidEsales\Eshop\Application\Controller\Fronten
      * @param int $iLang language id
      *
      * @return object
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getSubject" in next major
      */
     protected function _getSubject($iLang) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -328,6 +333,7 @@ class ContentController extends \OxidEsales\Eshop\Application\Controller\Fronten
      * Returns name of template
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getTplName" in next major
      */
     protected function _getTplName() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {

--- a/source/Application/Controller/CreditsController.php
+++ b/source/Application/Controller/CreditsController.php
@@ -23,6 +23,7 @@ class CreditsController extends \OxidEsales\Eshop\Application\Controller\Content
      * Returns active content id to load its seo meta info
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getSeoObjectId" in next major
      */
     protected function _getSeoObjectId() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {

--- a/source/Application/Controller/ExceptionErrorController.php
+++ b/source/Application/Controller/ExceptionErrorController.php
@@ -46,6 +46,7 @@ class ExceptionErrorController extends \OxidEsales\Eshop\Application\Controller\
      * return page errors array
      *
      * @return array
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getErrors" in next major
      */
     protected function _getErrors() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {

--- a/source/Application/Controller/FrontendController.php
+++ b/source/Application/Controller/FrontendController.php
@@ -459,6 +459,7 @@ class FrontendController extends \OxidEsales\Eshop\Core\Controller\BaseControlle
      * so aUserComponentNames was added to config.inc.php file.
      *
      * @return array
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getComponentNames" in next major
      */
     protected function _getComponentNames() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -485,6 +486,7 @@ class FrontendController extends \OxidEsales\Eshop\Core\Controller\BaseControlle
      * If NOT, then tries to load alternative SEO url and if url is available -
      * redirects to it. If no alternative path was found - 404 header is emitted
      * and page is rendered
+     * @deprecated underscore prefix violates PSR12, will be renamed to "processRequest" in next major
      */
     protected function _processRequest() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -1025,6 +1027,7 @@ class FrontendController extends \OxidEsales\Eshop\Core\Controller\BaseControlle
      * @param string $dataType data type "oxkeywords" or "oxdescription"
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getMetaFromSeo" in next major
      */
     protected function _getMetaFromSeo($dataType) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -1046,6 +1049,7 @@ class FrontendController extends \OxidEsales\Eshop\Core\Controller\BaseControlle
      * @param string $metaIdent meta content ident
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getMetaFromContent" in next major
      */
     protected function _getMetaFromContent($metaIdent) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -1143,6 +1147,7 @@ class FrontendController extends \OxidEsales\Eshop\Core\Controller\BaseControlle
 
     /**
      * Forces output no index meta data for current view
+     * @deprecated underscore prefix violates PSR12, will be renamed to "forceNoIndex" in next major
      */
     protected function _forceNoIndex() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -1197,6 +1202,7 @@ class FrontendController extends \OxidEsales\Eshop\Core\Controller\BaseControlle
 
     /**
      * Sets number of articles per page to config value
+     * @deprecated underscore prefix violates PSR12, will be renamed to "setNrOfArtPerPage" in next major
      */
     protected function _setNrOfArtPerPage() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -1252,6 +1258,7 @@ class FrontendController extends \OxidEsales\Eshop\Core\Controller\BaseControlle
 
     /**
      * Override this function to return object it which is used to identify its seo meta info
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getSeoObjectId" in next major
      */
     protected function _getSeoObjectId() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -1265,6 +1272,7 @@ class FrontendController extends \OxidEsales\Eshop\Core\Controller\BaseControlle
      * @param bool   $removeDuplicatedWords If true - performs additional duplicate cleaning
      *
      * @return  string  $string    converted string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "prepareMetaDescription" in next major
      */
     protected function _prepareMetaDescription($meta, $length = 1024, $removeDuplicatedWords = false) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -1311,6 +1319,7 @@ class FrontendController extends \OxidEsales\Eshop\Core\Controller\BaseControlle
      * @param bool   $removeDuplicatedWords If true - performs additional duplicate cleaning
      *
      * @return string of keywords separated by comma
+     * @deprecated underscore prefix violates PSR12, will be renamed to "prepareMetaKeyword" in next major
      */
     protected function _prepareMetaKeyword($keywords, $removeDuplicatedWords = true) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -1330,6 +1339,7 @@ class FrontendController extends \OxidEsales\Eshop\Core\Controller\BaseControlle
      * @param array $skipTags in admin defined strings
      *
      * @return string of words separated by comma
+     * @deprecated underscore prefix violates PSR12, will be renamed to "removeDuplicatedWords" in next major
      */
     protected function _removeDuplicatedWords($input, $skipTags = []) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -1509,6 +1519,7 @@ class FrontendController extends \OxidEsales\Eshop\Core\Controller\BaseControlle
      * @param int $languageId language id
      *
      * @return object
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getSubject" in next major
      */
     protected function _getSubject($languageId) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -1631,6 +1642,7 @@ class FrontendController extends \OxidEsales\Eshop\Core\Controller\BaseControlle
      * @param bool $addPageNumber if TRUE - page number will be added
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getRequestParams" in next major
      */
     protected function _getRequestParams($addPageNumber = true) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -1720,6 +1732,7 @@ class FrontendController extends \OxidEsales\Eshop\Core\Controller\BaseControlle
      * collects _GET parameters used by eShop SEO and returns uri
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getSeoRequestParams" in next major
      */
     protected function _getSeoRequestParams() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -1989,6 +2002,7 @@ class FrontendController extends \OxidEsales\Eshop\Core\Controller\BaseControlle
      * @param int    $languageId Language id
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "addPageNrParam" in next major
      */
     protected function _addPageNrParam($url, $page, $languageId = null) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -2409,6 +2423,7 @@ class FrontendController extends \OxidEsales\Eshop\Core\Controller\BaseControlle
      * Checks if current request parameters does not block SEO redirection process
      *
      * @return bool
+     * @deprecated underscore prefix violates PSR12, will be renamed to "canRedirect" in next major
      */
     protected function _canRedirect() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {

--- a/source/Application/Controller/ManufacturerListController.php
+++ b/source/Application/Controller/ManufacturerListController.php
@@ -122,6 +122,7 @@ class ManufacturerListController extends \OxidEsales\Eshop\Application\Controlle
      * Returns product link type (OXARTICLE_LINKTYPE_MANUFACTURER)
      *
      * @return int
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getProductLinkType" in next major
      */
     protected function _getProductLinkType() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -134,6 +135,7 @@ class ManufacturerListController extends \OxidEsales\Eshop\Application\Controlle
      * @param \OxidEsales\Eshop\Application\Model\Manufacturer $oManufacturer Manufacturer object
      *
      * @return array
+     * @deprecated underscore prefix violates PSR12, will be renamed to "loadArticles" in next major
      */
     protected function _loadArticles($oManufacturer) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -160,6 +162,7 @@ class ManufacturerListController extends \OxidEsales\Eshop\Application\Controlle
      * Returns active product id to load its seo meta info
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getSeoObjectId" in next major
      */
     protected function _getSeoObjectId() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -177,6 +180,7 @@ class ManufacturerListController extends \OxidEsales\Eshop\Application\Controlle
      * @param int    $iLang active language id
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "addPageNrParam" in next major
      */
     protected function _addPageNrParam($sUrl, $iPage, $iLang = null) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -349,6 +353,7 @@ class ManufacturerListController extends \OxidEsales\Eshop\Application\Controlle
      * @param bool  $blRemoveDuplicatedWords remove duplicated words
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "prepareMetaKeyword" in next major
      */
     protected function _prepareMetaKeyword($aCatPath, $blRemoveDuplicatedWords = true) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -366,6 +371,7 @@ class ManufacturerListController extends \OxidEsales\Eshop\Application\Controlle
      * @param bool  $blDescTag if true - performs additional duplicate cleaning
      *
      * @return  string  $sString    converted string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "prepareMetaDescription" in next major
      */
     protected function _prepareMetaDescription($aCatPath, $iLength = 1024, $blDescTag = false) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -379,6 +385,7 @@ class ManufacturerListController extends \OxidEsales\Eshop\Application\Controlle
      * @param int $iLang language id
      *
      * @return object
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getSubject" in next major
      */
     protected function _getSubject($iLang) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {

--- a/source/Application/Controller/OrderController.php
+++ b/source/Application/Controller/OrderController.php
@@ -496,6 +496,7 @@ class OrderController extends \OxidEsales\Eshop\Application\Controller\FrontendC
      * @param integer $iSuccess status code
      *
      * @return  string  $sNextStep  partial parameter url for next step
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getNextStep" in next major
      */
     protected function _getNextStep($iSuccess) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -540,6 +541,7 @@ class OrderController extends \OxidEsales\Eshop\Application\Controller\FrontendC
      * Validates whether necessary terms and conditions checkboxes were checked.
      *
      * @return bool
+     * @deprecated underscore prefix violates PSR12, will be renamed to "validateTermsAndConditions" in next major
      */
     protected function _validateTermsAndConditions() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {

--- a/source/Application/Controller/OxidStartController.php
+++ b/source/Application/Controller/OxidStartController.php
@@ -105,6 +105,7 @@ class OxidStartController extends \OxidEsales\Eshop\Application\Controller\Front
      * Gets system event handler.
      *
      * @return SystemEventHandler
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getSystemEventHandler" in next major
      */
     protected function _getSystemEventHandler() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {

--- a/source/Application/Controller/PaymentController.php
+++ b/source/Application/Controller/PaymentController.php
@@ -208,6 +208,7 @@ class PaymentController extends \OxidEsales\Eshop\Application\Controller\Fronten
      * Set default empty payment. If config param 'blOtherCountryOrder' is on,
      * tries to set 'oxempty' payment to aViewData['oxemptypayment'].
      * On error sets aViewData['payerror'] to -2
+     * @deprecated underscore prefix violates PSR12, will be renamed to "setDefaultEmptyPayment" in next major
      */
     protected function _setDefaultEmptyPayment() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -227,6 +228,7 @@ class PaymentController extends \OxidEsales\Eshop\Application\Controller\Fronten
 
     /**
      * Unsets payment errors from session
+     * @deprecated underscore prefix violates PSR12, will be renamed to "unsetPaymentErrors" in next major
      */
     protected function _unsetPaymentErrors() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -418,6 +420,7 @@ class PaymentController extends \OxidEsales\Eshop\Application\Controller\Fronten
      *
      * @param array                                      $aPaymentList payments array
      * @param \OxidEsales\Eshop\Application\Model\Basket $oBasket      basket object
+     * @deprecated underscore prefix violates PSR12, will be renamed to "setValues" in next major
      */
     protected function _setValues(&$aPaymentList, $oBasket = null) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -515,6 +518,7 @@ class PaymentController extends \OxidEsales\Eshop\Application\Controller\Fronten
     /**
      * Assign debit note payment values to view data. Loads user debit note payment
      * if available and assigns payment data to $this->_aDynValue
+     * @deprecated underscore prefix violates PSR12, will be renamed to "assignDebitNoteParams" in next major
      */
     protected function _assignDebitNoteParams() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -623,6 +627,7 @@ class PaymentController extends \OxidEsales\Eshop\Application\Controller\Fronten
      * @param array $aKeys array of array indexes
      *
      * @return bool
+     * @deprecated underscore prefix violates PSR12, will be renamed to "checkArrValuesEmpty" in next major
      */
     protected function _checkArrValuesEmpty($aData, $aKeys) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {

--- a/source/Application/Controller/PriceAlarmController.php
+++ b/source/Application/Controller/PriceAlarmController.php
@@ -134,6 +134,7 @@ class PriceAlarmController extends \OxidEsales\Eshop\Application\Controller\Fron
      * Returns params (article id, bid price)
      *
      * @return array
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getParams" in next major
      */
     private function _getParams() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {

--- a/source/Application/Controller/RecommListController.php
+++ b/source/Application/Controller/RecommListController.php
@@ -153,6 +153,7 @@ class RecommListController extends \OxidEsales\Eshop\Application\Controller\Arti
      * Returns product link type (OXARTICLE_LINKTYPE_RECOMM)
      *
      * @return int
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getProductLinkType" in next major
      */
     protected function _getProductLinkType() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -486,6 +487,7 @@ class RecommListController extends \OxidEsales\Eshop\Application\Controller\Arti
      * @param int    $iLang requested language
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "addPageNrParam" in next major
      */
     protected function _addPageNrParam($sUrl, $iPage, $iLang = null) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {

--- a/source/Application/Controller/ReviewController.php
+++ b/source/Application/Controller/ReviewController.php
@@ -278,6 +278,7 @@ class ReviewController extends \OxidEsales\Eshop\Application\Controller\ArticleD
      * Template variable getter. Returns active object (oxarticle or oxrecommlist)
      *
      * @return object
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getActiveObject" in next major
      */
     protected function _getActiveObject() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -300,6 +301,7 @@ class ReviewController extends \OxidEsales\Eshop\Application\Controller\ArticleD
      * Template variable getter. Returns active type (oxarticle or oxrecommlist)
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getActiveType" in next major
      */
     protected function _getActiveType() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {

--- a/source/Application/Controller/RssController.php
+++ b/source/Application/Controller/RssController.php
@@ -48,6 +48,7 @@ class RssController extends \OxidEsales\Eshop\Application\Controller\FrontendCon
      * get RssFeed
      *
      * @return RssFeed
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getRssFeed" in next major
      */
     protected function _getRssFeed() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -105,6 +106,7 @@ class RssController extends \OxidEsales\Eshop\Application\Controller\FrontendCon
      * @param string $sInput input to process
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "processOutput" in next major
      */
     protected function _processOutput($sInput) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {

--- a/source/Application/Controller/SearchController.php
+++ b/source/Application/Controller/SearchController.php
@@ -236,6 +236,7 @@ class SearchController extends \OxidEsales\Eshop\Application\Controller\Frontend
     /**
      * Iterates through list articles and performs list view specific tasks:
      *  - sets type of link which needs to be generated (Manufacturer link)
+     * @deprecated underscore prefix violates PSR12, will be renamed to "processListArticles" in next major
      */
     protected function _processListArticles() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -287,6 +288,7 @@ class SearchController extends \OxidEsales\Eshop\Application\Controller\Frontend
      * Template variable getter. Returns similar recommendation lists
      *
      * @return object
+     * @deprecated underscore prefix violates PSR12, will be renamed to "isSearchClass" in next major
      */
     protected function _isSearchClass() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -487,6 +489,7 @@ class SearchController extends \OxidEsales\Eshop\Application\Controller\Frontend
      * Checks if current request parameters does not block SEO redirection process
      *
      * @return bool
+     * @deprecated underscore prefix violates PSR12, will be renamed to "canRedirect" in next major
      */
     protected function _canRedirect() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {

--- a/source/Application/Controller/StartController.php
+++ b/source/Application/Controller/StartController.php
@@ -141,6 +141,7 @@ class StartController extends \OxidEsales\Eshop\Application\Controller\FrontendC
      * @param bool   $blDescTag if true - performs additional duplicate cleaning
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "prepareMetaDescription" in next major
      */
     protected function _prepareMetaDescription($sMeta, $iLength = 1024, $blDescTag = false) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -165,6 +166,7 @@ class StartController extends \OxidEsales\Eshop\Application\Controller\FrontendC
      * @param bool   $blRemoveDuplicatedWords remove duplicated words
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "prepareMetaKeyword" in next major
      */
     protected function _prepareMetaKeyword($sKeywords, $blRemoveDuplicatedWords = true) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -184,6 +186,7 @@ class StartController extends \OxidEsales\Eshop\Application\Controller\FrontendC
      * Template variable getter. Returns if actions are ON
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getLoadActionsParam" in next major
      */
     protected function _getLoadActionsParam() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {

--- a/source/Application/Controller/VendorListController.php
+++ b/source/Application/Controller/VendorListController.php
@@ -119,6 +119,7 @@ class VendorListController extends \OxidEsales\Eshop\Application\Controller\Arti
      * Returns product link type (OXARTICLE_LINKTYPE_VENDOR)
      *
      * @return int
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getProductLinkType" in next major
      */
     protected function _getProductLinkType() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -131,6 +132,7 @@ class VendorListController extends \OxidEsales\Eshop\Application\Controller\Arti
      * @param object $oVendor vendor object
      *
      * @return array
+     * @deprecated underscore prefix violates PSR12, will be renamed to "loadArticles" in next major
      */
     protected function _loadArticles($oVendor) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -157,6 +159,7 @@ class VendorListController extends \OxidEsales\Eshop\Application\Controller\Arti
      * Returns active product id to load its seo meta info
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getSeoObjectId" in next major
      */
     protected function _getSeoObjectId() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -174,6 +177,7 @@ class VendorListController extends \OxidEsales\Eshop\Application\Controller\Arti
      * @param int    $iLang active language id
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "addPageNrParam" in next major
      */
     protected function _addPageNrParam($sUrl, $iPage, $iLang = null) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -295,6 +299,7 @@ class VendorListController extends \OxidEsales\Eshop\Application\Controller\Arti
      * Returns request parameter of vendor id.
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getVendorId" in next major
      */
     protected function _getVendorId() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -357,6 +362,7 @@ class VendorListController extends \OxidEsales\Eshop\Application\Controller\Arti
      * @param bool   $blRemoveDuplicatedWords remove duplicated words
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "prepareMetaKeyword" in next major
      */
     protected function _prepareMetaKeyword($sKeywords, $blRemoveDuplicatedWords = true) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -372,6 +378,7 @@ class VendorListController extends \OxidEsales\Eshop\Application\Controller\Arti
      * @param bool   $blDescTag if true - performs additional duplicate cleaning
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "prepareMetaDescription" in next major
      */
     protected function _prepareMetaDescription($sMeta, $iLength = 1024, $blDescTag = false) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -385,6 +392,7 @@ class VendorListController extends \OxidEsales\Eshop\Application\Controller\Arti
      * @param int $iLang language id
      *
      * @return object
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getSubject" in next major
      */
     protected function _getSubject($iLang) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {

--- a/source/Application/Model/ActionList.php
+++ b/source/Application/Model/ActionList.php
@@ -111,6 +111,7 @@ class ActionList extends \OxidEsales\Eshop\Core\Model\ListModel
      * @param \OxidEsales\Eshop\Application\Model\User $oUser user object
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getUserGroupFilter" in next major
      */
     protected function _getUserGroupFilter($oUser = null) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {

--- a/source/Application/Model/Address.php
+++ b/source/Application/Model/Address.php
@@ -35,6 +35,7 @@ class Address extends \OxidEsales\Eshop\Core\Model\BaseModel
      * Returns oxState object
      *
      * @return oxState
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getStateObject" in next major
      */
     protected function _getStateObject() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -148,6 +149,7 @@ class Address extends \OxidEsales\Eshop\Core\Model\BaseModel
      * Returns merged address fields.
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getMergedAddressFields" in next major
      */
     protected function _getMergedAddressFields() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {

--- a/source/Application/Model/AmountPriceList.php
+++ b/source/Application/Model/AmountPriceList.php
@@ -76,6 +76,7 @@ class AmountPriceList extends \OxidEsales\Eshop\Core\Model\ListModel
      * Get data from db
      *
      * @return array
+     * @deprecated underscore prefix violates PSR12, will be renamed to "loadFromDb" in next major
      */
     protected function _loadFromDb() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {

--- a/source/Application/Model/Article.php
+++ b/source/Application/Model/Article.php
@@ -712,6 +712,7 @@ class Article extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
      * @param bool $forceCoreTable forces core table usage (optional)
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "createSqlActiveSnippet" in next major
      */
     protected function _createSqlActiveSnippet($forceCoreTable) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -971,6 +972,7 @@ class Article extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
      * Calculates lowest price of available article variants.
      *
      * @return double
+     * @deprecated underscore prefix violates PSR12, will be renamed to "calculateVarMinPrice" in next major
      */
     protected function _calculateVarMinPrice() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -1009,6 +1011,7 @@ class Article extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
      * @param double $dPrice
      *
      * @return double
+     * @deprecated underscore prefix violates PSR12, will be renamed to "prepareModifiedPrice" in next major
      */
     protected function _prepareModifiedPrice($dPrice) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -1137,6 +1140,7 @@ class Article extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
 
     /**
      * @param \OxidEsales\Eshop\Application\Model\Article $article
+     * @deprecated underscore prefix violates PSR12, will be renamed to "setShopValues" in next major
      */
     protected function _setShopValues($article) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -1180,6 +1184,7 @@ class Article extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
      * @param string $articleId
      *
      * @return array
+     * @deprecated underscore prefix violates PSR12, will be renamed to "loadData" in next major
      */
     protected function _loadData($articleId) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -1819,6 +1824,7 @@ class Article extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
 
     /**
      * @return oxi18n
+     * @deprecated underscore prefix violates PSR12, will be renamed to "createMultilanguageVendorObject" in next major
      */
     protected function _createMultilanguageVendorObject() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -2061,6 +2067,7 @@ class Article extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
      * @param int $amount
      *
      * @return double
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getModifiedAmountPrice" in next major
      */
     protected function _getModifiedAmountPrice($amount) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -3558,7 +3565,8 @@ class Article extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
      * @param bool      $blRemoveNotOrderables if true, removes from list not orderable articles, which are out of stock [optional]
      * @param bool|null $forceCoreTableUsage   if true forces core table use, default is false [optional]
      *
-     * @return array | oxsimplevariantlist | oxarticlelist
+     * @return array|oxsimplevariantlist|oxarticlelist
+     * @deprecated underscore prefix violates PSR12, will be renamed to "loadVariantList" in next major
      */
     protected function _loadVariantList($loadSimpleVariants, $blRemoveNotOrderables = true, $forceCoreTableUsage = null) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -3642,6 +3650,7 @@ class Article extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
      * @param string $field category ID field name
      *
      * @return array
+     * @deprecated underscore prefix violates PSR12, will be renamed to "selectCategoryIds" in next major
      */
     protected function _selectCategoryIds($query, $field) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -3664,6 +3673,7 @@ class Article extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
      * @param bool $blActCats select categories if all parents are active
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getCategoryIdsSelect" in next major
      */
     protected function _getCategoryIdsSelect($blActCats = false) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -3690,6 +3700,7 @@ class Article extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
      * Returns active category select snippet
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getActiveCategorySelectSnippet" in next major
      */
     protected function _getActiveCategorySelectSnippet() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -3705,6 +3716,7 @@ class Article extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
      * @param double                       $dVat   vat value, optional, if passed, bypasses "bl_perfCalcVatOnlyForBasketOrder" config value
      *
      * @return \OxidEsales\Eshop\Core\Price
+     * @deprecated underscore prefix violates PSR12, will be renamed to "calculatePrice" in next major
      */
     protected function _calculatePrice($oPrice, $dVat = null) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -3736,6 +3748,7 @@ class Article extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
      * @param bool $blForceCoreTable force core table usage
      *
      * @return bool
+     * @deprecated underscore prefix violates PSR12, will be renamed to "hasAnyVariant" in next major
      */
     protected function _hasAnyVariant($blForceCoreTable = null) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -3758,6 +3771,7 @@ class Article extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
      * Check if stock status has changed since loading the article
      *
      * @return bool
+     * @deprecated underscore prefix violates PSR12, will be renamed to "isStockStatusChanged" in next major
      */
     protected function _isStockStatusChanged() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -3768,6 +3782,7 @@ class Article extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
      * Check if visibility has changed since loading the article
      *
      * @return bool
+     * @deprecated underscore prefix violates PSR12, will be renamed to "isVisibilityChanged" in next major
      */
     protected function _isVisibilityChanged() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -3778,6 +3793,7 @@ class Article extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
      * inserts article long description to artextends table
      *
      * @return null
+     * @deprecated underscore prefix violates PSR12, will be renamed to "saveArtLongDesc" in next major
      */
     protected function _saveArtLongDesc() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -3830,6 +3846,7 @@ class Article extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
 
     /**
      * Removes object data fields (oxarticles__oxtimestamp, oxarticles__oxparentid, oxarticles__oxinsert).
+     * @deprecated underscore prefix violates PSR12, will be renamed to "skipSaveFields" in next major
      */
     protected function _skipSaveFields() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -3853,6 +3870,7 @@ class Article extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
      * @param array $aItemDiscounts Discount array
      *
      * @return array $aDiscounts
+     * @deprecated underscore prefix violates PSR12, will be renamed to "mergeDiscounts" in next major
      */
     protected function _mergeDiscounts($aDiscounts, $aItemDiscounts) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -3872,6 +3890,7 @@ class Article extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
      * get user Group A, B or C price, returns db price if user is not in groups
      *
      * @return double
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getGroupPrice" in next major
      */
     protected function _getGroupPrice() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -3894,6 +3913,7 @@ class Article extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
      * @param int $amount Basket amount
      *
      * @return double
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getAmountPrice" in next major
      */
     protected function _getAmountPrice($amount = 1) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -3923,6 +3943,7 @@ class Article extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
      * @param array  $aChosenList Selection list array
      *
      * @return double
+     * @deprecated underscore prefix violates PSR12, will be renamed to "modifySelectListPrice" in next major
      */
     protected function _modifySelectListPrice($dPrice, $aChosenList = null) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -3952,6 +3973,7 @@ class Article extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
      * @param array $aAmPriceList Amount price list
      *
      * @return array
+     * @deprecated underscore prefix violates PSR12, will be renamed to "fillAmountPriceList" in next major
      */
     protected function _fillAmountPriceList($aAmPriceList) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -4040,6 +4062,7 @@ class Article extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
      *
      * @param \OxidEsales\Eshop\Core\Price $oPrice Price object
      * @param double                       $dVat   VAT percent
+     * @deprecated underscore prefix violates PSR12, will be renamed to "applyVAT" in next major
      */
     protected function _applyVAT(\OxidEsales\Eshop\Core\Price $oPrice, $dVat) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -4058,6 +4081,7 @@ class Article extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
      *
      * @param \OxidEsales\Eshop\Core\Price $oPrice Price object
      * @param object                       $oCur   Currency object
+     * @deprecated underscore prefix violates PSR12, will be renamed to "applyCurrency" in next major
      */
     protected function _applyCurrency(\OxidEsales\Eshop\Core\Price $oPrice, $oCur = null) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -4073,6 +4097,7 @@ class Article extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
      *
      * @param string $sAttributeSql Attribute selection snippet
      * @param int    $iCnt          The number of selected attributes
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getAttribsString" in next major
      */
     protected function _getAttribsString(&$sAttributeSql, &$iCnt) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -4102,6 +4127,7 @@ class Article extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
      * @param int    $iCnt          Similar list article count
      *
      * @return array
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getSimList" in next major
      */
     protected function _getSimList($sAttributeSql, $iCnt) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -4138,6 +4164,7 @@ class Article extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
      * @param array  $aList         A list of original articles
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "generateSimListSearchStr" in next major
      */
     protected function _generateSimListSearchStr($sArticleTable, $aList) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -4161,6 +4188,7 @@ class Article extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
      * @param bool   $blSearchPriceCat Whether to perform the search within price categories
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "generateSearchStr" in next major
      */
     protected function _generateSearchStr($sOXID, $blSearchPriceCat = false) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -4182,6 +4210,7 @@ class Article extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
      * Generates SQL select string for getCustomerAlsoBoughtThisProduct
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "generateSearchStrForCustomerBought" in next major
      */
     protected function _generateSearchStrForCustomerBought() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -4245,6 +4274,7 @@ class Article extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
      * @param bool   $dPriceFromTo Article price for price categories
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "generateSelectCatStr" in next major
      */
     protected function _generateSelectCatStr($sOXID, $sCatId, $dPriceFromTo = false) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -4322,6 +4352,7 @@ class Article extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
      * @param string $sFieldName Field name
      *
      * @return bool
+     * @deprecated underscore prefix violates PSR12, will be renamed to "isFieldEmpty" in next major
      */
     protected function _isFieldEmpty($sFieldName) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -4376,7 +4407,8 @@ class Article extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
      *
      * @param string $sFieldName field name
      *
-     * @return null;
+     * @return null ;
+     * @deprecated underscore prefix violates PSR12, will be renamed to "assignParentFieldValue" in next major
      */
     protected function _assignParentFieldValue($sFieldName) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -4415,7 +4447,8 @@ class Article extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
      *
      * @param string $sFieldName Field name
      *
-     * @return bool.
+     * @return bool .
+     * @deprecated underscore prefix violates PSR12, will be renamed to "isImageField" in next major
      */
     protected function _isImageField($sFieldName) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -4427,6 +4460,7 @@ class Article extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
 
     /**
      * Assigns parent field values to article
+     * @deprecated underscore prefix violates PSR12, will be renamed to "assignParentFieldValues" in next major
      */
     protected function _assignParentFieldValues() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -4444,6 +4478,7 @@ class Article extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
 
     /**
      * if we have variants then depending on config option the parent may be non buyable
+     * @deprecated underscore prefix violates PSR12, will be renamed to "assignNotBuyableParent" in next major
      */
     protected function _assignNotBuyableParent() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -4457,6 +4492,7 @@ class Article extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
 
     /**
      * Assigns stock status to article
+     * @deprecated underscore prefix violates PSR12, will be renamed to "assignStock" in next major
      */
     protected function _assignStock() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -4542,6 +4578,7 @@ class Article extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
 
     /**
      * assigns dynimagedir to article
+     * @deprecated underscore prefix violates PSR12, will be renamed to "assignDynImageDir" in next major
      */
     protected function _assignDynImageDir() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -4557,6 +4594,7 @@ class Article extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
 
     /**
      * Adds a flag if article is on comparisonlist.
+     * @deprecated underscore prefix violates PSR12, will be renamed to "assignComparisonListFlag" in next major
      */
     protected function _assignComparisonListFlag() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -4574,6 +4612,7 @@ class Article extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
      * parent::_insert() and returns insertion status.
      *
      * @return bool
+     * @deprecated underscore prefix violates PSR12, will be renamed to "insert" in next major
      */
     protected function _insert() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -4591,6 +4630,7 @@ class Article extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
      * Executes \OxidEsales\Eshop\Application\Model\Article::_skipSaveFields() and updates article information
      *
      * @return bool
+     * @deprecated underscore prefix violates PSR12, will be renamed to "update" in next major
      */
     protected function _update() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -4608,6 +4648,7 @@ class Article extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
      * @param string $articleId Article ID
      *
      * @return int
+     * @deprecated underscore prefix violates PSR12, will be renamed to "deleteRecords" in next major
      */
     protected function _deleteRecords($articleId) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -4688,6 +4729,7 @@ class Article extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
      * Deletes variant records
      *
      * @param string $sOXID Article ID
+     * @deprecated underscore prefix violates PSR12, will be renamed to "deleteVariantRecords" in next major
      */
     protected function _deleteVariantRecords($sOXID) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -4711,6 +4753,7 @@ class Article extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
 
     /**
      * Delete pics
+     * @deprecated underscore prefix violates PSR12, will be renamed to "deletePics" in next major
      */
     protected function _deletePics() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -4736,6 +4779,7 @@ class Article extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
      * @param string $sOxid           object to reset id ID
      * @param string $sVendorId       Vendor ID
      * @param string $sManufacturerId Manufacturer ID
+     * @deprecated underscore prefix violates PSR12, will be renamed to "onChangeResetCounts" in next major
      */
     protected function _onChangeResetCounts($sOxid, $sVendorId = null, $sManufacturerId = null) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -4760,6 +4804,7 @@ class Article extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
      * Updates article stock. This method is supposed to be called on article change trigger.
      *
      * @param string $parentId product parent id
+     * @deprecated underscore prefix violates PSR12, will be renamed to "onChangeUpdateStock" in next major
      */
     protected function _onChangeUpdateStock($parentId) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -4807,6 +4852,7 @@ class Article extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
      * Resets article count cache when stock value is zero and article goes offline.
      *
      * @param string $sOxid product id
+     * @deprecated underscore prefix violates PSR12, will be renamed to "onChangeStockResetCount" in next major
      */
     protected function _onChangeStockResetCount($sOxid) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -4828,6 +4874,7 @@ class Article extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
      * Updates variant count. This method is supposed to be called on article change trigger.
      *
      * @param string $parentId Parent ID
+     * @deprecated underscore prefix violates PSR12, will be renamed to "onChangeUpdateVarCount" in next major
      */
     protected function _onChangeUpdateVarCount($parentId) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -4851,6 +4898,7 @@ class Article extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
      * Updates variant min price. This method is supposed to be called on article change trigger.
      *
      * @param string $sParentId Parent ID
+     * @deprecated underscore prefix violates PSR12, will be renamed to "setVarMinMaxPrice" in next major
      */
     protected function _setVarMinMaxPrice($sParentId) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -4900,6 +4948,7 @@ class Article extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
      * @param int $iIndex master picture index
      *
      * @return bool
+     * @deprecated underscore prefix violates PSR12, will be renamed to "hasMasterImage" in next major
      */
     protected function _hasMasterImage($iIndex) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -4930,6 +4979,7 @@ class Article extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
      * Checks and return true if price view mode is netto
      *
      * @return bool
+     * @deprecated underscore prefix violates PSR12, will be renamed to "isPriceViewModeNetto" in next major
      */
     protected function _isPriceViewModeNetto() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -4949,6 +4999,7 @@ class Article extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
      * @param bool $blCalculationModeNetto - if calculation mode netto - true
      *
      * @return oxPice
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getPriceObject" in next major
      */
     protected function _getPriceObject($blCalculationModeNetto = null) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -4974,6 +5025,7 @@ class Article extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
      * @param \OxidEsales\Eshop\Core\Price $oPrice price object
      *
      * @return double
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getPriceForView" in next major
      */
     protected function _getPriceForView($oPrice) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -4995,6 +5047,7 @@ class Article extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
      * @param bool   $blCalculationModeNetto - if calculation mode netto - true
      *
      * @return double
+     * @deprecated underscore prefix violates PSR12, will be renamed to "preparePrice" in next major
      */
     protected function _preparePrice($dPrice, $dVat, $blCalculationModeNetto = null) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -5019,6 +5072,7 @@ class Article extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
      * Return price suffix
      *
      * @return null
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getUserPriceSufix" in next major
      */
     protected function _getUserPriceSufix() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -5042,6 +5096,7 @@ class Article extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
      * Return prepared price
      *
      * @return null
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getPrice" in next major
      */
     protected function _getPrice() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -5063,6 +5118,7 @@ class Article extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
      * Return variant min price
      *
      * @return null
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getVarMinPrice" in next major
      */
     protected function _getVarMinPrice() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -5101,6 +5157,7 @@ class Article extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
      * Return variant max price
      *
      * @return null
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getVarMaxPrice" in next major
      */
     protected function _getVarMaxPrice() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -5140,6 +5197,7 @@ class Article extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
      * for example for subshops.
      *
      * @return double|null
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getShopVarMinPrice" in next major
      */
     protected function _getShopVarMinPrice() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -5151,6 +5209,7 @@ class Article extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
      * for example for subshops.
      *
      * @return double|null
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getShopVarMaxPrice" in next major
      */
     protected function _getShopVarMaxPrice() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -5163,6 +5222,7 @@ class Article extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
      * @param string $articleId id
      *
      * @return array
+     * @deprecated underscore prefix violates PSR12, will be renamed to "loadFromDb" in next major
      */
     protected function _loadFromDb($articleId) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -5186,6 +5246,7 @@ class Article extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
      * Set parent field value to child - variants in DB
      *
      * @return bool
+     * @deprecated underscore prefix violates PSR12, will be renamed to "updateParentDependFields" in next major
      */
     protected function _updateParentDependFields() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -5207,6 +5268,7 @@ class Article extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
      * Returns array of fields which should not changed in variants
      *
      * @return array
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getCopyParentFields" in next major
      */
     protected function _getCopyParentFields() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -5215,6 +5277,7 @@ class Article extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
 
     /**
      * Set parent field value to child - variants
+     * @deprecated underscore prefix violates PSR12, will be renamed to "assignParentDependFields" in next major
      */
     protected function _assignParentDependFields() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -5228,6 +5291,7 @@ class Article extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
 
     /**
      * Saves values of sorting fields on article load.
+     * @deprecated underscore prefix violates PSR12, will be renamed to "saveSortingFieldValuesOnLoad" in next major
      */
     protected function _saveSortingFieldValuesOnLoad() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {

--- a/source/Application/Model/ArticleList.php
+++ b/source/Application/Model/ArticleList.php
@@ -154,6 +154,7 @@ class ArticleList extends \OxidEsales\Eshop\Core\Model\ListModel
      * @see oxArticleList::sortByIds
      *
      * @return int
+     * @deprecated underscore prefix violates PSR12, will be renamed to "sortByOrderMapCallback" in next major
      */
     protected function _sortByOrderMapCallback($key1, $key2) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -832,6 +833,7 @@ class ArticleList extends \OxidEsales\Eshop\Core\Model\ListModel
      * fills the list simply with keys of the oxid and the position as value for the given sql
      *
      * @param string $sSql SQL select
+     * @deprecated underscore prefix violates PSR12, will be renamed to "createIdListFromSql" in next major
      */
     protected function _createIdListFromSql($sSql) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -852,6 +854,7 @@ class ArticleList extends \OxidEsales\Eshop\Core\Model\ListModel
      * @param array  $aFilter filters for this category
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getFilterIdsSql" in next major
      */
     protected function _getFilterIdsSql($sCatId, $aFilter) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -892,6 +895,7 @@ class ArticleList extends \OxidEsales\Eshop\Core\Model\ListModel
      * @param array  $aFilter filters for this category
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getFilterSql" in next major
      */
     protected function _getFilterSql($sCatId, $aFilter) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -926,6 +930,7 @@ class ArticleList extends \OxidEsales\Eshop\Core\Model\ListModel
      * @param array  $aSessionFilter Like array ( catid => array( attrid => value,...))
      *
      * @return string SQL
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getCategorySelect" in next major
      */
     protected function _getCategorySelect($sFields, $sCatId, $aSessionFilter) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -964,6 +969,7 @@ class ArticleList extends \OxidEsales\Eshop\Core\Model\ListModel
      * @param array  $aSessionFilter Like array ( catid => array( attrid => value,...))
      *
      * @return string SQL
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getCategoryCountSelect" in next major
      */
     protected function _getCategoryCountSelect($sCatId, $aSessionFilter) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -995,6 +1001,7 @@ class ArticleList extends \OxidEsales\Eshop\Core\Model\ListModel
      * @param string $sSearchString searching string
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getSearchSelect" in next major
      */
     protected function _getSearchSelect($sSearchString) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -1062,6 +1069,7 @@ class ArticleList extends \OxidEsales\Eshop\Core\Model\ListModel
      * @param double $dPriceTo   Max price
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getPriceSelect" in next major
      */
     protected function _getPriceSelect($dPriceFrom, $dPriceTo) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -1090,6 +1098,7 @@ class ArticleList extends \OxidEsales\Eshop\Core\Model\ListModel
      * @param string $sVendorId Vendor ID
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getVendorSelect" in next major
      */
     protected function _getVendorSelect($sVendorId) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -1113,6 +1122,7 @@ class ArticleList extends \OxidEsales\Eshop\Core\Model\ListModel
      * @param string $sManufacturerId Manufacturer ID
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getManufacturerSelect" in next major
      */
     protected function _getManufacturerSelect($sManufacturerId) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -1134,6 +1144,7 @@ class ArticleList extends \OxidEsales\Eshop\Core\Model\ListModel
      * Checks if price update can be executed - current time > next price update time
      *
      * @return bool
+     * @deprecated underscore prefix violates PSR12, will be renamed to "canUpdatePrices" in next major
      */
     protected function _canUpdatePrices() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {

--- a/source/Application/Model/Attribute.php
+++ b/source/Application/Model/Attribute.php
@@ -136,6 +136,7 @@ class Attribute extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel
      * @param string $sSelTitle selection list title
      *
      * @return mixed attribute id or false
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getAttrId" in next major
      */
     protected function _getAttrId($sSelTitle) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -153,6 +154,7 @@ class Attribute extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel
      * @param array $aSelTitle selection list title
      *
      * @return string attribute id
+     * @deprecated underscore prefix violates PSR12, will be renamed to "createAttribute" in next major
      */
     protected function _createAttribute($aSelTitle) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {

--- a/source/Application/Model/AttributeList.php
+++ b/source/Application/Model/AttributeList.php
@@ -57,6 +57,7 @@ class AttributeList extends \OxidEsales\Eshop\Core\Model\ListModel
      * @param string $sSelect SQL select
      *
      * @return array $aAttributes
+     * @deprecated underscore prefix violates PSR12, will be renamed to "createAttributeListFromSql" in next major
      */
     protected function _createAttributeListFromSql($sSelect) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -218,6 +219,7 @@ class AttributeList extends \OxidEsales\Eshop\Core\Model\ListModel
      * @param array $aParentAttributes array of parent article attributes
      *
      * @return array $aAttributes
+     * @deprecated underscore prefix violates PSR12, will be renamed to "mergeAttributes" in next major
      */
     protected function _mergeAttributes($aAttributes, $aParentAttributes) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {

--- a/source/Application/Model/Basket.php
+++ b/source/Application/Model/Basket.php
@@ -396,6 +396,7 @@ class Basket extends \OxidEsales\Eshop\Core\Base
      * @param string $sOldKey old key
      * @param string $sNewKey new key to place in old one's place
      * @param mixed  $value   (optional)
+     * @deprecated underscore prefix violates PSR12, will be renamed to "changeBasketItemKey" in next major
      */
     protected function _changeBasketItemKey($sOldKey, $sNewKey, $value = null) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -623,6 +624,7 @@ class Basket extends \OxidEsales\Eshop\Core\Base
 
     /**
      * Unsets bundled basket items from basket contents array
+     * @deprecated underscore prefix violates PSR12, will be renamed to "clearBundles" in next major
      */
     protected function _clearBundles() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -640,6 +642,7 @@ class Basket extends \OxidEsales\Eshop\Core\Base
      * @param object $oBasketItem basket item object
      *
      * @return array
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getArticleBundles" in next major
      */
     protected function _getArticleBundles($oBasketItem) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -664,6 +667,7 @@ class Basket extends \OxidEsales\Eshop\Core\Base
      * @param array  $aBundles    array of found bundles
      *
      * @return array
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getItemBundles" in next major
      */
     protected function _getItemBundles($oBasketItem, $aBundles = []) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -701,6 +705,7 @@ class Basket extends \OxidEsales\Eshop\Core\Base
      * @param array $aBundles array of found bundles
      *
      * @return array
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getBasketBundles" in next major
      */
     protected function _getBasketBundles($aBundles = []) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -730,6 +735,7 @@ class Basket extends \OxidEsales\Eshop\Core\Base
     /**
      * Iterates through basket contents and adds bundles to items + adds
      * global basket bundles
+     * @deprecated underscore prefix violates PSR12, will be renamed to "addBundles" in next major
      */
     protected function _addBundles() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -770,6 +776,7 @@ class Basket extends \OxidEsales\Eshop\Core\Base
      * Adds bundles to basket
      *
      * @param array $aBundles added bundle articles
+     * @deprecated underscore prefix violates PSR12, will be renamed to "addBundlesToBasket" in next major
      */
     protected function _addBundlesToBasket($aBundles) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -792,6 +799,7 @@ class Basket extends \OxidEsales\Eshop\Core\Base
 
     /**
      * Iterates through basket items and calculates its prices and discounts
+     * @deprecated underscore prefix violates PSR12, will be renamed to "calcItemsPrice" in next major
      */
     protected function _calcItemsPrice() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -878,6 +886,7 @@ class Basket extends \OxidEsales\Eshop\Core\Base
      * @param array $aItemDiscounts Discount array
      *
      * @return array $aDiscounts
+     * @deprecated underscore prefix violates PSR12, will be renamed to "mergeDiscounts" in next major
      */
     protected function _mergeDiscounts($aDiscounts, $aItemDiscounts) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -897,6 +906,7 @@ class Basket extends \OxidEsales\Eshop\Core\Base
      * Iterates through basket items and calculates its delivery costs
      *
      * @return \OxidEsales\Eshop\Core\Price
+     * @deprecated underscore prefix violates PSR12, will be renamed to "calcDeliveryCost" in next major
      */
     protected function _calcDeliveryCost() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -1015,6 +1025,7 @@ class Basket extends \OxidEsales\Eshop\Core\Base
     //P
     /**
      * Performs final sum calculation and rounding.
+     * @deprecated underscore prefix violates PSR12, will be renamed to "calcTotalPrice" in next major
      */
     protected function _calcTotalPrice() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -1073,6 +1084,7 @@ class Basket extends \OxidEsales\Eshop\Core\Base
 
     /**
      * Calculates voucher discount
+     * @deprecated underscore prefix violates PSR12, will be renamed to "calcVoucherDiscount" in next major
      */
     protected function _calcVoucherDiscount() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -1137,6 +1149,7 @@ class Basket extends \OxidEsales\Eshop\Core\Base
 
     /**
      * Performs netto price and VATs calculations including discounts and vouchers.
+     * @deprecated underscore prefix violates PSR12, will be renamed to "applyDiscounts" in next major
      */
     protected function _applyDiscounts() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -1182,6 +1195,7 @@ class Basket extends \OxidEsales\Eshop\Core\Base
      * Returns prepared price object depending on view mode
      *
      * @return \OxidEsales\Eshop\Core\Price
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getPriceObject" in next major
      */
     protected function _getPriceObject() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -1198,6 +1212,7 @@ class Basket extends \OxidEsales\Eshop\Core\Base
 
     /**
      * Loads basket discounts and calculates discount values.
+     * @deprecated underscore prefix violates PSR12, will be renamed to "calcBasketDiscount" in next major
      */
     protected function _calcBasketDiscount() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -1261,6 +1276,7 @@ class Basket extends \OxidEsales\Eshop\Core\Base
 
     /**
      * Calculates total basket discount value.
+     * @deprecated underscore prefix violates PSR12, will be renamed to "calcBasketTotalDiscount" in next major
      */
     protected function _calcBasketTotalDiscount() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -1288,6 +1304,7 @@ class Basket extends \OxidEsales\Eshop\Core\Base
      * $this->oBasket. Returns price object for wrapping.
      *
      * @return \OxidEsales\Eshop\Core\Price
+     * @deprecated underscore prefix violates PSR12, will be renamed to "calcBasketWrapping" in next major
      */
     protected function _calcBasketWrapping() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -1314,6 +1331,7 @@ class Basket extends \OxidEsales\Eshop\Core\Base
      * $this->oBasket. Returns oxprice object for wrapping.
      *
      * @return \OxidEsales\Eshop\Core\Price
+     * @deprecated underscore prefix violates PSR12, will be renamed to "calcBasketGiftCard" in next major
      */
     protected function _calcBasketGiftCard() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -1344,6 +1362,7 @@ class Basket extends \OxidEsales\Eshop\Core\Base
      * Payment cost calculation, applying payment discount if available.
      *
      * @return \OxidEsales\Eshop\Core\Price
+     * @deprecated underscore prefix violates PSR12, will be renamed to "calcPaymentCost" in next major
      */
     protected function _calcPaymentCost() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -1693,6 +1712,7 @@ class Basket extends \OxidEsales\Eshop\Core\Base
 
     /**
      * Saves existing basket to database
+     * @deprecated underscore prefix violates PSR12, will be renamed to "save" in next major
      */
     protected function _save() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -1719,6 +1739,7 @@ class Basket extends \OxidEsales\Eshop\Core\Base
      * Cleans up saved basket data. This method usually is initiated by
      * \OxidEsales\Eshop\Application\Model\Basket::deleteBasket() method which cleans up basket data when
      * user completes order.
+     * @deprecated underscore prefix violates PSR12, will be renamed to "deleteSavedBasket" in next major
      */
     protected function _deleteSavedBasket() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -1737,6 +1758,7 @@ class Basket extends \OxidEsales\Eshop\Core\Base
      * Tries to fetch user delivery country ID
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "findDelivCountry" in next major
      */
     protected function _findDelivCountry() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -2700,6 +2722,7 @@ class Basket extends \OxidEsales\Eshop\Core\Base
      * Returns ( current basket products sum - total discount - voucher discount )
      *
      * @return double
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getDiscountedProductsSum" in next major
      */
     public function _getDiscountedProductsSum()  // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -2860,6 +2883,7 @@ class Basket extends \OxidEsales\Eshop\Core\Base
      * @param string $sRootCatId root category id
      *
      * @return bool
+     * @deprecated underscore prefix violates PSR12, will be renamed to "isProductInRootCategory" in next major
      */
     protected function _isProductInRootCategory($sProductId, $sRootCatId) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {

--- a/source/Application/Model/BasketContentMarkGenerator.php
+++ b/source/Application/Model/BasketContentMarkGenerator.php
@@ -63,6 +63,7 @@ class BasketContentMarkGenerator
      * Basket that is used to get article type(downloadable, intangible etc..).
      *
      * @return \OxidEsales\Eshop\Application\Model\Basket
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getBasket" in next major
      */
     private function _getBasket() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -75,6 +76,7 @@ class BasketContentMarkGenerator
      * @param string $sCurrentMark Current mark.
      *
      * @return array
+     * @deprecated underscore prefix violates PSR12, will be renamed to "formMarks" in next major
      */
     private function _formMarks($sCurrentMark) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {

--- a/source/Application/Model/BasketItem.php
+++ b/source/Application/Model/BasketItem.php
@@ -715,6 +715,7 @@ class BasketItem extends \OxidEsales\Eshop\Core\Base
      * @param string $sProductId product id
      *
      * @throws oxNoArticleException exception
+     * @deprecated underscore prefix violates PSR12, will be renamed to "setArticle" in next major
      */
     protected function _setArticle($sProductId) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -753,6 +754,7 @@ class BasketItem extends \OxidEsales\Eshop\Core\Base
      *  - sNativeShopId  - article shop ID;
      *
      * @param \OxidEsales\Eshop\Application\Model\OrderArticle $oOrderArticle order article
+     * @deprecated underscore prefix violates PSR12, will be renamed to "setFromOrderArticle" in next major
      */
     protected function _setFromOrderArticle($oOrderArticle) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -774,6 +776,7 @@ class BasketItem extends \OxidEsales\Eshop\Core\Base
      * Stores item select lists ( oxbasketitem::aSelList )
      *
      * @param array $aSelList item select lists
+     * @deprecated underscore prefix violates PSR12, will be renamed to "setSelectList" in next major
      */
     protected function _setSelectList($aSelList) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {

--- a/source/Application/Model/BasketReservation.php
+++ b/source/Application/Model/BasketReservation.php
@@ -39,6 +39,7 @@ class BasketReservation extends \OxidEsales\Eshop\Core\Base
      * return the ID of active resevations user basket
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getReservationsId" in next major
      */
     protected function _getReservationsId() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -58,6 +59,7 @@ class BasketReservation extends \OxidEsales\Eshop\Core\Base
      * @param string $sBasketId basket id for this user basket
      *
      * @return \OxidEsales\EshopCommunity\Application\Model\UserBasket
+     * @deprecated underscore prefix violates PSR12, will be renamed to "loadReservations" in next major
      */
     protected function _loadReservations($sBasketId) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -99,6 +101,7 @@ class BasketReservation extends \OxidEsales\Eshop\Core\Base
      * return currently reserved items in an array format array (artId => amount)
      *
      * @return array
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getReservedItems" in next major
      */
     protected function _getReservedItems() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -145,6 +148,7 @@ class BasketReservation extends \OxidEsales\Eshop\Core\Base
      * @param \OxidEsales\Eshop\Application\Model\Basket $oBasket basket object
      *
      * @return array
+     * @deprecated underscore prefix violates PSR12, will be renamed to "basketDifference" in next major
      */
     protected function _basketDifference(\OxidEsales\Eshop\Application\Model\Basket $oBasket) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -168,6 +172,7 @@ class BasketReservation extends \OxidEsales\Eshop\Core\Base
      * @param array $aBasketDiff basket difference array
      *
      * @see oxBasketReservation::_basketDifference
+     * @deprecated underscore prefix violates PSR12, will be renamed to "reserveArticles" in next major
      */
     protected function _reserveArticles($aBasketDiff) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {

--- a/source/Application/Model/Category.php
+++ b/source/Application/Model/Category.php
@@ -211,6 +211,7 @@ class Category extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implement
      * @param string $sOXID id
      *
      * @return array
+     * @deprecated underscore prefix violates PSR12, will be renamed to "loadFromDb" in next major
      */
     protected function _loadFromDb($sOXID) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -835,6 +836,7 @@ class Category extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implement
      * Inserts new category (and updates existing node oxLeft amd oxRight accordingly). Returns true on success.
      *
      * @return bool
+     * @deprecated underscore prefix violates PSR12, will be renamed to "insert" in next major
      */
     protected function _insert() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -897,6 +899,7 @@ class Category extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implement
      * Updates category tree, returns true on success.
      *
      * @return bool
+     * @deprecated underscore prefix violates PSR12, will be renamed to "update" in next major
      */
     protected function _update() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -1022,6 +1025,7 @@ class Category extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implement
      * @param int    $dataType  field type
      *
      * @return null
+     * @deprecated underscore prefix violates PSR12, will be renamed to "setFieldData" in next major
      */
     protected function _setFieldData($fieldName, $value, $dataType = \OxidEsales\Eshop\Core\Field::T_TEXT) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {

--- a/source/Application/Model/CategoryList.php
+++ b/source/Application/Model/CategoryList.php
@@ -130,6 +130,7 @@ class CategoryList extends \OxidEsales\Eshop\Core\Model\ListModel
      * @param array  $aColumns required column names (optional)
      *
      * @return string return
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getSqlSelectFieldsForTree" in next major
      */
     protected function _getSqlSelectFieldsForTree($sTable, $aColumns = null) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -176,6 +177,7 @@ class CategoryList extends \OxidEsales\Eshop\Core\Model\ListModel
      * @param string $sOrder    order by string (optional)
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getSelectString" in next major
      */
     protected function _getSelectString($blReverse = false, $aColumns = null, $sOrder = null) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -212,6 +214,7 @@ class CategoryList extends \OxidEsales\Eshop\Core\Model\ListModel
      * @param \OxidEsales\Eshop\Application\Model\Category $oCat selected category
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getDepthSqlSnippet" in next major
      */
     protected function _getDepthSqlSnippet($oCat) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -248,6 +251,7 @@ class CategoryList extends \OxidEsales\Eshop\Core\Model\ListModel
      * @param array                                        $aColumns required column names (optional)
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getDepthSqlUnion" in next major
      */
     protected function _getDepthSqlUnion($oCat, $aColumns = null) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -269,6 +273,7 @@ class CategoryList extends \OxidEsales\Eshop\Core\Model\ListModel
      * Get data from db
      *
      * @return array
+     * @deprecated underscore prefix violates PSR12, will be renamed to "loadFromDb" in next major
      */
     protected function _loadFromDb() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -326,6 +331,7 @@ class CategoryList extends \OxidEsales\Eshop\Core\Model\ListModel
      * set full category object in tree
      *
      * @param string $sId category id
+     * @deprecated underscore prefix violates PSR12, will be renamed to "ppLoadFullCategory" in next major
      */
     protected function _ppLoadFullCategory($sId) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -405,6 +411,7 @@ class CategoryList extends \OxidEsales\Eshop\Core\Model\ListModel
 
     /**
      * Category list postprocessing routine, responsible for removal of inactive of forbidden categories, and subcategories.
+     * @deprecated underscore prefix violates PSR12, will be renamed to "ppRemoveInactiveCategories" in next major
      */
     protected function _ppRemoveInactiveCategories() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -446,6 +453,7 @@ class CategoryList extends \OxidEsales\Eshop\Core\Model\ListModel
      * Category list postprocessing routine, responsible for generation of active category path
      *
      * @return null
+     * @deprecated underscore prefix violates PSR12, will be renamed to "ppAddPathInfo" in next major
      */
     protected function _ppAddPathInfo() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -468,6 +476,7 @@ class CategoryList extends \OxidEsales\Eshop\Core\Model\ListModel
 
     /**
      * Category list postprocessing routine, responsible adding of content categories
+     * @deprecated underscore prefix violates PSR12, will be renamed to "ppAddContentCategories" in next major
      */
     protected function _ppAddContentCategories() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -484,6 +493,7 @@ class CategoryList extends \OxidEsales\Eshop\Core\Model\ListModel
 
     /**
      * Category list postprocessing routine, responsible building an sorting of hierarchical category tree
+     * @deprecated underscore prefix violates PSR12, will be renamed to "ppBuildTree" in next major
      */
     protected function _ppBuildTree() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -505,6 +515,7 @@ class CategoryList extends \OxidEsales\Eshop\Core\Model\ListModel
     /**
      * Category list postprocessing routine, responsible for making flat category tree and adding depth information.
      * Requires reversed category list!
+     * @deprecated underscore prefix violates PSR12, will be renamed to "ppAddDepthInformation" in next major
      */
     protected function _ppAddDepthInformation() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -529,6 +540,7 @@ class CategoryList extends \OxidEsales\Eshop\Core\Model\ListModel
      * @param string $sDepth string to show category depth
      *
      * @return array $aTree
+     * @deprecated underscore prefix violates PSR12, will be renamed to "addDepthInfo" in next major
      */
     protected function _addDepthInfo($aTree, $oCat, $sDepth = "") // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -621,6 +633,7 @@ class CategoryList extends \OxidEsales\Eshop\Core\Model\ListModel
      * @param string $oxRootId rootid of tree
      * @param bool   $isRoot   is the current node root?
      * @param string $thisRoot the id of the root
+     * @deprecated underscore prefix violates PSR12, will be renamed to "updateNodes" in next major
      */
     protected function _updateNodes($oxRootId, $isRoot, $thisRoot) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {

--- a/source/Application/Model/CompanyVatIn.php
+++ b/source/Application/Model/CompanyVatIn.php
@@ -57,6 +57,7 @@ class CompanyVatIn
      * @param string $sValue Value.
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "cleanUp" in next major
      */
     protected function _cleanUp($sValue) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {

--- a/source/Application/Model/Content.php
+++ b/source/Application/Model/Content.php
@@ -126,6 +126,7 @@ class Content extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
      * @param string $sLoadId id
      *
      * @return array
+     * @deprecated underscore prefix violates PSR12, will be renamed to "loadFromDb" in next major
      */
     protected function _loadFromDb($sLoadId) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -351,6 +352,7 @@ class Content extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
      * @param int    $iDataType  field type
      *
      * @return null
+     * @deprecated underscore prefix violates PSR12, will be renamed to "setFieldData" in next major
      */
     protected function _setFieldData($sFieldName, $sValue, $iDataType = \OxidEsales\Eshop\Core\Field::T_TEXT) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -368,6 +370,7 @@ class Content extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
      * @param string $sFieldName name of the field which value to get
      *
      * @return mixed
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getFieldData" in next major
      */
     protected function _getFieldData($sFieldName) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {

--- a/source/Application/Model/ContentList.php
+++ b/source/Application/Model/ContentList.php
@@ -115,6 +115,7 @@ class ContentList extends \OxidEsales\Eshop\Core\Model\ListModel
      * @param integer $iType - type of content
      *
      * @return array
+     * @deprecated underscore prefix violates PSR12, will be renamed to "loadFromDb" in next major
      */
     protected function _loadFromDb($iType) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -128,6 +129,7 @@ class ContentList extends \OxidEsales\Eshop\Core\Model\ListModel
      * Load category list data
      *
      * @param integer $type - type of content
+     * @deprecated underscore prefix violates PSR12, will be renamed to "load" in next major
      */
     protected function _load($type) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -146,6 +148,7 @@ class ContentList extends \OxidEsales\Eshop\Core\Model\ListModel
 
     /**
      * Extract oxContentList object to associative array with oxloadid as keys.
+     * @deprecated underscore prefix violates PSR12, will be renamed to "extractListToArray" in next major
      */
     protected function _extractListToArray() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -163,6 +166,7 @@ class ContentList extends \OxidEsales\Eshop\Core\Model\ListModel
      * @param integer $iType type.
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getSQLByType" in next major
      */
     protected function _getSQLByType($iType) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {

--- a/source/Application/Model/Delivery.php
+++ b/source/Application/Model/Delivery.php
@@ -456,6 +456,7 @@ class Delivery extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel
      * @param double $iAmount amount
      *
      * @return boolean
+     * @deprecated underscore prefix violates PSR12, will be renamed to "checkDeliveryAmount" in next major
      */
     protected function _checkDeliveryAmount($iAmount) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -585,6 +586,7 @@ class Delivery extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel
      * Calculate multiplier for price calculation
      *
      * @return float|int
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getMultiplier" in next major
      */
     protected function _getMultiplier() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -605,6 +607,7 @@ class Delivery extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel
      * Calculate cost sum
      *
      * @return float
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getCostSum" in next major
      */
     protected function _getCostSum() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {

--- a/source/Application/Model/DeliveryList.php
+++ b/source/Application/Model/DeliveryList.php
@@ -98,6 +98,7 @@ class DeliveryList extends \OxidEsales\Eshop\Core\Model\ListModel
      * @param string                                   $sDelSet    user chosen delivery set
      *
      * @return array
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getList" in next major
      */
     protected function _getList($oUser = null, $sCountryId = null, $sDelSet = null) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -138,6 +139,7 @@ class DeliveryList extends \OxidEsales\Eshop\Core\Model\ListModel
      * @param string                                   $sDelSet    user chosen delivery set
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getFilterSelect" in next major
      */
     protected function _getFilterSelect($oUser, $sCountryId, $sDelSet) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {

--- a/source/Application/Model/DeliverySetList.php
+++ b/source/Application/Model/DeliverySetList.php
@@ -79,6 +79,7 @@ class DeliverySetList extends \OxidEsales\Eshop\Core\Model\ListModel
      * @param string                                   $sCountryId user country id
      *
      * @return array
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getList" in next major
      */
     protected function _getList($oUser = null, $sCountryId = null) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -120,6 +121,7 @@ class DeliverySetList extends \OxidEsales\Eshop\Core\Model\ListModel
      * @param string                                   $sCountryId user country id
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getFilterSelect" in next major
      */
     protected function _getFilterSelect($oUser, $sCountryId) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {

--- a/source/Application/Model/Diagnostics.php
+++ b/source/Application/Model/Diagnostics.php
@@ -249,6 +249,7 @@ class Diagnostics
      * @param boolean $blMode mode
      *
      * @return integer
+     * @deprecated underscore prefix violates PSR12, will be renamed to "countRows" in next major
      */
     protected function _countRows($sTable, $blMode) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -365,6 +366,7 @@ class Diagnostics
      * Returns Apache version
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getApacheVersion" in next major
      */
     protected function _getApacheVersion() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -381,6 +383,7 @@ class Diagnostics
      * Tries to find out which VM is used
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getVirtualizationSystem" in next major
      */
     protected function _getVirtualizationSystem() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -421,6 +424,7 @@ class Diagnostics
      * @param string $sSystemType System type.
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getDeviceList" in next major
      */
     protected function _getDeviceList($sSystemType) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -431,6 +435,7 @@ class Diagnostics
      * Returns amount of CPU units.
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getCpuAmount" in next major
      */
     protected function _getCpuAmount() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -442,6 +447,7 @@ class Diagnostics
      * Returns CPU speed in Mhz
      *
      * @return float
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getCpuMhz" in next major
      */
     protected function _getCpuMhz() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -452,6 +458,7 @@ class Diagnostics
      * Returns BogoMIPS evaluation of processor
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getBogoMips" in next major
      */
     protected function _getBogoMips() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -462,6 +469,7 @@ class Diagnostics
      * Returns total amount of memory
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getMemoryTotal" in next major
      */
     protected function _getMemoryTotal() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -472,6 +480,7 @@ class Diagnostics
      * Returns amount of free memory
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getMemoryFree" in next major
      */
     protected function _getMemoryFree() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -482,6 +491,7 @@ class Diagnostics
      * Returns CPU model information
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getCpuModel" in next major
      */
     protected function _getCpuModel() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -492,6 +502,7 @@ class Diagnostics
      * Returns total disk space
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getDiskTotalSpace" in next major
      */
     protected function _getDiskTotalSpace() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -502,6 +513,7 @@ class Diagnostics
      * Returns free disk space
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getDiskFreeSpace" in next major
      */
     protected function _getDiskFreeSpace() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -512,6 +524,7 @@ class Diagnostics
      * Returns PHP version
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getPhpVersion" in next major
      */
     protected function _getPhpVersion() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -522,6 +535,7 @@ class Diagnostics
      * Returns MySQL server Information
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getMySqlServerInfo" in next major
      */
     protected function _getMySqlServerInfo() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {

--- a/source/Application/Model/Discount.php
+++ b/source/Application/Model/Discount.php
@@ -523,6 +523,7 @@ class Discount extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel
      * @param object $oArticle article object to chesk
      *
      * @return bool
+     * @deprecated underscore prefix violates PSR12, will be renamed to "checkForArticleCategories" in next major
      */
     protected function _checkForArticleCategories($oArticle) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -555,6 +556,7 @@ class Discount extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel
      * @param \OxidEsales\Eshop\Application\Model\Article $oProduct product used for discount check
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getProductCheckQuery" in next major
      */
     protected function _getProductCheckQuery($oProduct) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -575,6 +577,7 @@ class Discount extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel
      * @param \OxidEsales\Eshop\Application\Model\Article $oArticle
      *
      * @return bool
+     * @deprecated underscore prefix violates PSR12, will be renamed to "isArticleAssigned" in next major
      */
     protected function _isArticleAssigned($oArticle) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -599,6 +602,7 @@ class Discount extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel
      * @param array $aCategoryIds
      *
      * @return bool
+     * @deprecated underscore prefix violates PSR12, will be renamed to "isCategoriesAssigned" in next major
      */
     protected function _isCategoriesAssigned($aCategoryIds) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {

--- a/source/Application/Model/DiscountList.php
+++ b/source/Application/Model/DiscountList.php
@@ -54,6 +54,7 @@ class DiscountList extends \OxidEsales\Eshop\Core\Model\ListModel
      * @param \OxidEsales\Eshop\Application\Model\User $oUser user object (optional)
      *
      * @return array
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getList" in next major
      */
     protected function _getList($oUser = null) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -105,6 +106,7 @@ class DiscountList extends \OxidEsales\Eshop\Core\Model\ListModel
      * @param \OxidEsales\Eshop\Application\Model\User $oUser user object
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getFilterSelect" in next major
      */
     protected function _getFilterSelect($oUser) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {

--- a/source/Application/Model/File.php
+++ b/source/Application/Model/File.php
@@ -112,6 +112,7 @@ class File extends \OxidEsales\Eshop\Core\Model\BaseModel
      * @param array $aFileInfo File info array
      *
      * @throws oxException Throws exception if file wasn't uploaded successfully.
+     * @deprecated underscore prefix violates PSR12, will be renamed to "checkArticleFile" in next major
      */
     protected function _checkArticleFile($aFileInfo) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -130,6 +131,7 @@ class File extends \OxidEsales\Eshop\Core\Model\BaseModel
      * Return full path of root dir where download files are stored
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getBaseDownloadDirPath" in next major
      */
     protected function _getBaseDownloadDirPath() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -191,6 +193,7 @@ class File extends \OxidEsales\Eshop\Core\Model\BaseModel
      * Returns relative file path from oxConfig 'sDownloadsDir' variable.
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getFileLocation" in next major
      */
     protected function _getFileLocation() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -221,6 +224,7 @@ class File extends \OxidEsales\Eshop\Core\Model\BaseModel
      * @param string $sFileHash File hash value
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getHashedFileDir" in next major
      */
     protected function _getHashedFileDir($sFileHash) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -241,6 +245,7 @@ class File extends \OxidEsales\Eshop\Core\Model\BaseModel
      * @param string $sFileName File name values
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getFileHash" in next major
      */
     protected function _getFileHash($sFileName) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -255,6 +260,7 @@ class File extends \OxidEsales\Eshop\Core\Model\BaseModel
      * @param string $sTarget Target filename
      *
      * @return bool
+     * @deprecated underscore prefix violates PSR12, will be renamed to "uploadFile" in next major
      */
     protected function _uploadFile($sSource, $sTarget) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -310,6 +316,7 @@ class File extends \OxidEsales\Eshop\Core\Model\BaseModel
      * If not used, unlink the file.
      *
      * @return null|false
+     * @deprecated underscore prefix violates PSR12, will be renamed to "deleteFile" in next major
      */
     protected function _deleteFile() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -334,6 +341,7 @@ class File extends \OxidEsales\Eshop\Core\Model\BaseModel
      * converts spec symbols to %xx combination
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getFilenameForUrl" in next major
      */
     protected function _getFilenameForUrl() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {

--- a/source/Application/Model/FileChecker.php
+++ b/source/Application/Model/FileChecker.php
@@ -249,6 +249,7 @@ class FileChecker
      * in case if a general error is thrown by webservice
      *
      * @return string error
+     * @deprecated underscore prefix violates PSR12, will be renamed to "isWebServiceOnline" in next major
      */
     protected function _isWebServiceOnline() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -288,6 +289,7 @@ class FileChecker
      * asks the webservice, if the shop version is known.
      *
      * @return boolean
+     * @deprecated underscore prefix violates PSR12, will be renamed to "isShopVersionIsKnown" in next major
      */
     protected function _isShopVersionIsKnown() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -401,6 +403,7 @@ class FileChecker
      * @param string $sFile File to check
      *
      * @return \SimpleXMLElement
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getFileVersion" in next major
      */
     protected function _getFileVersion($sMD5, $sFile) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {

--- a/source/Application/Model/Links.php
+++ b/source/Application/Model/Links.php
@@ -41,6 +41,7 @@ class Links extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel
      * @param int    $iDataType  field type
      *
      * @return null
+     * @deprecated underscore prefix violates PSR12, will be renamed to "setFieldData" in next major
      */
     protected function _setFieldData($sFieldName, $sValue, $iDataType = \OxidEsales\Eshop\Core\Field::T_TEXT) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {

--- a/source/Application/Model/Manufacturer.php
+++ b/source/Application/Model/Manufacturer.php
@@ -155,6 +155,7 @@ class Manufacturer extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel imple
      * Sets root manufacturer data. Returns true
      *
      * @return bool
+     * @deprecated underscore prefix violates PSR12, will be renamed to "setRootObjectData" in next major
      */
     protected function _setRootObjectData() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {

--- a/source/Application/Model/ManufacturerList.php
+++ b/source/Application/Model/ManufacturerList.php
@@ -146,6 +146,7 @@ class ManufacturerList extends \OxidEsales\Eshop\Core\Model\ListModel
      * Adds category specific fields to manufacturer object
      *
      * @param object $oManufacturer manufacturer object
+     * @deprecated underscore prefix violates PSR12, will be renamed to "addCategoryFields" in next major
      */
     protected function _addCategoryFields($oManufacturer) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -180,6 +181,7 @@ class ManufacturerList extends \OxidEsales\Eshop\Core\Model\ListModel
 
     /**
      * Processes manufacturer category URLs
+     * @deprecated underscore prefix violates PSR12, will be renamed to "seoSetManufacturerData" in next major
      */
     protected function _seoSetManufacturerData() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {

--- a/source/Application/Model/MdVariant.php
+++ b/source/Application/Model/MdVariant.php
@@ -361,6 +361,7 @@ class MdVariant extends \OxidEsales\Eshop\Core\Base
      * Adds one subvariant to subvariant set
      *
      * @param \OxidEsales\Eshop\Application\Model\MdVariant $oSubvariant Subvariant
+     * @deprecated underscore prefix violates PSR12, will be renamed to "addMdSubvariant" in next major
      */
     protected function _addMdSubvariant($oSubvariant) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -371,6 +372,7 @@ class MdVariant extends \OxidEsales\Eshop\Core\Base
      * Checks if variant price is fixed or not ("from" price)
      *
      * @return bool
+     * @deprecated underscore prefix violates PSR12, will be renamed to "isFixedPrice" in next major
      */
     protected function _isFixedPrice() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {

--- a/source/Application/Model/MediaUrl.php
+++ b/source/Application/Model/MediaUrl.php
@@ -117,6 +117,7 @@ class MediaUrl extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel
      * Transforms the link to YouTube object, and returns it.
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getYoutubeHtml" in next major
      */
     protected function _getYoutubeHtml() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {

--- a/source/Application/Model/News.php
+++ b/source/Application/Model/News.php
@@ -131,6 +131,7 @@ class News extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel
 
     /**
      * Updates object information in DB.
+     * @deprecated underscore prefix violates PSR12, will be renamed to "update" in next major
      */
     protected function _update() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -143,6 +144,7 @@ class News extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel
      * Inserts object details to DB, returns true on success.
      *
      * @return bool
+     * @deprecated underscore prefix violates PSR12, will be renamed to "insert" in next major
      */
     protected function _insert() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -164,6 +166,7 @@ class News extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel
      * @param int    $iDataType  field type
      *
      * @return null
+     * @deprecated underscore prefix violates PSR12, will be renamed to "setFieldData" in next major
      */
     protected function _setFieldData($sFieldName, $sValue, $iDataType = \OxidEsales\Eshop\Core\Field::T_TEXT) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {

--- a/source/Application/Model/NewsSubscribed.php
+++ b/source/Application/Model/NewsSubscribed.php
@@ -127,6 +127,7 @@ class NewsSubscribed extends \OxidEsales\Eshop\Core\Model\BaseModel
      * Inserts nbews object data to DB. Returns true on success.
      *
      * @return mixed oxid on success or false on failure
+     * @deprecated underscore prefix violates PSR12, will be renamed to "insert" in next major
      */
     protected function _insert() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -140,6 +141,7 @@ class NewsSubscribed extends \OxidEsales\Eshop\Core\Model\BaseModel
      * We need to check if we unsubscribe here
      *
      * @return mixed oxid on success or false on failure
+     * @deprecated underscore prefix violates PSR12, will be renamed to "update" in next major
      */
     protected function _update() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {

--- a/source/Application/Model/Newsletter.php
+++ b/source/Application/Model/Newsletter.php
@@ -182,6 +182,7 @@ class Newsletter extends \OxidEsales\Eshop\Core\Model\BaseModel
      * this user, generates HTML and plaintext format newsletters.
      *
      * @param bool $blPerfLoadAktion perform option load actions
+     * @deprecated underscore prefix violates PSR12, will be renamed to "setParams" in next major
      */
     protected function _setParams($blPerfLoadAktion = false) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -214,6 +215,7 @@ class Newsletter extends \OxidEsales\Eshop\Core\Model\BaseModel
      * Creates oxuser object (user ID passed to method),
      *
      * @param string $sUserid User ID or OBJECT
+     * @deprecated underscore prefix violates PSR12, will be renamed to "setUser" in next major
      */
     protected function _setUser($sUserid) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -233,6 +235,7 @@ class Newsletter extends \OxidEsales\Eshop\Core\Model\BaseModel
      *
      * @param \OxidEsales\Eshop\Core\Controller\BaseController $oView            view object to store view data
      * @param bool                                             $blPerfLoadAktion perform option load actions
+     * @deprecated underscore prefix violates PSR12, will be renamed to "assignProducts" in next major
      */
     protected function _assignProducts($oView, $blPerfLoadAktion = false) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -274,6 +277,7 @@ class Newsletter extends \OxidEsales\Eshop\Core\Model\BaseModel
      * @param int    $iDataType  field type
      *
      * @return null
+     * @deprecated underscore prefix violates PSR12, will be renamed to "setFieldData" in next major
      */
     protected function _setFieldData($sFieldName, $sValue, $iDataType = \OxidEsales\Eshop\Core\Field::T_TEXT) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {

--- a/source/Application/Model/Order.php
+++ b/source/Application/Model/Order.php
@@ -298,6 +298,7 @@ class Order extends \OxidEsales\Eshop\Core\Model\BaseModel
      * @param string $sCountryId country ID
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getCountryTitle" in next major
      */
     protected function _getCountryTitle($sCountryId) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -317,6 +318,7 @@ class Order extends \OxidEsales\Eshop\Core\Model\BaseModel
      * @param bool $blExcludeCanceled excludes canceled items from list
      *
      * @return \oxlist
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getArticles" in next major
      */
     protected function _getArticles($blExcludeCanceled = false) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -583,6 +585,7 @@ class Order extends \OxidEsales\Eshop\Core\Model\BaseModel
      * Updates order transaction status. Faster than saving whole object
      *
      * @param string $sStatus order transaction status
+     * @deprecated underscore prefix violates PSR12, will be renamed to "setOrderStatus" in next major
      */
     protected function _setOrderStatus($sStatus) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -603,6 +606,7 @@ class Order extends \OxidEsales\Eshop\Core\Model\BaseModel
      * @param string $sVat vat value
      *
      * @return float
+     * @deprecated underscore prefix violates PSR12, will be renamed to "convertVat" in next major
      */
     protected function _convertVat($sVat) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -617,6 +621,7 @@ class Order extends \OxidEsales\Eshop\Core\Model\BaseModel
 
     /**
      * Reset Vat info
+     * @deprecated underscore prefix violates PSR12, will be renamed to "resetVats" in next major
      */
     protected function _resetVats() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -633,6 +638,7 @@ class Order extends \OxidEsales\Eshop\Core\Model\BaseModel
      * and creates oxOrderArticle objects and assigns to them basket articles.
      *
      * @param \OxidEsales\Eshop\Application\Model\Basket $oBasket Shopping basket object
+     * @deprecated underscore prefix violates PSR12, will be renamed to "loadFromBasket" in next major
      */
     protected function _loadFromBasket(\OxidEsales\Eshop\Application\Model\Basket $oBasket) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -738,6 +744,7 @@ class Order extends \OxidEsales\Eshop\Core\Model\BaseModel
      * Assigns to new oxorder object customer delivery and shipping info
      *
      * @param object $oUser user object
+     * @deprecated underscore prefix violates PSR12, will be renamed to "setUser" in next major
      */
     protected function _setUser($oUser) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -784,6 +791,7 @@ class Order extends \OxidEsales\Eshop\Core\Model\BaseModel
      * Assigns wrapping VAT and card price + card message info
      *
      * @param \OxidEsales\Eshop\Application\Model\Basket $oBasket basket object
+     * @deprecated underscore prefix violates PSR12, will be renamed to "setWrapping" in next major
      */
     protected function _setWrapping(\OxidEsales\Eshop\Application\Model\Basket $oBasket) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -811,6 +819,7 @@ class Order extends \OxidEsales\Eshop\Core\Model\BaseModel
      * Updates quantity of sold articles (\OxidEsales\Eshop\Application\Model\Article::updateSoldAmount()).
      *
      * @param array $aArticleList article list
+     * @deprecated underscore prefix violates PSR12, will be renamed to "setOrderArticles" in next major
      */
     protected function _setOrderArticles($aArticleList) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -914,6 +923,7 @@ class Order extends \OxidEsales\Eshop\Core\Model\BaseModel
      * @param object                                     $oUserpayment user payment object
      *
      * @return  integer 2 or an error code
+     * @deprecated underscore prefix violates PSR12, will be renamed to "executePayment" in next major
      */
     protected function _executePayment(\OxidEsales\Eshop\Application\Model\Basket $oBasket, $oUserpayment) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -948,6 +958,7 @@ class Order extends \OxidEsales\Eshop\Core\Model\BaseModel
      * and IPayment, can be extended later.
      *
      * @return object $oPayTransaction payment gateway object
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getGateway" in next major
      */
     protected function _getGateway() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -960,6 +971,7 @@ class Order extends \OxidEsales\Eshop\Core\Model\BaseModel
      * @param string $sPaymentid used payment id
      *
      * @return \OxidEsales\Eshop\Application\Model\UserPayment
+     * @deprecated underscore prefix violates PSR12, will be renamed to "setPayment" in next major
      */
     protected function _setPayment($sPaymentid) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -1010,6 +1022,7 @@ class Order extends \OxidEsales\Eshop\Core\Model\BaseModel
 
     /**
      * Assigns oxfolder as new
+     * @deprecated underscore prefix violates PSR12, will be renamed to "setFolder" in next major
      */
     protected function _setFolder() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -1023,6 +1036,7 @@ class Order extends \OxidEsales\Eshop\Core\Model\BaseModel
      *
      * @param array  $aArticleList basket products
      * @param object $oUser        user object
+     * @deprecated underscore prefix violates PSR12, will be renamed to "updateWishlist" in next major
      */
     protected function _updateWishlist($aArticleList, $oUser) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -1061,6 +1075,7 @@ class Order extends \OxidEsales\Eshop\Core\Model\BaseModel
      * @param \OxidEsales\Eshop\Application\Model\User $oUser        basket user object
      *
      * @return null
+     * @deprecated underscore prefix violates PSR12, will be renamed to "updateNoticeList" in next major
      */
     protected function _updateNoticeList($aArticleList, $oUser) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -1095,6 +1110,7 @@ class Order extends \OxidEsales\Eshop\Core\Model\BaseModel
 
     /**
      * Updates order date to current date
+     * @deprecated underscore prefix violates PSR12, will be renamed to "updateOrderDate" in next major
      */
     protected function _updateOrderDate() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -1114,6 +1130,7 @@ class Order extends \OxidEsales\Eshop\Core\Model\BaseModel
      *
      * @param \OxidEsales\Eshop\Application\Model\Basket $oBasket basket object
      * @param \OxidEsales\Eshop\Application\Model\User   $oUser   user object
+     * @deprecated underscore prefix violates PSR12, will be renamed to "markVouchers" in next major
      */
     protected function _markVouchers($oBasket, $oUser) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -1224,6 +1241,7 @@ class Order extends \OxidEsales\Eshop\Core\Model\BaseModel
      * Inserts order object information in DB. Returns true on success.
      *
      * @return bool
+     * @deprecated underscore prefix violates PSR12, will be renamed to "insert" in next major
      */
     protected function _insert() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -1259,6 +1277,7 @@ class Order extends \OxidEsales\Eshop\Core\Model\BaseModel
      * creates counter ident
      *
      * @return String
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getCounterIdent" in next major
      */
     protected function _getCounterIdent() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -1272,6 +1291,7 @@ class Order extends \OxidEsales\Eshop\Core\Model\BaseModel
      * Tries to fetch and set next record number in DB. Returns true on success
      *
      * @return bool
+     * @deprecated underscore prefix violates PSR12, will be renamed to "setNumber" in next major
      */
     protected function _setNumber() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -1295,6 +1315,7 @@ class Order extends \OxidEsales\Eshop\Core\Model\BaseModel
      * Updates object parameters to DB.
      *
      * @return null
+     * @deprecated underscore prefix violates PSR12, will be renamed to "update" in next major
      */
     protected function _update() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -1388,6 +1409,7 @@ class Order extends \OxidEsales\Eshop\Core\Model\BaseModel
      * @param bool $blStockCheck perform stock check or not (default true)
      *
      * @return \OxidEsales\Eshop\Application\Model\Basket
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getOrderBasket" in next major
      */
     protected function _getOrderBasket($blStockCheck = true) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -1687,6 +1709,7 @@ class Order extends \OxidEsales\Eshop\Core\Model\BaseModel
      * @param string $sOxId order ID
      *
      * @return bool
+     * @deprecated underscore prefix violates PSR12, will be renamed to "checkOrderExist" in next major
      */
     protected function _checkOrderExist($sOxId = null) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -1714,6 +1737,7 @@ class Order extends \OxidEsales\Eshop\Core\Model\BaseModel
      * @param \OxidEsales\Eshop\Application\Model\UserPayment $oPayment order payment
      *
      * @return bool
+     * @deprecated underscore prefix violates PSR12, will be renamed to "sendOrderByEmail" in next major
      */
     protected function _sendOrderByEmail($oUser = null, $oBasket = null, $oPayment = null) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -1856,6 +1880,7 @@ class Order extends \OxidEsales\Eshop\Core\Model\BaseModel
      *
      * @param \OxidEsales\Eshop\Application\Model\Basket $oBasket        basket object
      * @param array                                      $aOrderArticles order articles
+     * @deprecated underscore prefix violates PSR12, will be renamed to "addOrderArticlesToBasket" in next major
      */
     protected function _addOrderArticlesToBasket($oBasket, $aOrderArticles) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -1873,6 +1898,7 @@ class Order extends \OxidEsales\Eshop\Core\Model\BaseModel
      *
      * @param \OxidEsales\Eshop\Application\Model\Basket $oBasket   basket to add articles
      * @param array                                      $aArticles article array
+     * @deprecated underscore prefix violates PSR12, will be renamed to "addArticlesToBasket" in next major
      */
     protected function _addArticlesToBasket($oBasket, $aArticles) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {

--- a/source/Application/Model/OrderArticle.php
+++ b/source/Application/Model/OrderArticle.php
@@ -163,6 +163,7 @@ class OrderArticle extends \OxidEsales\Eshop\Core\Model\BaseModel implements Art
      * @param bool   $blAllowNegativeStock allow/disallow negative stock value
      *
      * @return double
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getArtStock" in next major
      */
     protected function _getArtStock($dAddAmount = 0, $blAllowNegativeStock = false) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -225,6 +226,7 @@ class OrderArticle extends \OxidEsales\Eshop\Core\Model\BaseModel implements Art
      * @param int    $iDataType  field type
      *
      * @return null
+     * @deprecated underscore prefix violates PSR12, will be renamed to "setFieldData" in next major
      */
     protected function _setFieldData($sFieldName, $sValue, $iDataType = \OxidEsales\Eshop\Core\Field::T_TEXT) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -291,6 +293,7 @@ class OrderArticle extends \OxidEsales\Eshop\Core\Model\BaseModel implements Art
 
     /**
      * Sets article parameters to current object, so this object can be used for basket calculation
+     * @deprecated underscore prefix violates PSR12, will be renamed to "setArticleParams" in next major
      */
     protected function _setArticleParams() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -348,7 +351,8 @@ class OrderArticle extends \OxidEsales\Eshop\Core\Model\BaseModel implements Art
      *
      * @param string $sArticleId article id (optional, is not passed oxorderarticles__oxartid will be used)
      *
-     * @return \OxidEsales\Eshop\Application\Model\Article | false
+     * @return \OxidEsales\Eshop\Application\Model\Article|false
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getOrderArticle" in next major
      */
     protected function _getOrderArticle($sArticleId = null) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -764,6 +768,7 @@ class OrderArticle extends \OxidEsales\Eshop\Core\Model\BaseModel implements Art
      * parent::_insert() and returns insertion status.
      *
      * @return bool
+     * @deprecated underscore prefix violates PSR12, will be renamed to "insert" in next major
      */
     protected function _insert() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -804,6 +809,7 @@ class OrderArticle extends \OxidEsales\Eshop\Core\Model\BaseModel implements Art
 
     /**
      * Set order files
+     * @deprecated underscore prefix violates PSR12, will be renamed to "setOrderFiles" in next major
      */
     public function _setOrderFiles() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {

--- a/source/Application/Model/OrderFile.php
+++ b/source/Application/Model/OrderFile.php
@@ -132,6 +132,7 @@ class OrderFile extends \OxidEsales\Eshop\Core\Model\BaseModel
      * @param string $sFieldName - field name
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getFieldLongName" in next major
      */
     protected function _getFieldLongName($sFieldName) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {

--- a/source/Application/Model/PaymentGateway.php
+++ b/source/Application/Model/PaymentGateway.php
@@ -105,6 +105,7 @@ class PaymentGateway extends \OxidEsales\Eshop\Core\Base
      * Returns true is payment active.
      *
      * @return bool
+     * @deprecated underscore prefix violates PSR12, will be renamed to "isActive" in next major
      */
     protected function _isActive() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {

--- a/source/Application/Model/PaymentList.php
+++ b/source/Application/Model/PaymentList.php
@@ -53,6 +53,7 @@ class PaymentList extends \OxidEsales\Eshop\Core\Model\ListModel
      * @param \OxidEsales\Eshop\Application\Model\User $oUser      session user object
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getFilterSelect" in next major
      */
     protected function _getFilterSelect($sShipSetId, $dPrice, $oUser) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {

--- a/source/Application/Model/PriceAlarm.php
+++ b/source/Application/Model/PriceAlarm.php
@@ -87,6 +87,7 @@ class PriceAlarm extends \OxidEsales\Eshop\Core\Model\BaseModel
      * Inserts object data into DB, returns true on success.
      *
      * @return bool
+     * @deprecated underscore prefix violates PSR12, will be renamed to "insert" in next major
      */
     protected function _insert() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {

--- a/source/Application/Model/RecommendationList.php
+++ b/source/Application/Model/RecommendationList.php
@@ -106,6 +106,7 @@ class RecommendationList extends \OxidEsales\Eshop\Core\Model\BaseModel implemen
      * Returns the appropriate SQL select
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getArticleSelect" in next major
      */
     protected function _getArticleSelect() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -302,6 +303,7 @@ class RecommendationList extends \OxidEsales\Eshop\Core\Model\BaseModel implemen
      *
      * @param \OxidEsales\Eshop\Core\Model\ListModel $oRecommList recommendation list
      * @param array                                  $aIds        article ids
+     * @deprecated underscore prefix violates PSR12, will be renamed to "loadFirstArticles" in next major
      */
     protected function _loadFirstArticles(\OxidEsales\Eshop\Core\Model\ListModel $oRecommList, $aIds) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -389,6 +391,7 @@ class RecommendationList extends \OxidEsales\Eshop\Core\Model\BaseModel implemen
      * @param string $sSearchStr Search string
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getSearchSelect" in next major
      */
     protected function _getSearchSelect($sSearchStr) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {

--- a/source/Application/Model/Remark.php
+++ b/source/Application/Model/Remark.php
@@ -60,6 +60,7 @@ class Remark extends \OxidEsales\Eshop\Core\Model\BaseModel
      * Inserts object data fields in DB. Returns true on success.
      *
      * @return bool
+     * @deprecated underscore prefix violates PSR12, will be renamed to "insert" in next major
      */
     protected function _insert() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {

--- a/source/Application/Model/RequiredAddressFields.php
+++ b/source/Application/Model/RequiredAddressFields.php
@@ -100,6 +100,7 @@ class RequiredAddressFields
      * @param string $sPrefix
      *
      * @return mixed
+     * @deprecated underscore prefix violates PSR12, will be renamed to "filterFields" in next major
      */
     private function _filterFields($aFields, $sPrefix) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {

--- a/source/Application/Model/RequiredFieldValidator.php
+++ b/source/Application/Model/RequiredFieldValidator.php
@@ -40,6 +40,7 @@ class RequiredFieldValidator
      * @param array $aFieldValues field values
      *
      * @return bool
+     * @deprecated underscore prefix violates PSR12, will be renamed to "validateFieldValueArray" in next major
      */
     private function _validateFieldValueArray($aFieldValues) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {

--- a/source/Application/Model/RequiredFieldsValidator.php
+++ b/source/Application/Model/RequiredFieldsValidator.php
@@ -125,6 +125,7 @@ class RequiredFieldsValidator
      * Add fields to invalid fields array.
      *
      * @param array $aFields Invalid field name.
+     * @deprecated underscore prefix violates PSR12, will be renamed to "setInvalidFields" in next major
      */
     private function _setInvalidFields($aFields) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {

--- a/source/Application/Model/Review.php
+++ b/source/Application/Model/Review.php
@@ -87,6 +87,7 @@ class Review extends \OxidEsales\Eshop\Core\Model\BaseModel
      * Inserts object data fiels in DB. Returns true on success.
      *
      * @return bool
+     * @deprecated underscore prefix violates PSR12, will be renamed to "insert" in next major
      */
     protected function _insert() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {

--- a/source/Application/Model/RssFeed.php
+++ b/source/Application/Model/RssFeed.php
@@ -95,6 +95,7 @@ class RssFeed extends \OxidEsales\Eshop\Core\Base
      * _loadBaseChannel loads basic channel data
      *
      * @access protected
+     * @deprecated underscore prefix violates PSR12, will be renamed to "loadBaseChannel" in next major
      */
     protected function _loadBaseChannel() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -131,6 +132,7 @@ class RssFeed extends \OxidEsales\Eshop\Core\Base
      *
      * @access protected
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getCacheId" in next major
      */
     protected function _getCacheId($name) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -146,6 +148,7 @@ class RssFeed extends \OxidEsales\Eshop\Core\Base
      *
      * @access protected
      * @return array
+     * @deprecated underscore prefix violates PSR12, will be renamed to "loadFromCache" in next major
      */
     protected function _loadFromCache($name) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -168,6 +171,7 @@ class RssFeed extends \OxidEsales\Eshop\Core\Base
      *
      * @access protected
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getLastBuildDate" in next major
      */
     protected function _getLastBuildDate($name, $aData) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -194,6 +198,7 @@ class RssFeed extends \OxidEsales\Eshop\Core\Base
      *
      * @access protected
      * @return void
+     * @deprecated underscore prefix violates PSR12, will be renamed to "saveToCache" in next major
      */
     protected function _saveToCache($name, $aContent) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -210,6 +215,7 @@ class RssFeed extends \OxidEsales\Eshop\Core\Base
      *
      * @access protected
      * @return array
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getArticleItems" in next major
      */
     protected function _getArticleItems(\OxidEsales\Eshop\Application\Model\ArticleList $oList) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -280,6 +286,7 @@ class RssFeed extends \OxidEsales\Eshop\Core\Base
      * @access protected
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "prepareUrl" in next major
      */
     protected function _prepareUrl($sUri, $sTitle) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -303,6 +310,7 @@ class RssFeed extends \OxidEsales\Eshop\Core\Base
      * @access protected
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "prepareFeedName" in next major
      */
     protected function _prepareFeedName($sTitle) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -316,6 +324,7 @@ class RssFeed extends \OxidEsales\Eshop\Core\Base
      *
      * @access protected
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getShopUrl" in next major
      */
     protected function _getShopUrl() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -343,6 +352,7 @@ class RssFeed extends \OxidEsales\Eshop\Core\Base
      * @param string $sTargetUrl url of page rss represents
      *
      * @access protected
+     * @deprecated underscore prefix violates PSR12, will be renamed to "loadData" in next major
      */
     protected function _loadData($sTag, $sTitle, $sDesc, $aItems, $sRssUrl, $sTargetUrl = null) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -498,6 +508,7 @@ class RssFeed extends \OxidEsales\Eshop\Core\Base
      * @param \OxidEsales\Eshop\Application\Model\Category $oCat category object
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getCatPath" in next major
      */
     protected function _getCatPath($oCat) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -593,6 +604,7 @@ class RssFeed extends \OxidEsales\Eshop\Core\Base
      * @access protected
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getSearchParamsUrl" in next major
      */
     protected function _getSearchParamsUrl($sSearch, $sCatId, $sVendorId, $sManufacturerId) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -621,6 +633,7 @@ class RssFeed extends \OxidEsales\Eshop\Core\Base
      *
      * @access protected
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getObjectField" in next major
      */
     protected function _getObjectField($sId, $sObject, $sField) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -647,6 +660,7 @@ class RssFeed extends \OxidEsales\Eshop\Core\Base
      *
      * @access protected
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getSearchParamsTranslation" in next major
      */
     protected function _getSearchParamsTranslation($sSearch, $sId, $sCatId, $sVendorId, $sManufacturerId) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -964,6 +978,7 @@ class RssFeed extends \OxidEsales\Eshop\Core\Base
      * @param string $sFilePath The path of the file we want to delete.
      *
      * @return bool Went everything well?
+     * @deprecated underscore prefix violates PSR12, will be renamed to "deleteFile" in next major
      */
     protected function _deleteFile($sFilePath) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {

--- a/source/Application/Model/Search.php
+++ b/source/Application/Model/Search.php
@@ -112,6 +112,7 @@ class Search extends \OxidEsales\Eshop\Core\Base
      * @param string $sSortBy                    sort by
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getSearchSelect" in next major
      */
     protected function _getSearchSelect($sSearchParamForQuery = false, $sInitialSearchCat = false, $sInitialSearchVendor = false, $sInitialSearchManufacturer = false, $sSortBy = false) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -239,6 +240,7 @@ class Search extends \OxidEsales\Eshop\Core\Base
      * @param string $sSearchString searching string
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getWhere" in next major
      */
     protected function _getWhere($sSearchString) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {

--- a/source/Application/Model/SeoEncoderArticle.php
+++ b/source/Application/Model/SeoEncoderArticle.php
@@ -30,6 +30,7 @@ class SeoEncoderArticle extends \OxidEsales\Eshop\Core\SeoEncoder
      * Returns target "extension" (.html)
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getUrlExtension" in next major
      */
     protected function _getUrlExtension() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -44,6 +45,7 @@ class SeoEncoderArticle extends \OxidEsales\Eshop\Core\SeoEncoder
      * @param int                                         $iLang    user defined language id
      *
      * @return \OxidEsales\Eshop\Application\Model\Article
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getProductForLang" in next major
      */
     protected function _getProductForLang($oArticle, $iLang) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -127,6 +129,7 @@ class SeoEncoderArticle extends \OxidEsales\Eshop\Core\SeoEncoder
      * Returns active list type
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getListType" in next major
      */
     protected function _getListType() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -141,6 +144,7 @@ class SeoEncoderArticle extends \OxidEsales\Eshop\Core\SeoEncoder
      * @param int                                          $iLang     language to generate uri for
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "createArticleCategoryUri" in next major
      */
     protected function _createArticleCategoryUri($oArticle, $oCategory, $iLang) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -223,7 +227,8 @@ class SeoEncoderArticle extends \OxidEsales\Eshop\Core\SeoEncoder
      * @param \OxidEsales\Eshop\Application\Model\Article $oArticle product
      * @param int                                         $iLang    language id
      *
-     * @return \OxidEsales\Eshop\Application\Model\Category | null
+     * @return \OxidEsales\Eshop\Application\Model\Category|null
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getCategory" in next major
      */
     protected function _getCategory($oArticle, $iLang) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -244,6 +249,7 @@ class SeoEncoderArticle extends \OxidEsales\Eshop\Core\SeoEncoder
      * @param \OxidEsales\Eshop\Application\Model\Article $oArticle product
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getMainCategory" in next major
      */
     protected function _getMainCategory($oArticle) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -331,6 +337,7 @@ class SeoEncoderArticle extends \OxidEsales\Eshop\Core\SeoEncoder
      * @param \OxidEsales\Eshop\Application\Model\Article $oArticle article object
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "prepareArticleTitle" in next major
      */
     protected function _prepareArticleTitle($oArticle) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -415,7 +422,8 @@ class SeoEncoderArticle extends \OxidEsales\Eshop\Core\SeoEncoder
      * @param \OxidEsales\Eshop\Application\Model\Article $oArticle product
      * @param int                                         $iLang    language id
      *
-     * @return \OxidEsales\Eshop\Application\Model\Vendor | null
+     * @return \OxidEsales\Eshop\Application\Model\Vendor|null
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getVendor" in next major
      */
     protected function _getVendor($oArticle, $iLang) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -492,7 +500,8 @@ class SeoEncoderArticle extends \OxidEsales\Eshop\Core\SeoEncoder
      * @param \OxidEsales\Eshop\Application\Model\Article $oArticle product
      * @param int                                         $iLang    language id
      *
-     * @return \OxidEsales\Eshop\Application\Model\Manufacturer | null
+     * @return \OxidEsales\Eshop\Application\Model\Manufacturer|null
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getManufacturer" in next major
      */
     protected function _getManufacturer($oArticle, $iLang) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -602,6 +611,7 @@ class SeoEncoderArticle extends \OxidEsales\Eshop\Core\SeoEncoder
      * @param int    $iLang     language id
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getAltUri" in next major
      */
     protected function _getAltUri($sObjectId, $iLang) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {

--- a/source/Application/Model/SeoEncoderCategory.php
+++ b/source/Application/Model/SeoEncoderCategory.php
@@ -21,6 +21,7 @@ class SeoEncoderCategory extends \OxidEsales\Eshop\Core\SeoEncoder
      * Returns target "extension" (/)
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getUrlExtension" in next major
      */
     protected function _getUrlExtension() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -37,6 +38,7 @@ class SeoEncoderCategory extends \OxidEsales\Eshop\Core\SeoEncoder
      * @access protected
      *
      * @return boolean
+     * @deprecated underscore prefix violates PSR12, will be renamed to "categoryUrlLoader" in next major
      */
     protected function _categoryUrlLoader($oCat, $iLang) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -60,6 +62,7 @@ class SeoEncoderCategory extends \OxidEsales\Eshop\Core\SeoEncoder
      * @access private
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getCategoryCacheId" in next major
      */
     private function _getCategoryCacheId($oCat, $iLang) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -254,6 +257,7 @@ class SeoEncoderCategory extends \OxidEsales\Eshop\Core\SeoEncoder
      * @param int    $iLang     language id
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getAltUri" in next major
      */
     protected function _getAltUri($sObjectId, $iLang) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {

--- a/source/Application/Model/SeoEncoderContent.php
+++ b/source/Application/Model/SeoEncoderContent.php
@@ -19,6 +19,7 @@ class SeoEncoderContent extends \OxidEsales\Eshop\Core\SeoEncoder
      * Returns target "extension" (/)
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getUrlExtension" in next major
      */
     protected function _getUrlExtension() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -114,6 +115,7 @@ class SeoEncoderContent extends \OxidEsales\Eshop\Core\SeoEncoder
      * @param int    $iLang     language id
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getAltUri" in next major
      */
     protected function _getAltUri($sObjectId, $iLang) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {

--- a/source/Application/Model/SeoEncoderManufacturer.php
+++ b/source/Application/Model/SeoEncoderManufacturer.php
@@ -25,6 +25,7 @@ class SeoEncoderManufacturer extends \OxidEsales\Eshop\Core\SeoEncoder
      * Returns target "extension" (/)
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getUrlExtension" in next major
      */
     protected function _getUrlExtension() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -144,6 +145,7 @@ class SeoEncoderManufacturer extends \OxidEsales\Eshop\Core\SeoEncoder
      * @param int    $iLang     language id
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getAltUri" in next major
      */
     protected function _getAltUri($sObjectId, $iLang) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {

--- a/source/Application/Model/SeoEncoderVendor.php
+++ b/source/Application/Model/SeoEncoderVendor.php
@@ -26,6 +26,7 @@ class SeoEncoderVendor extends \OxidEsales\Eshop\Core\SeoEncoder
      * Returns target "extension" (/)
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getUrlExtension" in next major
      */
     protected function _getUrlExtension() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -146,6 +147,7 @@ class SeoEncoderVendor extends \OxidEsales\Eshop\Core\SeoEncoder
      * @param int    $languageId Language id
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getAltUri" in next major
      */
     protected function _getAltUri($vendorId, $languageId) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {

--- a/source/Application/Model/Shop.php
+++ b/source/Application/Model/Shop.php
@@ -192,6 +192,7 @@ class Shop extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel
      * @param int    $iLang  Language id
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getViewSelect" in next major
      */
     protected function _getViewSelect($sTable, $iLang) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -212,6 +213,7 @@ class Shop extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel
      * @param string $sTable table name
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getViewSelectMultilang" in next major
      */
     protected function _getViewSelectMultilang($sTable) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -237,6 +239,7 @@ class Shop extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel
      * @param string $sTable table name
      *
      * @return string $sSQL
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getViewJoinAll" in next major
      */
     protected function _getViewJoinAll($sTable) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -259,6 +262,7 @@ class Shop extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel
      * @param int    $iLang  language id
      *
      * @return string $sSQL
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getViewJoinLang" in next major
      */
     protected function _getViewJoinLang($sTable, $iLang) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -273,6 +277,7 @@ class Shop extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel
 
     /**
      * Gets all invalid views and drops them from database
+     * @deprecated underscore prefix violates PSR12, will be renamed to "cleanInvalidViews" in next major
      */
     protected function _cleanInvalidViews() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -303,6 +308,7 @@ class Shop extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel
 
     /**
      * Creates all view queries and adds them in query array
+     * @deprecated underscore prefix violates PSR12, will be renamed to "prepareViewsQueries" in next major
      */
     protected function _prepareViewsQueries() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -350,6 +356,7 @@ class Shop extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel
      * Returns false when any of the queries fail, otherwise return true
      *
      * @return bool
+     * @deprecated underscore prefix violates PSR12, will be renamed to "runQueries" in next major
      */
     protected function _runQueries() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {

--- a/source/Application/Model/ShopViewValidator.php
+++ b/source/Application/Model/ShopViewValidator.php
@@ -138,6 +138,7 @@ class ShopViewValidator
      * Returns list of all shop views
      *
      * @return array
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getAllViews" in next major
      */
     protected function _getAllViews() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -154,6 +155,7 @@ class ShopViewValidator
      * @param string $sViewName View name
      *
      * @return bool
+     * @deprecated underscore prefix violates PSR12, will be renamed to "isCurrentShopView" in next major
      */
     protected function _isCurrentShopView($sViewName) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -178,6 +180,7 @@ class ShopViewValidator
      * Returns list of shop specific views currently in database
      *
      * @return array
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getShopViews" in next major
      */
     protected function _getShopViews() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -199,6 +202,7 @@ class ShopViewValidator
      * Returns list of valid shop views
      *
      * @return array
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getValidShopViews" in next major
      */
     protected function _getValidShopViews() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -248,6 +252,7 @@ class ShopViewValidator
      * @param string $sViewName View name
      *
      * @return bool
+     * @deprecated underscore prefix violates PSR12, will be renamed to "isViewValid" in next major
      */
     protected function _isViewValid($sViewName) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {

--- a/source/Application/Model/SimpleVariant.php
+++ b/source/Application/Model/SimpleVariant.php
@@ -105,6 +105,7 @@ class SimpleVariant extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel impl
      * get user Group A, B or C price, returns db price if user is not in groups
      *
      * @return double
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getGroupPrice" in next major
      */
     protected function _getGroupPrice() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -174,6 +175,7 @@ class SimpleVariant extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel impl
      *
      * @param \OxidEsales\Eshop\Core\Price $oPrice Price object
      * @param object                       $oCur   Currency object
+     * @deprecated underscore prefix violates PSR12, will be renamed to "applyCurrency" in next major
      */
     protected function _applyCurrency(\OxidEsales\Eshop\Core\Price $oPrice, $oCur = null) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -188,6 +190,7 @@ class SimpleVariant extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel impl
      * Applies discounts which should be applied in general case (for 0 amount)
      *
      * @param \OxidEsales\Eshop\Core\Price $oPrice Price object
+     * @deprecated underscore prefix violates PSR12, will be renamed to "applyParentDiscounts" in next major
      */
     protected function _applyParentDiscounts($oPrice) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -200,6 +203,7 @@ class SimpleVariant extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel impl
      * apply parent article VAT to given price
      *
      * @param \OxidEsales\Eshop\Core\Price $oPrice price object
+     * @deprecated underscore prefix violates PSR12, will be renamed to "applyParentVat" in next major
      */
     protected function _applyParentVat($oPrice) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {

--- a/source/Application/Model/SimpleVariantList.php
+++ b/source/Application/Model/SimpleVariantList.php
@@ -40,6 +40,7 @@ class SimpleVariantList extends \OxidEsales\Eshop\Core\Model\ListModel
      *
      * @param oxSimleVariant $oListObject Simple variant
      * @param array          $aDbFields   Array of available
+     * @deprecated underscore prefix violates PSR12, will be renamed to "assignElement" in next major
      */
     protected function _assignElement($oListObject, $aDbFields) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {

--- a/source/Application/Model/User.php
+++ b/source/Application/Model/User.php
@@ -181,6 +181,7 @@ class User extends \OxidEsales\Eshop\Core\Model\BaseModel
      * Gets state object.
      *
      * @return oxState
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getStateObject" in next major
      */
     protected function _getStateObject() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -423,6 +424,7 @@ class User extends \OxidEsales\Eshop\Core\Model\BaseModel
      * Checks if product from wishlist is added
      *
      * @return $sWishId
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getWishListId" in next major
      */
     protected function _getWishListId() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -1234,6 +1236,7 @@ class User extends \OxidEsales\Eshop\Core\Model\BaseModel
      * Returns merged delivery address fields.
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getMergedAddressFields" in next major
      */
     protected function _getMergedAddressFields() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -1261,6 +1264,7 @@ class User extends \OxidEsales\Eshop\Core\Model\BaseModel
      * creates new address entry or updates existing
      *
      * @param array $aDelAddress address data array
+     * @deprecated underscore prefix violates PSR12, will be renamed to "assignAddress" in next major
      */
     protected function _assignAddress($aDelAddress) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -1372,6 +1376,7 @@ class User extends \OxidEsales\Eshop\Core\Model\BaseModel
      * @param bool   $blAdmin  admin/non admin mode
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getShopSelect" in next major
      */
     protected function _getShopSelect($myConfig, $sShopID, $blAdmin) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -1599,6 +1604,7 @@ class User extends \OxidEsales\Eshop\Core\Model\BaseModel
      * Checks if user is connected via cookies and if so, returns user id.
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getCookieUserId" in next major
      */
     protected function _getCookieUserId() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -1711,6 +1717,7 @@ class User extends \OxidEsales\Eshop\Core\Model\BaseModel
      * user rights index.
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getUserRights" in next major
      */
     protected function _getUserRights() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -1763,6 +1770,7 @@ class User extends \OxidEsales\Eshop\Core\Model\BaseModel
      * Inserts user object data to DB. Returns true on success.
      *
      * @return bool
+     * @deprecated underscore prefix violates PSR12, will be renamed to "insert" in next major
      */
     protected function _insert() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -1781,6 +1789,7 @@ class User extends \OxidEsales\Eshop\Core\Model\BaseModel
      * Updates changed user object data to DB. Returns true on success.
      *
      * @return bool
+     * @deprecated underscore prefix violates PSR12, will be renamed to "update" in next major
      */
     protected function _update() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -1930,6 +1939,7 @@ class User extends \OxidEsales\Eshop\Core\Model\BaseModel
      * according to users country information
      *
      * @param string $sCountryId users country id
+     * @deprecated underscore prefix violates PSR12, will be renamed to "setAutoGroups" in next major
      */
     protected function _setAutoGroups($sCountryId) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -2429,6 +2439,7 @@ class User extends \OxidEsales\Eshop\Core\Model\BaseModel
      * Return true - if shop is in demo mode
      *
      * @return bool
+     * @deprecated underscore prefix violates PSR12, will be renamed to "isDemoShop" in next major
      */
     protected function _isDemoShop() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -2450,6 +2461,7 @@ class User extends \OxidEsales\Eshop\Core\Model\BaseModel
      * @throws object $oEx
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getDemoShopLoginQuery" in next major
      */
     protected function _getDemoShopLoginQuery($sUser, $sPassword) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {

--- a/source/Application/Model/UserBasket.php
+++ b/source/Application/Model/UserBasket.php
@@ -62,6 +62,7 @@ class UserBasket extends \OxidEsales\Eshop\Core\Model\BaseModel
      * Inserts object data to DB, returns true on success.
      *
      * @return mixed
+     * @deprecated underscore prefix violates PSR12, will be renamed to "insert" in next major
      */
     protected function _insert() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -185,6 +186,7 @@ class UserBasket extends \OxidEsales\Eshop\Core\Model\BaseModel
      * @param string $aPersParams persistent parameters
      *
      * @return oxUserBasketItem
+     * @deprecated underscore prefix violates PSR12, will be renamed to "createItem" in next major
      */
     protected function _createItem($sProductId, $aSelList = null, $aPersParams = null) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -246,6 +248,7 @@ class UserBasket extends \OxidEsales\Eshop\Core\Model\BaseModel
      * @param array  $aPersParam basket item persistent parameters
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getItemKey" in next major
      */
     protected function _getItemKey($sProductId, $aSel = null, $aPersParam = null) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {

--- a/source/Application/Model/UserBasketItem.php
+++ b/source/Application/Model/UserBasketItem.php
@@ -195,6 +195,7 @@ class UserBasketItem extends \OxidEsales\Eshop\Core\Model\BaseModel
      * @param int    $iDataType  field type
      *
      * @return null
+     * @deprecated underscore prefix violates PSR12, will be renamed to "setFieldData" in next major
      */
     protected function _setFieldData($sFieldName, $sValue, $iDataType = \OxidEsales\Eshop\Core\Field::T_TEXT) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {

--- a/source/Application/Model/UserPayment.php
+++ b/source/Application/Model/UserPayment.php
@@ -135,6 +135,7 @@ class UserPayment extends \OxidEsales\Eshop\Core\Model\BaseModel
      * Inserts payment information to DB. Returns insert status.
      *
      * @return bool
+     * @deprecated underscore prefix violates PSR12, will be renamed to "insert" in next major
      */
     protected function _insert() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -170,6 +171,7 @@ class UserPayment extends \OxidEsales\Eshop\Core\Model\BaseModel
      * Updates payment record in DB. Returns update status.
      *
      * @return bool
+     * @deprecated underscore prefix violates PSR12, will be renamed to "update" in next major
      */
     protected function _update() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {

--- a/source/Application/Model/VariantHandler.php
+++ b/source/Application/Model/VariantHandler.php
@@ -128,6 +128,7 @@ class VariantHandler extends \OxidEsales\Eshop\Core\Base
      * @param array  $aConfLanguages array of all active languages
      *
      * @return mixed
+     * @deprecated underscore prefix violates PSR12, will be renamed to "assignValues" in next major
      */
     protected function _assignValues($aValues, $oVariants, $oArticle, $aConfLanguages) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -214,6 +215,7 @@ class VariantHandler extends \OxidEsales\Eshop\Core\Base
      * @param double $dParentPrice parent article price
      *
      * @return double
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getValuePrice" in next major
      */
     protected function _getValuePrice($oValue, $dParentPrice) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -242,6 +244,7 @@ class VariantHandler extends \OxidEsales\Eshop\Core\Base
      * @param string $sParentId parent article id
      *
      * @return null
+     * @deprecated underscore prefix violates PSR12, will be renamed to "createNewVariant" in next major
      */
     protected function _createNewVariant($aParams = null, $sParentId = null) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -268,6 +271,7 @@ class VariantHandler extends \OxidEsales\Eshop\Core\Base
      *
      * @param string $sUpdate query for update variant name
      * @param string $sArtId  parent article id
+     * @deprecated underscore prefix violates PSR12, will be renamed to "updateArticleVarName" in next major
      */
     protected function _updateArticleVarName($sUpdate, $sArtId) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -303,6 +307,7 @@ class VariantHandler extends \OxidEsales\Eshop\Core\Base
      * @param string                                          $sActVariantId active variant id
      *
      * @return array
+     * @deprecated underscore prefix violates PSR12, will be renamed to "fillVariantSelections" in next major
      */
     protected function _fillVariantSelections($oVariantList, $iVarSelCnt, &$aFilter, $sActVariantId) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -335,7 +340,8 @@ class VariantHandler extends \OxidEsales\Eshop\Core\Base
      *
      * @param array $aFilter user given filter
      *
-     * @return array | bool
+     * @return array|bool
+     * @deprecated underscore prefix violates PSR12, will be renamed to "cleanFilter" in next major
      */
     protected function _cleanFilter($aFilter) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -358,6 +364,7 @@ class VariantHandler extends \OxidEsales\Eshop\Core\Base
      * @param array $aFilter     filter
      *
      * @return array
+     * @deprecated underscore prefix violates PSR12, will be renamed to "applyVariantSelectionsFilter" in next major
      */
     protected function _applyVariantSelectionsFilter($aSelections, $aFilter) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -409,6 +416,7 @@ class VariantHandler extends \OxidEsales\Eshop\Core\Base
      * @param array $aSelections variant selections
      *
      * @return array
+     * @deprecated underscore prefix violates PSR12, will be renamed to "buildVariantSelectionsList" in next major
      */
     protected function _buildVariantSelectionsList($aVarSelects, $aSelections) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -434,6 +442,7 @@ class VariantHandler extends \OxidEsales\Eshop\Core\Base
      * @param string $sTitle title to process
      *
      * @return array
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getSelections" in next major
      */
     protected function _getSelections($sTitle) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {

--- a/source/Application/Model/VatSelector.php
+++ b/source/Application/Model/VatSelector.php
@@ -78,6 +78,7 @@ class VatSelector extends \OxidEsales\Eshop\Core\Base
      * @param \OxidEsales\Eshop\Application\Model\Country $oCountry given country object
      *
      * @return mixed
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getForeignCountryUserVat" in next major
      */
     protected function _getForeignCountryUserVat(\OxidEsales\Eshop\Application\Model\User $oUser, \OxidEsales\Eshop\Application\Model\Country $oCountry) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -97,7 +98,8 @@ class VatSelector extends \OxidEsales\Eshop\Core\Base
      *
      * @param \OxidEsales\Eshop\Application\Model\Article $oArticle given article
      *
-     * @return float | false
+     * @return float|false
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getVatForArticleCategory" in next major
      */
     protected function _getVatForArticleCategory(\OxidEsales\Eshop\Application\Model\Article $oArticle) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -201,6 +203,7 @@ class VatSelector extends \OxidEsales\Eshop\Core\Base
      * @param \OxidEsales\Eshop\Application\Model\User $oUser user object
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getVatCountry" in next major
      */
     protected function _getVatCountry(\OxidEsales\Eshop\Application\Model\User $oUser) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {

--- a/source/Application/Model/Vendor.php
+++ b/source/Application/Model/Vendor.php
@@ -123,6 +123,7 @@ class Vendor extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements 
      * Sets root vendor data. Returns true
      *
      * @return bool
+     * @deprecated underscore prefix violates PSR12, will be renamed to "setRootObjectData" in next major
      */
     protected function _setRootObjectData() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {

--- a/source/Application/Model/VendorList.php
+++ b/source/Application/Model/VendorList.php
@@ -147,6 +147,7 @@ class VendorList extends \OxidEsales\Eshop\Core\Model\ListModel
      * Adds category specific fields to vendor object
      *
      * @param object $oVendor vendor object
+     * @deprecated underscore prefix violates PSR12, will be renamed to "addCategoryFields" in next major
      */
     protected function _addCategoryFields($oVendor) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -181,6 +182,7 @@ class VendorList extends \OxidEsales\Eshop\Core\Model\ListModel
 
     /**
      * Processes vendor category URLs
+     * @deprecated underscore prefix violates PSR12, will be renamed to "seoSetVendorData" in next major
      */
     protected function _seoSetVendorData() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {

--- a/source/Application/Model/Voucher.php
+++ b/source/Application/Model/Voucher.php
@@ -219,6 +219,7 @@ class Voucher extends \OxidEsales\Eshop\Core\Model\BaseModel
      * @throws oxVoucherException exception
      *
      * @return array
+     * @deprecated underscore prefix violates PSR12, will be renamed to "isAvailablePrice" in next major
      */
     protected function _isAvailablePrice($dPrice) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -244,6 +245,7 @@ class Voucher extends \OxidEsales\Eshop\Core\Model\BaseModel
      *
      * @return bool
      *
+     * @deprecated underscore prefix violates PSR12, will be renamed to "isAvailableWithSameSeries" in next major
      */
     protected function _isAvailableWithSameSeries($aVouchers) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -279,6 +281,7 @@ class Voucher extends \OxidEsales\Eshop\Core\Model\BaseModel
      * @throws oxVoucherException exception
      *
      * @return bool
+     * @deprecated underscore prefix violates PSR12, will be renamed to "isAvailableWithOtherSeries" in next major
      */
     protected function _isAvailableWithOtherSeries($aVouchers) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -320,6 +323,7 @@ class Voucher extends \OxidEsales\Eshop\Core\Model\BaseModel
      * @throws oxVoucherException exception
      *
      * @return bool
+     * @deprecated underscore prefix violates PSR12, will be renamed to "isValidDate" in next major
      */
     protected function _isValidDate() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -357,6 +361,7 @@ class Voucher extends \OxidEsales\Eshop\Core\Model\BaseModel
      * @throws oxVoucherException exception
      *
      * @return bool
+     * @deprecated underscore prefix violates PSR12, will be renamed to "isNotReserved" in next major
      */
     protected function _isNotReserved() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -397,6 +402,7 @@ class Voucher extends \OxidEsales\Eshop\Core\Model\BaseModel
      * @throws oxVoucherException exception
      *
      * @return boolean
+     * @deprecated underscore prefix violates PSR12, will be renamed to "isAvailableInOtherOrder" in next major
      */
     protected function _isAvailableInOtherOrder($oUser) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -432,6 +438,7 @@ class Voucher extends \OxidEsales\Eshop\Core\Model\BaseModel
      * @throws oxVoucherException exception
      *
      * @return bool
+     * @deprecated underscore prefix violates PSR12, will be renamed to "isValidUserGroup" in next major
      */
     protected function _isValidUserGroup($oUser) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -500,6 +507,7 @@ class Voucher extends \OxidEsales\Eshop\Core\Model\BaseModel
      * Returns true if voucher is product specific, otherwise false
      *
      * @return boolean
+     * @deprecated underscore prefix violates PSR12, will be renamed to "isProductVoucher" in next major
      */
     protected function _isProductVoucher() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -519,6 +527,7 @@ class Voucher extends \OxidEsales\Eshop\Core\Model\BaseModel
      * Returns true if voucher is category specific, otherwise false
      *
      * @return boolean
+     * @deprecated underscore prefix violates PSR12, will be renamed to "isCategoryVoucher" in next major
      */
     protected function _isCategoryVoucher() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -538,6 +547,7 @@ class Voucher extends \OxidEsales\Eshop\Core\Model\BaseModel
      * Returns the discount object created from voucher serie data
      *
      * @return object
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getSerieDiscount" in next major
      */
     protected function _getSerieDiscount() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -569,6 +579,7 @@ class Voucher extends \OxidEsales\Eshop\Core\Model\BaseModel
      * @param \OxidEsales\Eshop\Application\Model\Discount $oDiscount discount object
      *
      * @return array
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getBasketItems" in next major
      */
     protected function _getBasketItems($oDiscount = null) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -587,6 +598,7 @@ class Voucher extends \OxidEsales\Eshop\Core\Model\BaseModel
      * @param \OxidEsales\Eshop\Application\Model\Discount $oDiscount discount object
      *
      * @return array
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getOrderBasketItems" in next major
      */
     protected function _getOrderBasketItems($oDiscount = null) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -621,6 +633,7 @@ class Voucher extends \OxidEsales\Eshop\Core\Model\BaseModel
      * @param \OxidEsales\Eshop\Application\Model\Discount $oDiscount discount object
      *
      * @return array
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getSessionBasketItems" in next major
      */
     protected function _getSessionBasketItems($oDiscount = null) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -672,6 +685,7 @@ class Voucher extends \OxidEsales\Eshop\Core\Model\BaseModel
      * @throws oxVoucherException exception
      *
      * @return double
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getGenericDiscountValue" in next major
      */
     protected function _getGenericDiscountValue($dPrice) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -739,6 +753,7 @@ class Voucher extends \OxidEsales\Eshop\Core\Model\BaseModel
      * @throws oxVoucherException exception
      *
      * @return double
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getProductDiscountValue" in next major
      */
     protected function _getProductDiscountValue($dPrice) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -820,6 +835,7 @@ class Voucher extends \OxidEsales\Eshop\Core\Model\BaseModel
      * @throws oxVoucherException exception
      *
      * @return double
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getCategoryDiscountValue" in next major
      */
     protected function _getCategoryDiscountValue($dPrice) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -878,6 +894,7 @@ class Voucher extends \OxidEsales\Eshop\Core\Model\BaseModel
      * of 3 hours if not configured
      *
      * @return integer Seconds a voucher can stay in status reserved
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getVoucherTimeout" in next major
      */
     protected function _getVoucherTimeout() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {

--- a/source/Application/Model/Wrapping.php
+++ b/source/Application/Model/Wrapping.php
@@ -153,6 +153,7 @@ class Wrapping extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel
      * Checks and return true if price view mode is netto
      *
      * @return bool
+     * @deprecated underscore prefix violates PSR12, will be renamed to "isPriceViewModeNetto" in next major
      */
     protected function _isPriceViewModeNetto() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {

--- a/source/Core/Config.php
+++ b/source/Core/Config.php
@@ -362,6 +362,7 @@ class Config extends \OxidEsales\Eshop\Core\Base
 
     /**
      * Parse SEO url parameters.
+     * @deprecated underscore prefix violates PSR12, will be renamed to "processSeoCall" in next major
      */
     protected function _processSeoCall() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -473,6 +474,7 @@ class Config extends \OxidEsales\Eshop\Core\Base
 
     /**
      * Loads vars from default config file
+     * @deprecated underscore prefix violates PSR12, will be renamed to "loadVarsFromFile" in next major
      */
     protected function _loadVarsFromFile() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -492,6 +494,7 @@ class Config extends \OxidEsales\Eshop\Core\Base
 
     /**
      * Set important defaults.
+     * @deprecated underscore prefix violates PSR12, will be renamed to "setDefaults" in next major
      */
     protected function _setDefaults() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -535,6 +538,7 @@ class Config extends \OxidEsales\Eshop\Core\Base
 
     /**
      * Loads vars from custom config file
+     * @deprecated underscore prefix violates PSR12, will be renamed to "loadCustomConfig" in next major
      */
     protected function _loadCustomConfig() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -552,6 +556,7 @@ class Config extends \OxidEsales\Eshop\Core\Base
      * @param string $module   module vars to load, empty for base options
      *
      * @return bool
+     * @deprecated underscore prefix violates PSR12, will be renamed to "loadVarsFromDb" in next major
      */
     protected function _loadVarsFromDb($shopID, $onlyVars = null, $module = '') // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -598,6 +603,7 @@ class Config extends \OxidEsales\Eshop\Core\Base
      * @param array $vars
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getConfigParamsSelectSnippet" in next major
      */
     protected function _getConfigParamsSelectSnippet($vars) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -621,6 +627,7 @@ class Config extends \OxidEsales\Eshop\Core\Base
      * @param string $varVal  serialized by type value
      *
      * @return null
+     * @deprecated underscore prefix violates PSR12, will be renamed to "setConfVarFromDb" in next major
      */
     protected function _setConfVarFromDb($varName, $varType, $varVal) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -828,6 +835,7 @@ class Config extends \OxidEsales\Eshop\Core\Base
 
     /**
      * Checks if WEB session is SSL.
+     * @deprecated underscore prefix violates PSR12, will be renamed to "checkSsl" in next major
      */
     protected function _checkSsl() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -2256,6 +2264,7 @@ class Config extends \OxidEsales\Eshop\Core\Base
      * So just go straight and call the ExceptionHandler.
      *
      * @param \OxidEsales\Eshop\Core\Exception\DatabaseException $exception
+     * @deprecated underscore prefix violates PSR12, will be renamed to "handleDbConnectionException" in next major
      */
     protected function _handleDbConnectionException(\OxidEsales\Eshop\Core\Exception\DatabaseException $exception) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -2267,6 +2276,7 @@ class Config extends \OxidEsales\Eshop\Core\Base
      * Redirect to start page and display the error
      *
      * @param \OxidEsales\Eshop\Core\Exception\StandardException $ex message to show on exit
+     * @deprecated underscore prefix violates PSR12, will be renamed to "handleCookieException" in next major
      */
     protected function _handleCookieException($ex) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -2310,6 +2320,7 @@ class Config extends \OxidEsales\Eshop\Core\Base
      * @param string $shopId
      *
      * @return bool
+     * @deprecated underscore prefix violates PSR12, will be renamed to "isValidShopId" in next major
      */
     protected function _isValidShopId($shopId) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {

--- a/source/Core/ConfigFile.php
+++ b/source/Core/ConfigFile.php
@@ -85,6 +85,7 @@ class ConfigFile
      * this method is a subject to be changed.
      *
      * @param string $fileName Configuration file name
+     * @deprecated underscore prefix violates PSR12, will be renamed to "loadVars" in next major
      */
     private function _loadVars($fileName) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {

--- a/source/Core/Controller/BaseController.php
+++ b/source/Core/Controller/BaseController.php
@@ -559,6 +559,7 @@ class BaseController extends \OxidEsales\Eshop\Core\Base
      * @param string $sNewAction new action params
      *
      * @throws \OxidEsales\Eshop\Core\Exception\SystemComponentException system component exception
+     * @deprecated underscore prefix violates PSR12, will be renamed to "executeNewAction" in next major
      */
     protected function _executeNewAction($sNewAction) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {

--- a/source/Core/CreditCardValidator.php
+++ b/source/Core/CreditCardValidator.php
@@ -89,7 +89,7 @@ class CreditCardValidator
             // Luhn algorithm
             for ($pos = 0; $pos < $length; $pos++) {
                 // taking digit to check..
-                $currDigit = (int) $number{$pos};
+                $currDigit = (int) $number[$pos];
 
                 // multiplying if needed..
                 $addValue = (($pos % 2 == $mod) ? 2 : 1) * $currDigit;

--- a/source/Core/CreditCardValidator.php
+++ b/source/Core/CreditCardValidator.php
@@ -38,6 +38,7 @@ class CreditCardValidator
      * @param string $number credit card number
      *
      * @return bool
+     * @deprecated underscore prefix violates PSR12, will be renamed to "isValidType" in next major
      */
     protected function _isValidType($type, $number) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -55,6 +56,7 @@ class CreditCardValidator
      * @param string $date credit card type
      *
      * @return bool
+     * @deprecated underscore prefix violates PSR12, will be renamed to "isExpired" in next major
      */
     protected function _isExpired($date) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -78,6 +80,7 @@ class CreditCardValidator
      * @param string $number credit card number
      *
      * @return bool
+     * @deprecated underscore prefix violates PSR12, will be renamed to "isValidNumer" in next major
      */
     protected function _isValidNumer($number) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {

--- a/source/Core/Curl.php
+++ b/source/Core/Curl.php
@@ -338,6 +338,7 @@ class Curl
      * Sets resource
      *
      * @param resource $rCurl curl.
+     * @deprecated underscore prefix violates PSR12, will be renamed to "setResource" in next major
      */
     protected function _setResource($rCurl) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -348,6 +349,7 @@ class Curl
      * Returns curl resource
      *
      * @return resource
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getResource" in next major
      */
     protected function _getResource() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -360,6 +362,7 @@ class Curl
 
     /**
      * Set Curl Options
+     * @deprecated underscore prefix violates PSR12, will be renamed to "setOptions" in next major
      */
     protected function _setOptions() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -385,6 +388,7 @@ class Curl
      * Wrapper function to be mocked for testing.
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "execute" in next major
      */
     protected function _execute() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -393,6 +397,7 @@ class Curl
 
     /**
      * Wrapper function to be mocked for testing.
+     * @deprecated underscore prefix violates PSR12, will be renamed to "close" in next major
      */
     protected function _close() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -405,6 +410,7 @@ class Curl
      *
      * @param string $name  curl option name to set value to.
      * @param string $value curl option value to set.
+     * @deprecated underscore prefix violates PSR12, will be renamed to "setOpt" in next major
      */
     protected function _setOpt($name, $value) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -415,6 +421,7 @@ class Curl
      * Check if curl has errors. Set error message if has.
      *
      * @return int
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getErrorNumber" in next major
      */
     protected function _getErrorNumber() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -423,6 +430,7 @@ class Curl
 
     /**
      * Sets current request HTTP status code.
+     * @deprecated underscore prefix violates PSR12, will be renamed to "saveStatusCode" in next major
      */
     protected function _saveStatusCode() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -435,6 +443,7 @@ class Curl
      * @param array $params Parameters.
      *
      * @return array
+     * @deprecated underscore prefix violates PSR12, will be renamed to "prepareQueryParameters" in next major
      */
     protected function _prepareQueryParameters($params) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -447,6 +456,7 @@ class Curl
      * @param mixed $mParam query
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "htmlDecode" in next major
      */
     protected function _htmlDecode($mParam) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {

--- a/source/Core/Database/Adapter/DatabaseInterface.php
+++ b/source/Core/Database/Adapter/DatabaseInterface.php
@@ -363,7 +363,6 @@ interface DatabaseInterface
      *
      * @return bool|integer
      */
-
     /**
      * Set the transaction isolation level.
      * Allowed values 'READ UNCOMMITTED', 'READ COMMITTED', 'REPEATABLE READ' and 'SERIALIZABLE'.

--- a/source/Core/DbMetaDataHandler.php
+++ b/source/Core/DbMetaDataHandler.php
@@ -213,6 +213,7 @@ class DbMetaDataHandler extends \OxidEsales\Eshop\Core\Base
      *
      * @return string
      *
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getCreateTableSetSql" in next major
      */
     protected function _getCreateTableSetSql($table, $lang) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {

--- a/source/Core/Decryptor.php
+++ b/source/Core/Decryptor.php
@@ -39,6 +39,7 @@ class Decryptor
      * @param string $string
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "formKey" in next major
      */
     protected function _formKey($key, $string) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {

--- a/source/Core/DynamicImageGenerator.php
+++ b/source/Core/DynamicImageGenerator.php
@@ -171,6 +171,7 @@ namespace OxidEsales\EshopCommunity\Core {
          * Returns shops base path
          *
          * @return string
+         * @deprecated underscore prefix violates PSR12, will be renamed to "getShopBasePath" in next major
          */
         protected function _getShopBasePath() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
         {
@@ -181,6 +182,7 @@ namespace OxidEsales\EshopCommunity\Core {
          * Returns requested image uri
          *
          * @return string
+         * @deprecated underscore prefix violates PSR12, will be renamed to "getImageUri" in next major
          */
         protected function _getImageUri() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
         {
@@ -204,6 +206,7 @@ namespace OxidEsales\EshopCommunity\Core {
          * Returns requested image name
          *
          * @return string
+         * @deprecated underscore prefix violates PSR12, will be renamed to "getImageName" in next major
          */
         protected function _getImageName() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
         {
@@ -214,6 +217,7 @@ namespace OxidEsales\EshopCommunity\Core {
          * Returns path to possible master image
          *
          * @return string
+         * @deprecated underscore prefix violates PSR12, will be renamed to "getImageMasterPath" in next major
          */
         protected function _getImageMasterPath() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
         {
@@ -231,6 +235,7 @@ namespace OxidEsales\EshopCommunity\Core {
          * Returns image info array
          *
          * @return array
+         * @deprecated underscore prefix violates PSR12, will be renamed to "getImageInfo" in next major
          */
         protected function _getImageInfo() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
         {
@@ -246,6 +251,7 @@ namespace OxidEsales\EshopCommunity\Core {
          * Returns full requested image path on file system
          *
          * @return string
+         * @deprecated underscore prefix violates PSR12, will be renamed to "getImageTarget" in next major
          */
         protected function _getImageTarget() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
         {
@@ -256,6 +262,7 @@ namespace OxidEsales\EshopCommunity\Core {
          * Nopic image path
          *
          * @return string
+         * @deprecated underscore prefix violates PSR12, will be renamed to "getNopicImageTarget" in next major
          */
         protected function _getNopicImageTarget() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
         {
@@ -268,6 +275,7 @@ namespace OxidEsales\EshopCommunity\Core {
          * Returns image type used for image generation and header setting
          *
          * @return string
+         * @deprecated underscore prefix violates PSR12, will be renamed to "getImageType" in next major
          */
         protected function _getImageType() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
         {
@@ -294,6 +302,7 @@ namespace OxidEsales\EshopCommunity\Core {
          * @param int    $height image height
          *
          * @return string
+         * @deprecated underscore prefix violates PSR12, will be renamed to "generatePng" in next major
          */
         protected function _generatePng($source, $target, $width, $height) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
         {
@@ -310,6 +319,7 @@ namespace OxidEsales\EshopCommunity\Core {
          * @param int    $quality new image quality
          *
          * @return string
+         * @deprecated underscore prefix violates PSR12, will be renamed to "generateJpg" in next major
          */
         protected function _generateJpg($source, $target, $width, $height, $quality) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
         {
@@ -325,6 +335,7 @@ namespace OxidEsales\EshopCommunity\Core {
          * @param int    $height image height
          *
          * @return string
+         * @deprecated underscore prefix violates PSR12, will be renamed to "generateGif" in next major
          */
         protected function _generateGif($source, $target, $width, $height) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
         {
@@ -340,6 +351,7 @@ namespace OxidEsales\EshopCommunity\Core {
          * @param string $path image path name to check
          *
          * @return bool
+         * @deprecated underscore prefix violates PSR12, will be renamed to "isTargetPathValid" in next major
          */
         protected function _isTargetPathValid($path) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
         {
@@ -361,6 +373,7 @@ namespace OxidEsales\EshopCommunity\Core {
          * @param string $dir folder(s) to create
          *
          * @return bool
+         * @deprecated underscore prefix violates PSR12, will be renamed to "createFolders" in next major
          */
         protected function _createFolders($dir) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
         {
@@ -390,6 +403,7 @@ namespace OxidEsales\EshopCommunity\Core {
          * @param string $path image path name to check
          *
          * @return bool
+         * @deprecated underscore prefix violates PSR12, will be renamed to "isValidPath" in next major
          */
         protected function _isValidPath($path) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
         {
@@ -468,6 +482,7 @@ namespace OxidEsales\EshopCommunity\Core {
          * @throws OxidEsales\Eshop\Core\Exception\StandardException If the path of imageTarget and generated image are not the same
          *
          * @return bool|string Return false on failure or file path of the generated image on success
+         * @deprecated underscore prefix violates PSR12, will be renamed to "generateImage" in next major
          */
         protected function _generateImage($imageSource, $imageTarget) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
         {
@@ -533,6 +548,7 @@ namespace OxidEsales\EshopCommunity\Core {
          * @param string $name original file name
          *
          * @return string
+         * @deprecated underscore prefix violates PSR12, will be renamed to "getLockName" in next major
          */
         protected function _getLockName($name) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
         {
@@ -545,6 +561,7 @@ namespace OxidEsales\EshopCommunity\Core {
          * @param string $source source file which should be locked
          *
          * @return bool
+         * @deprecated underscore prefix violates PSR12, will be renamed to "lock" in next major
          */
         protected function _lock($source) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
         {
@@ -578,6 +595,7 @@ namespace OxidEsales\EshopCommunity\Core {
          * Deletes lock file
          *
          * @param string $source source file which should be locked
+         * @deprecated underscore prefix violates PSR12, will be renamed to "unlock" in next major
          */
         protected function _unlock($source) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
         {
@@ -698,6 +716,7 @@ namespace OxidEsales\EshopCommunity\Core {
          * Custom header setter
          *
          * @param string $header header
+         * @deprecated underscore prefix violates PSR12, will be renamed to "setHeader" in next major
          */
         protected function _setHeader($header) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
         {
@@ -708,6 +727,7 @@ namespace OxidEsales\EshopCommunity\Core {
          * Return headers array
          *
          * @return array
+         * @deprecated underscore prefix violates PSR12, will be renamed to "getHeaders" in next major
          */
         protected function _getHeaders() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
         {

--- a/source/Core/Email.php
+++ b/source/Core/Email.php
@@ -477,6 +477,7 @@ class Email extends PHPMailer
      * @param string $url initial smtp
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "setSmtpProtocol" in next major
      */
     protected function _setSmtpProtocol($url) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -535,6 +536,7 @@ class Email extends PHPMailer
      * @param string $smtpHost currently used smtp server host name
      *
      * @return bool
+     * @deprecated underscore prefix violates PSR12, will be renamed to "isValidSmtpHost" in next major
      */
     protected function _isValidSmtpHost($smtpHost) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -886,6 +888,7 @@ class Email extends PHPMailer
      * @param string $confirmCode confirmation code
      *
      * @return string $url
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getNewsSubsLink" in next major
      */
     protected function _getNewsSubsLink($id, $confirmCode = null) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -1451,6 +1454,7 @@ class Email extends PHPMailer
      * @param string $dynImageDir    Path to Dyn images
      * @param string $absImageDir    Absolute path to images
      * @param string $absDynImageDir Absolute path to Dyn images
+     * @deprecated underscore prefix violates PSR12, will be renamed to "includeImages" in next major
      */
     protected function _includeImages($imageDir = null, $imageDirNoSSL = null, $dynImageDir = null, $absImageDir = null, $absDynImageDir = null) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -1895,6 +1899,7 @@ class Email extends PHPMailer
      * Gets use inline images.
      *
      * @return bool
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getUseInlineImages" in next major
      */
     protected function _getUseInlineImages() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -1905,6 +1910,7 @@ class Email extends PHPMailer
      * Try to send error message when original mailing by smtp and via mail() fails
      *
      * @return bool
+     * @deprecated underscore prefix violates PSR12, will be renamed to "sendMailErrorMsg" in next major
      */
     protected function _sendMailErrorMsg() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -1934,6 +1940,7 @@ class Email extends PHPMailer
      * @param \OxidEsales\Eshop\Application\Model\Order $order Ordering object
      *
      * @return \OxidEsales\Eshop\Application\Model\Order
+     * @deprecated underscore prefix violates PSR12, will be renamed to "addUserInfoOrderEMail" in next major
      */
     protected function _addUserInfoOrderEMail($order) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -1948,6 +1955,7 @@ class Email extends PHPMailer
      * @param \OxidEsales\Eshop\Application\Model\User $user User object
      *
      * @return \OxidEsales\Eshop\Application\Model\User
+     * @deprecated underscore prefix violates PSR12, will be renamed to "addUserRegisterEmail" in next major
      */
     protected function _addUserRegisterEmail($user) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -1962,6 +1970,7 @@ class Email extends PHPMailer
      * @param \OxidEsales\Eshop\Application\Model\Shop $shop Shop object
      *
      * @return \OxidEsales\Eshop\Application\Model\Shop
+     * @deprecated underscore prefix violates PSR12, will be renamed to "addForgotPwdEmail" in next major
      */
     protected function _addForgotPwdEmail($shop) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -1976,6 +1985,7 @@ class Email extends PHPMailer
      * @param \OxidEsales\Eshop\Application\Model\User $user User object
      *
      * @return \OxidEsales\Eshop\Application\Model\User
+     * @deprecated underscore prefix violates PSR12, will be renamed to "addNewsletterDbOptInMail" in next major
      */
     protected function _addNewsletterDbOptInMail($user) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -1984,6 +1994,7 @@ class Email extends PHPMailer
 
     /**
      * Clears mailer settings (AllRecipients, ReplyTos, Attachments, Errors)
+     * @deprecated underscore prefix violates PSR12, will be renamed to "clearMailer" in next major
      */
     protected function _clearMailer() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -1998,6 +2009,7 @@ class Email extends PHPMailer
      * Set mail From, FromName, SMTP values
      *
      * @param \OxidEsales\Eshop\Application\Model\Shop $shop Shop object
+     * @deprecated underscore prefix violates PSR12, will be renamed to "setMailParams" in next major
      */
     protected function _setMailParams($shop = null) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -2019,6 +2031,7 @@ class Email extends PHPMailer
      * @param int $shopId shop id
      *
      * @return \OxidEsales\Eshop\Application\Model\Shop
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getShop" in next major
      */
     protected function _getShop($langId = null, $shopId = null) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -2049,6 +2062,7 @@ class Email extends PHPMailer
      *
      * @param string                                   $userName     smtp user
      * @param \OxidEsales\Eshop\Application\Model\Shop $userPassword smtp password
+     * @deprecated underscore prefix violates PSR12, will be renamed to "setSmtpAuthInfo" in next major
      */
     protected function _setSmtpAuthInfo($userName = null, $userPassword = null) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -2061,6 +2075,7 @@ class Email extends PHPMailer
      * Sets SMTP class debugging on or off
      *
      * @param bool $debug show debug info or not
+     * @deprecated underscore prefix violates PSR12, will be renamed to "setSmtpDebug" in next major
      */
     protected function _setSmtpDebug($debug = null) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -2070,6 +2085,7 @@ class Email extends PHPMailer
     /**
      * Process email body and alt body thought oxOutput.
      * Calls \OxidEsales\Eshop\Core\Output::processEmail() on class instance.
+     * @deprecated underscore prefix violates PSR12, will be renamed to "makeOutputProcessing" in next major
      */
     protected function _makeOutputProcessing() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -2083,6 +2099,7 @@ class Email extends PHPMailer
      * Sends email via phpmailer.
      *
      * @return bool
+     * @deprecated underscore prefix violates PSR12, will be renamed to "sendMail" in next major
      */
     protected function _sendMail() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -2104,6 +2121,7 @@ class Email extends PHPMailer
 
     /**
      * Process view data array through oxOutput processor
+     * @deprecated underscore prefix violates PSR12, will be renamed to "processViewArray" in next major
      */
     protected function _processViewArray() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -2261,6 +2279,7 @@ class Email extends PHPMailer
      * @param string $altBody Body.
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "clearSidFromBody" in next major
      */
     private function _clearSidFromBody($altBody) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {

--- a/source/Core/Encryptor.php
+++ b/source/Core/Encryptor.php
@@ -40,6 +40,7 @@ class Encryptor
      * @param string $string
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "formKey" in next major
      */
     protected function _formKey($key, $string) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {

--- a/source/Core/Field.php
+++ b/source/Core/Field.php
@@ -153,6 +153,7 @@ class Field // extends \OxidEsales\Eshop\Core\Base
      *
      * @param mixed $value Field value
      * @param int   $type  Value type
+     * @deprecated underscore prefix violates PSR12, will be renamed to "initValue" in next major
      */
     protected function _initValue($value = null, $type = self::T_TEXT) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {

--- a/source/Core/InputValidator.php
+++ b/source/Core/InputValidator.php
@@ -292,6 +292,7 @@ class InputValidator extends \OxidEsales\Eshop\Core\Base
      * @param array        $fields
      *
      * @return User|Address
+     * @deprecated underscore prefix violates PSR12, will be renamed to "setFields" in next major
      */
     private function _setFields($object, $fields) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -386,6 +387,7 @@ class InputValidator extends \OxidEsales\Eshop\Core\Base
      * @param string $countryId
      *
      * @return \OxidEsales\Eshop\Application\Model\Country
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getCountry" in next major
      */
     protected function _getCountry($countryId) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -498,6 +500,7 @@ class InputValidator extends \OxidEsales\Eshop\Core\Base
      * @param array $debitInformation Debit information
      *
      * @return bool|int
+     * @deprecated underscore prefix violates PSR12, will be renamed to "validateDebitNote" in next major
      */
     protected function _validateDebitNote($debitInformation) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -527,6 +530,7 @@ class InputValidator extends \OxidEsales\Eshop\Core\Base
      * @param array $debitInfo Debit info
      *
      * @return bool|int
+     * @deprecated underscore prefix violates PSR12, will be renamed to "validateOldDebitInfo" in next major
      */
     protected function _validateOldDebitInfo($debitInfo) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -555,6 +559,7 @@ class InputValidator extends \OxidEsales\Eshop\Core\Base
      * @param array $debitInfo Debit info.
      *
      * @return array
+     * @deprecated underscore prefix violates PSR12, will be renamed to "fixAccountNumber" in next major
      */
     protected function _fixAccountNumber($debitInfo) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -578,6 +583,7 @@ class InputValidator extends \OxidEsales\Eshop\Core\Base
      * @param array $bankInformation actual information.
      *
      * @return bool
+     * @deprecated underscore prefix violates PSR12, will be renamed to "isAllBankInformationSet" in next major
      */
     protected function _isAllBankInformationSet($requiredFields, $bankInformation) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -598,6 +604,7 @@ class InputValidator extends \OxidEsales\Eshop\Core\Base
      * @param array $debitInformation Debit information.
      *
      * @return mixed
+     * @deprecated underscore prefix violates PSR12, will be renamed to "cleanDebitInformation" in next major
      */
     protected function _cleanDebitInformation($debitInformation) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -613,6 +620,7 @@ class InputValidator extends \OxidEsales\Eshop\Core\Base
      * @param array $invAddress Address.
      *
      * @return bool
+     * @deprecated underscore prefix violates PSR12, will be renamed to "hasRequiredParametersForVatInCheck" in next major
      */
     protected function _hasRequiredParametersForVatInCheck($invAddress) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {

--- a/source/Core/Language.php
+++ b/source/Core/Language.php
@@ -470,6 +470,7 @@ class Language extends \OxidEsales\Eshop\Core\Base
      * @param array  $aCollection array to append found items [optional]
      *
      * @return array
+     * @deprecated underscore prefix violates PSR12, will be renamed to "collectSimilar" in next major
      */
     protected function _collectSimilar($aData, $sKey, $aCollection = []) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -719,6 +720,7 @@ class Language extends \OxidEsales\Eshop\Core\Base
      * @param int $iLang active language
      *
      * @return array
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getLangFilesPathArray" in next major
      */
     protected function _getLangFilesPathArray($iLang) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -785,6 +787,7 @@ class Language extends \OxidEsales\Eshop\Core\Base
      * @param int $activeLanguage The active language
      *
      * @return array
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getAdminLangFilesPathArray" in next major
      */
     protected function _getAdminLangFilesPathArray($activeLanguage) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -833,6 +836,7 @@ class Language extends \OxidEsales\Eshop\Core\Base
      * @param string $sFilePattern file pattern to search for, default is "lang"
      *
      * @return array
+     * @deprecated underscore prefix violates PSR12, will be renamed to "appendLangFile" in next major
      */
     protected function _appendLangFile($aLangFiles, $sFullPath, $sFilePattern = "lang") // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -856,6 +860,7 @@ class Language extends \OxidEsales\Eshop\Core\Base
      * @param bool   $forAdmin      add files for admin
      *
      * @return array
+     * @deprecated underscore prefix violates PSR12, will be renamed to "appendCustomLangFiles" in next major
      */
     protected function _appendCustomLangFiles($languageFiles, $language, $forAdmin = false) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -900,6 +905,7 @@ class Language extends \OxidEsales\Eshop\Core\Base
      * @param bool   $blForAdmin   add files for admin
      *
      * @return array
+     * @deprecated underscore prefix violates PSR12, will be renamed to "appendModuleLangFiles" in next major
      */
     protected function _appendModuleLangFiles($aLangFiles, $aModulePaths, $sLang, $blForAdmin = false) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -927,6 +933,7 @@ class Language extends \OxidEsales\Eshop\Core\Base
      * @param array $aLangFiles language files to load [optional]
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getLangFileCacheName" in next major
      */
     protected function _getLangFileCacheName($blAdmin, $iLang, $aLangFiles = null) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -947,6 +954,7 @@ class Language extends \OxidEsales\Eshop\Core\Base
      * @param array $aLangFiles language files to load [optional]
      *
      * @return array
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getLanguageFileData" in next major
      */
     protected function _getLanguageFileData($blAdmin = false, $iLang = 0, $aLangFiles = null) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -1001,6 +1009,7 @@ class Language extends \OxidEsales\Eshop\Core\Base
      * @param bool $isAdmin admin mode [default NULL]
      *
      * @return array
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getLanguageMap" in next major
      */
     protected function _getLanguageMap($language, $isAdmin = null) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -1067,6 +1076,7 @@ class Language extends \OxidEsales\Eshop\Core\Base
      * @param int  $iLang   language id [optional]
      *
      * @return int
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getCacheLanguageId" in next major
      */
     protected function _getCacheLanguageId($blAdmin, $iLang = null) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -1089,6 +1099,7 @@ class Language extends \OxidEsales\Eshop\Core\Base
      * @param array $aLangFiles language files to load [optional]
      *
      * @return array
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getLangTranslationArray" in next major
      */
     protected function _getLangTranslationArray($iLang = null, $blAdmin = null, $aLangFiles = null) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -1119,6 +1130,7 @@ class Language extends \OxidEsales\Eshop\Core\Base
      * @param object $a2 second value to check
      *
      * @return bool
+     * @deprecated underscore prefix violates PSR12, will be renamed to "sortLanguagesCallback" in next major
      */
     protected function _sortLanguagesCallback($a1, $a2) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -1275,6 +1287,7 @@ class Language extends \OxidEsales\Eshop\Core\Base
      * Returns active module Ids with paths
      *
      * @return array
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getActiveModuleInfo" in next major
      */
     protected function _getActiveModuleInfo() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -1290,6 +1303,7 @@ class Language extends \OxidEsales\Eshop\Core\Base
      * Returns active module Ids with paths
      *
      * @return array
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getDisabledModuleInfo" in next major
      */
     protected function _getDisabledModuleInfo() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -1305,6 +1319,7 @@ class Language extends \OxidEsales\Eshop\Core\Base
      * Gets browser language.
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getBrowserLanguage" in next major
      */
     protected function _getBrowserLanguage() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -1367,6 +1382,7 @@ class Language extends \OxidEsales\Eshop\Core\Base
      * @param null $shopId
      *
      * @return array
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getLanguageIdsFromDatabase" in next major
      */
     protected function _getLanguageIdsFromDatabase($shopId = null) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -1380,6 +1396,7 @@ class Language extends \OxidEsales\Eshop\Core\Base
      * @param int    $iShopId                shop id
      *
      * @return array
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getConfigLanguageValues" in next major
      */
     protected function _getConfigLanguageValues($sLanguageParameterName, $iShopId = null) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -1409,6 +1426,7 @@ class Language extends \OxidEsales\Eshop\Core\Base
      * @param string|null $sShopId    Shop id
      *
      * @return array
+     * @deprecated underscore prefix violates PSR12, will be renamed to "selectLanguageParamValues" in next major
      */
     protected function _selectLanguageParamValues($sParamName, $sShopId = null) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -1437,6 +1455,7 @@ class Language extends \OxidEsales\Eshop\Core\Base
      * @param array $aLanguageParams Language parameters
      *
      * @return array
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getLanguageIdsFromLanguageParamsArray" in next major
      */
     protected function _getLanguageIdsFromLanguageParamsArray($aLanguageParams) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -1455,6 +1474,7 @@ class Language extends \OxidEsales\Eshop\Core\Base
      * @param array $aLanguages Languages
      *
      * @return array
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getLanguageIdsFromLanguagesArray" in next major
      */
     protected function _getLanguageIdsFromLanguagesArray($aLanguages) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {

--- a/source/Core/Model/BaseModel.php
+++ b/source/Core/Model/BaseModel.php
@@ -423,6 +423,7 @@ class BaseModel extends \OxidEsales\Eshop\Core\Base
      * and if atleast one requires seo update, other checks won't override that.
      *
      * @param string $fieldName Field name that will be checked
+     * @deprecated underscore prefix violates PSR12, will be renamed to "setUpdateSeoOnFieldChange" in next major
      */
     protected function _setUpdateSeoOnFieldChange($fieldName) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -817,6 +818,7 @@ class BaseModel extends \OxidEsales\Eshop\Core\Base
      * Removes relevant mapping data for selected object if it is a multishop inheritable table
      *
      * @param string $oxid Object ID
+     * @deprecated underscore prefix violates PSR12, will be renamed to "removeElement2ShopRelations" in next major
      */
     protected function _removeElement2ShopRelations($oxid) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -986,6 +988,7 @@ class BaseModel extends \OxidEsales\Eshop\Core\Base
      * Checks if this instance is one of oxList elements.
      *
      * @return bool
+     * @deprecated underscore prefix violates PSR12, will be renamed to "isInList" in next major
      */
     protected function _isInList() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -999,6 +1002,7 @@ class BaseModel extends \OxidEsales\Eshop\Core\Base
      * @param int    $shopID Shop ID
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getObjectViewName" in next major
      */
     protected function _getObjectViewName($table, $shopID = null) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -1014,6 +1018,7 @@ class BaseModel extends \OxidEsales\Eshop\Core\Base
      * @param bool   $returnSimpleArray Set $returnSimple to true when you need simple array (meta data array is returned otherwise)
      *
      * @return array
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getTableFields" in next major
      */
     protected function _getTableFields($table, $returnSimpleArray = false) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -1057,6 +1062,7 @@ class BaseModel extends \OxidEsales\Eshop\Core\Base
      * @see \OxidEsales\Eshop\Core\Model\BaseModel::_getTableFields()
      *
      * @return array
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getAllFields" in next major
      */
     protected function _getAllFields($returnSimple = false) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -1072,6 +1078,7 @@ class BaseModel extends \OxidEsales\Eshop\Core\Base
      * Either by trying to load from cache or by calling $this->_getNonCachedFieldNames
      *
      * @param bool $forceFullStructure Set to true if you want to load full structure in any case.
+     * @deprecated underscore prefix violates PSR12, will be renamed to "initDataStructure" in next major
      */
     protected function _initDataStructure($forceFullStructure = false) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -1108,6 +1115,7 @@ class BaseModel extends \OxidEsales\Eshop\Core\Base
      * @param bool $forceFullStructure Whether to force loading of full data structure
      *
      * @return array|bool
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getNonCachedFieldNames" in next major
      */
     protected function _getNonCachedFieldNames($forceFullStructure = false) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -1159,6 +1167,7 @@ class BaseModel extends \OxidEsales\Eshop\Core\Base
      * @param string $fieldName Field name
      *
      * @return int
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getFieldStatus" in next major
      */
     protected function _getFieldStatus($fieldName) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -1174,6 +1183,7 @@ class BaseModel extends \OxidEsales\Eshop\Core\Base
      * @param string $length      Field Length
      *
      * @return null
+     * @deprecated underscore prefix violates PSR12, will be renamed to "addField" in next major
      */
     protected function _addField($fieldName, $fieldStatus, $type = null, $length = null) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -1217,6 +1227,7 @@ class BaseModel extends \OxidEsales\Eshop\Core\Base
      * @param string $fieldName Short field name
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getFieldLongName" in next major
      */
     protected function _getFieldLongName($fieldName) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -1235,6 +1246,7 @@ class BaseModel extends \OxidEsales\Eshop\Core\Base
      * @param string $fieldName  Index OR name (eg. 'oxarticles__oxtitle') of a data field to set
      * @param string $fieldValue Value of data field
      * @param int    $dataType   Field type
+     * @deprecated underscore prefix violates PSR12, will be renamed to "setFieldData" in next major
      */
     protected function _setFieldData($fieldName, $fieldValue, $dataType = Field::T_TEXT) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -1284,6 +1296,7 @@ class BaseModel extends \OxidEsales\Eshop\Core\Base
      * @param string $fieldName db field name
      *
      * @return bool
+     * @deprecated underscore prefix violates PSR12, will be renamed to "canFieldBeNull" in next major
      */
     protected function _canFieldBeNull($fieldName) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -1303,6 +1316,7 @@ class BaseModel extends \OxidEsales\Eshop\Core\Base
      * @param string $fieldName db field name
      *
      * @return mixed
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getFieldDefaultValue" in next major
      */
     protected function _getFieldDefaultValue($fieldName) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -1323,6 +1337,7 @@ class BaseModel extends \OxidEsales\Eshop\Core\Base
      * @param Field  $field     field object
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getUpdateFieldValue" in next major
      */
     protected function _getUpdateFieldValue($fieldName, $field) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -1353,6 +1368,7 @@ class BaseModel extends \OxidEsales\Eshop\Core\Base
      * @param bool $useSkipSaveFields forces usage of skip save fields array (default is true)
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getUpdateFields" in next major
      */
     protected function _getUpdateFields($useSkipSaveFields = true) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -1397,6 +1413,7 @@ class BaseModel extends \OxidEsales\Eshop\Core\Base
      * @throws DatabaseException On database errors
      *
      * @return bool Will always return true. On failure an exception is thrown.
+     * @deprecated underscore prefix violates PSR12, will be renamed to "update" in next major
      */
     protected function _update() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -1447,6 +1464,7 @@ class BaseModel extends \OxidEsales\Eshop\Core\Base
      * might be loaded through oxlist.
      *
      * @return bool
+     * @deprecated underscore prefix violates PSR12, will be renamed to "insert" in next major
      */
     protected function _insert() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -1484,6 +1502,7 @@ class BaseModel extends \OxidEsales\Eshop\Core\Base
      * This method is primary used in unit tests.
      *
      * @return bool
+     * @deprecated underscore prefix violates PSR12, will be renamed to "isDisabledFieldCache" in next major
      */
     protected function _isDisabledFieldCache() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -1497,6 +1516,7 @@ class BaseModel extends \OxidEsales\Eshop\Core\Base
 
     /**
      * Add additional fields to skipped save fields
+     * @deprecated underscore prefix violates PSR12, will be renamed to "addSkippedSaveFieldsForMapping" in next major
      */
     protected function _addSkippedSaveFieldsForMapping() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -1504,6 +1524,7 @@ class BaseModel extends \OxidEsales\Eshop\Core\Base
 
     /**
      * Disable lazy loading if cache is enabled
+     * @deprecated underscore prefix violates PSR12, will be renamed to "disableLazyLoadingForCaching" in next major
      */
     protected function _disableLazyLoadingForCaching() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {

--- a/source/Core/Model/ListModel.php
+++ b/source/Core/Model/ListModel.php
@@ -482,6 +482,7 @@ class ListModel extends \OxidEsales\Eshop\Core\Base implements \ArrayAccess, \It
      *
      * @param BaseModel $oListObject List object (the one derived from BaseModel)
      * @param array     $aDbFields   An array holding db field values (normally the result of \OxidEsales\Eshop\Core\DatabaseProvider::Execute())
+     * @deprecated underscore prefix violates PSR12, will be renamed to "assignElement" in next major
      */
     protected function _assignElement($oListObject, $aDbFields) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -494,6 +495,7 @@ class ListModel extends \OxidEsales\Eshop\Core\Base implements \ArrayAccess, \It
      * @param string $sFieldName Field name
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getFieldLongName" in next major
      */
     protected function _getFieldLongName($sFieldName) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {

--- a/source/Core/Model/MultiLanguageModel.php
+++ b/source/Core/Model/MultiLanguageModel.php
@@ -241,6 +241,7 @@ class MultiLanguageModel extends \OxidEsales\Eshop\Core\Model\BaseModel
      * @param string $fieldName Field name
      *
      * @return int
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getFieldStatus" in next major
      */
     protected function _getFieldStatus($fieldName) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -262,6 +263,7 @@ class MultiLanguageModel extends \OxidEsales\Eshop\Core\Model\BaseModel
      * @param bool $forceFullStructure Whether to force loading of full data structure
      *
      * @return array
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getNonCachedFieldNames" in next major
      */
     protected function _getNonCachedFieldNames($forceFullStructure = false) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -300,6 +302,7 @@ class MultiLanguageModel extends \OxidEsales\Eshop\Core\Model\BaseModel
      * @param string $fieldName Field name
      *
      * @return bool
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getFieldLang" in next major
      */
     protected function _getFieldLang($fieldName) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -337,6 +340,7 @@ class MultiLanguageModel extends \OxidEsales\Eshop\Core\Model\BaseModel
      * Will try to get multilang table name for relevant field check.
      *
      * @param string $field Field name that will be checked
+     * @deprecated underscore prefix violates PSR12, will be renamed to "setUpdateSeoOnFieldChange" in next major
      */
     protected function _setUpdateSeoOnFieldChange($field) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -351,6 +355,7 @@ class MultiLanguageModel extends \OxidEsales\Eshop\Core\Model\BaseModel
      * @param bool   $useSkipSaveFields use skip save fields array?
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getUpdateFieldsForTable" in next major
      */
     protected function _getUpdateFieldsForTable($table, $useSkipSaveFields = true) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -430,6 +435,7 @@ class MultiLanguageModel extends \OxidEsales\Eshop\Core\Model\BaseModel
      * @param bool $useSkipSaveFields forces usage of skip save fields array (default is true)
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getUpdateFields" in next major
      */
     protected function _getUpdateFields($useSkipSaveFields = true) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -445,6 +451,7 @@ class MultiLanguageModel extends \OxidEsales\Eshop\Core\Model\BaseModel
      * @throws oxObjectException Throws on failure inserting
      *
      * @return bool
+     * @deprecated underscore prefix violates PSR12, will be renamed to "update" in next major
      */
     protected function _update() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -486,6 +493,7 @@ class MultiLanguageModel extends \OxidEsales\Eshop\Core\Model\BaseModel
      * @param string $coreTableName core table name [optional]
      *
      * @return array
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getLanguageSetTables" in next major
      */
     protected function _getLanguageSetTables($coreTableName = null) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -500,6 +508,7 @@ class MultiLanguageModel extends \OxidEsales\Eshop\Core\Model\BaseModel
      * might be loaded through oxlist.
      *
      * @return bool
+     * @deprecated underscore prefix violates PSR12, will be renamed to "insert" in next major
      */
     protected function _insert() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -524,6 +533,7 @@ class MultiLanguageModel extends \OxidEsales\Eshop\Core\Model\BaseModel
      * @param int    $shopID Shop ID
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getObjectViewName" in next major
      */
     protected function _getObjectViewName($table, $shopID = null) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -544,6 +554,7 @@ class MultiLanguageModel extends \OxidEsales\Eshop\Core\Model\BaseModel
      * @see \OxidEsales\Eshop\Core\Model\BaseModel::_getTableFields()
      *
      * @return array
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getAllFields" in next major
      */
     protected function _getAllFields($returnSimple = false) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -567,7 +578,8 @@ class MultiLanguageModel extends \OxidEsales\Eshop\Core\Model\BaseModel
      * @param string $type   Field type
      * @param string $length Field Length
      *
-     * @return null;
+     * @return null ;
+     * @deprecated underscore prefix violates PSR12, will be renamed to "addField" in next major
      */
     protected function _addField($name, $status, $type = null, $length = null) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -588,6 +600,7 @@ class MultiLanguageModel extends \OxidEsales\Eshop\Core\Model\BaseModel
      * @param string $fieldName db field name
      *
      * @return bool
+     * @deprecated underscore prefix violates PSR12, will be renamed to "canFieldBeNull" in next major
      */
     protected function _canFieldBeNull($fieldName) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {

--- a/source/Core/Module/ModuleCache.php
+++ b/source/Core/Module/ModuleCache.php
@@ -71,6 +71,7 @@ class ModuleCache extends \OxidEsales\Eshop\Core\Base
 
     /**
      * Cleans PHP APC cache
+     * @deprecated underscore prefix violates PSR12, will be renamed to "clearApcCache" in next major
      */
     protected function _clearApcCache() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {

--- a/source/Core/Module/ModuleList.php
+++ b/source/Core/Module/ModuleList.php
@@ -517,6 +517,7 @@ class ModuleList extends \OxidEsales\Eshop\Core\Base
      * @param object $oModule2 module object
      *
      * @return bool
+     * @deprecated underscore prefix violates PSR12, will be renamed to "sortModules" in next major
      */
     protected function _sortModules($oModule1, $oModule2) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -529,6 +530,7 @@ class ModuleList extends \OxidEsales\Eshop\Core\Base
      * @param string $sModuleDir dir path
      *
      * @return bool
+     * @deprecated underscore prefix violates PSR12, will be renamed to "isVendorDir" in next major
      */
     protected function _isVendorDir($sModuleDir) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -553,6 +555,7 @@ class ModuleList extends \OxidEsales\Eshop\Core\Base
      * @param string $moduleId Module id
      *
      * @return array
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getInvalidExtensions" in next major
      */
     private function _getInvalidExtensions($moduleId) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {

--- a/source/Core/OnlineCaller.php
+++ b/source/Core/OnlineCaller.php
@@ -47,13 +47,14 @@ abstract class OnlineCaller
      * Gets XML document name.
      *
      * @return string XML document tag name.
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getXMLDocumentName" in next major
      */
     abstract protected function _getXMLDocumentName(); // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
-
     /**
      * Gets service url.
      *
      * @return string Web service url.
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getServiceUrl" in next major
      */
     abstract protected function _getServiceUrl(); // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
 
@@ -130,6 +131,7 @@ abstract class OnlineCaller
      * @param \OxidEsales\Eshop\Core\OnlineRequest $oRequest Request object from which email should be formed.
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "formEmail" in next major
      */
     protected function _formEmail($oRequest) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -142,6 +144,7 @@ abstract class OnlineCaller
      * @param \OxidEsales\Eshop\Core\OnlineRequest $oRequest Request object from which server request should be formed.
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "formXMLRequest" in next major
      */
     protected function _formXMLRequest($oRequest) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -152,6 +155,7 @@ abstract class OnlineCaller
      * Gets simple XML.
      *
      * @return \OxidEsales\Eshop\Core\SimpleXml
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getSimpleXml" in next major
      */
     protected function _getSimpleXml() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -162,6 +166,7 @@ abstract class OnlineCaller
      * Gets curl.
      *
      * @return \OxidEsales\Eshop\Core\Curl
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getCurl" in next major
      */
     protected function _getCurl() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -172,6 +177,7 @@ abstract class OnlineCaller
      * Gets email builder.
      *
      * @return \OxidEsales\Eshop\Core\OnlineServerEmailBuilder
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getEmailBuilder" in next major
      */
     protected function _getEmailBuilder() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -185,6 +191,7 @@ abstract class OnlineCaller
      * @param string $sXml Data to send. Currently OXID servers only accept XML formatted data.
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "executeCurlCall" in next major
      */
     private function _executeCurlCall($sUrl, $sXml) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -204,6 +211,7 @@ abstract class OnlineCaller
      * Sends an email with server information.
      *
      * @param string $sBody Mail content.
+     * @deprecated underscore prefix violates PSR12, will be renamed to "sendEmail" in next major
      */
     private function _sendEmail($sBody) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -215,6 +223,7 @@ abstract class OnlineCaller
      * Resets config parameter iFailedOnlineCallsCount if it's bigger than 0.
      *
      * @param int $iFailedOnlineCallsCount Amount of calls which previously failed.
+     * @deprecated underscore prefix violates PSR12, will be renamed to "resetFailedCallsCount" in next major
      */
     private function _resetFailedCallsCount($iFailedOnlineCallsCount) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -227,6 +236,7 @@ abstract class OnlineCaller
      * increases failed calls count.
      *
      * @param int $iFailedOnlineCallsCount Amount of calls which previously failed.
+     * @deprecated underscore prefix violates PSR12, will be renamed to "increaseFailedCallsCount" in next major
      */
     private function _increaseFailedCallsCount($iFailedOnlineCallsCount) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {

--- a/source/Core/OnlineLicenseCheckCaller.php
+++ b/source/Core/OnlineLicenseCheckCaller.php
@@ -51,6 +51,7 @@ class OnlineLicenseCheckCaller extends \OxidEsales\Eshop\Core\OnlineCaller
      * @param \OxidEsales\Eshop\Core\OnlineLicenseCheckRequest $oRequest
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "formEmail" in next major
      */
     protected function _formEmail($oRequest) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -67,6 +68,7 @@ class OnlineLicenseCheckCaller extends \OxidEsales\Eshop\Core\OnlineCaller
      * @throws oxException
      *
      * @return \OxidEsales\Eshop\Core\OnlineLicenseCheckResponse
+     * @deprecated underscore prefix violates PSR12, will be renamed to "formResponse" in next major
      */
     protected function _formResponse($sRawResponse) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -105,6 +107,7 @@ class OnlineLicenseCheckCaller extends \OxidEsales\Eshop\Core\OnlineCaller
      * Gets XML document name.
      *
      * @return string XML document tag name.
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getXMLDocumentName" in next major
      */
     protected function _getXMLDocumentName() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -115,6 +118,7 @@ class OnlineLicenseCheckCaller extends \OxidEsales\Eshop\Core\OnlineCaller
      * Gets service url.
      *
      * @return string Web service url.
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getServiceUrl" in next major
      */
     protected function _getServiceUrl() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {

--- a/source/Core/OnlineModuleVersionNotifier.php
+++ b/source/Core/OnlineModuleVersionNotifier.php
@@ -60,6 +60,7 @@ class OnlineModuleVersionNotifier
      * Collects only required modules information and returns as array.
      *
      * @return null
+     * @deprecated underscore prefix violates PSR12, will be renamed to "prepareModulesInformation" in next major
      */
     protected function _prepareModulesInformation() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -93,6 +94,7 @@ class OnlineModuleVersionNotifier
      * Send request message to Online Module Version Notifier web service.
      *
      * @return oxOnlineModulesNotifierRequest
+     * @deprecated underscore prefix violates PSR12, will be renamed to "formRequest" in next major
      */
     protected function _formRequest() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -108,6 +110,7 @@ class OnlineModuleVersionNotifier
      * Returns caller.
      *
      * @return \OxidEsales\Eshop\Core\OnlineModuleVersionNotifierCaller
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getOnlineModuleNotifierCaller" in next major
      */
     protected function _getOnlineModuleNotifierCaller() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {

--- a/source/Core/OnlineModuleVersionNotifierCaller.php
+++ b/source/Core/OnlineModuleVersionNotifierCaller.php
@@ -41,6 +41,7 @@ class OnlineModuleVersionNotifierCaller extends \OxidEsales\Eshop\Core\OnlineCal
      * Gets XML document name.
      *
      * @return string XML document tag name.
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getXMLDocumentName" in next major
      */
     protected function _getXMLDocumentName() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -51,6 +52,7 @@ class OnlineModuleVersionNotifierCaller extends \OxidEsales\Eshop\Core\OnlineCal
      * Gets service url.
      *
      * @return string Web service url.
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getServiceUrl" in next major
      */
     protected function _getServiceUrl() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {

--- a/source/Core/OnlineRequest.php
+++ b/source/Core/OnlineRequest.php
@@ -74,6 +74,7 @@ class OnlineRequest
      * Takes cluster id from configuration if set, otherwise generates it.
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getClusterId" in next major
      */
     private function _getClusterId() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {

--- a/source/Core/OnlineVatIdCheck.php
+++ b/source/Core/OnlineVatIdCheck.php
@@ -110,6 +110,7 @@ class OnlineVatIdCheck extends \OxidEsales\Eshop\Core\CompanyVatInChecker
      *  - if output, returned by service, is valid.
      *
      * @return bool
+     * @deprecated underscore prefix violates PSR12, will be renamed to "isServiceAvailable" in next major
      */
     protected function _isServiceAvailable() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -147,6 +148,7 @@ class OnlineVatIdCheck extends \OxidEsales\Eshop\Core\CompanyVatInChecker
      * @param object $oCheckVat vat object
      *
      * @return bool
+     * @deprecated underscore prefix violates PSR12, will be renamed to "checkOnline" in next major
      */
     protected function _checkOnline($oCheckVat) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {

--- a/source/Core/PasswordHasher.php
+++ b/source/Core/PasswordHasher.php
@@ -27,6 +27,7 @@ class PasswordHasher
      * Gets hasher.
      *
      * @return \OxidEsales\Eshop\Core\Hasher
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getHasher" in next major
      */
     protected function _getHasher() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {

--- a/source/Core/PasswordSaltGenerator.php
+++ b/source/Core/PasswordSaltGenerator.php
@@ -54,6 +54,7 @@ class PasswordSaltGenerator
      * Gets open SSL functionality checker.
      *
      * @return \OxidEsales\Eshop\Core\OpenSSLFunctionalityChecker
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getOpenSSLFunctionalityChecker" in next major
      */
     protected function _getOpenSSLFunctionalityChecker() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -64,6 +65,7 @@ class PasswordSaltGenerator
      * Generates custom salt.
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "customSaltGenerator" in next major
      */
     protected function _customSaltGenerator() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {

--- a/source/Core/PictureHandler.php
+++ b/source/Core/PictureHandler.php
@@ -191,6 +191,7 @@ class PictureHandler extends \OxidEsales\Eshop\Core\Base
      * @param string $sMasterImageFile master image file name
      *
      * @return null
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getBaseMasterImageFileName" in next major
      */
     protected function _getBaseMasterImageFileName($sMasterImageFile) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -235,6 +236,7 @@ class PictureHandler extends \OxidEsales\Eshop\Core\Base
      * @param int    $iShopId   shop id
      *
      * @return array
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getPictureInfo" in next major
      */
     protected function _getPictureInfo($sFilePath, $sFile, $blAdmin = false, $blSSL = null, $iLang = null, $iShopId = null) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {

--- a/source/Core/Price.php
+++ b/source/Core/Price.php
@@ -420,6 +420,7 @@ class Price
 
     /**
      * Flush assigned discounts
+     * @deprecated underscore prefix violates PSR12, will be renamed to "flushDiscounts" in next major
      */
     protected function _flushDiscounts() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {

--- a/source/Core/SeoDecoder.php
+++ b/source/Core/SeoDecoder.php
@@ -40,6 +40,7 @@ class SeoDecoder extends \OxidEsales\Eshop\Core\Base
      * @param bool   $blIgnore if FALSE - blocks from direct access when default language seo url with language ident executed
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getIdent" in next major
      */
     protected function _getIdent($sSeoUrl, $blIgnore = false) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -95,6 +96,7 @@ class SeoDecoder extends \OxidEsales\Eshop\Core\Base
      *
      * @access         public
      * @return string || false
+     * @deprecated underscore prefix violates PSR12, will be renamed to "decodeOldUrl" in next major
      */
     protected function _decodeOldUrl($seoUrl) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -146,6 +148,7 @@ class SeoDecoder extends \OxidEsales\Eshop\Core\Base
      * @param string $sUrl url to append
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "addQueryString" in next major
      */
     protected function _addQueryString($sUrl) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -169,6 +172,7 @@ class SeoDecoder extends \OxidEsales\Eshop\Core\Base
      * @param int    $iShopId   shop id
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getSeoUrl" in next major
      */
     protected function _getSeoUrl($sObjectId, $iLang, $iShopId) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -246,6 +250,7 @@ class SeoDecoder extends \OxidEsales\Eshop\Core\Base
      * @param string $sParams request params (url chunk)
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "decodeSimpleUrl" in next major
      */
     protected function _decodeSimpleUrl($sParams) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -284,6 +289,7 @@ class SeoDecoder extends \OxidEsales\Eshop\Core\Base
      * @param string $sType     type of object to search in seo table
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getObjectUrl" in next major
      */
     protected function _getObjectUrl($sSeoId, $sTable, $iLanguage, $sType) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -314,6 +320,7 @@ class SeoDecoder extends \OxidEsales\Eshop\Core\Base
      * @param string $sPath    path
      *
      * @return array $aParams extracted params
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getParams" in next major
      */
     protected function _getParams($sRequest, $sPath) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {

--- a/source/Core/SeoEncoder.php
+++ b/source/Core/SeoEncoder.php
@@ -122,6 +122,7 @@ class SeoEncoder extends \OxidEsales\Eshop\Core\Base
      * @param bool   $blExclude exclude language prefix while building seo url
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "processSeoUrl" in next major
      */
     protected function _processSeoUrl($sSeoUrl, $sObjectId = null, $iLang = null, $blExclude = false) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -155,6 +156,7 @@ class SeoEncoder extends \OxidEsales\Eshop\Core\Base
      * @param int    $iLang   object language
      * @param string $sType   object type (if you pass real object - type is not necessary)
      * @param string $sNewId  new object id, mostly used for static url updates (optional)
+     * @deprecated underscore prefix violates PSR12, will be renamed to "copyToHistory" in next major
      */
     protected function _copyToHistory($sId, $iShopId, $iLang, $sType = null, $sNewId = null) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -192,6 +194,7 @@ class SeoEncoder extends \OxidEsales\Eshop\Core\Base
      * @param int    $iLang   active language
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getDynamicUri" in next major
      */
     protected function _getDynamicUri($sStdUrl, $sSeoUrl, $iLang) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -229,6 +232,7 @@ class SeoEncoder extends \OxidEsales\Eshop\Core\Base
      * @param bool   $blSsl   forces to build ssl url
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getFullUrl" in next major
      */
     protected function _getFullUrl($sSeoUrl, $iLang = null, $blSsl = false) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -249,6 +253,7 @@ class SeoEncoder extends \OxidEsales\Eshop\Core\Base
      * @access protected
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getSeoIdent" in next major
      */
     protected function _getSeoIdent($sSeoUrl) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -263,6 +268,7 @@ class SeoEncoder extends \OxidEsales\Eshop\Core\Base
      * @param int    $iLang   active language
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getStaticUri" in next major
      */
     protected function _getStaticUri($sStdUrl, $iShopId, $iLang) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -275,6 +281,7 @@ class SeoEncoder extends \OxidEsales\Eshop\Core\Base
      * Returns target "extension"
      *
      * @return null
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getUrlExtension" in next major
      */
     protected function _getUrlExtension() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -292,6 +299,7 @@ class SeoEncoder extends \OxidEsales\Eshop\Core\Base
      * @access protected
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getUniqueSeoUrl" in next major
      */
     protected function _getUniqueSeoUrl($sSeoUrl, $sObjectId = null, $iObjectLang = null) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -348,6 +356,7 @@ class SeoEncoder extends \OxidEsales\Eshop\Core\Base
      * @access protected
      *
      * @return bool
+     * @deprecated underscore prefix violates PSR12, will be renamed to "isFixed" in next major
      */
     protected function _isFixed($sType, $sId, $iLang, $iShopId = null, $sParams = null, $blStrictParamsCheck = true) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -389,6 +398,7 @@ class SeoEncoder extends \OxidEsales\Eshop\Core\Base
      * @param string $sParams additional seo params. optional (mostly used for db indexing)
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getCacheKey" in next major
      */
     protected function _getCacheKey($sType, $iLang = null, $iShopId = null, $sParams = null) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -418,6 +428,7 @@ class SeoEncoder extends \OxidEsales\Eshop\Core\Base
      * @param string $sParams     additional seo params. optional (mostly used for db indexing)
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "loadFromCache" in next major
      */
     protected function _loadFromCache($sCacheIdent, $sType, $iLang = null, $iShopId = null, $sParams = null) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -454,6 +465,7 @@ class SeoEncoder extends \OxidEsales\Eshop\Core\Base
      * @param string $sParams     additional seo params. optional (mostly used for db indexing)
      *
      * @return bool
+     * @deprecated underscore prefix violates PSR12, will be renamed to "saveInCache" in next major
      */
     protected function _saveInCache($sCacheIdent, $sCache, $sType, $iLang = null, $iShopId = null, $sParams = null) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -488,6 +500,7 @@ class SeoEncoder extends \OxidEsales\Eshop\Core\Base
      * @access         protected
      *
      * @return string || false
+     * @deprecated underscore prefix violates PSR12, will be renamed to "loadFromDb" in next major
      */
     protected function _loadFromDb($sType, $sId, $iLang, $iShopId = null, $sParams = null, $blStrictParamsCheck = true) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -563,6 +576,7 @@ class SeoEncoder extends \OxidEsales\Eshop\Core\Base
      * because then apache will execute that php file instead of url parser
      *
      * @return array
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getReservedEntryKeys" in next major
      */
     protected function _getReservedEntryKeys() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -591,6 +605,7 @@ class SeoEncoder extends \OxidEsales\Eshop\Core\Base
      * @param int    $iLang language ID, for which URI should be prepared
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "prepareUri" in next major
      */
     protected function _prepareUri($sUri, $iLang = false) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -659,6 +674,7 @@ class SeoEncoder extends \OxidEsales\Eshop\Core\Base
      * @param int    $iLang          language ID, for which to prepare the title
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "prepareTitle" in next major
      */
     protected function _prepareTitle($sTitle, $blSkipTruncate = false, $iLang = false) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -706,6 +722,7 @@ class SeoEncoder extends \OxidEsales\Eshop\Core\Base
      * @access protected
      *
      * @return mixed
+     * @deprecated underscore prefix violates PSR12, will be renamed to "saveToDb" in next major
      */
     protected function _saveToDb($sType, $sObjectId, $sStdUrl, $sSeoUrl, $iLang, $iShopId = null, $blFixed = null, $sParams = null) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -822,6 +839,7 @@ class SeoEncoder extends \OxidEsales\Eshop\Core\Base
      * @access protected
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "trimUrl" in next major
      */
     protected function _trimUrl($sUrl, $iLang = null) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -850,6 +868,7 @@ class SeoEncoder extends \OxidEsales\Eshop\Core\Base
      * Returns maximum seo/dynamic url length
      *
      * @return int
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getMaxUrlLength" in next major
      */
     protected function _getMaxUrlLength() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -975,6 +994,7 @@ class SeoEncoder extends \OxidEsales\Eshop\Core\Base
      * @param bool                                   $blFixed fixed url marker (default is false)
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getPageUri" in next major
      */
     protected function _getPageUri($oObject, $sType, $sStdUrl, $sSeoUrl, $sParams, $iLang = null, $blFixed = false) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -1004,6 +1024,7 @@ class SeoEncoder extends \OxidEsales\Eshop\Core\Base
      * @param string $sStdUrl standard (dynamic) url
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getStaticObjectId" in next major
      */
     protected function _getStaticObjectId($iShopId, $sStdUrl) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -1220,6 +1241,7 @@ class SeoEncoder extends \OxidEsales\Eshop\Core\Base
      *
      * @param string $sObjectId object id
      * @param int    $iLang     language id
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getAltUri" in next major
      */
     protected function _getAltUri($sObjectId, $iLang) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {

--- a/source/Core/SepaIBANValidator.php
+++ b/source/Core/SepaIBANValidator.php
@@ -91,6 +91,7 @@ class SepaIBANValidator
      * @param string $sIBAN IBAN
      *
      * @return bool
+     * @deprecated underscore prefix violates PSR12, will be renamed to "isLengthValid" in next major
      */
     protected function _isLengthValid($sIBAN) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -108,6 +109,7 @@ class SepaIBANValidator
      * @param string $sIBAN IBAN
      *
      * @return null
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getLengthForCountry" in next major
      */
     protected function _getLengthForCountry($sIBAN) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -126,6 +128,7 @@ class SepaIBANValidator
      * @param string $sIBAN IBAN
      *
      * @return bool
+     * @deprecated underscore prefix violates PSR12, will be renamed to "isAlgorithmValid" in next major
      */
     protected function _isAlgorithmValid($sIBAN) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -142,6 +145,7 @@ class SepaIBANValidator
      * @param string $sIBAN IBAN
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "moveInitialCharactersToEnd" in next major
      */
     protected function _moveInitialCharactersToEnd($sIBAN) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -159,6 +163,7 @@ class SepaIBANValidator
      * @param string $sIBAN IBAN
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "replaceLettersToNumbers" in next major
      */
     protected function _replaceLettersToNumbers($sIBAN) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -204,6 +209,7 @@ class SepaIBANValidator
      * @param string $sIBAN IBAN
      *
      * @return bool
+     * @deprecated underscore prefix violates PSR12, will be renamed to "isIBANChecksumValid" in next major
      */
     protected function _isIBANChecksumValid($sIBAN) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -216,6 +222,7 @@ class SepaIBANValidator
      * @param array $aCodeLengths Code lengths
      *
      * @return bool
+     * @deprecated underscore prefix violates PSR12, will be renamed to "isNotEmptyArray" in next major
      */
     protected function _isNotEmptyArray($aCodeLengths) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -228,6 +235,7 @@ class SepaIBANValidator
      * @param array $aCodeLengths Code lengths
      *
      * @return bool
+     * @deprecated underscore prefix violates PSR12, will be renamed to "isEachCodeLengthValid" in next major
      */
     protected function _isEachCodeLengthValid($aCodeLengths) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -252,6 +260,7 @@ class SepaIBANValidator
      * @param string $sCountryAbbr Country abbreviation
      *
      * @return bool
+     * @deprecated underscore prefix violates PSR12, will be renamed to "isCodeLengthKeyValid" in next major
      */
     protected function _isCodeLengthKeyValid($sCountryAbbr) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -264,6 +273,7 @@ class SepaIBANValidator
      * @param integer $iLength Length
      *
      * @return bool
+     * @deprecated underscore prefix violates PSR12, will be renamed to "isCodeLengthValueValid" in next major
      */
     protected function _isCodeLengthValueValid($iLength) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {

--- a/source/Core/Session.php
+++ b/source/Core/Session.php
@@ -296,6 +296,7 @@ class Session extends \OxidEsales\Eshop\Core\Base
 
     /**
      * initialize new session challenge token
+     * @deprecated underscore prefix violates PSR12, will be renamed to "initNewSessionChallenge" in next major
      */
     protected function _initNewSessionChallenge() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -306,6 +307,7 @@ class Session extends \OxidEsales\Eshop\Core\Base
      * Initialize session data (calls php::session_start())
      *
      * @return bool
+     * @deprecated underscore prefix violates PSR12, will be renamed to "sessionStart" in next major
      */
     protected function _sessionStart() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -394,6 +396,7 @@ class Session extends \OxidEsales\Eshop\Core\Base
      * @param bool $blUnset if true, calls session_unset [optional]
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getNewSessionId" in next major
      */
     protected function _getNewSessionId($blUnset = true) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -634,6 +637,7 @@ class Session extends \OxidEsales\Eshop\Core\Base
      * @param \OxidEsales\Eshop\Application\Model\Basket $oBasket Basket object loaded from session.
      *
      * @return null
+     * @deprecated underscore prefix violates PSR12, will be renamed to "validateBasket" in next major
      */
     protected function _validateBasket(\OxidEsales\Eshop\Application\Model\Basket $oBasket) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -810,6 +814,7 @@ class Session extends \OxidEsales\Eshop\Core\Base
      * or _GET parameter "su" (suggested user id) is set.
      *
      * @return bool
+     * @deprecated underscore prefix violates PSR12, will be renamed to "forceSessionStart" in next major
      */
     protected function _forceSessionStart() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -820,6 +825,7 @@ class Session extends \OxidEsales\Eshop\Core\Base
      * Checks if we can start new session. Returns bool success status
      *
      * @return bool
+     * @deprecated underscore prefix violates PSR12, will be renamed to "allowSessionStart" in next major
      */
     protected function _allowSessionStart() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -855,6 +861,7 @@ class Session extends \OxidEsales\Eshop\Core\Base
      * Using this method we can detect different visitor with same session id.
      *
      * @return bool
+     * @deprecated underscore prefix violates PSR12, will be renamed to "isSwappedClient" in next major
      */
     protected function _isSwappedClient() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -886,6 +893,7 @@ class Session extends \OxidEsales\Eshop\Core\Base
      * @param string $sExistingAgent existing user agent
      *
      * @return bool
+     * @deprecated underscore prefix violates PSR12, will be renamed to "checkUserAgent" in next major
      */
     protected function _checkUserAgent($sAgent, $sExistingAgent) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -913,6 +921,7 @@ class Session extends \OxidEsales\Eshop\Core\Base
      * @param array  $aSessCookieSetOnce if session cookie is set
      *
      * @return bool
+     * @deprecated underscore prefix violates PSR12, will be renamed to "checkCookies" in next major
      */
     protected function _checkCookies($sCookieSid, $aSessCookieSetOnce) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -960,6 +969,7 @@ class Session extends \OxidEsales\Eshop\Core\Base
      * @param string $sSessId sesion ID
      *
      * @return null
+     * @deprecated underscore prefix violates PSR12, will be renamed to "setSessionId" in next major
      */
     protected function _setSessionId($sSessId) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -978,6 +988,7 @@ class Session extends \OxidEsales\Eshop\Core\Base
      * Returns name of shopping basket.
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getBasketName" in next major
      */
     protected function _getBasketName() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -993,6 +1004,7 @@ class Session extends \OxidEsales\Eshop\Core\Base
      * Returns cookie sid value
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getCookieSid" in next major
      */
     protected function _getCookieSid() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -1004,6 +1016,7 @@ class Session extends \OxidEsales\Eshop\Core\Base
      * start
      *
      * @return array
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getRequireSessionWithParams" in next major
      */
     protected function _getRequireSessionWithParams() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -1026,6 +1039,7 @@ class Session extends \OxidEsales\Eshop\Core\Base
      * Tests if current action requires session
      *
      * @return bool
+     * @deprecated underscore prefix violates PSR12, will be renamed to "isSessionRequiredAction" in next major
      */
     protected function _isSessionRequiredAction() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -1049,6 +1063,7 @@ class Session extends \OxidEsales\Eshop\Core\Base
      * return cookies usage for sid possibilities
      *
      * @return bool
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getSessionUseCookies" in next major
      */
     protected function _getSessionUseCookies() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -1059,6 +1074,7 @@ class Session extends \OxidEsales\Eshop\Core\Base
      * Checks if token supplied over 'rtoken' parameter matches remote access session token.
      *
      * @return bool
+     * @deprecated underscore prefix violates PSR12, will be renamed to "isValidRemoteAccessToken" in next major
      */
     protected function _isValidRemoteAccessToken() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {

--- a/source/Core/ShopControl.php
+++ b/source/Core/ShopControl.php
@@ -261,6 +261,7 @@ class ShopControl extends \OxidEsales\Eshop\Core\Base
      * @param string $function   Name of function
      * @param array  $parameters Parameters array
      * @param array  $viewsChain Array of views names that should be initialized also
+     * @deprecated underscore prefix violates PSR12, will be renamed to "process" in next major
      */
     protected function _process($class, $function, $parameters = null, $viewsChain = null) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -315,6 +316,7 @@ class ShopControl extends \OxidEsales\Eshop\Core\Base
      * Executes regular maintenance functions..
      *
      * @return null
+     * @deprecated underscore prefix violates PSR12, will be renamed to "executeMaintenanceTasks" in next major
      */
     protected function _executeMaintenanceTasks() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -375,6 +377,7 @@ class ShopControl extends \OxidEsales\Eshop\Core\Base
      * @param array  $viewsChain Array of views names that should be initialized also
      *
      * @return FrontendController
+     * @deprecated underscore prefix violates PSR12, will be renamed to "initializeViewObject" in next major
      */
     protected function _initializeViewObject($class, $function, $parameters = null, $viewsChain = null) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -413,6 +416,7 @@ class ShopControl extends \OxidEsales\Eshop\Core\Base
      * @param string             $function Method to check if it can be executed.
      *
      * @return bool
+     * @deprecated underscore prefix violates PSR12, will be renamed to "canExecuteFunction" in next major
      */
     protected function _canExecuteFunction($view, $function) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -433,6 +437,7 @@ class ShopControl extends \OxidEsales\Eshop\Core\Base
      * @param string $controllerName a class name
      *
      * @return array
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getFormattedErrors" in next major
      */
     protected function _getFormattedErrors($controllerName) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -456,6 +461,7 @@ class ShopControl extends \OxidEsales\Eshop\Core\Base
      * @param FrontendController $view view object to render
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "render" in next major
      */
     protected function _render($view) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -524,6 +530,7 @@ class ShopControl extends \OxidEsales\Eshop\Core\Base
      * Return output handler.
      *
      * @return oxOutput
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getOutputManager" in next major
      */
     protected function _getOutputManager() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -540,6 +547,7 @@ class ShopControl extends \OxidEsales\Eshop\Core\Base
      * @param string $currentControllerName Class name
      *
      * @return array
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getErrors" in next major
      */
     protected function _getErrors($currentControllerName) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -571,6 +579,7 @@ class ShopControl extends \OxidEsales\Eshop\Core\Base
     /**
      * This function is only executed one time here we perform checks if we
      * only need once per session.
+     * @deprecated underscore prefix violates PSR12, will be renamed to "runOnce" in next major
      */
     protected function _runOnce() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -606,6 +615,7 @@ class ShopControl extends \OxidEsales\Eshop\Core\Base
      * Returns disabled error logging if server is misconfigured #2015 E_NONE replaced with 0.
      *
      * @return int
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getErrorReportingLevel" in next major
      */
     protected function _getErrorReportingLevel() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -627,6 +637,7 @@ class ShopControl extends \OxidEsales\Eshop\Core\Base
      * Checks if shop is in debug mode.
      *
      * @return bool
+     * @deprecated underscore prefix violates PSR12, will be renamed to "isDebugMode" in next major
      */
     protected function _isDebugMode() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -635,6 +646,7 @@ class ShopControl extends \OxidEsales\Eshop\Core\Base
 
     /**
      * Starts resource monitor.
+     * @deprecated underscore prefix violates PSR12, will be renamed to "startMonitor" in next major
      */
     protected function _startMonitor() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -735,6 +747,7 @@ class ShopControl extends \OxidEsales\Eshop\Core\Base
      * possible reason: class does not exist etc. --> just redirect to start page.
      *
      * @param \OxidEsales\Eshop\Core\Exception\StandardException $exception
+     * @deprecated underscore prefix violates PSR12, will be renamed to "handleSystemException" in next major
      */
     protected function _handleSystemException($exception) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -765,6 +778,7 @@ class ShopControl extends \OxidEsales\Eshop\Core\Base
      * Redirect to start page, in debug mode shows error message.
      *
      * @param \OxidEsales\Eshop\Core\Exception\StandardException $exception Exception
+     * @deprecated underscore prefix violates PSR12, will be renamed to "handleCookieException" in next major
      */
     protected function _handleCookieException($exception) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -814,6 +828,7 @@ class ShopControl extends \OxidEsales\Eshop\Core\Base
      * Handling other not caught exceptions.
      *
      * @param \OxidEsales\Eshop\Core\Exception\StandardException $exception
+     * @deprecated underscore prefix violates PSR12, will be renamed to "handleBaseException" in next major
      */
     protected function _handleBaseException($exception) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {

--- a/source/Core/ShopIdCalculator.php
+++ b/source/Core/ShopIdCalculator.php
@@ -46,6 +46,7 @@ class ShopIdCalculator
      * Returns configuration key. This method is independent from oxConfig functionality.
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getConfKey" in next major
      */
     protected function _getConfKey() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -62,6 +63,7 @@ class ShopIdCalculator
      * Returns shop url to id map from config.
      *
      * @return array
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getShopUrlMap" in next major
      */
     protected function _getShopUrlMap() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {

--- a/source/Core/SimpleXml.php
+++ b/source/Core/SimpleXml.php
@@ -68,6 +68,7 @@ class SimpleXml
      * @param string              $sPreferredKey Key to use instead of node's key.
      *
      * @return SimpleXMLElement
+     * @deprecated underscore prefix violates PSR12, will be renamed to "addSimpleXmlElement" in next major
      */
     protected function _addSimpleXmlElement($oXml, $oInput, $sPreferredKey = null) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -89,6 +90,7 @@ class SimpleXml
      * @param string              $sPreferredKey
      *
      * @return SimpleXMLElement
+     * @deprecated underscore prefix violates PSR12, will be renamed to "addChildNode" in next major
      */
     protected function _addChildNode($oXml, $sKey, $mElement, $sPreferredKey = null) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -121,6 +123,7 @@ class SimpleXml
      * @param array            $aAttributes
      *
      * @return SimpleXMLElement
+     * @deprecated underscore prefix violates PSR12, will be renamed to "addNodeAttributes" in next major
      */
     protected function _addNodeAttributes($oNode, $aAttributes) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {

--- a/source/Core/Smarty/Plugin/Emos.php
+++ b/source/Core/Smarty/Plugin/Emos.php
@@ -449,6 +449,7 @@ class Emos
      * @param string $sCountry        customer country title
      * @param string $sCip            customer ip
      * @param string $sCity           customer city title
+     * @deprecated underscore prefix violates PSR12, will be renamed to "setEmosBillingArray" in next major
      */
     protected function _setEmosBillingArray($sBillingId = "", $sCustomerNumber = "", $iTotal = 0, $sCountry = "", $sCip = "", $sCity = "") // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -486,6 +487,7 @@ class Emos
      *
      * @param \OxidEsales\Eshop\Core\Smarty\Plugin\EmosItem $oItem      an instance of class EMOS_Item
      * @param string    $sEvent     Type of this event ("view","c_rmv","c_add")
+     * @deprecated underscore prefix violates PSR12, will be renamed to "setEmosECPageArray" in next major
      */
     protected function _setEmosECPageArray($oItem, $sEvent) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -503,6 +505,7 @@ class Emos
      * @param \OxidEsales\Eshop\Core\Smarty\Plugin\EmosItem $oItem item to format its parameters
      *
      * @return null
+     * @deprecated underscore prefix violates PSR12, will be renamed to "emos_ItemFormat" in next major
      */
     protected function _emos_ItemFormat($oItem) // phpcs:ignore PSR1.Methods.CamelCapsMethodName.NotCamelCaps,PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -522,6 +525,7 @@ class Emos
      * @param string $sStr data input to format
      *
      * @return null
+     * @deprecated underscore prefix violates PSR12, will be renamed to "emos_DataFormat" in next major
      */
     protected function _emos_DataFormat($sStr) //phpcs:ignore PSR1.Methods.CamelCapsMethodName.NotCamelCaps,PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -564,6 +568,7 @@ class Emos
 
     /**
      * formats up the connector script in a Econda ver 2 JS format
+     * @deprecated underscore prefix violates PSR12, will be renamed to "prepareScript" in next major
      */
     public function _prepareScript() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -603,6 +608,7 @@ class Emos
      * @param mixed  $mContents Variable value
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "addJsFormat" in next major
      */
     protected function _addJsFormat($sVarName, $mContents) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -627,6 +633,7 @@ class Emos
      * @param mixed $mContents Input contents
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "jsEncode" in next major
      */
     protected function _jsEncode($mContents) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {

--- a/source/Core/Smarty/Plugin/EmosAdapter.php
+++ b/source/Core/Smarty/Plugin/EmosAdapter.php
@@ -175,6 +175,7 @@ class EmosAdapter extends \OxidEsales\Eshop\Core\Base
      * Returns path to econda script files
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getScriptPath" in next major
      */
     protected function _getScriptPath() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -187,6 +188,7 @@ class EmosAdapter extends \OxidEsales\Eshop\Core\Base
      * Returns emos item object
      *
      * @return EMOS_Item
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getNewEmosItem" in next major
      */
     protected function _getNewEmosItem() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -219,6 +221,7 @@ class EmosAdapter extends \OxidEsales\Eshop\Core\Base
      * @param \OxidEsales\Eshop\Application\Model\Article $oProduct product which title must be prepared
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "prepareProductTitle" in next major
      */
     protected function _prepareProductTitle($oProduct) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -238,6 +241,7 @@ class EmosAdapter extends \OxidEsales\Eshop\Core\Base
      * @param int $iQty buyable amount
      *
      * @return EMOS_Item
+     * @deprecated underscore prefix violates PSR12, will be renamed to "convProd2EmosItem" in next major
      */
     protected function _convProd2EmosItem($oProduct, $sCatPath = "NULL", $iQty = 1) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -266,6 +270,7 @@ class EmosAdapter extends \OxidEsales\Eshop\Core\Base
      * @param array $aParams parameters where product info is kept
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getEmosPageTitle" in next major
      */
     protected function _getEmosPageTitle($aParams) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -276,6 +281,7 @@ class EmosAdapter extends \OxidEsales\Eshop\Core\Base
      * Returns purpose of this page (current view name)
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getEmosCl" in next major
      */
     protected function _getEmosCl() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -294,6 +300,7 @@ class EmosAdapter extends \OxidEsales\Eshop\Core\Base
      * Returns current view category path
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getEmosCatPath" in next major
      */
     protected function _getEmosCatPath() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -317,6 +324,7 @@ class EmosAdapter extends \OxidEsales\Eshop\Core\Base
      * @param \OxidEsales\Eshop\Application\Model\Article $oArticle article to build category id
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getBasketProductCatPath" in next major
      */
     protected function _getBasketProductCatPath($oArticle) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -355,6 +363,7 @@ class EmosAdapter extends \OxidEsales\Eshop\Core\Base
      * @param string $sTplName current view template name
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getEmosPageId" in next major
      */
     protected function _getEmosPageId($sTplName) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -372,6 +381,7 @@ class EmosAdapter extends \OxidEsales\Eshop\Core\Base
      * Returns active view template name
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getTplName" in next major
      */
     protected function _getTplName() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -387,6 +397,7 @@ class EmosAdapter extends \OxidEsales\Eshop\Core\Base
      * Returns page content array.
      *
      * @return array
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getPagesContent" in next major
      */
     private function _getPagesContent() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -397,6 +408,7 @@ class EmosAdapter extends \OxidEsales\Eshop\Core\Base
      * Returns each order step name in array.
      *
      * @return array
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getOrderStepNames" in next major
      */
     private function _getOrderStepNames() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -409,6 +421,7 @@ class EmosAdapter extends \OxidEsales\Eshop\Core\Base
      * @param \OxidEsales\Eshop\Core\Smarty\Plugin\Emos $oEmos
      * @param array $aParams
      * @param Smarty $oSmarty
+     * @deprecated underscore prefix violates PSR12, will be renamed to "setControllerInfo" in next major
      */
     private function _setControllerInfo($oEmos, $aParams, $oSmarty) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -531,6 +544,7 @@ class EmosAdapter extends \OxidEsales\Eshop\Core\Base
      *
      * @param \OxidEsales\Eshop\Core\Smarty\Plugin\Emos $oEmos
      * @param Smarty $oSmarty
+     * @deprecated underscore prefix violates PSR12, will be renamed to "setSearchInformation" in next major
      */
     private function _setSearchInformation($oEmos, $oSmarty) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -553,6 +567,7 @@ class EmosAdapter extends \OxidEsales\Eshop\Core\Base
      * @param \OxidEsales\Eshop\Application\Model\User $oUser
      * @param \OxidEsales\Eshop\Application\Model\Order $oOrder
      * @param \OxidEsales\Eshop\Application\Model\Basket $oBasket
+     * @deprecated underscore prefix violates PSR12, will be renamed to "setBasketInformation" in next major
      */
     private function _setBasketInformation($oEmos, $oUser, $oOrder, $oBasket) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -591,6 +606,7 @@ class EmosAdapter extends \OxidEsales\Eshop\Core\Base
      *
      * @param \OxidEsales\Eshop\Core\Smarty\Plugin\Emos $oEmos
      * @param \OxidEsales\Eshop\Application\Model\User $oUser
+     * @deprecated underscore prefix violates PSR12, will be renamed to "setUserRegistration" in next major
      */
     private function _setUserRegistration($oEmos, $oUser) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -610,6 +626,7 @@ class EmosAdapter extends \OxidEsales\Eshop\Core\Base
      * Sets basket actions (update and add) information to Emos.
      *
      * @param \OxidEsales\Eshop\Core\Smarty\Plugin\Emos $oEmos
+     * @deprecated underscore prefix violates PSR12, will be renamed to "setBasketActionsInfo" in next major
      */
     private function _setBasketActionsInfo($oEmos) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {

--- a/source/Core/Str.php
+++ b/source/Core/Str.php
@@ -53,6 +53,7 @@ class Str
      * possibility to extend it in modules by overriding _getStrHandler() method.
      *
      * @return oxStrRegular|oxStrMb
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getStrHandler" in next major
      */
     protected function _getStrHandler() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {

--- a/source/Core/SystemRequirements.php
+++ b/source/Core/SystemRequirements.php
@@ -342,6 +342,7 @@ class SystemRequirements
      * takes this info from eShop config.inc.php (via oxConfig class)
      *
      * @return array
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getShopHostInfoFromConfig" in next major
      */
     protected function _getShopHostInfoFromConfig() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -371,6 +372,7 @@ class SystemRequirements
      * takes this info from eShop config.inc.php (via oxConfig class)
      *
      * @return array
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getShopSSLHostInfoFromConfig" in next major
      */
     protected function _getShopSSLHostInfoFromConfig() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -400,6 +402,7 @@ class SystemRequirements
      * takes this info from _SERVER variable
      *
      * @return array
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getShopHostInfoFromServerVars" in next major
      */
     protected function _getShopHostInfoFromServerVars() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -424,6 +427,7 @@ class SystemRequirements
      * returns host, port, current script, ssl information as assotiative array, false on error
      *
      * @return array
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getShopHostInfo" in next major
      */
     protected function _getShopHostInfo() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -439,6 +443,7 @@ class SystemRequirements
      * Takes ssl address from config so important only in admin.
      *
      * @return array
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getShopSSLHostInfo" in next major
      */
     protected function _getShopSSLHostInfo() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -486,6 +491,7 @@ class SystemRequirements
      * @param array $aHostInfo host info to open socket
      *
      * @return integer
+     * @deprecated underscore prefix violates PSR12, will be renamed to "checkModRewrite" in next major
      */
     protected function _checkModRewrite($aHostInfo) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -797,6 +803,7 @@ class SystemRequirements
      * Additional sql: do not check collation for \OxidEsales\Eshop\Core\SystemRequirements::$_aException columns
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getAdditionalCheck" in next major
      */
     protected function _getAdditionalCheck() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -1034,6 +1041,7 @@ class SystemRequirements
      * @param string $sBytes string form byte value (64M, 32K etc)
      *
      * @return int
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getBytes" in next major
      */
     protected function _getBytes($sBytes) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -1067,6 +1075,7 @@ class SystemRequirements
      * @see getMissingTemplateBlocks
      *
      * @return bool
+     * @deprecated underscore prefix violates PSR12, will be renamed to "checkTemplateBlock" in next major
      */
     protected function _checkTemplateBlock($sTemplate, $sBlockName) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -1165,6 +1174,7 @@ class SystemRequirements
      * Return minimum memory limit by edition.
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getMinimumMemoryLimit" in next major
      */
     protected function _getMinimumMemoryLimit() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -1175,6 +1185,7 @@ class SystemRequirements
      * Return recommend memory limit by edition.
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getRecommendMemoryLimit" in next major
      */
     protected function _getRecommendMemoryLimit() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {

--- a/source/Core/UniversallyUniqueIdGenerator.php
+++ b/source/Core/UniversallyUniqueIdGenerator.php
@@ -88,6 +88,7 @@ class UniversallyUniqueIdGenerator
      * gets open SSL checker.
      *
      * @return \OxidEsales\Eshop\Core\OpenSSLFunctionalityChecker
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getOpenSSLChecker" in next major
      */
     protected function _getOpenSSLChecker() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -98,6 +99,7 @@ class UniversallyUniqueIdGenerator
      * Generates UUID based on OpenSSL's openssl_random_pseudo_bytes.
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "generateBasedOnOpenSSL" in next major
      */
     protected function _generateBasedOnOpenSSL() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -112,6 +114,7 @@ class UniversallyUniqueIdGenerator
      * Generates UUID based on mt_rand.
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "generateBasedOnMtRand" in next major
      */
     protected function _generateBasedOnMtRand() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {

--- a/source/Core/Utils.php
+++ b/source/Core/Utils.php
@@ -529,6 +529,7 @@ class Utils extends \OxidEsales\Eshop\Core\Base
      * @param string $sFilePath cache fiel path
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "readFile" in next major
      */
     protected function _readFile($sFilePath) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -543,6 +544,7 @@ class Utils extends \OxidEsales\Eshop\Core\Base
      * @param string $sFilePath cache file path
      *
      * @return mixed
+     * @deprecated underscore prefix violates PSR12, will be renamed to "includeFile" in next major
      */
     protected function _includeFile($sFilePath) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -559,6 +561,7 @@ class Utils extends \OxidEsales\Eshop\Core\Base
      * @param mixed  $mContents cache data
      *
      * @return mixed
+     * @deprecated underscore prefix violates PSR12, will be renamed to "processCache" in next major
      */
     protected function _processCache($sKey, $mContents) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -611,6 +614,7 @@ class Utils extends \OxidEsales\Eshop\Core\Base
      * @param int    $iLockMode lock mode - LOCK_EX/LOCK_SH
      *
      * @return mixed lock file resource or false on error
+     * @deprecated underscore prefix violates PSR12, will be renamed to "lockFile" in next major
      */
     protected function _lockFile($sFilePath, $sIdent, $iLockMode = LOCK_EX) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -663,6 +667,7 @@ class Utils extends \OxidEsales\Eshop\Core\Base
      * @param int    $iLockMode lock mode
      *
      * @return bool
+     * @deprecated underscore prefix violates PSR12, will be renamed to "releaseFile" in next major
      */
     protected function _releaseFile($sIdent, $iLockMode = LOCK_EX) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -1008,6 +1013,7 @@ class Utils extends \OxidEsales\Eshop\Core\Base
      *
      * @param string $sUrl        the URL to redirect to
      * @param string $sHeaderCode code to add to the header(e.g. "HTTP/1.1 301 Moved Permanently", or "HTTP/1.1 500 Internal Server Error"
+     * @deprecated underscore prefix violates PSR12, will be renamed to "simpleRedirect" in next major
      */
     protected function _simpleRedirect($sUrl, $sHeaderCode) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -1135,6 +1141,7 @@ class Utils extends \OxidEsales\Eshop\Core\Base
      * @param array  $aParams the params which will be added
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "addUrlParameters" in next major
      */
     protected function _addUrlParameters($sUrl, $aParams) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -1157,6 +1164,7 @@ class Utils extends \OxidEsales\Eshop\Core\Base
      *
      * @todo rename function more closely to actual purpose
      * @todo finish refactoring
+     * @deprecated underscore prefix violates PSR12, will be renamed to "fillExplodeArray" in next major
      */
     protected function _fillExplodeArray($aName, $dVat = null) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -1220,6 +1228,7 @@ class Utils extends \OxidEsales\Eshop\Core\Base
      * @param double $dVat   VAT
      *
      * @return float
+     * @deprecated underscore prefix violates PSR12, will be renamed to "preparePrice" in next major
      */
     protected function _preparePrice($dPrice, $dVat) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -1241,6 +1250,7 @@ class Utils extends \OxidEsales\Eshop\Core\Base
      * Checks and return true if price view mode is netto.
      *
      * @return bool
+     * @deprecated underscore prefix violates PSR12, will be renamed to "isPriceViewModeNetto" in next major
      */
     protected function _isPriceViewModeNetto() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -1257,6 +1267,7 @@ class Utils extends \OxidEsales\Eshop\Core\Base
      * Return article user.
      *
      * @return oxUser
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getArticleUser" in next major
      */
     protected function _getArticleUser() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {

--- a/source/Core/UtilsCount.php
+++ b/source/Core/UtilsCount.php
@@ -384,6 +384,7 @@ class UtilsCount extends \OxidEsales\Eshop\Core\Base
      * Loads and returns category cache data array
      *
      * @return array
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getCatCache" in next major
      */
     protected function _getCatCache() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -410,6 +411,7 @@ class UtilsCount extends \OxidEsales\Eshop\Core\Base
      * Writes category data into cache
      *
      * @param array $aCache A cacheable data
+     * @deprecated underscore prefix violates PSR12, will be renamed to "setCatCache" in next major
      */
     protected function _setCatCache($aCache) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -421,6 +423,7 @@ class UtilsCount extends \OxidEsales\Eshop\Core\Base
      * Writes vendor data into cache
      *
      * @param array $aCache A cacheable data
+     * @deprecated underscore prefix violates PSR12, will be renamed to "setVendorCache" in next major
      */
     protected function _setVendorCache($aCache) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -432,6 +435,7 @@ class UtilsCount extends \OxidEsales\Eshop\Core\Base
      * Writes Manufacturer data into cache
      *
      * @param array $aCache A cacheable data
+     * @deprecated underscore prefix violates PSR12, will be renamed to "setManufacturerCache" in next major
      */
     protected function _setManufacturerCache($aCache) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -443,6 +447,7 @@ class UtilsCount extends \OxidEsales\Eshop\Core\Base
      * Loads and returns category/vendor cache data array
      *
      * @return array
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getVendorCache" in next major
      */
     protected function _getVendorCache() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -468,6 +473,7 @@ class UtilsCount extends \OxidEsales\Eshop\Core\Base
      * Loads and returns category/Manufacturer cache data array
      *
      * @return array
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getManufacturerCache" in next major
      */
     protected function _getManufacturerCache() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -495,6 +501,7 @@ class UtilsCount extends \OxidEsales\Eshop\Core\Base
      * @param bool $blReset optional, default = false
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getUserViewId" in next major
      */
     protected function _getUserViewId($blReset = false) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {

--- a/source/Core/UtilsDate.php
+++ b/source/Core/UtilsDate.php
@@ -280,6 +280,7 @@ class UtilsDate extends \OxidEsales\Eshop\Core\Base
      * @param bool   $blOnlyDate       marker to format only date field (no time)
      *
      * @return null
+     * @deprecated underscore prefix violates PSR12, will be renamed to "setDefaultFormatedValue" in next major
      */
     protected function _setDefaultFormatedValue($oObject, $sDate, $sLocalDateFormat, $sLocalTimeFormat, $blOnlyDate) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -318,6 +319,7 @@ class UtilsDate extends \OxidEsales\Eshop\Core\Base
      * @param bool $blToTimeStamp -
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "defineAndCheckDefaultTimeValues" in next major
      */
     protected function _defineAndCheckDefaultTimeValues($blToTimeStamp) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -337,6 +339,7 @@ class UtilsDate extends \OxidEsales\Eshop\Core\Base
      * @param bool $blToTimeStamp marker how to format
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "defineAndCheckDefaultDateValues" in next major
      */
     protected function _defineAndCheckDefaultDateValues($blToTimeStamp) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -354,6 +357,7 @@ class UtilsDate extends \OxidEsales\Eshop\Core\Base
      * sets default date pattern
      *
      * @return array
+     * @deprecated underscore prefix violates PSR12, will be renamed to "defaultDatePattern" in next major
      */
     protected function _defaultDatePattern() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -367,6 +371,7 @@ class UtilsDate extends \OxidEsales\Eshop\Core\Base
      * sets default time pattern
      *
      * @return array
+     * @deprecated underscore prefix violates PSR12, will be renamed to "defaultTimePattern" in next major
      */
     protected function _defaultTimePattern() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -380,6 +385,7 @@ class UtilsDate extends \OxidEsales\Eshop\Core\Base
      * regular expressions to validate date input
      *
      * @return array
+     * @deprecated underscore prefix violates PSR12, will be renamed to "regexp2ValidateDateInput" in next major
      */
     protected function _regexp2ValidateDateInput() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -393,6 +399,7 @@ class UtilsDate extends \OxidEsales\Eshop\Core\Base
      * regular expressions to validate time input
      *
      * @return array
+     * @deprecated underscore prefix violates PSR12, will be renamed to "regexp2ValidateTimeInput" in next major
      */
     protected function _regexp2ValidateTimeInput() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -406,6 +413,7 @@ class UtilsDate extends \OxidEsales\Eshop\Core\Base
      * define date formatting rules
      *
      * @return array
+     * @deprecated underscore prefix violates PSR12, will be renamed to "defineDateFormattingRules" in next major
      */
     protected function _defineDateFormattingRules() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -419,6 +427,7 @@ class UtilsDate extends \OxidEsales\Eshop\Core\Base
      * defines time formatting rules
      *
      * @return array
+     * @deprecated underscore prefix violates PSR12, will be renamed to "defineTimeFormattingRules" in next major
      */
     protected function _defineTimeFormattingRules() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -435,6 +444,7 @@ class UtilsDate extends \OxidEsales\Eshop\Core\Base
      * @param string $sLocalDateFormat input format
      * @param string $sLocalTimeFormat local format
      * @param bool   $blOnlyDate       marker to format only date field (no time)
+     * @deprecated underscore prefix violates PSR12, will be renamed to "setDefaultDateTimeValue" in next major
      */
     protected function _setDefaultDateTimeValue($oObject, $sLocalDateFormat, $sLocalTimeFormat, $blOnlyDate) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -462,6 +472,7 @@ class UtilsDate extends \OxidEsales\Eshop\Core\Base
      * @param string $sDateFormat  date format
      * @param array  $aDFields     days
      * @param array  $aDateMatches new date as array (month, year)
+     * @deprecated underscore prefix violates PSR12, will be renamed to "setDate" in next major
      */
     protected function _setDate($oObject, $sDateFormat, $aDFields, $aDateMatches) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -494,6 +505,7 @@ class UtilsDate extends \OxidEsales\Eshop\Core\Base
      * @param array  $aTimeMatches new time
      * @param array  $aTFields     defines the time fields
      * @param array  $aDFields     defines the date fields
+     * @deprecated underscore prefix violates PSR12, will be renamed to "formatCorrectTimeValue" in next major
      */
     protected function _formatCorrectTimeValue($oObject, $sDateFormat, $sTimeFormat, $aDateMatches, $aTimeMatches, $aTFields, $aDFields) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -693,6 +705,7 @@ class UtilsDate extends \OxidEsales\Eshop\Core\Base
      * @param string $sFormat  date format to produce
      *
      * @return string formatted string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "processDate" in next major
      */
     protected function _processDate($aTime, $aDate, $blGerman, $sFormat) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {

--- a/source/Core/UtilsFile.php
+++ b/source/Core/UtilsFile.php
@@ -139,6 +139,7 @@ class UtilsFile extends \OxidEsales\Eshop\Core\Base
      * Setter for param _iNewFilesCounter which counts how many new files added.
      *
      * @param integer $iNewFilesCounter New files count.
+     * @deprecated underscore prefix violates PSR12, will be renamed to "setNewFilesCounter" in next major
      */
     protected function _setNewFilesCounter($iNewFilesCounter) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -260,6 +261,7 @@ class UtilsFile extends \OxidEsales\Eshop\Core\Base
      * @param bool   $blUnique   if TRUE - generates unique file name
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "prepareImageName" in next major
      */
     protected function _prepareImageName($sValue, $sType, $blDemo, $sImagePath, $blUnique = true) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -300,6 +302,7 @@ class UtilsFile extends \OxidEsales\Eshop\Core\Base
      * @param string $sType image type
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getImagePath" in next major
      */
     protected function _getImagePath($sType) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -316,7 +319,8 @@ class UtilsFile extends \OxidEsales\Eshop\Core\Base
      * @param int    $iImgNum  number of image (e.g. numper of ZOOM1 is 1)
      * @param string $sImgConf config parameter name, which keeps size info
      *
-     * @return array | null
+     * @return array|null
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getImageSize" in next major
      */
     protected function _getImageSize($sImgType, $iImgNum, $sImgConf) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -346,6 +350,7 @@ class UtilsFile extends \OxidEsales\Eshop\Core\Base
      * @param string $sTarget file location
      *
      * @return bool
+     * @deprecated underscore prefix violates PSR12, will be renamed to "copyFile" in next major
      */
     protected function _copyFile($sSource, $sTarget) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -372,6 +377,7 @@ class UtilsFile extends \OxidEsales\Eshop\Core\Base
      * @param string $sTarget image copy location
      *
      * @return bool
+     * @deprecated underscore prefix violates PSR12, will be renamed to "moveImage" in next major
      */
     protected function _moveImage($sSource, $sTarget) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -592,6 +598,7 @@ class UtilsFile extends \OxidEsales\Eshop\Core\Base
      * @param bool   $blUnique  TRUE - generates unique file name, FALSE - just glues given parts of file name
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getUniqueFileName" in next major
      */
     protected function _getUniqueFileName($sFilePath, $sFileName, $sFileExt, $sSufix = "", $blUnique = true) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {

--- a/source/Core/UtilsPic.php
+++ b/source/Core/UtilsPic.php
@@ -73,6 +73,7 @@ class UtilsPic extends \OxidEsales\Eshop\Core\Base
      * @param string $sAbsDynImageDir the absolute image diectory, where to delete the given image ($myConfig->getPictureDir(false))
      *
      * @return null
+     * @deprecated underscore prefix violates PSR12, will be renamed to "deletePicture" in next major
      */
     protected function _deletePicture($sPicName, $sAbsDynImageDir) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -114,6 +115,7 @@ class UtilsPic extends \OxidEsales\Eshop\Core\Base
      * @param string $sField   table field value
      *
      * @return bool
+     * @deprecated underscore prefix violates PSR12, will be renamed to "isPicDeletable" in next major
      */
     protected function _isPicDeletable($sPicName, $sTable, $sField) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -187,6 +189,7 @@ class UtilsPic extends \OxidEsales\Eshop\Core\Base
      * @param bool   $blDisableTouch  false if "touch()" should be called
      *
      * @return bool
+     * @deprecated underscore prefix violates PSR12, will be renamed to "resizeGif" in next major
      */
     protected function _resizeGif($sSrc, $sTarget, $iNewWidth, $iNewHeight, $iOriginalWidth, $iOriginalHeigth, $iGDVer, $blDisableTouch) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -207,6 +210,7 @@ class UtilsPic extends \OxidEsales\Eshop\Core\Base
      * @param string $iDefQuality       quality for "imagejpeg" function
      *
      * @return bool
+     * @deprecated underscore prefix violates PSR12, will be renamed to "resize" in next major
      */
     protected function _resize($aImageInfo, $sSrc, $hDestinationImage, $sTarget, $iNewWidth, $iNewHeight, $iGdVer, $blDisableTouch, $iDefQuality) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -251,6 +255,7 @@ class UtilsPic extends \OxidEsales\Eshop\Core\Base
      * @param bool   $blDisableTouch    wether Touch() should be called or not
      *
      * @return null
+     * @deprecated underscore prefix violates PSR12, will be renamed to "copyAlteredImage" in next major
      */
     protected function _copyAlteredImage($sDestinationImage, $sSourceImage, $iNewWidth, $iNewHeight, $aImageInfo, $sTarget, $iGdVer, $blDisableTouch) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {

--- a/source/Core/UtilsServer.php
+++ b/source/Core/UtilsServer.php
@@ -79,6 +79,7 @@ class UtilsServer extends \OxidEsales\Eshop\Core\Base
      * Checks if cookie must be saved to session in order to transfer it to different domain
      *
      * @return bool
+     * @deprecated underscore prefix violates PSR12, will be renamed to "mustSaveToSession" in next major
      */
     protected function _mustSaveToSession() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -109,6 +110,7 @@ class UtilsServer extends \OxidEsales\Eshop\Core\Base
      * @param bool $blGet mode - true - get, false - set cookie
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getSessionCookieKey" in next major
      */
     protected function _getSessionCookieKey($blGet) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -130,6 +132,7 @@ class UtilsServer extends \OxidEsales\Eshop\Core\Base
      * @param int    $iExpire expiration time
      * @param string $sPath   cookie path
      * @param string $sDomain cookie domain
+     * @deprecated underscore prefix violates PSR12, will be renamed to "saveSessionCookie" in next major
      */
     protected function _saveSessionCookie($sName, $sValue, $iExpire, $sPath, $sDomain) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -173,6 +176,7 @@ class UtilsServer extends \OxidEsales\Eshop\Core\Base
      * @param string $sPath user defined cookie path
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getCookiePath" in next major
      */
     protected function _getCookiePath($sPath) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -195,6 +199,7 @@ class UtilsServer extends \OxidEsales\Eshop\Core\Base
      * @param string $sDomain the domain that the cookie is available.
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getCookieDomain" in next major
      */
     protected function _getCookieDomain($sDomain) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -416,6 +421,7 @@ class UtilsServer extends \OxidEsales\Eshop\Core\Base
      * @param string $sServerHost request host.
      *
      * @return bool true if $sURL is equal to current page URL
+     * @deprecated underscore prefix violates PSR12, will be renamed to "isCurrentUrl" in next major
      */
     public function _isCurrentUrl($sURL, $sServerHost) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {

--- a/source/Core/UtilsUrl.php
+++ b/source/Core/UtilsUrl.php
@@ -499,6 +499,7 @@ class UtilsUrl extends \OxidEsales\Eshop\Core\Base
      *
      * @param string $sUrl   url to extract
      * @param array  $aHosts hosts array
+     * @deprecated underscore prefix violates PSR12, will be renamed to "addHost" in next major
      */
     protected function _addHost($sUrl, &$aHosts) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -514,6 +515,7 @@ class UtilsUrl extends \OxidEsales\Eshop\Core\Base
      *
      * @param array $aLanguageUrls array of language urls to extract
      * @param array $aHosts        hosts array
+     * @deprecated underscore prefix violates PSR12, will be renamed to "addLanguageHost" in next major
      */
     protected function _addLanguageHost($aLanguageUrls, &$aHosts) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -528,6 +530,7 @@ class UtilsUrl extends \OxidEsales\Eshop\Core\Base
      * Collects and returns current shop hosts array.
      *
      * @return array
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getHosts" in next major
      */
     protected function _getHosts() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -557,6 +560,7 @@ class UtilsUrl extends \OxidEsales\Eshop\Core\Base
      * Appends shop mall urls to $aHosts if needed
      *
      * @param array $aHosts hosts array
+     * @deprecated underscore prefix violates PSR12, will be renamed to "addMallHosts" in next major
      */
     protected function _addMallHosts(&$aHosts) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {

--- a/source/Core/UtilsView.php
+++ b/source/Core/UtilsView.php
@@ -575,6 +575,7 @@ class UtilsView extends \OxidEsales\Eshop\Core\Base
      * Returns active module Ids
      *
      * @return array
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getActiveModuleInfo" in next major
      */
     protected function _getActiveModuleInfo() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {

--- a/source/Core/ViewConfig.php
+++ b/source/Core/ViewConfig.php
@@ -189,6 +189,7 @@ class ViewConfig extends \OxidEsales\Eshop\Core\Base
      * Returns help content link idents
      *
      * @return array
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getHelpContentIdents" in next major
      */
     protected function _getHelpContentIdents() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -1399,6 +1400,7 @@ class ViewConfig extends \OxidEsales\Eshop\Core\Base
      * @param array  $aModuleVersions Modules from oxconfig 'aModuleVersions'
      *
      * @return bool
+     * @deprecated underscore prefix violates PSR12, will be renamed to "moduleExists" in next major
      */
     private function _moduleExists($sModuleId, $aModuleVersions) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -1432,6 +1434,7 @@ class ViewConfig extends \OxidEsales\Eshop\Core\Base
      * @param string $sVersionTo   Version to
      *
      * @return bool
+     * @deprecated underscore prefix violates PSR12, will be renamed to "isModuleVersionCorrect" in next major
      */
     private function _isModuleVersionCorrect($sModuleId, $sVersionFrom, $sVersionTo) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {

--- a/source/Core/WidgetControl.php
+++ b/source/Core/WidgetControl.php
@@ -70,6 +70,7 @@ class WidgetControl extends \OxidEsales\Eshop\Core\ShopControl
 
     /**
      * Runs actions that should be performed at the controller finish.
+     * @deprecated underscore prefix violates PSR12, will be renamed to "runLast" in next major
      */
     protected function _runLast() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -100,6 +101,7 @@ class WidgetControl extends \OxidEsales\Eshop\Core\ShopControl
      * @throws ObjectException
      *
      * @return \OxidEsales\Eshop\Core\Controller\BaseController Current active view
+     * @deprecated underscore prefix violates PSR12, will be renamed to "initializeViewObject" in next major
      */
     protected function _initializeViewObject($class, $function, $parameters = null, $viewsChain = null) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {

--- a/source/Internal/Framework/DIContainer/DataObject/DIConfigWrapper.php
+++ b/source/Internal/Framework/DIContainer/DataObject/DIConfigWrapper.php
@@ -241,9 +241,6 @@ class DIConfigWrapper
             }
         }
     }
-    /**
-     *
-     */
     private function removeInactiveServices()
     {
         /** @var DIServiceWrapper $service */

--- a/source/Internal/Framework/DIContainer/DataObject/DIServiceWrapper.php
+++ b/source/Internal/Framework/DIContainer/DataObject/DIServiceWrapper.php
@@ -129,9 +129,6 @@ class DIServiceWrapper
         return class_exists($this->getClass());
     }
 
-    /**
-     *
-     */
     private function addShopAwareCallsIfMissing()
     {
         if (!$this->hasCall($this::SET_ACTIVE_SHOPS_METHOD)) {

--- a/source/Setup/Dispatcher.php
+++ b/source/Setup/Dispatcher.php
@@ -40,7 +40,8 @@ class Dispatcher extends Core
     /**
      * Returns name of controller action script to perform
      *
-     * @return string | null
+     * @return string|null
+     * @deprecated underscore prefix violates PSR12, will be renamed to "chooseCurrentAction" in next major
      */
     protected function _chooseCurrentAction() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {

--- a/source/Setup/Session.php
+++ b/source/Setup/Session.php
@@ -54,6 +54,7 @@ class Session extends Core
 
     /**
      * Start session
+     * @deprecated underscore prefix violates PSR12, will be renamed to "startSession" in next major
      */
     protected function _startSession() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -80,6 +81,7 @@ class Session extends Core
      * Validate if session is started by setup script, if not, generate new session.
      *
      * @return string Session ID
+     * @deprecated underscore prefix violates PSR12, will be renamed to "validateSession" in next major
      */
     protected function _validateSession() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -101,6 +103,7 @@ class Session extends Core
      * Generate new unique session ID
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getNewSessionID" in next major
      */
     protected function _getNewSessionID() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -133,6 +136,7 @@ class Session extends Core
 
     /**
      * Initializes setup session data array
+     * @deprecated underscore prefix violates PSR12, will be renamed to "initSessionData" in next major
      */
     protected function _initSessionData() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -174,6 +178,7 @@ class Session extends Core
      * Return session object reference.
      *
      * @return array
+     * @deprecated underscore prefix violates PSR12, will be renamed to "getSessionData" in next major
      */
     protected function &_getSessionData() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {

--- a/source/Setup/Utilities.php
+++ b/source/Setup/Utilities.php
@@ -121,6 +121,7 @@ class Utilities extends Core
      * @param array $aPath path info array
      *
      * @return string
+     * @deprecated underscore prefix violates PSR12, will be renamed to "extractPath" in next major
      */
     protected function _extractPath($aPath) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {


### PR DESCRIPTION
Hello there :open_hands:,

this pull request will deprecate most methods that start with an `_` as stated in OXDEV-3281. In `master` these methods will be renamed to be without the prefixed `_`, to be released with the next major.

/Flo