### PR TITLE
added deltime for variants

### DIFF
--- a/source/Application/views/admin/tpl/article_stock.tpl
+++ b/source/Application/views/admin/tpl/article_stock.tpl
@@ -103,10 +103,10 @@ function editThis( sID )
 
                     [{oxmultilang ident="ARTICLE_STOCK_MAXDELTIME"}]&nbsp;<input type="text" class="editinput" size="3" maxlength="[{$edit->oxarticles__oxmaxdeltime->fldmax_width}]" name="editval[oxarticles__oxmaxdeltime]" value="[{$edit->oxarticles__oxmaxdeltime->value}]">
 
-                    &nbsp;<select name="editval[oxarticles__oxdeltimeunit]" class="editinput">
-                    <option value="DAY" [{if $edit->oxarticles__oxdeltimeunit->value == "DAY"}]SELECTED[{/if}]>[{oxmultilang ident="ARTICLE_STOCK_DAYS"}]</option>
-                    <option value="WEEK" [{if $edit->oxarticles__oxdeltimeunit->value == "WEEK"}]SELECTED[{/if}]>[{oxmultilang ident="ARTICLE_STOCK_WEEKS"}]</option>
-                    <option value="MONTH" [{if $edit->oxarticles__oxdeltimeunit->value == "MONTH"}]SELECTED[{/if}]>[{oxmultilang ident="ARTICLE_STOCK_MONTHS"}]</option>
+                    <select name="editval[oxarticles__oxdeltimeunit]" class="editinput">
+                      <option value="DAY" [{if $edit->oxarticles__oxdeltimeunit->value == "DAY"}]SELECTED[{/if}]>[{oxmultilang ident="ARTICLE_STOCK_DAYS"}]</option>
+                      <option value="WEEK" [{if $edit->oxarticles__oxdeltimeunit->value == "WEEK"}]SELECTED[{/if}]>[{oxmultilang ident="ARTICLE_STOCK_WEEKS"}]</option>
+                      <option value="MONTH" [{if $edit->oxarticles__oxdeltimeunit->value == "MONTH"}]SELECTED[{/if}]>[{oxmultilang ident="ARTICLE_STOCK_MONTHS"}]</option>
                     </select>
                   [{oxinputhelp ident="HELP_ARTICLE_STOCK_DELTIME"}]
                   </td>

--- a/source/Application/views/admin/tpl/article_variant.tpl
+++ b/source/Application/views/admin/tpl/article_variant.tpl
@@ -199,6 +199,15 @@ function editThis( sID )
             <td class="[{$listclass}]"><input type="text" class="editinput" size="7" maxlength="[{$listitem->oxarticles__oxsort->fldmax_length}]" name="editval[[{$listitem->oxarticles__oxid->value}]][oxarticles__oxsort]" value="[{$listitem->oxarticles__oxsort->value}]" [{$readonly}]></td>
             <td class="[{$listclass}]"><input type="text" class="editinput" size="7" maxlength="[{$listitem->oxarticles__oxstock->fldmax_length}]" name="editval[[{$listitem->oxarticles__oxid->value}]][oxarticles__oxstock]" value="[{$listitem->oxarticles__oxstock->value}]" [{$readonly}]></td>
             <td class="[{$listclass}]">
+              [{oxmultilang ident="ARTICLE_STOCK_MINDELTIME"}] <input type="text" class="editinput" size="2" maxlength="[{$listitem->oxarticles__oxstock->fldmax_length}]" name="editval[[{$listitem->oxarticles__oxid->value}]][oxarticles__oxmindeltime]" value="[{$listitem->oxarticles__oxmindeltime->value}]" [{$readonly}]>
+              [{oxmultilang ident="ARTICLE_STOCK_MAXDELTIME"}] <input type="text" class="editinput" size="2" maxlength="[{$listitem->oxarticles__oxstock->fldmax_length}]" name="editval[[{$listitem->oxarticles__oxid->value}]][oxarticles__oxmaxdeltime]" value="[{$listitem->oxarticles__oxmaxdeltime->value}]" [{$readonly}]>
+              <select name="editval[[{$listitem->oxarticles__oxid->value}]][oxarticles__oxdeltimeunit]" class="editinput">
+                <option value="DAY" [{if $listitem->oxarticles__oxdeltimeunit->value == "DAY"}]SELECTED[{/if}]>[{oxmultilang ident="ARTICLE_STOCK_DAYS"}]</option>
+                <option value="WEEK" [{if $listitem->oxarticles__oxdeltimeunit->value == "WEEK"}]SELECTED[{/if}]>[{oxmultilang ident="ARTICLE_STOCK_WEEKS"}]</option>
+                <option value="MONTH" [{if $listitem->oxarticles__oxdeltimeunit->value == "MONTH"}]SELECTED[{/if}]>[{oxmultilang ident="ARTICLE_STOCK_MONTHS"}]</option>
+              </select>
+            </td>
+            <td class="[{$listclass}]">
               <select name="editval[[{$listitem->oxarticles__oxid->value}]][oxarticles__oxstockflag]" class="editinput" [{$readonly}]>
               <option value="1" [{if $listitem->oxarticles__oxstockflag->value == 1}]SELECTED[{/if}]>[{oxmultilang ident="GENERAL_STANDARD"}]</option>
               <option value="4" [{if $listitem->oxarticles__oxstockflag->value == 4}]SELECTED[{/if}]>[{oxmultilang ident="GENERAL_EXTERNALSTOCK"}]</option>


### PR DESCRIPTION
This PR adds min & max deliverytimes inputs and units select to variants admin templates.
So you can specify deliverytimes per variant.
This should work without backend changes and should also work in themes.

Further it fixes an indent in article_stock.tpl