### PR TITLE
Change return type in render method to string

### DIFF
--- a/source/Application/Controller/FrontendController.php
+++ b/source/Application/Controller/FrontendController.php
@@ -2103,7 +2103,7 @@ class FrontendController extends \OxidEsales\Eshop\Core\Controller\BaseControlle
      * While ordering disables navigation controls if \OxidEsales\Eshop\Core\Config::blDisableNavBars
      * is on and executes parent::render()
      *
-     * @return null
+     * @return string
      */
     public function render()
     {


### PR DESCRIPTION
Psalm reported several problems, because the return type of the `render` method in the `BaseController` and in the `FrontendController` differs:

https://github.com/OXID-eSales/oxideshop_ce/blob/b-6.1.x/source/Core/Controller/BaseController.php#L231

https://github.com/OXID-eSales/oxideshop_ce/blob/b-6.1.x/source/Application/Controller/FrontendController.php#L2106

Maybe we should change both docblocks to use `?string` as a return type or change the [default value of `$_sThisTemplate`](https://github.com/OXID-eSales/oxideshop_ce/blob/b-6.1.x/source/Core/Controller/BaseController.php#L58) to an empty string instead of `null`