### PR TITLE
Throw exception if language could not be loaded

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Don't copy module files to the `source/modules` directory
 - Copy module assets to the shop out directory
 - Updated a list of bots (aRobots array in config) [PR-853](https://github.com/OXID-eSales/oxideshop_ce/pull/853)
+- Throw exception in getLanguageAbbr method if no abbreviation is available by specific id [PR-802](https://github.com/OXID-eSales/oxideshop_ce/pull/802)
 
 ### Deprecated
 - `\OxidEsales\EshopCommunity\Core\Controller\BaseController::getConfig`

--- a/source/Core/Autoload/UnifiedNameSpaceClassMap.php
+++ b/source/Core/Autoload/UnifiedNameSpaceClassMap.php
@@ -2542,6 +2542,12 @@ return [
         'isInterface'      => false,
         'isDeprecated'     => false
     ],
+    'OxidEsales\Eshop\Core\Exception\LanguageNotFoundException'                          => [
+        'editionClassName' => \OxidEsales\EshopCommunity\Core\Exception\LanguageNotFoundException::class,
+        'isAbstract'       => false,
+        'isInterface'      => false,
+        'isDeprecated'     => false
+    ],
     'OxidEsales\Eshop\Core\Exception\LanguageException'                          => [
         'editionClassName' => \OxidEsales\EshopCommunity\Core\Exception\LanguageException::class,
         'isAbstract'       => false,

--- a/source/Core/Exception/LanguageNotFoundException.php
+++ b/source/Core/Exception/LanguageNotFoundException.php
@@ -1,0 +1,15 @@
+<?php
+
+/**
+ * Copyright © OXID eSales AG. All rights reserved.
+ * See LICENSE file for license details.
+ */
+
+namespace OxidEsales\EshopCommunity\Core\Exception;
+
+/**
+ * exception class for missing languages
+ */
+class LanguageNotFoundException extends \OxidEsales\Eshop\Core\Exception\StandardException
+{
+}

--- a/source/Core/Language.php
+++ b/source/Core/Language.php
@@ -10,6 +10,7 @@ namespace OxidEsales\EshopCommunity\Core;
 use OxidEsales\EshopCommunity\Internal\Framework\Module\Translation\Bridge\AdminAreaModuleTranslationFileLocatorBridgeInterface;
 use OxidEsales\EshopCommunity\Internal\Framework\Module\Translation\Bridge\FrontendModuleTranslationFileLocatorBridgeInterface;
 use OxidEsales\EshopCommunity\Internal\Framework\Theme\Bridge\AdminThemeBridgeInterface;
+use OxidEsales\Eshop\Core\Exception\LanguageNotFoundException;
 use OxidEsales\Eshop\Core\Registry;
 use OxidEsales\Eshop\Core\Str;
 use stdClass;
@@ -374,10 +375,17 @@ class Language extends \OxidEsales\Eshop\Core\Base
 
         $iLanguage = isset($iLanguage) ? (int) $iLanguage : $this->getBaseLanguage();
         if (isset($this->_aLangAbbr[$iLanguage])) {
-            $iLanguage = $this->_aLangAbbr[$iLanguage];
+            return $this->_aLangAbbr[$iLanguage];
         }
 
-        return $iLanguage;
+        throw new LanguageNotFoundException(
+            'Could not find language abbreviation for language-id ' . $iLanguage . '! '
+            . (
+                count($this->_aLangAbbr) === 0
+                ? 'No languages available'
+                : 'Available languages: ' . implode(', ', $this->_aLangAbbr)
+            )
+        );
     }
 
     /**

--- a/source/Core/Language.php
+++ b/source/Core/Language.php
@@ -67,7 +67,7 @@ class Language extends \OxidEsales\Eshop\Core\Base
      *
      * @var array
      */
-    protected $_aLangAbbr = null;
+    protected $_aLangAbbr = [];
 
     /**
      * registered additional language filesets to load
@@ -369,7 +369,7 @@ class Language extends \OxidEsales\Eshop\Core\Base
      */
     public function getLanguageAbbr($iLanguage = null)
     {
-        if ($this->_aLangAbbr === null) {
+        if ($this->_aLangAbbr === []) {
             $this->_aLangAbbr = $this->getLanguageIds();
         }
 

--- a/source/Core/ViewConfig.php
+++ b/source/Core/ViewConfig.php
@@ -889,9 +889,13 @@ class ViewConfig extends \OxidEsales\Eshop\Core\Base
      */
     public function getActLanguageId()
     {
-        if (($sValue = $this->getViewConfigParam('lang')) === null) {
-            $iLang = Registry::getConfig()->getRequestParameter('lang');
-            $sValue = ($iLang !== null) ? $iLang : \OxidEsales\Eshop\Core\Registry::getLang()->getBaseLanguage();
+        $sValue = $this->getViewConfigParam('lang');
+        if ($sValue === null) {
+            $languageService = \OxidEsales\Eshop\Core\Registry::getLang();
+            $request = \OxidEsales\Eshop\Core\Registry::getRequest();
+
+            $iLang = $request->getRequestParameter('lang');
+            $sValue = ($iLang !== null) ? $languageService->validateLanguage($iLang) : $languageService->getBaseLanguage();
             $this->setViewConfigParam('lang', $sValue);
         }
 

--- a/tests/Unit/Core/ConfigTest.php
+++ b/tests/Unit/Core/ConfigTest.php
@@ -1139,7 +1139,6 @@ class ConfigTest extends \OxidTestCase
 
     public function testGetTemplateDirExpectsDefault()
     {
-        oxRegistry::getLang()->setBaseLanguage(999);
         $oConfig = oxNew('oxConfig');
         $oConfig->init();
         $sDir = $this->_getViewsPath($oConfig, 'admin') . 'tpl/';
@@ -1163,7 +1162,6 @@ class ConfigTest extends \OxidTestCase
     public function testGetTemplateUrlExpectsDefault()
     {
         $oConfig = oxNew('oxConfig');
-        oxRegistry::getLang()->setBaseLanguage(999);
         $oConfig->init();
         $sDir = $oConfig->getConfigParam('sShopURL') . $this->_getViewsPath($oConfig, 'admin', false) . 'tpl/';
         $this->assertEquals($sDir, $oConfig->getTemplateUrl(null, true));
@@ -1306,7 +1304,6 @@ class ConfigTest extends \OxidTestCase
      */
     public function testGetAbsAdminGetImageDirDefault()
     {
-        oxRegistry::getLang()->setBaseLanguage(999);
         $oConfig = oxNew('oxConfig');
         $oConfig->init();
         $sDir = $oConfig->getConfigParam('sShopDir') . 'out/admin/img/';
@@ -1414,7 +1411,6 @@ class ConfigTest extends \OxidTestCase
 
     public function testGetImageDirDefaultLanguage()
     {
-        oxRegistry::getLang()->setBaseLanguage(999);
         $oConfig = $this->getMock(Config::class, array('isAdmin'));
         $oConfig->expects($this->any())->method('isAdmin')->will($this->returnValue(false));
         $oConfig->init();
@@ -1450,9 +1446,6 @@ class ConfigTest extends \OxidTestCase
 
     public function testGetNoSslgetImageUrlDefaults()
     {
-        $this->getConfig()->setConfigParam('aLanguages', array(0 => 'DE', 1 => 'EN', 2 => 'LT'));
-        oxRegistry::getLang()->setBaseLanguage(2);
-
         $oConfig = oxNew('oxConfig');
         $oConfig->init();
         $sDir = $oConfig->getConfigParam('sShopURL') . $this->_getOutPath($oConfig, null, false) . 'img/';

--- a/tests/Unit/Core/LangTest.php
+++ b/tests/Unit/Core/LangTest.php
@@ -969,7 +969,15 @@ class LangTest extends \OxidTestCase
 
         $this->assertEquals('de', $oLang->getLanguageAbbr(0));
         $this->assertEquals('en', $oLang->getLanguageAbbr(1));
-        $this->assertEquals(3, $oLang->getLanguageAbbr(3));
+
+        $this->expectException(
+            \OxidEsales\EshopCommunity\Core\Exception\LanguageNotFoundException::class
+        );
+        $this->expectExceptionMessage(
+            'Could not find language abbreviation for language-id 3! Available languages: de, en'
+        );
+        $oLang->getLanguageAbbr(3);
+
         $this->assertEquals('de', $oLang->getLanguageAbbr(null));
     }
 
@@ -992,7 +1000,15 @@ class LangTest extends \OxidTestCase
 
         $this->assertEquals('de', $oLang->getLanguageAbbr(0));
         $this->assertEquals('ru', $oLang->getLanguageAbbr(1));
-        $this->assertEquals(2, $oLang->getLanguageAbbr(2));
+
+        $this->expectException(
+            \OxidEsales\EshopCommunity\Core\Exception\LanguageNotFoundException::class
+        );
+        $this->expectExceptionMessage(
+            'Could not find language abbreviation for language-id 2! Available languages: de, ru, en'
+        );
+        $oLang->getLanguageAbbr(2);
+
         $this->assertEquals('en', $oLang->getLanguageAbbr(3));
         $this->assertEquals('de', $oLang->getLanguageAbbr(null));
     }
@@ -1007,7 +1023,15 @@ class LangTest extends \OxidTestCase
 
         $this->assertEquals('de', $oLang->getLanguageAbbr(0));
         $this->assertEquals('en', $oLang->getLanguageAbbr(1));
-        $this->assertEquals(3, $oLang->getLanguageAbbr(3));
+
+        $this->expectException(
+            \OxidEsales\EshopCommunity\Core\Exception\LanguageNotFoundException::class
+        );
+        $this->expectExceptionMessage(
+            'Could not find language abbreviation for language-id 3! Available languages: de, en'
+        );
+        $oLang->getLanguageAbbr(3);
+
         $this->assertEquals('de', $oLang->getLanguageAbbr(null));
     }
 
@@ -1029,7 +1053,14 @@ class LangTest extends \OxidTestCase
 
         $this->assertEquals('de', $oLang->getLanguageAbbr(0));
         $this->assertEquals('en', $oLang->getLanguageAbbr(1));
-        $this->assertEquals(2, $oLang->getLanguageAbbr(2));
+
+        $this->expectException(
+            \OxidEsales\EshopCommunity\Core\Exception\LanguageNotFoundException::class
+        );
+        $this->expectExceptionMessage(
+            'Could not find language abbreviation for language-id 2! Available languages: de, en'
+        );
+        $oLang->getLanguageAbbr(2);
     }
 
     /**

--- a/tests/Unit/Core/Module/ModuleTest.php
+++ b/tests/Unit/Core/Module/ModuleTest.php
@@ -102,7 +102,14 @@ class ModuleTest extends \OxidTestCase
 
         $this->assertEquals("test DE value", $oModule->getInfo("description", 0));
         $this->assertEquals("test EN value", $oModule->getInfo("description", 1));
-        $this->assertEquals("test EN value", $oModule->getInfo("description", 2));
+
+        $this->expectException(
+            \OxidEsales\EshopCommunity\Core\Exception\LanguageNotFoundException::class
+        );
+        $this->expectExceptionMessage(
+            'Could not find language abbreviation for language-id 2! Available languages: de, en'
+        );
+        $oModule->getInfo("description", 2);
     }
 
     /**


### PR DESCRIPTION
I stumbled upon [this issue](https://gist.github.com/alfredbez/e03e3797d2cf73c40969b8fa452ea76a) a few times and finally took some time to think about a better fix, than just to fail with a weird error message.

Things to cleanup if you like the idea:

- [x] Use a better fitting exception instead of `\Exception`
- [x] Fix the failing tests
- [x] Add a new testcase if needed
- [x] Check if there is a related error in the psalm-baseline and remove it from there (We returned an `int` instead of a `string`)