### PR TITLE
Added str_starts_with(), str_ends_with(), str_contains()

### DIFF
--- a/source/Core/IStr.php
+++ b/source/Core/IStr.php
@@ -1,0 +1,293 @@
+<?php
+
+/**
+ * Copyright © OXID eSales AG. All rights reserved.
+ * See LICENSE file for license details.
+ */
+
+namespace OxidEsales\EshopCommunity\Core;
+
+/**
+ * Factory class responsible for redirecting string handling functions to specific
+ * string handling class. String handler basically is intended for dealing with multibyte string
+ * and is NOT supposed to replace all string handling functions.
+ * We use the handler for shop data and user input, but prefer not to use it for ascii strings
+ * (eg. field or file names).
+ */
+interface IStr
+{
+
+    /**
+     * Get string length
+     *
+     * @param string $sStr string to measure its length
+     *
+     * @return int
+     */
+    public function strlen($sStr);
+
+    /**
+     * Return part of a string
+     *
+     * @param string $sStr    value to truncate
+     * @param int    $iStart  start position
+     * @param int    $iLength length
+     *
+     * @return string
+     */
+    public function substr($sStr, $iStart, $iLength = null);
+
+    /**
+     * Find the position of the first occurrence of a substring in a string
+     *
+     * @param string $sHaystack value to search in
+     * @param string $sNeedle   value to search for
+     * @param int    $iOffset   initial search position
+     *
+     * @return string
+     */
+    public function strpos($sHaystack, $sNeedle, $iOffset = null);
+
+    /**
+     *  Find the first occurrence of a string
+     *
+     * @param string $sHaystack value to search in
+     * @param string $sNeedle   value to search for
+     *
+     * @return string
+     */
+    public function strstr($sHaystack, $sNeedle);
+
+    /**
+     * Make a string lowercase
+     *
+     * @param string $sString string being lower cased
+     *
+     * @return string
+     */
+    public function strtolower($sString);
+
+    /**
+     * Make a string uppercase
+     *
+     * @param string $sString string being lower cased
+     *
+     * @return string
+     */
+    public function strtoupper($sString);
+
+    /**
+     * Convert special characters to HTML entities
+     *
+     * @param string $sString    string being converted
+     * @param int    $iQuotStyle quoting rule
+     *
+     * @return string
+     */
+    public function htmlspecialchars($sString, $iQuotStyle = ENT_QUOTES);
+
+    /**
+     * Convert all applicable characters to HTML entities
+     *
+     * @param string $sString    string being converted
+     * @param int    $iQuotStyle quoting rule
+     *
+     * @return string
+     */
+    public function htmlentities($sString, $iQuotStyle = ENT_QUOTES);
+
+    // @codingStandardsIgnoreStart
+
+    /**
+     * Convert HTML entities to their corresponding characters
+     *
+     * @param string $sString    string being converted
+     * @param int    $iQuotStyle quoting rule
+     *
+     * @return string
+     */
+    public function html_entity_decode($sString, $iQuotStyle = ENT_QUOTES);
+
+    /**
+     * Split string by a regular expression
+     *
+     * @param string $sPattern pattern to search for, as a string
+     * @param string $sString  input string
+     * @param int    $iLimit   (optional) only sub strings up to limit are returned
+     * @param int    $iFlag    flags
+     *
+     * @return string
+     */
+    public function preg_split($sPattern, $sString, $iLimit = -1, $iFlag = 0);
+
+    /**
+     * Perform a regular expression search and replace
+     *
+     * @param mixed  $aPattern pattern to search for, as a string
+     * @param mixed  $sString  string to replace
+     * @param string $sSubject strings to search and replace
+     * @param int    $iLimit   maximum possible replacements
+     * @param int    $iCount   number of replacements done
+     *
+     * @return string
+     */
+    public function preg_replace($aPattern, $sString, $sSubject, $iLimit = -1, $iCount = null);
+
+    /**
+     * Perform a regular expression search and replace using a callback
+     *
+     * @param mixed    $pattern  pattern to search for, as a string
+     * @param callable $callback Callback function
+     * @param string   $subject  strings to search and replace
+     * @param int      $limit    maximum possible replacements
+     * @param int      $count    number of replacements done
+     *
+     * @return string
+     */
+    public function preg_replace_callback($pattern, $callback, $subject, $limit = -1, &$count = null);
+
+    /**
+     * Perform a regular expression match
+     *
+     * @param string $sPattern pattern to search for, as a string
+     * @param string $sSubject input string
+     * @param array  $aMatches is filled with the results of search
+     * @param int    $iFlags   flags
+     * @param int    $iOffset  place from which to start the search
+     *
+     * @return string
+     */
+    public function preg_match($sPattern, $sSubject, &$aMatches = null, $iFlags = null, $iOffset = null);
+
+    /**
+     * Perform a global regular expression match
+     *
+     * @param string $sPattern pattern to search for, as a string
+     * @param string $sSubject input string
+     * @param array  $aMatches is filled with the results of search
+     * @param int    $iFlags   flags
+     * @param int    $iOffset  place from which to start the search
+     *
+     * @return string
+     */
+    public function preg_match_all($sPattern, $sSubject, &$aMatches = null, $iFlags = null, $iOffset = null);
+
+    /**
+     * Make a string's first character uppercase
+     *
+     * @param string $sSubject input string
+     *
+     * @return string
+     */
+    public function ucfirst($sSubject);
+
+    /**
+     * Wraps a string to a given number of characters
+     *
+     * @param string $sString input string
+     * @param int    $iLength column width
+     * @param string $sBreak  line is broken using the optional break parameter
+     * @param bool   $blCut   string is always wrapped at the specified width
+     *
+     * @return string
+     */
+    public function wordwrap($sString, $iLength = 75, $sBreak = "\n", $blCut = null);
+
+    /**
+     * Recodes and returns passed input:
+     * if $blToHtmlEntities == true  ä -> &auml;
+     * if $blToHtmlEntities == false &auml; -> ä
+     *
+     * @param string $sInput           text to recode
+     * @param bool   $blToHtmlEntities recode direction
+     * @param array  $aUmls            language specific characters
+     * @param array  $aUmlEntities     language specific characters equivalents in entities form
+     *
+     * @return string
+     */
+    public function recodeEntities($sInput, $blToHtmlEntities = false, $aUmls = [], $aUmlEntities = []);
+
+    /**
+     * Checks if string has special chars
+     *
+     * @param string $sStr string to search in
+     *
+     * @return bool
+     */
+    public function hasSpecialChars($sStr);
+
+    /**
+     * Replaces special characters with passed char.
+     * Special chars are: \n \r \t \xc2\x95 \xc2\xa0 ;
+     *
+     * @param string $sStr      string to cleanup
+     * @param string $sCleanChr which character should be used as a replacement (default is empty space)
+     *
+     * @return string
+     */
+    public function cleanStr($sStr, $sCleanChr = ' ');
+
+    /**
+     * wrapper for json encode, which does not work with non utf8 characters
+     *
+     * @param mixed $data data to encode
+     *
+     * @return string
+     */
+    public function jsonEncode($data);
+
+    // @codingStandardsIgnoreStart
+
+    /**
+     * Strip HTML and PHP tags from a string
+     *
+     * @param string $sString        the input string
+     * @param string $sAllowableTags an optional parameter to specify tags which should not be stripped
+     *
+     * @return string
+     */
+    public function strip_tags($sString, $sAllowableTags = '');
+
+    /**
+     * Compares two strings. Case sensitive.
+     * For use in sorting with reverse order
+     *
+     * @param string $sStr1 String to compare
+     * @param string $sStr2 String to compare
+     *
+     * @return int > 0 if str1 is less than str2; < 0 if str1 is greater than str2, and 0 if they are equal.
+     */
+    public function strrcmp($sStr1, $sStr2);
+
+    /**
+     * Checks if $haystack begins with $needle
+     * (If $needle is longer than $haystack, it returns false)
+     *
+     * @param string $haystack value to search in
+     * @param string $needle   value to search for
+     *
+     * @return bool
+     */
+    public function str_starts_with(string $haystack, string $needle);
+
+    /**
+     * Checks if $haystack ends with $needle
+     * (If $needle is longer than $haystack, it returns false)
+     *
+     * @param string $haystack value to search in
+     * @param string $needle   value to search for
+     *
+     * @return bool
+     */
+    public function str_ends_with(string $haystack, string $needle);
+
+    /**
+     * Returns true if $needle is found in $haystack
+     *
+     * @param string $haystack value to search in
+     * @param string $needle   value to search for
+     *
+     * @return bool
+     */
+    public function str_contains(string $haystack, string $needle);
+}

