### PR TITLE
refactor _sendOrderByEmail function

### DIFF
--- a/tests/Unit/Application/Model/OrderTest.php
+++ b/tests/Unit/Application/Model/OrderTest.php
@@ -3219,11 +3219,6 @@ class OrderTest extends \OxidTestCase
         //checking if email functions were called with correct param
         $this->assertEquals(oxEmailHelper::$oOwnerOrder, $oOrder);
         $this->assertEquals(oxEmailHelper::$oUserOrder, $oOrder);
-
-        //checking if oUser, oBasket, oPayment were attached to oOrder
-        $this->assertEquals($oUser, $oOrder->getNonPublicVar('_oUser'));
-        $this->assertEquals($oBasket, $oOrder->getNonPublicVar('_oBasket'));
-        $this->assertEquals($oPayment, $oOrder->getNonPublicVar('_oPayment'));
     }
 
     public function testSendOrderByEmailWhenMailingFails()


### PR DESCRIPTION
- moved internal variables assignment out of the _sendOrderByEmail
- removed redundant iRet temp variables

Sometimes we need to override `_sendOrderByEmail`, but it contains code that modifies object state, thus should be moved out of the scope of the function.