### PR TITLE
turning off autocomplete for smtp fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Removed multilines in translation files to make it fit for localization platforms [PR-729](https://github.com/OXID-eSales/oxideshop_ce/pull/729)
 - Update symfony components to version 5
 - Change translations loading source for themes to be same as for core and modules
+- Turn off `autocomplete` for SMTP fields in admin template [PR-794](https://github.com/OXID-eSales/oxideshop_ce/pull/794)
 
 ### Deprecated
 - `\OxidEsales\EshopCommunity\Core\Controller\BaseController::getConfig`

--- a/source/Application/views/admin/tpl/shop_main.tpl
+++ b/source/Application/views/admin/tpl/shop_main.tpl
@@ -308,7 +308,7 @@ window.onload = function ()
                             [{oxmultilang ident="SHOP_MAIN_SMTPUSER"}]
                 </td>
                 <td class="edittext">
-                <input type="text" class="editinput" size="35" maxlength="[{$edit->oxshops__oxsmtpuser->fldmax_length}]" name="editval[oxshops__oxsmtpuser]" value="[{$edit->oxshops__oxsmtpuser->value}]" [{$readonly}]>
+                <input autocomplete="off" type="text" class="editinput" size="35" maxlength="[{$edit->oxshops__oxsmtpuser->fldmax_length}]" name="editval[oxshops__oxsmtpuser]" value="[{$edit->oxshops__oxsmtpuser->value}]" [{$readonly}]>
                 [{oxinputhelp ident="HELP_SHOP_MAIN_SMTPUSER"}]
                 </td>
             </tr>
@@ -317,7 +317,7 @@ window.onload = function ()
                             [{oxmultilang ident="SHOP_MAIN_SMTPPASSWORD"}]
                 </td>
                 <td class="edittext">
-                <input type="password" name="oxsmtppwd" size="35" maxlength="50" class="editinput" [{$readonly}] onfocus="modSmtpField()" onChange="modSmtpField()">
+                <input autocomplete="off" type="password" name="oxsmtppwd" size="35" maxlength="50" class="editinput" [{$readonly}] onfocus="modSmtpField()" onChange="modSmtpField()">
                 [{oxmultilang ident="SHOP_MAIN_SMTPPWUNSET"}]
                 [{oxinputhelp ident="HELP_SHOP_MAIN_SMTPPASSWORD"}]
                 </td>


### PR DESCRIPTION
because this prevents the browser to fill in wrong data in empty fields and that prevents antecedently wrong smtp configuration or personal passwords to be stored in that field.

That fields are used to be empty in environments where a local mail forwarder is installed.