### PR TITLE
Cant register module console command

### DIFF
--- a/source/Internal/Framework/Event/ShopAwareServiceTrait.php
+++ b/source/Internal/Framework/Event/ShopAwareServiceTrait.php
@@ -56,6 +56,11 @@ trait ShopAwareServiceTrait
      */
     public function isActive()
     {
+        if(!$this->context) {
+            return false;
+        }
+//        PHP Fatal error:  Uncaught Error: Call to a member function getCurrentShopId() on null in /var/www/html/vendor/oxid-esales/oxideshop-ce/source/Internal/Framework/Event/ShopAwareServiceTrait.php:62
+
         return in_array(strval($this->context->getCurrentShopId()), $this->activeShops);
     }
 }


### PR DESCRIPTION
When registering a new custom commend the context cant be found in OXID 6.2.1:

```
PHP Fatal error:  Uncaught Error: Call to undefined method OxidEsales\EshopCommunity\Internal\Framework\Module\Command\ModuleActivateCommand::isActive() in /var/www/html/vendor/oxid-esales/oxideshop-ce/source/Internal/Framework/Console/CommandsProvider/ServicesCommandsProvider.php:60
Stack trace:
#0 /var/www/html/vendor/oxid-esales/oxideshop-ce/source/Internal/Framework/Console/CommandsProvider/ServicesCommandsProvider.php(44): OxidEsales\EshopCommunity\Internal\Framework\Console\CommandsProvider\ServicesCommandsProvider->setShopAwareCommands(Object(OxidEsales\EshopCommunity\Internal\Framework\Module\Command\ModuleActivateCommand))
#1 /var/www/html/vendor/oxid-esales/oxideshop-ce/source/Internal/Framework/Console/Executor.php(55): OxidEsales\EshopCommunity\Internal\Framework\Console\CommandsProvider\ServicesCommandsProvider->getCommands()
#2 /var/www/html/vendor/oxid-esales/oxideshop-ce/bin/oe-console(43): OxidEsales\EshopCommunity\Internal\Framework\Console\Executor->execute()
#3 {main}
  thrown in /var/www/html/vendor/oxid-esales/oxideshop-ce/source/Internal/Framework/Console/CommandsProvider/ServicesCommandsProvider.php on line 60
```

Seems the DI doesnt set the context and therefor the command is never active.
The PR doesnt really fix the real cause but prevents the error message.

What can cause that setContext isn't used for the Custom Command?

Module was successful activated.

```
<?php

namespace IvobaOxid\OxidSiteMap\Commands;

use IvobaOxid\OxidSiteMap\SiteMapGenerator;
use OxidEsales\EshopCommunity\Internal\Framework\Console\AbstractShopAwareCommand;
use Symfony\Component\Console\Input\InputInterface;
use Symfony\Component\Console\Output\OutputInterface;

class SiteMapCommand extends AbstractShopAwareCommand
{
    private $siteMapGenerator;

    /**
     * SiteMapCommand constructor.
     * @param SiteMapGenerator $siteMapGenerator
     */
    public function __construct(
        SiteMapGenerator $siteMapGenerator,
        $name = null
    ) {
        $this->siteMapGenerator = $siteMapGenerator;
        parent::__construct($name);
    }

    protected function configure()
    {
        $this
            ->setName('ivoba-oxid:sitemap:generate')
            ->setDescription('Sitemap Generator');
    }

    protected function execute(InputInterface $input, OutputInterface $output)
    {
        $output->writeln('Generating Sitemap');
        $this->siteMapGenerator->generate();
        $output->writeln(
            'Generated Sitemap in '.$this->siteMapGenerator->getConfig()->getFilename().'/'.$this->siteMapGenerator->getConfig()->getFilename()
        );
    }
}
```
-----------------------
```
  IvobaOxid\OxidSiteMap\Commands\SiteMapCommand:
    public: true
    tags:
      - { name: 'console.command', command: 'ivoba-oxid:sitemap:generate' }
```