### PR TITLE
Dont show shop versions in html while in productive mode

### DIFF
--- a/source/Core/ShopControl.php
+++ b/source/Core/ShopControl.php
@@ -509,6 +509,11 @@ class ShopControl extends \OxidEsales\Eshop\Core\Base
         //Output processing - useful for modules as sometimes you may want to process output manually.
         $output = $outputManager->process($output, $view->getClassName());
 
+        // don't add version tags to the html while in productive mode.
+        if (\OxidEsales\Eshop\Core\Registry::getConfig()->isProductiveMode()) {
+            return $output;
+        }
+
         return $outputManager->addVersionTags($output);
     }
 


### PR DESCRIPTION
Security improvement suggested by security experts: By displaying the shop's version and edition (as a comment) in the HTML an attacker is able to look more specifically for vulnerabilities in the software used.