### PR TITLE
Add missing translation

### DIFF
--- a/source/Application/translations/de/lang.php
+++ b/source/Application/translations/de/lang.php
@@ -692,6 +692,7 @@ $aLang = [
 'PAGE_DETAILS_THANKYOUMESSAGE2'                               => '.',
 'PAGE_DETAILS_THANKYOUMESSAGE3'                               => 'Sie bekommen eine Nachricht von uns sobald der Preis unter',
 'PAGE_DETAILS_THANKYOUMESSAGE4'                               => 'fällt.',
+'PAGE_TITLE_START'                                            => 'Startseite',
 'PAGE_TITLE_BASKET'                                           => 'Warenkorb',
 'PAGE_TITLE_USER'                                             => 'Lieferadresse',
 'PAGE_TITLE_PAYMENT'                                          => 'Versand & Zahlungsart ',


### PR DESCRIPTION
The shop requires a translation corresponding to the key 'PAGE_TITLE_START'. This has already been mentioned in a comment from 23 August 2018 here: https://github.com/OXID-eSales/oxideshop_ce/pull/520. 

To see that this is indeed the case you can for instance set a break point in the `getTitle()` method in the `FrontendController` and refresh the shop's start page. 

https://github.com/OXID-eSales/oxideshop_ce/blob/b-6.2.x/source/Application/Controller/FrontendController.php#L1896


