### PR TITLE
Hide shop version in productive mode.

### DIFF
--- a/source/Core/ShopControl.php
+++ b/source/Core/ShopControl.php
@@ -490,6 +490,10 @@ class ShopControl extends \OxidEsales\Eshop\Core\Base
         //Output processing - useful for modules as sometimes you may want to process output manually.
         $output = $outputManager->process($output, $view->getClassName());
 
+        if (\OxidEsales\Eshop\Core\Registry::getConfig()->isProductiveMode()) {
+            return $output;
+        }
+
         return $outputManager->addVersionTags($output);
     }
 


### PR DESCRIPTION
Security improvement suggested by security experts: By displaying the shop's version and edition (as a comment) in the HTML an attacker is able to look more specifically for vulnerabilities in the software used.