--- a/source/Core/StrMb.php
+++ b/source/Core/StrMb.php
@@ -10,7 +10,7 @@ namespace OxidEsales\EshopCommunity\Core;
 /**
  * Class dealing with multibyte strings
  */
-class StrMb
+class StrMb implements IStr
 {
     /**
      * The character encoding.
@@ -415,5 +415,67 @@ class StrMb
     public function strrcmp($sStr1, $sStr2)
     {
         return -strcmp($sStr1, $sStr2);
+    }
+
+    /**
+     * Checks if $haystack begins with $needle
+     * (If $needle is longer than $haystack, it returns false)
+     *
+     * @param string $haystack value to search in
+     * @param string $needle   value to search for
+     *
+     * @return bool
+     */
+    public function str_starts_with(string $haystack, string $needle): bool
+    {
+        // According to https://wiki.php.net/rfc/str_contains:
+        // 'behavior of '' in string search functions is well defined, and we consider '' to occur at every position
+        // in the string
+        if ($needle === '') {
+            return true;
+        }
+
+        return ($this->substr($haystack, 0, $this->strlen($needle)) === $needle);
+    }
+
+    /**
+     * Checks if $haystack ends with $needle
+     * (If $needle is longer than $haystack, it returns false)
+     *
+     * @param string $haystack value to search in
+     * @param string $needle   value to search for
+     *
+     * @return bool
+     */
+    public function str_ends_with(string $haystack, string $needle): bool
+    {
+        // According to https://wiki.php.net/rfc/str_contains:
+        // 'behavior of '' in string search functions is well defined, and we consider '' to occur at every position
+        // in the string
+        if ($needle === '') {
+            return true;
+        }
+
+        return ($this->substr($haystack, -$this->strlen($needle)) === $needle);
+    }
+
+    /**
+     * Returns true if $needle is found in $haystack
+     *
+     * @param string $haystack value to search in
+     * @param string $needle   value to search for
+     *
+     * @return bool
+     */
+    public function str_contains(string $haystack, string $needle): bool
+    {
+        // According to https://wiki.php.net/rfc/str_contains:
+        // 'behavior of '' in string search functions is well defined, and we consider '' to occur at every position
+        // in the string
+        if ($needle === '') {
+            return true;
+        }
+
+        return ($this->strpos($haystack, $needle) !== false);
     }
 }

