### PR TITLE
fix for generated_services in gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,4 +38,4 @@
 .DS_Store
 
 # DI for modules and packages
-/var/generated_services.yaml
+/var/generated/generated_services.yaml


### PR DESCRIPTION
Its 
`/var/generated/generated_services.yaml`
not
`/var/generated_services.yaml`