### PR TITLE
Fix wrong return type in language class

### DIFF
--- a/source/Core/Language.php
+++ b/source/Core/Language.php
@@ -424,7 +424,7 @@ class Language extends \OxidEsales\Eshop\Core\Base
      * @param int    $iLang              optional language number
      * @param bool   $blAdminMode        on special case you can force mode, to load language constant from admin/shops language file
      *
-     * @return string
+     * @return string|array
      */
     public function translateString($sStringToTranslate, $iLang = null, $blAdminMode = null)
     {


### PR DESCRIPTION
There is a special case in the language class, when `translateString` returns an `array` (for `_aSeoReplaceChars`).

A better solution would be to refactor the code so that this always returns a string.