### PR TITLE
Make setSessionCookie protected, correct _sessionStart regression

### DIFF
--- a/source/Core/Session.php
+++ b/source/Core/Session.php
@@ -309,23 +309,11 @@ class Session extends \OxidEsales\Eshop\Core\Base
      */
     protected function _sessionStart() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
-        if (!headers_sent() && (PHP_SESSION_NONE === session_status())) {
-            if ($this->needToSetHeaders()) {
-                //enforcing no caching when session is started
-                session_cache_limiter('nocache');
-
-                //cache limiter workaround for AOL browsers
-                //as suggested at http://ilia.ws/archives/59-AOL-Browser-Woes.html
-                if (
-                    isset($_SERVER['HTTP_USER_AGENT']) &&
-                    strpos($_SERVER['HTTP_USER_AGENT'], 'AOL') !== false
-                ) {
-                    session_cache_limiter('');
-                    Registry::getUtils()->setHeader("Cache-Control: no-store, private, must-revalidate, proxy-revalidate, post-check=0, pre-check=0, max-age=0, s-maxage=0");
-                }
-            } else {
-                session_cache_limiter('');
-            }
+        if ($this->needToSetHeaders()) {
+            //enforcing no caching when session is started
+            session_cache_limiter('nocache');
+        } else {
+            session_cache_limiter('');
         }
 
         $this->_blStarted = session_start();
@@ -1129,7 +1117,14 @@ class Session extends \OxidEsales\Eshop\Core\Base
     {
     }
 
-    private function setSessionCookie($sessionId): void
+    /**
+     * Set the session cookie
+     *
+     * @param string $sessionId   Session cookie value
+     *
+     * @return void
+     */
+    protected function setSessionCookie($sessionId): void
     {
         if ($this->_getSessionUseCookies()) {
             if (!$this->_allowSessionStart()) {


### PR DESCRIPTION
This PR implements the requested changes and replaces PR #782. It also corrects a regression.

1. Make the setSessionCookie function protected, so that modules that extend Session can modify the parameters passed to setOxCookie, for example to change the session lifetime.

2. Add a standard comment header to setSessionCookie.

3. Correct a regression in _sessionStart between master and b-6.2.x, where some redundant code that is removed in master has reappeared.
See lines 313-318 in
https://github.com/OXID-eSales/oxideshop_ce/blob/master/source/Core/Session.php
See lines 312-329 in
https://github.com/OXID-eSales/oxideshop_ce/blob/b-6.2.x/source/Core/Session.php