### PR TITLE
fix for removing bonus article from basket bug:0007061

### DIFF
--- a/source/Application/Component/BasketComponent.php
+++ b/source/Application/Component/BasketComponent.php
@@ -372,6 +372,7 @@ class BasketComponent extends \OxidEsales\Eshop\Core\Controller\BaseController
                 foreach ($aProducts as $sProductId => $aProduct) {
                     if (isset($aProduct['remove']) && $aProduct['remove']) {
                         $aProducts[$sProductId]['am'] = 0;
+                        Registry::getSession()->getBasket()->addRecentlyRemoved($sProductId);
                     } else {
                         unset($aProducts[$sProductId]);
                     }

--- a/source/Application/Model/Basket.php
+++ b/source/Application/Model/Basket.php
@@ -291,6 +291,21 @@ class Basket extends \OxidEsales\Eshop\Core\Base
     protected $_sCardMessage = '';
 
     /**
+     * recently removed bundle items to avoid auto reinsert to basket
+     * @var array
+     */
+    protected $_aRecentlyRemoved = [];
+
+    /**
+     * @param string $sItemId
+     */
+    public function addRecentlyRemoved($sItemId)
+    {
+        if (in_array($sItemId, $this->_aRecentlyRemoved) === false) {
+            $this->_aRecentlyRemoved[] = $sItemId;
+        }
+    }
+    /**
      * Enables or disable saving to data base
      *
      * @param boolean $blSave
@@ -481,6 +496,9 @@ class Basket extends \OxidEsales\Eshop\Core\Base
             //inserting new
             $oBasketItem = oxNew(\OxidEsales\Eshop\Application\Model\BasketItem::class);
             try {
+                if ($blBundle && in_array($sItemId, $this->_aRecentlyRemoved)) {
+                    throw new \OxidEsales\Eshop\Core\Exception\ArticleInputException('Article was removed before.');
+                }
                 $oBasketItem->setStockCheckStatus($this->getStockCheckMode());
                 $oBasketItem->init($sProductID, $dAmount, $aSel, $aPersParam, $blBundle);
             } catch (\OxidEsales\Eshop\Core\Exception\NoArticleException $oEx) {


### PR DESCRIPTION
Possible fix for https://bugs.oxid-esales.com/view.php?id=7061

When removing an item the id is buffered and on discount readding its checked if the id was removed before, so the article is not readded.