### PR TITLE
Update Config.php

### DIFF
--- a/source/Core/Config.php
+++ b/source/Core/Config.php
@@ -566,7 +566,7 @@ class Config extends \OxidEsales\Eshop\Core\Base
 
         if ($module) {
             $select .= " oxmodule LIKE :oxmodule";
-            $params[':oxmodule'] = $module . "%";
+            $params[':oxmodule'] = $module;
         } else {
             $select .= "oxmodule = ''";
         }


### PR DESCRIPTION
The "%" in the LIKE-statement selects more config-records than it should.
For example, if you have 2 themes "mytheme" and "mytheme-mobile" and lets say "mytheme" is the active one, this query selects all configs from both themes, because LIKE "mytheme%" also matches "mytheme-mobile".
Whats the purpose of this "%" anyway?