### PR TITLE
getRenderer() shouldn't be private

### DIFF
--- a/source/Core/Email.php
+++ b/source/Core/Email.php
@@ -347,7 +347,7 @@ class Email extends PHPMailer
      *
      * @return TemplateRendererInterface
      */
-    private function getRenderer()
+    protected function getRenderer()
     {
         $bridge = $this->getContainer()->get(TemplateRendererBridgeInterface::class);
         $bridge->setEngine($this->_getSmarty());


### PR DESCRIPTION
Every module author should be able to use this method, like in sendOrderEmailToUser()