### PR TITLE
added empty cust_lang.php.dist files for de and en

### DIFF
--- a/source/Application/translations/de/cust_lang.php.dist
+++ b/source/Application/translations/de/cust_lang.php.dist
@@ -1,0 +1,20 @@
+<?php
+
+/**
+ * Copyright © OXID eSales AG. All rights reserved.
+ * See LICENSE file for license details.
+ */
+
+$sLangName  = "Deutsch";
+// -------------------------------
+// RESOURCE IDENTIFIER = STRING
+// -------------------------------
+$aLang = [
+
+'charset'                                   => 'UTF-8',
+
+];
+
+/*
+[{ oxmultilang ident="GENERAL_YOUWANTTODELETE" }]
+*/

--- a/source/Application/translations/en/cust_lang.php.dist
+++ b/source/Application/translations/en/cust_lang.php.dist
@@ -1,0 +1,20 @@
+<?php
+
+/**
+ * Copyright © OXID eSales AG. All rights reserved.
+ * See LICENSE file for license details.
+ */
+
+$sLangName  = "English";
+// -------------------------------
+// RESOURCE IDENTIFIER = STRING
+// -------------------------------
+$aLang = [
+
+'charset'                                   => 'UTF-8',
+
+];
+
+/*
+[{ oxmultilang ident="GENERAL_YOUWANTTODELETE" }]
+*/


### PR DESCRIPTION
Added empty and prepared cust_lang.php.dist files to the translations directory for de and en: As a shop user I want so see prepared and ready-to-use files for my language alterations. In support and forums, this way it is much easier to explain how to maintain one's own translations and stay updatable. 