### PR TITLE
fix getting raw password

### DIFF
--- a/source/Core/Email.php
+++ b/source/Core/Email.php
@@ -473,7 +473,7 @@ class Email extends PHPMailer
         $this->setMailer("smtp");
 
         if ($shop->oxshops__oxsmtpuser->value) {
-            $this->_setSmtpAuthInfo($shop->oxshops__oxsmtpuser->value, $shop->oxshops__oxsmtppwd->value);
+            $this->_setSmtpAuthInfo($shop->oxshops__oxsmtpuser->value, $shop->oxshops__oxsmtppwd->getRawValue());
         }
 
         if ($myConfig->getConfigParam('iDebug') == 6) {


### PR DESCRIPTION
`value` gets encoded data eg. `BsNNF&amp;yQ&amp;F3p`, original: `BsNNF&yQ&F3p` --> smtp authentication failed