### PR TITLE
trim default value in Database class also for non empty strings (MariaDb)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [unreleased]
+
+### Fixed
+- MariaDB column default values must be trimmed [PR-796](https://github.com/OXID-eSales/oxideshop_ce/pull/796)
+
 ## [6.5.5] - 2020-05-05
 
 ### Deprecated

--- a/source/Core/Database/Adapter/Doctrine/Database.php
+++ b/source/Core/Database/Adapter/Doctrine/Database.php
@@ -1086,6 +1086,10 @@ class Database implements DatabaseInterface
             $characterSet = $this->getMetaColumnValueByKey($column, 'CharacterSet');
             $collation = $this->getMetaColumnValueByKey($column, 'Collation');
 
+            if ($default !== null) {
+                // MariaDB puts quotes around default values:
+                $default = trim($default, "'");
+            }
 
             $typeInformation = explode('(', $type);
             $typeName = trim($typeInformation[0]);
@@ -1098,7 +1102,7 @@ class Database implements DatabaseInterface
             $item->auto_increment = strtolower($extra) == 'auto_increment';
             $item->binary = (false !== strpos(strtolower($type), 'blob'));
             $item->unsigned = (false !== strpos(strtolower($type), 'unsigned'));
-            $item->has_default = ('' === trim($default, "'") || is_null($default)) ? false : true;
+            $item->has_default = ((is_null($default)) || ($default === '')) ? false : true;
             if ($item->has_default) {
                 $item->default_value = $default;
             }


### PR DESCRIPTION
Related to: https://github.com/OXID-eSales/oxideshop_ce/pull/709

If a table has a `VARCHAR`-column with `DEFAULT 'EUR'`, `$item->default_value` gets set to `'EUR'` instead of `EUR` on some newer MariaDB versions
=> The quoting issue not only appears for DEFAULT ''

This pull-request suggests to simply always trim quotes from default-values.
Drawback: Default-Values that actually have quotes at the beginning or end would lose the quotes (never noticed such default-values in real projects yet). 

If quotation marks cannot be trimmed in general, it would be necessary to explicitly check whether MariaDB is being used (i.e. the DB variables `version` and `version_comments` would have to be queried via an extra SQL query)