--- a/source/Core/StrMb.php
+++ b/source/Core/StrMb.php
@@ -426,6 +426,7 @@ class StrMb implements IStr
      *
      * @return bool
      */
+    // phpcs:disable
     public function str_starts_with(string $haystack, string $needle): bool
     {
         // According to https://wiki.php.net/rfc/str_contains:
@@ -447,6 +448,7 @@ class StrMb implements IStr
      *
      * @return bool
      */
+    // phpcs:disable
     public function str_ends_with(string $haystack, string $needle): bool
     {
         // According to https://wiki.php.net/rfc/str_contains:
@@ -467,6 +469,7 @@ class StrMb implements IStr
      *
      * @return bool
      */
+    // phpcs:disable
     public function str_contains(string $haystack, string $needle): bool
     {
         // According to https://wiki.php.net/rfc/str_contains:

--- a/source/Core/StrRegular.php
+++ b/source/Core/StrRegular.php
@@ -417,6 +417,7 @@ class StrRegular implements IStr
      *
      * @return bool
      */
+    // phpcs:disable
     public function str_starts_with(string $haystack, string $needle): bool
     {
         // According to https://wiki.php.net/rfc/str_contains:
@@ -438,6 +439,7 @@ class StrRegular implements IStr
      *
      * @return bool
      */
+    // phpcs:disable
     public function str_ends_with(string $haystack, string $needle): bool
     {
         // According to https://wiki.php.net/rfc/str_contains:
@@ -458,6 +460,7 @@ class StrRegular implements IStr
      *
      * @return bool
      */
+    // phpcs:disable
     public function str_contains(string $haystack, string $needle): bool
     {
         // According to https://wiki.php.net/rfc/str_contains:

--- a/source/Core/StrRegular.php
+++ b/source/Core/StrRegular.php
@@ -10,7 +10,7 @@ namespace OxidEsales\EshopCommunity\Core;
 /**
  * Class dealing with regular string handling
  */
-class StrRegular
+class StrRegular implements IStr
 {
     /**
      * The character encoding.
@@ -406,5 +406,67 @@ class StrRegular
     public function strrcmp($sStr1, $sStr2)
     {
         return -strcmp($sStr1, $sStr2);
+    }
+
+    /**
+     * Checks if $haystack begins with $needle
+     * (If $needle is longer than $haystack, it returns false)
+     *
+     * @param string $haystack value to search in
+     * @param string $needle   value to search for
+     *
+     * @return bool
+     */
+    public function str_starts_with(string $haystack, string $needle): bool
+    {
+        // According to https://wiki.php.net/rfc/str_contains:
+        // 'behavior of '' in string search functions is well defined, and we consider '' to occur at every position
+        // in the string
+        if ($needle === '') {
+            return true;
+        }
+
+        return ($this->substr($haystack, 0, $this->strlen($needle)) === $needle);
+    }
+
+    /**
+     * Checks if $haystack ends with $needle
+     * (If $needle is longer than $haystack, it returns false)
+     *
+     * @param string $haystack value to search in
+     * @param string $needle   value to search for
+     *
+     * @return bool
+     */
+    public function str_ends_with(string $haystack, string $needle): bool
+    {
+        // According to https://wiki.php.net/rfc/str_contains:
+        // 'behavior of '' in string search functions is well defined, and we consider '' to occur at every position
+        // in the string
+        if ($needle === '') {
+            return true;
+        }
+
+        return ($this->substr($haystack, -$this->strlen($needle)) === $needle);
+    }
+
+    /**
+     * Returns true if $needle is found in $haystack
+     *
+     * @param string $haystack value to search in
+     * @param string $needle   value to search for
+     *
+     * @return bool
+     */
+    public function str_contains(string $haystack, string $needle): bool
+    {
+        // According to https://wiki.php.net/rfc/str_contains:
+        // 'behavior of '' in string search functions is well defined, and we consider '' to occur at every position
+        // in the string
+        if ($needle === '') {
+            return true;
+        }
+
+        return ($this->strpos($haystack, $needle) !== false);
     }
 }

--- a/tests/Unit/Core/StrMbTest.php
+++ b/tests/Unit/Core/StrMbTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * Copyright Â© OXID eSales AG. All rights reserved.
+ * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
 
@@ -311,5 +311,251 @@ class StrMbTest extends \OxidTestCase
     {
         $this->assertEquals('without styling definition.', $this->_oSubj->strip_tags('<div>without</div> <style type="text/css">p {color:blue;}</style>styling definition.'));
         $this->assertEquals('with <style type="text/css">p {color:blue;}</style>styling definition.', $this->_oSubj->strip_tags('<div>with</div> <style type="text/css">p {color:blue;}</style>styling definition.', '<style>'));
+    }
+
+    public function testStrStartsWith()
+    {
+        // analog to phps /ext/standard/tests/strings/str_starts_with.phpt
+
+        $testStr = $this->_2Utf("Höher, schneller, weiter");
+
+        $this->assertEquals(
+            true,
+            $this->_oSubj->str_starts_with($testStr, $this->_2Utf("Höher"))
+        );
+
+        $this->assertEquals(
+            false,
+            $this->_oSubj->str_starts_with($this->_2Utf("Höher, schneller, weiter"), $this->_2Utf("höher"))
+        );
+
+        $this->assertEquals(
+            false,
+            $this->_oSubj->str_starts_with($this->_2Utf("Höher, schneller, weiter"), $this->_2Utf("öher"))
+        );
+
+        $this->assertEquals(
+            true,
+            $this->_oSubj->str_starts_with($testStr, $testStr)
+        );
+
+        $this->assertEquals(
+            false,
+            $this->_oSubj->str_starts_with($testStr, $testStr . $testStr)
+        );
+
+        $this->assertEquals(
+            true,
+            $this->_oSubj->str_starts_with($testStr, "")
+        );
+
+        $this->assertEquals(
+            true,
+            $this->_oSubj->str_starts_with("", "")
+        );
+
+        $this->assertEquals(
+            false,
+            $this->_oSubj->str_starts_with("", " ")
+        );
+
+        $this->assertEquals(
+            false,
+            $this->_oSubj->str_starts_with($testStr, "\x00")
+        );
+
+        $this->assertEquals(
+            true,
+            $this->_oSubj->str_starts_with("\x00", "")
+        );
+
+        $this->assertEquals(
+            true,
+            $this->_oSubj->str_starts_with("\x00", "\x00")
+        );
+
+        $this->assertEquals(
+            true,
+            $this->_oSubj->str_starts_with("\x00a", "\x00")
+        );
+
+        $this->assertEquals(
+            true,
+            $this->_oSubj->str_starts_with("a\x00bc", "a\x00b")
+        );
+
+        $this->assertEquals(
+            false,
+            $this->_oSubj->str_starts_with("a\x00b", "a\x00d")
+        );
+
+        $this->assertEquals(
+            false,
+            $this->_oSubj->str_starts_with("a\x00b", "z\x00b")
+        );
+
+        $this->assertEquals(
+            false,
+            $this->_oSubj->str_starts_with("a", "a\x00")
+        );
+
+        $this->assertEquals(
+            false,
+            $this->_oSubj->str_starts_with("a", "\x00a")
+        );
+    }
+
+    public function testStrEndWith()
+    {
+        // analog to phps /ext/standard/tests/strings/str_ends_with.phpt
+
+        $testStr = $this->_2Utf("Höher, schneller, weiter");
+
+        $this->assertEquals(
+            true,
+            $this->_oSubj->str_ends_with($testStr, $this->_2Utf("weiter"))
+        );
+
+        $this->assertEquals(
+            false,
+            $this->_oSubj->str_ends_with($testStr, $this->_2Utf("Weiter"))
+        );
+
+        $this->assertEquals(
+            false,
+            $this->_oSubj->str_ends_with($testStr, $this->_2Utf("weite"))
+        );
+
+        $this->assertEquals(
+            true,
+            $this->_oSubj->str_ends_with($testStr, $testStr)
+        );
+
+        $this->assertEquals(
+            false,
+            $this->_oSubj->str_ends_with($testStr, $this->_2Utf($testStr . $testStr))
+        );
+
+        $this->assertEquals(
+            true,
+            $this->_oSubj->str_ends_with($testStr, "")
+        );
+
+        $this->assertEquals(
+            true,
+            $this->_oSubj->str_ends_with("", "")
+        );
+
+        $this->assertEquals(
+            false,
+            $this->_oSubj->str_ends_with("", " ")
+        );
+
+        $this->assertEquals(
+            false,
+            $this->_oSubj->str_ends_with($testStr, "\x00")
+        );
+
+        $this->assertEquals(
+            true,
+            $this->_oSubj->str_ends_with("\x00", "")
+        );
+
+        $this->assertEquals(
+            true,
+            $this->_oSubj->str_ends_with("\x00", "\x00")
+        );
+
+        $this->assertEquals(
+            true,
+            $this->_oSubj->str_ends_with("ab\x00c", "b\x00c")
+        );
+
+        $this->assertEquals(
+            false,
+            $this->_oSubj->str_ends_with("a\x00b", "d\x00b")
+        );
+
+        $this->assertEquals(
+            false,
+            $this->_oSubj->str_ends_with("a\x00b", "a\x00z")
+        );
+
+        $this->assertEquals(
+            false,
+            $this->_oSubj->str_ends_with("a", "\x00a")
+        );
+
+        $this->assertEquals(
+            false,
+            $this->_oSubj->str_ends_with("a", "a\x00")
+        );
+    }
+
+    public function testStrContains()
+    {
+        // analog to phps /ext/standard/tests/strings/str_contains.phpt
+
+        $testStr = $this->_2Utf("Höher, schneller, weiter");
+
+        $this->assertEquals(
+            true,
+            $this->_oSubj->str_contains($testStr, $this->_2Utf("Höher"))
+        );
+
+        $this->assertEquals(
+            true,
+            $this->_oSubj->str_contains($testStr, $this->_2Utf("weiter"))
+        );
+
+        $this->assertEquals(
+            true,
+            $this->_oSubj->str_contains($testStr, $this->_2Utf("weite"))
+        );
+
+        $this->assertEquals(
+            true,
+            $this->_oSubj->str_contains($testStr, $this->_2Utf("r, s"))
+        );
+
+        $this->assertEquals(
+            true,
+            $this->_oSubj->str_contains($testStr, "r")
+        );
+
+        $this->assertEquals(
+            true,
+            $this->_oSubj->str_contains("te" . chr(0) . "st", chr(0))
+        );
+
+        $this->assertEquals(
+            false,
+            $this->_oSubj->str_contains("tEst", "test")
+        );
+
+        $this->assertEquals(
+            false,
+            $this->_oSubj->str_contains("teSt", "test")
+        );
+
+        $this->assertEquals(
+            true,
+            $this->_oSubj->str_contains("", "")
+        );
+
+        $this->assertEquals(
+            true,
+            $this->_oSubj->str_contains("a", "")
+        );
+
+        $this->assertEquals(
+            false,
+            $this->_oSubj->str_contains("", "a")
+        );
+
+        $this->assertEquals(
+            true,
+            $this->_oSubj->str_contains("\\\\a", "\\a")
+        );
     }
 }

--- a/tests/Unit/Core/StrRegularTest.php
+++ b/tests/Unit/Core/StrRegularTest.php
@@ -263,4 +263,250 @@ class StrRegularTest extends \OxidTestCase
         $this->assertEquals('without styling definition.', $this->_oSubj->strip_tags('<div>without</div> <style type="text/css">p {color:blue;}</style>styling definition.'));
         $this->assertEquals('with <style type="text/css">p {color:blue;}</style>styling definition.', $this->_oSubj->strip_tags('<div>with</div> <style type="text/css">p {color:blue;}</style>styling definition.', '<style>'));
     }
+
+    public function testStrStartsWith()
+    {
+        // analog to phps /ext/standard/tests/strings/str_starts_with.phpt
+
+        $testStr = "Höher, schneller, weiter";
+
+        $this->assertEquals(
+            true,
+            $this->_oSubj->str_starts_with($testStr, "Höher")
+        );
+
+        $this->assertEquals(
+            false,
+            $this->_oSubj->str_starts_with("Höher, schneller, weiter", "höher")
+        );
+
+        $this->assertEquals(
+            false,
+            $this->_oSubj->str_starts_with("Höher, schneller, weiter", "öher")
+        );
+
+        $this->assertEquals(
+            true,
+            $this->_oSubj->str_starts_with($testStr, $testStr)
+        );
+
+        $this->assertEquals(
+            false,
+            $this->_oSubj->str_starts_with($testStr, $testStr . $testStr)
+        );
+
+        $this->assertEquals(
+            true,
+            $this->_oSubj->str_starts_with($testStr, "")
+        );
+
+        $this->assertEquals(
+            true,
+            $this->_oSubj->str_starts_with("", "")
+        );
+
+        $this->assertEquals(
+            false,
+            $this->_oSubj->str_starts_with("", " ")
+        );
+
+        $this->assertEquals(
+            false,
+            $this->_oSubj->str_starts_with($testStr, "\x00")
+        );
+
+        $this->assertEquals(
+            true,
+            $this->_oSubj->str_starts_with("\x00", "")
+        );
+
+        $this->assertEquals(
+            true,
+            $this->_oSubj->str_starts_with("\x00", "\x00")
+        );
+
+        $this->assertEquals(
+            true,
+            $this->_oSubj->str_starts_with("\x00a", "\x00")
+        );
+
+        $this->assertEquals(
+            true,
+            $this->_oSubj->str_starts_with("a\x00bc", "a\x00b")
+        );
+
+        $this->assertEquals(
+            false,
+            $this->_oSubj->str_starts_with("a\x00b", "a\x00d")
+        );
+
+        $this->assertEquals(
+            false,
+            $this->_oSubj->str_starts_with("a\x00b", "z\x00b")
+        );
+
+        $this->assertEquals(
+            false,
+            $this->_oSubj->str_starts_with("a", "a\x00")
+        );
+
+        $this->assertEquals(
+            false,
+            $this->_oSubj->str_starts_with("a", "\x00a")
+        );
+    }
+
+    public function testStrEndWith()
+    {
+        // analog to phps /ext/standard/tests/strings/str_ends_with.phpt
+
+        $testStr = "Höher, schneller, weiter";
+
+        $this->assertEquals(
+            true,
+            $this->_oSubj->str_ends_with($testStr, "weiter")
+        );
+
+        $this->assertEquals(
+            false,
+            $this->_oSubj->str_ends_with($testStr, "Weiter")
+        );
+
+        $this->assertEquals(
+            false,
+            $this->_oSubj->str_ends_with($testStr, "weite")
+        );
+
+        $this->assertEquals(
+            true,
+            $this->_oSubj->str_ends_with($testStr, $testStr)
+        );
+
+        $this->assertEquals(
+            false,
+            $this->_oSubj->str_ends_with($testStr, $testStr . $testStr)
+        );
+
+        $this->assertEquals(
+            true,
+            $this->_oSubj->str_ends_with($testStr, "")
+        );
+
+        $this->assertEquals(
+            true,
+            $this->_oSubj->str_ends_with("", "")
+        );
+
+        $this->assertEquals(
+            false,
+            $this->_oSubj->str_ends_with("", " ")
+        );
+
+        $this->assertEquals(
+            false,
+            $this->_oSubj->str_ends_with($testStr, "\x00")
+        );
+
+        $this->assertEquals(
+            true,
+            $this->_oSubj->str_ends_with("\x00", "")
+        );
+
+        $this->assertEquals(
+            true,
+            $this->_oSubj->str_ends_with("\x00", "\x00")
+        );
+
+        $this->assertEquals(
+            true,
+            $this->_oSubj->str_ends_with("ab\x00c", "b\x00c")
+        );
+
+        $this->assertEquals(
+            false,
+            $this->_oSubj->str_ends_with("a\x00b", "d\x00b")
+        );
+
+        $this->assertEquals(
+            false,
+            $this->_oSubj->str_ends_with("a\x00b", "a\x00z")
+        );
+
+        $this->assertEquals(
+            false,
+            $this->_oSubj->str_ends_with("a", "\x00a")
+        );
+
+        $this->assertEquals(
+            false,
+            $this->_oSubj->str_ends_with("a", "a\x00")
+        );
+    }
+
+    public function testStrContains()
+    {
+        // analog to phps /ext/standard/tests/strings/str_contains.phpt
+
+        $testStr = "Höher, schneller, weiter";
+
+        $this->assertEquals(
+            true,
+            $this->_oSubj->str_contains($testStr, "Höher")
+        );
+
+        $this->assertEquals(
+            true,
+            $this->_oSubj->str_contains($testStr, "weiter")
+        );
+
+        $this->assertEquals(
+            true,
+            $this->_oSubj->str_contains($testStr, "weite")
+        );
+
+        $this->assertEquals(
+            true,
+            $this->_oSubj->str_contains($testStr, "r, s")
+        );
+
+        $this->assertEquals(
+            true,
+            $this->_oSubj->str_contains($testStr, "r")
+        );
+
+        $this->assertEquals(
+            true,
+            $this->_oSubj->str_contains("te" . chr(0) . "st", chr(0))
+        );
+
+        $this->assertEquals(
+            false,
+            $this->_oSubj->str_contains("tEst", "test")
+        );
+
+        $this->assertEquals(
+            false,
+            $this->_oSubj->str_contains("teSt", "test")
+        );
+
+        $this->assertEquals(
+            true,
+            $this->_oSubj->str_contains("", "")
+        );
+
+        $this->assertEquals(
+            true,
+            $this->_oSubj->str_contains("a", "")
+        );
+
+        $this->assertEquals(
+            false,
+            $this->_oSubj->str_contains("", "a")
+        );
+
+        $this->assertEquals(
+            true,
+            $this->_oSubj->str_contains("\\\\a", "\\a")
+        );
+    }
 }


### PR DESCRIPTION
to StrMb and StrRegular as they are often needed in oxid-modules (often emulated with strpos, ...)

The behaviour is analog to the upcoming php8 functions:
https://wiki.php.net/rfc/add_str_starts_with_and_ends_with_functions
https://wiki.php.net/rfc/str_contains
The tests for those functions are also analog to the tests that can be found in
https://github.com/php/php-src/tree/31fb6a08b3a02e665d0e24d2cbd56d13342423c8/ext/standard/tests/strings

Also added an IStr-Interface to make it easier to keep StrMb and StrRegular in sync