### PR TITLE
Remove redundant return statement

### DIFF
--- a/source/admin/oxajax.php
+++ b/source/admin/oxajax.php
@@ -77,5 +77,4 @@ if ($blAjaxCall) {
 
     // closing session handlers
     // session_write_close();
-    return;
 }


### PR DESCRIPTION
Shows up as code smell in sonarcloud in OXID cloud projects