### PR TITLE
Add aliases to the module commands

### DIFF
--- a/source/Internal/Framework/Module/Command/ApplyModulesConfigurationCommand.php
+++ b/source/Internal/Framework/Module/Command/ApplyModulesConfigurationCommand.php
@@ -49,7 +49,8 @@ class ApplyModulesConfigurationCommand extends Command
 
     protected function configure()
     {
-        $this->setDescription('Applies configuration for installed modules.');
+        $this->setDescription('Applies configuration for installed modules.')
+             ->setAliases(['m:ac']);
     }
 
     protected function execute(InputInterface $input, OutputInterface $output)

--- a/source/Internal/Framework/Module/Command/InstallModuleConfigurationCommand.php
+++ b/source/Internal/Framework/Module/Command/InstallModuleConfigurationCommand.php
@@ -73,7 +73,8 @@ class InstallModuleConfigurationCommand extends Command
                 'module-target-path',
                 InputArgument::OPTIONAL,
                 'Path to module target, e.g. source/modules/vendor/my_module'
-            );
+            )
+            ->setAliases(['m:ic']);
     }
 
     /**

--- a/source/Internal/Framework/Module/Command/ModuleActivateCommand.php
+++ b/source/Internal/Framework/Module/Command/ModuleActivateCommand.php
@@ -53,7 +53,7 @@ class ModuleActivateCommand extends Command
         ModuleActivationServiceInterface $moduleActivationService
     ) {
         parent::__construct(null);
-        
+
         $this->shopConfigurationDao = $shopConfigurationDao;
         $this->context = $context;
         $this->moduleActivationService = $moduleActivationService;
@@ -67,7 +67,8 @@ class ModuleActivateCommand extends Command
     {
         $this->setDescription('Activates a module.')
             ->addArgument('module-id', InputArgument::REQUIRED, 'Module ID')
-            ->setHelp('Command activates module by defined module ID.');
+            ->setHelp('Command activates module by defined module ID.')
+            ->setAliases(['m:a']);
     }
 
     /**
@@ -77,7 +78,7 @@ class ModuleActivateCommand extends Command
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         $moduleId = $input->getArgument('module-id');
-        
+
         if ($this->isInstalled($moduleId)) {
             $this->activateModule($output, $moduleId);
         } else {
@@ -112,7 +113,7 @@ class ModuleActivateCommand extends Command
         $shopConfiguration = $this->shopConfigurationDao->get(
             $this->context->getCurrentShopId()
         );
-        
+
         return $shopConfiguration->hasModuleConfiguration($moduleId);
     }
 }

--- a/source/Internal/Framework/Module/Command/ModuleDeactivateCommand.php
+++ b/source/Internal/Framework/Module/Command/ModuleDeactivateCommand.php
@@ -68,7 +68,8 @@ class ModuleDeactivateCommand extends Command
     {
         $this->setDescription('Deactivates a module.')
             ->addArgument(static::ARGUMENT_MODULE_ID, InputArgument::REQUIRED, 'Module ID')
-            ->setHelp('Command deactivates module by defined module ID.');
+            ->setHelp('Command deactivates module by defined module ID.')
+            ->setAliases(['m:d']);
     }
 
     /**

--- a/tests/Integration/Internal/Framework/Module/Command/ActivateConfiguredModulesCommandTest.php
+++ b/tests/Integration/Internal/Framework/Module/Command/ActivateConfiguredModulesCommandTest.php
@@ -128,13 +128,13 @@ final class ActivateConfiguredModulesCommandTest extends ModuleCommandsTestCase
             $this->get('oxid_esales.console.commands_provider.services_commands_provider'),
             new ArrayInput(
                 [
-                    'command'            => 'm:ac',
+                    'command' => 'm:ac',
                     '--help',
                 ]
             )
         );
 
-        $this->assertContains('oe:module:apply-configuration', $consoleOutput);
+        $this->assertStringContainsString('oe:module:apply-configuration', $consoleOutput);
     }
 
     private function prepareTestModuleConfigurations(bool $isConfigured, int $shopId, array $settings): void

--- a/tests/Integration/Internal/Framework/Module/Command/InstallModuleConfigurationCommandTest.php
+++ b/tests/Integration/Internal/Framework/Module/Command/InstallModuleConfigurationCommandTest.php
@@ -154,13 +154,13 @@ class InstallModuleConfigurationCommandTest extends ModuleCommandsTestCase
             $this->get('oxid_esales.console.commands_provider.services_commands_provider'),
             new ArrayInput(
                 [
-                    'command'            => 'm:ic',
+                    'command' => 'm:ic',
                     '--help',
                 ]
             )
         );
 
-        $this->assertContains('oe:module:install-configuration', $consoleOutput);
+        $this->assertStringContainsString('oe:module:install-configuration', $consoleOutput);
     }
 
     private function executeModuleInstallCommand(string $moduleSourcePath, string $moduleTargetPath = null): string

--- a/tests/Integration/Internal/Framework/Module/Command/ModuleActivateCommandTest.php
+++ b/tests/Integration/Internal/Framework/Module/Command/ModuleActivateCommandTest.php
@@ -82,12 +82,12 @@ final class ModuleActivateCommandTest extends ModuleCommandsTestCase
             $this->get('oxid_esales.console.commands_provider.services_commands_provider'),
             new ArrayInput(
                 [
-                    'command'            => 'm:a',
+                    'command' => 'm:a',
                     '--help',
                 ]
             )
         );
 
-        $this->assertContains('oe:module:activate', $consoleOutput);
+        $this->assertStringContainsString('oe:module:activate', $consoleOutput);
     }
 }

--- a/tests/Integration/Internal/Framework/Module/Command/ModuleDeactivateCommandTest.php
+++ b/tests/Integration/Internal/Framework/Module/Command/ModuleDeactivateCommandTest.php
@@ -81,12 +81,12 @@ final class ModuleDeactivateCommandTest extends ModuleCommandsTestCase
             $this->get('oxid_esales.console.commands_provider.services_commands_provider'),
             new ArrayInput(
                 [
-                    'command'            => 'm:d',
+                    'command' => 'm:d',
                     '--help',
                 ]
             )
         );
 
-        $this->assertContains('oe:module:deactivate', $consoleOutput);
+        $this->assertStringContainsString('oe:module:deactivate', $consoleOutput);
     }
 }


### PR DESCRIPTION
### In a Nutshell
This PR adds aliases to the OXID console module commands to increase typing speed during module and project development.


### Motivation
During module and project development modules will often be activated / deactivated or changed so that the new configuration must be applied. inspired by the Symfony command aliases this PR introduces intuitive aliases for the common OXID module commands e.g. "oe:module:activate".


### Usage
Instead of typing the whole command name the aliases can be used. 


**Example:**
`vendor/bin/oe-console oe:module:activate` becomes `vendor/bin/oe-console m:a`


### Available aliases
- `m:a` => `oe:module:activate`
- `m:d` => `oe:module:deactivate`
- `m:ac` =>  `oe:module:apply-configuration`
- `m:ic` => `oe:module:install-configuration`



### Tests
To ensure that the aliases are functional, the given module command tests were extended.