### PR TITLE
Fix return value for Article::getCategory method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Ensure \OxidEsales\EshopCommunity\Application\Model\NewsSubscribed::getOptInStatus int result type
 - Change broken "Requirements" links to current shop documentation [PR-877](https://github.com/OXID-eSales/oxideshop_ce/pull/877)
+- Fix static cache variable usage in `Model\Article::getCategory` [PR-803](https://github.com/OXID-eSales/oxideshop_ce/pull/803)
+- Fix not initialized category case possible in `Model\Article::getCategory` [PR-803](https://github.com/OXID-eSales/oxideshop_ce/pull/803)
 
 ### Removed
 

--- a/source/Application/Model/Article.php
+++ b/source/Application/Model/Article.php
@@ -1696,12 +1696,14 @@ class Article extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
     public function getCategory()
     {
         $id = $this->getParentId();
-        if (!$id || $id === '') {
+        $shopId = $this->getShopId();
+        if (!$id) {
             $id = $this->getId();
         }
 
-        if (\array_key_exists($id, self::$_aCategoryCache)) {
-            return self::$_aCategoryCache[$id];
+        $this->initializeShopArticleCategoryCache($shopId);
+        if (\array_key_exists($id, self::$_aCategoryCache[$shopId])) {
+            return self::$_aCategoryCache[$shopId][$id];
         }
 
         startProfile('getCategory');
@@ -1732,16 +1734,23 @@ class Article extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
         }
 
         // add the category instance to cache
-        self::$_aCategoryCache[$id] = $category;
+        self::$_aCategoryCache[$shopId][$id] = $category;
         stopProfile('getCategory');
 
         return $category;
     }
 
+    private function initializeShopArticleCategoryCache($shopId): void
+    {
+        if (!\array_key_exists($shopId, self::$_aCategoryCache)) {
+            self::$_aCategoryCache[$shopId] = [];
+        }
+    }
+
     /**
      * Returns ID's of categories where this article is assigned
      *
-     * @param bool $blActCats   select categories if all parents are active
+     * @param bool $blActCats select categories if all parents are active
      * @param bool $blSkipCache Whether to skip cache
      *
      * @return array

--- a/source/Application/Model/Article.php
+++ b/source/Application/Model/Article.php
@@ -1695,8 +1695,8 @@ class Article extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
      */
     public function getCategory()
     {
+        $shopId = Registry::getConfig()->getShopId();
         $id = $this->getParentId();
-        $shopId = $this->getShopId();
         if (!$id) {
             $id = $this->getId();
         }

--- a/source/Application/Model/Article.php
+++ b/source/Application/Model/Article.php
@@ -1711,7 +1711,7 @@ class Article extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
 
         $str = Str::getStr();
         $where = $category->getSqlActiveSnippet();
-        $select = $this->_generateSearchStr($id);
+        $select = $this->generateSearchStr($id);
         $select .= (
             $str->strstr(
                 $select,
@@ -1722,7 +1722,7 @@ class Article extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
 
         // category not found ?
         if (!$category->assignRecord($select)) {
-            $select = $this->_generateSearchStr($id, true);
+            $select = $this->generateSearchStr($id, true);
             $select .= ($str->strstr($select, 'where') ? ' and ' : ' where ') . $where . " limit 1";
 
             // looking for price category

--- a/tests/Unit/Application/Model/ArticleTest.php
+++ b/tests/Unit/Application/Model/ArticleTest.php
@@ -2805,13 +2805,16 @@ class ArticleTest extends \OxidTestCase
         // test variables
         $sCacheIndex = "test";
         $sCacheResult = "already cached";
+        $shopId = $this->getShopId();
 
         // setting the "cached" variables
         $reflectedArticles = new \ReflectionClass(\OxidEsales\EshopCommunity\Application\Model\Article::class);
         $property = $reflectedArticles->getProperty('_aCategoryCache');
         $property->setAccessible(true);
         $property->setValue('_aCategoryCache', [
-            $sCacheIndex => $sCacheResult
+            $shopId => [
+                $sCacheIndex => $sCacheResult
+            ]
         ]);
 
         // setting the used article ID

--- a/tests/Unit/Application/Model/ArticleTest.php
+++ b/tests/Unit/Application/Model/ArticleTest.php
@@ -2805,18 +2805,28 @@ class ArticleTest extends \OxidTestCase
         // test variables
         $sCacheIndex = "test";
         $sCacheResult = "already cached";
-        $aCache = array($sCacheIndex => $sCacheResult);
 
         // setting the "cached" variables
-        $oArticle = $this->getProxyClass('oxarticle');
-        $oArticle->setNonPublicVar('_aCategoryCache', $aCache);
+        $reflectedArticles = new \ReflectionClass(\OxidEsales\EshopCommunity\Application\Model\Article::class);
+        $property = $reflectedArticles->getProperty('_aCategoryCache');
+        $property->setAccessible(true);
+        $property->setValue('_aCategoryCache', [
+            $sCacheIndex => $sCacheResult
+        ]);
 
         // setting the used article ID
+        $oArticle = oxNew(\OxidEsales\Eshop\Application\Model\Article::class);
         $oArticle->setId($sCacheIndex);
 
         // asserts are equals if the articles ID is in the caches index
         // and returns the cached result
-        $this->assertEquals($sCacheResult, $oArticle->getCategory());
+        $this->assertSame(
+            $sCacheResult,
+            $oArticle->getCategory()
+        );
+
+        // reset to old state
+        $property->setValue('_aCategoryCache', []);
     }
 
     /**
@@ -2915,7 +2925,7 @@ class ArticleTest extends \OxidTestCase
     }
 
     /**
-     * Test if get category returns empty result.
+     * Test that get category returns cached `_testCat` result.
      *
      * @return null
      */
@@ -2924,7 +2934,10 @@ class ArticleTest extends \OxidTestCase
         $oArticle = $this->createArticle('_testArt');
         $oArticle->oxarticles__oxprice = new oxField(75, oxField::T_RAW);
         $oCat = $oArticle->getCategory();
-        $this->assertNull($oCat);
+        $this->assertSame(
+            '_testCat',
+            $oCat->getId()
+        );
     }
 
     /**


### PR DESCRIPTION
Hey there :vulcan_salute: 

the return value of the `OxidEsales\EshopCommunity\Application\Model\Article::getCategory` method is not easy to work with and puts a burden on the caller. This PR tries to fix most of it.

#### Problems with the return value
- you might get `null` or `\OxidEsales\Eshop\Application\Model\Category`
- but `\OxidEsales\Eshop\Application\Model\Category` is not guaranteed to be initialized

Therefore the caller musst always check if the returned value is `null` and if not, call the `getId()` method and check that response additionally to make sure.

#### What this PR changes
Return type is still `Category|null` but with this patches applied, you can not get an uninitialized Category object anymore.

##### Additionally fixed with this PR:
- wrong usage of static member `_aCategoryCache` with `$this` instead of `self`

#### Open problems I see that are not fixed in this PR
- you can not rely on the `Category::isLoaded()` method on the caller side, as the `protected _isLoaded` property is only set in the `load` method wich is not used
- loading of the `Category` object and querying the `oxcategories` table does not belong into the `Article` model

/Flo