### PR TITLE
Remove wrong code for getting module URL from admin

### DIFF
--- a/source/Core/ViewConfig.php
+++ b/source/Core/ViewConfig.php
@@ -1201,16 +1201,7 @@ class ViewConfig extends \OxidEsales\Eshop\Core\Base
         $shopUrl = null;
         if ($this->isAdmin()) {
             if ($c->isSsl()) {
-                // From admin and with SSL we try to use sAdminSSLURL config directive
-                $shopUrl = $c->getConfigParam('sAdminSSLURL');
-                if ($shopUrl) {
-                    // but we don't need the admin directory
-                    $adminDir = '/' . $c->getConfigParam('sAdminDir');
-                    $shopUrl = substr($shopUrl, 0, -strlen($adminDir));
-                } else {
-                    // if no sAdminSSLURL directive were defined we use sSSLShopURL config directive instead
-                    $shopUrl = $c->getConfigParam('sSSLShopURL');
-                }
+                $shopUrl = $c->getConfigParam('sSSLShopURL');
             }
             // From admin and with no config usefull directive, we use the sShopURL directive
             if (!$shopUrl) {


### PR DESCRIPTION
Removing code that assumes that the module URL has anything to do with the admin URL. Probably even the rest of the code can also be simplified a lot.
The code is not just unnecessary, it also causes problems when the shop admin runs under a completely different URL (e.g. a subdomain) than the rest of the shop. (Which is often the case for bigger customers).

![image](https://user-images.githubusercontent.com/4963144/85861412-99ca5780-b7c0-11ea-9069-a0f26b779b2f.png)
