### PR TITLE
Replace ^ with & ~  to clearly define what we want

### DIFF
--- a/source/admin/oxajax.php
+++ b/source/admin/oxajax.php
@@ -24,7 +24,7 @@ require_once dirname(__FILE__) . "/../bootstrap.php";
 $blAjaxCall = (isset($_SERVER['HTTP_X_REQUESTED_WITH']) && $_SERVER['HTTP_X_REQUESTED_WITH'] == 'XMLHttpRequest');
 if ($blAjaxCall) {
     // Setting error reporting mode
-    error_reporting(E_ALL ^ E_NOTICE);
+    error_reporting(E_ALL & ~E_NOTICE);
 
     $myConfig = Registry::getConfig();
 


### PR DESCRIPTION
Copy past from the according PHP documentation:
"^ is the xor (bit flipping) operator and would actually turn notices *on* if they were previously off (in the error level on its left). It works in the example because E_ALL is guaranteed to have the bit for E_NOTICE set, so when ^ flips that bit, it is in fact turned off. & ~ (and not) will always turn off the bits specified by the right-hand parameter, whether or not they were on or off. "
Thus the example on https://www.php.net/manual/en/function.error-reporting.php is now like this as well:
// Report all errors except E_NOTICE
error_reporting(E_ALL & ~E_NOTICE);

Hint: this also shows up as Security Hotspot in the sonarcloud report of OXID Cloud projects.