### PR TITLE
Optimize opcode usage

### DIFF
--- a/source/Application/Component/BasketComponent.php
+++ b/source/Application/Component/BasketComponent.php
@@ -284,7 +284,7 @@ class BasketComponent extends \OxidEsales\Eshop\Core\Controller\BaseController
 
         // special treatment
         // search param
-        $sParam = rawurlencode(Registry::getConfig()->getRequestParameter('searchparam', true));
+        $sParam = \rawurlencode(Registry::getConfig()->getRequestParameter('searchparam', true));
         $sPosition .= $sParam ? 'searchparam=' . $sParam . '&' : '';
 
         // current page number
@@ -313,10 +313,10 @@ class BasketComponent extends \OxidEsales\Eshop\Core\Controller\BaseController
     protected function getPersistedParameters($persistedParameters = null)
     {
         $persistedParameters = ($persistedParameters ?: Registry::getConfig()->getRequestParameter('persparam'));
-        if (!is_array($persistedParameters)) {
+        if (!\is_array($persistedParameters)) {
             return null;
         }
-        return array_filter($persistedParameters) ?: null;
+        return \array_filter($persistedParameters) ?: null;
     }
 
     /**
@@ -366,7 +366,7 @@ class BasketComponent extends \OxidEsales\Eshop\Core\Controller\BaseController
             ];
         }
 
-        if (is_array($aProducts) && count($aProducts)) {
+        if (\is_array($aProducts) && \count($aProducts)) {
             if (Registry::getConfig()->getRequestParameter('removeBtn') !== null) {
                 //setting amount to 0 if removing article from basket
                 foreach ($aProducts as $sProductId => $aProduct) {

--- a/source/Application/Component/CategoriesComponent.php
+++ b/source/Application/Component/CategoriesComponent.php
@@ -241,7 +241,7 @@ class CategoriesComponent extends \OxidEsales\Eshop\Core\Controller\BaseControll
                 // setting list type directly
                 $sListType = 'manufacturer';
                 $sActCat = $sActManufacturer;
-            } elseif ($sActVendor && (substr($sActVendor, 2) == $oProduct->getVendorId())) {
+            } elseif ($sActVendor && (\substr($sActVendor, 2) == $oProduct->getVendorId())) {
                 // such vendor is available ?
                 $sListType = 'vendor';
                 $sActCat = $sActVendor;
@@ -272,8 +272,8 @@ class CategoriesComponent extends \OxidEsales\Eshop\Core\Controller\BaseControll
     {
         $sListType = null;
         $aArticleCats = $oProduct->getCategoryIds(true);
-        if (is_array($aArticleCats) && count($aArticleCats)) {
-            $sActCat = reset($aArticleCats);
+        if (\is_array($aArticleCats) && \count($aArticleCats)) {
+            $sActCat = \reset($aArticleCats);
         } elseif (($sActCat = $oProduct->getManufacturerId())) {
             // not assigned to any category ? maybe it is assigned to Manufacturer ?
             $sListType = 'manufacturer';

--- a/source/Application/Component/CurrencyComponent.php
+++ b/source/Application/Component/CurrencyComponent.php
@@ -55,7 +55,7 @@ class CurrencyComponent extends \OxidEsales\Eshop\Core\Controller\BaseController
         if (!$myConfig->getConfigParam('bl_perfLoadCurrency')) {
             //#861C -  show first currency
             $aCurrencies = $myConfig->getCurrencyArray();
-            $this->_oActCur = current($aCurrencies);
+            $this->_oActCur = \current($aCurrencies);
 
             return;
         }
@@ -109,7 +109,7 @@ class CurrencyComponent extends \OxidEsales\Eshop\Core\Controller\BaseController
             $oUrlUtils = \OxidEsales\Eshop\Core\Registry::getUtilsUrl();
             $sUrl = $oUrlUtils->cleanUrl(\OxidEsales\Eshop\Core\Registry::getConfig()->getTopActiveView()->getLink(), ["cur"]);
 
-            reset($this->aCurrencies);
+            \reset($this->aCurrencies);
             foreach ($this->aCurrencies as $oItem) {
                 $oItem->link = $oUrlUtils->processUrl($sUrl, true, ["cur" => $oItem->id]);
             }

--- a/source/Application/Component/LanguageComponent.php
+++ b/source/Application/Component/LanguageComponent.php
@@ -36,7 +36,7 @@ class LanguageComponent extends \OxidEsales\Eshop\Core\Controller\BaseController
         // Performance
         if (\OxidEsales\Eshop\Core\Registry::getConfig()->getConfigParam('bl_perfLoadLanguages')) {
             $aLanguages = \OxidEsales\Eshop\Core\Registry::getLang()->getLanguageArray(null, true, true);
-            reset($aLanguages);
+            \reset($aLanguages);
             foreach ($aLanguages as $oVal) {
                 $oVal->link = \OxidEsales\Eshop\Core\Registry::getConfig()->getTopActiveView()->getLink($oVal->id);
             }

--- a/source/Application/Component/Locator.php
+++ b/source/Application/Component/Locator.php
@@ -56,7 +56,7 @@ class Locator extends \OxidEsales\Eshop\Core\Base
     {
         // setting locator type
         if ($sType) {
-            $this->_sType = trim($sType);
+            $this->_sType = \trim($sType);
         }
     }
 
@@ -71,7 +71,7 @@ class Locator extends \OxidEsales\Eshop\Core\Base
         $sLocfnc = "_set{$this->_sType}LocatorData";
 
         try {
-            call_user_func([$this, $sLocfnc], $oLocatorTarget, $oCurrArticle);
+            \call_user_func([$this, $sLocfnc], $oLocatorTarget, $oCurrArticle);
         } catch (\Exception $e) {
             $this->_sType = '';
             getLogger()->warning('Locator Type is wrong ' . $this->_sType);
@@ -238,16 +238,16 @@ class Locator extends \OxidEsales\Eshop\Core\Base
             // #1834/1184M - specialchar search
             $sSearchParam = Registry::getConfig()->getRequestParameter('searchparam', true);
             $sSearchFormParam = Registry::getConfig()->getRequestParameter('searchparam');
-            $sSearchLinkParam = rawurlencode($sSearchParam);
+            $sSearchLinkParam = \rawurlencode($sSearchParam);
 
             $sSearchCat = Registry::getConfig()->getRequestParameter('searchcnid');
-            $sSearchCat = $sSearchCat ? rawurldecode($sSearchCat) : $sSearchCat;
+            $sSearchCat = $sSearchCat ? \rawurldecode($sSearchCat) : $sSearchCat;
 
             $sSearchVendor = Registry::getConfig()->getRequestParameter('searchvendor');
-            $sSearchVendor = $sSearchVendor ? rawurldecode($sSearchVendor) : $sSearchVendor;
+            $sSearchVendor = $sSearchVendor ? \rawurldecode($sSearchVendor) : $sSearchVendor;
 
             $sSearchManufacturer = Registry::getConfig()->getRequestParameter('searchmanufacturer');
-            $sSearchManufacturer = $sSearchManufacturer ? rawurldecode($sSearchManufacturer) : $sSearchManufacturer;
+            $sSearchManufacturer = $sSearchManufacturer ? \rawurldecode($sSearchManufacturer) : $sSearchManufacturer;
 
             // loading data for article navigation
             $oIdList = oxNew(\OxidEsales\Eshop\Application\Model\ArticleList::class);
@@ -285,7 +285,7 @@ class Locator extends \OxidEsales\Eshop\Core\Base
             $oSearchCat->prevProductLink = $oBackProd ? $this->_makeLink($oBackProd->getLink(), $sAddSearch) : null;
 
             $sFormat = Registry::getLang()->translateString('SEARCH_RESULT');
-            $oLocatorTarget->setSearchTitle(sprintf($sFormat, $sSearchFormParam));
+            $oLocatorTarget->setSearchTitle(\sprintf($sFormat, $sSearchFormParam));
             $oLocatorTarget->setActiveCategory($oSearchCat);
         }
     }
@@ -315,7 +315,7 @@ class Locator extends \OxidEsales\Eshop\Core\Base
 
             if ($sSearchRecomm !== null) {
                 $sSearchFormRecomm = Registry::getConfig()->getRequestParameter('searchrecomm');
-                $sSearchLinkRecomm = rawurlencode($sSearchRecomm);
+                $sSearchLinkRecomm = \rawurlencode($sSearchRecomm);
                 $sAddSearch = 'searchrecomm=' . $sSearchLinkRecomm;
             }
 
@@ -398,7 +398,7 @@ class Locator extends \OxidEsales\Eshop\Core\Base
     protected function _makeLink($sLink, $sParams) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         if ($sParams) {
-            $sLink .= ((strpos($sLink, '?') !== false) ? '&amp;' : '?') . $sParams;
+            $sLink .= ((\strpos($sLink, '?') !== false) ? '&amp;' : '?') . $sParams;
         }
 
         return $sLink;
@@ -427,7 +427,7 @@ class Locator extends \OxidEsales\Eshop\Core\Base
             $sParentIdField = 'oxarticles__oxparentid';
             $sArticleId = $oArticle->$sParentIdField->value ? $oArticle->$sParentIdField->value : $oArticle->getId();
             $iPos = Registry::getUtils()->arrayStringSearch($sArticleId, $oIdList->arrayKeys());
-            $iPageNr = floor($iPos / $iNrofCatArticles);
+            $iPageNr = \floor($iPos / $iNrofCatArticles);
         }
 
         return $iPageNr;
@@ -469,7 +469,7 @@ class Locator extends \OxidEsales\Eshop\Core\Base
             $aIds = $oIdList->arrayKeys();
             $iPos = Registry::getUtils()->arrayStringSearch($sOxid, $aIds);
 
-            if (array_key_exists($iPos - 1, $aIds)) {
+            if (\array_key_exists($iPos - 1, $aIds)) {
                 $oBackProduct = oxNew(Article::class);
                 $oBackProduct->modifyCacheKey('_locator');
                 $oBackProduct->setNoVariantLoading(true);
@@ -479,7 +479,7 @@ class Locator extends \OxidEsales\Eshop\Core\Base
                 }
             }
 
-            if (array_key_exists($iPos + 1, $aIds)) {
+            if (\array_key_exists($iPos + 1, $aIds)) {
                 $oNextProduct = oxNew(Article::class);
                 $oNextProduct->modifyCacheKey('_locator');
                 $oNextProduct->setNoVariantLoading(true);

--- a/source/Application/Component/UserComponent.php
+++ b/source/Application/Component/UserComponent.php
@@ -21,9 +21,9 @@ use OxidEsales\Eshop\Application\Model\User\UserShippingAddressUpdatableFields;
 use OxidEsales\EshopCommunity\Application\Model\User;
 
 // defining login/logout states
-define('USER_LOGIN_SUCCESS', 1);
-define('USER_LOGIN_FAIL', 2);
-define('USER_LOGOUT', 3);
+\define('USER_LOGIN_SUCCESS', 1);
+\define('USER_LOGIN_FAIL', 2);
+\define('USER_LOGOUT', 3);
 
 /**
  * User object manager.
@@ -136,11 +136,11 @@ class UserComponent extends \OxidEsales\Eshop\Core\Controller\BaseController
             $sClass = $this->getParent()->getClassName();
 
             // no session user
-            if (!$oUser && !in_array($sClass, $this->_aAllowedClasses)) {
+            if (!$oUser && !\in_array($sClass, $this->_aAllowedClasses)) {
                 Registry::getUtils()->redirect($oConfig->getShopHomeUrl() . 'cl=account', false, 302);
             }
 
-            if ($oUser && !$oUser->isTermsAccepted() && !in_array($sClass, $this->_aAllowedClasses)) {
+            if ($oUser && !$oUser->isTermsAccepted() && !\in_array($sClass, $this->_aAllowedClasses)) {
                 Registry::getUtils()->redirect($oConfig->getShopHomeUrl() . 'cl=account&term=1', false, 302);
             }
         }
@@ -777,12 +777,12 @@ class UserComponent extends \OxidEsales\Eshop\Core\Controller\BaseController
         $aDeladr = ($blShowShipAddressParameter || $blShowShipAddressVariable) ? $sDeliveryAddressParameter : [];
         $aDelAdress = $aDeladr;
 
-        if (is_array($aDeladr)) {
+        if (\is_array($aDeladr)) {
             // checking if data is filled
             if (isset($aDeladr['oxaddress__oxsal'])) {
                 unset($aDeladr['oxaddress__oxsal']);
             }
-            if (!count($aDeladr) || implode('', $aDeladr) == '') {
+            if (!\count($aDeladr) || \implode('', $aDeladr) == '') {
                 // resetting to avoid empty records
                 $aDelAdress = [];
             }
@@ -881,7 +881,7 @@ class UserComponent extends \OxidEsales\Eshop\Core\Controller\BaseController
      */
     private function cleanAddress($address, $updatableFields)
     {
-        if (is_array($address)) {
+        if (\is_array($address)) {
             /** @var UpdatableFieldsConstructor $updatableFieldsConstructor */
             $updatableFieldsConstructor = oxNew(UpdatableFieldsConstructor::class);
             $cleaner = $updatableFieldsConstructor->getAllowedFieldsCleaner($updatableFields);
@@ -900,7 +900,7 @@ class UserComponent extends \OxidEsales\Eshop\Core\Controller\BaseController
      */
     private function trimAddress($address)
     {
-        if (is_array($address)) {
+        if (\is_array($address)) {
             $fields  = oxNew(FormFields::class, $address);
             $trimmer = oxNew(FormFieldsTrimmer::class);
 

--- a/source/Application/Component/UtilsComponent.php
+++ b/source/Application/Component/UtilsComponent.php
@@ -72,7 +72,7 @@ class UtilsComponent extends \OxidEsales\Eshop\Core\Controller\BaseController
                 }
 
                 $aViewProds = $oParentView->getViewProductList();
-                if (is_array($aViewProds) && count($aViewProds)) {
+                if (\is_array($aViewProds) && \count($aViewProds)) {
                     foreach ($aViewProds as $oProduct) {
                         if (isset($aItems[$oProduct->getId()])) {
                             $oProduct->setOnComparisonList(true);
@@ -145,13 +145,13 @@ class UtilsComponent extends \OxidEsales\Eshop\Core\Controller\BaseController
             $aSel = $aSel ? $aSel : Registry::getConfig()->getRequestParameter('sel');
 
             // processing amounts
-            $dAmount = str_replace(',', '.', $dAmount);
+            $dAmount = \str_replace(',', '.', $dAmount);
             if (!\OxidEsales\Eshop\Core\Registry::getConfig()->getConfigParam('blAllowUnevenAmounts')) {
-                $dAmount = round((string) $dAmount);
+                $dAmount = \round((string) $dAmount);
             }
 
             $oBasket = $oUser->getBasket($sListType);
-            $oBasket->addItemToBasket($sProductId, abs($dAmount), $aSel, ($dAmount == 0));
+            $oBasket->addItemToBasket($sProductId, \abs($dAmount), $aSel, ($dAmount == 0));
 
             // recalculate basket count
             $oBasket->getItemCount(true);

--- a/source/Application/Component/Widget/ArticleBox.php
+++ b/source/Application/Component/Widget/ArticleBox.php
@@ -94,7 +94,7 @@ class ArticleBox extends \OxidEsales\Eshop\Application\Component\Widget\WidgetCo
      */
     public function getProduct()
     {
-        if (is_null($this->_oArticle)) {
+        if (\is_null($this->_oArticle)) {
             if ($this->getViewParameter('_object')) {
                 $oArticle = $this->getViewParameter('_object');
             } else {
@@ -214,7 +214,7 @@ class ArticleBox extends \OxidEsales\Eshop\Application\Component\Widget\WidgetCo
     public function getRSSLinks()
     {
         $aRSS = $this->getViewParameter('rsslinks');
-        if (!is_array($aRSS)) {
+        if (!\is_array($aRSS)) {
             $aRSS = null;
         }
 

--- a/source/Application/Component/Widget/ArticleDetails.php
+++ b/source/Application/Component/Widget/ArticleDetails.php
@@ -311,7 +311,7 @@ class ArticleDetails extends \OxidEsales\Eshop\Application\Component\Widget\Widg
             //making a new array for backward compatibility
             $this->_aAttributes = false;
 
-            if (count($aArtAttributes)) {
+            if (\count($aArtAttributes)) {
                 foreach ($aArtAttributes as $sKey => $oAttribute) {
                     $this->_aAttributes[$sKey] = new stdClass();
                     $this->_aAttributes[$sKey]->title = $oAttribute->oxattribute__oxtitle->value;
@@ -362,7 +362,7 @@ class ArticleDetails extends \OxidEsales\Eshop\Application\Component\Widget\Widg
     public function getVariantListExceptCurrent()
     {
         $oList = $this->getVariantList();
-        if (is_object($oList)) {
+        if (\is_object($oList)) {
             $oList = clone $oList;
         }
 
@@ -393,11 +393,11 @@ class ArticleDetails extends \OxidEsales\Eshop\Application\Component\Widget\Widg
                 $this->_aVariantList = $oParent->getFullVariants(false);
 
                 //lets additionally add parent article if it is sellable
-                if (count($this->_aVariantList) && $myConfig->getConfigParam('blVariantParentBuyable')) {
+                if (\count($this->_aVariantList) && $myConfig->getConfigParam('blVariantParentBuyable')) {
                     //#1104S if parent is buyable load select lists too
                     $oParent->enablePriceLoad();
                     $oParent->aSelectlist = $oParent->getSelectLists();
-                    $this->_aVariantList = array_merge([$oParent], $this->_aVariantList->getArray());
+                    $this->_aVariantList = \array_merge([$oParent], $this->_aVariantList->getArray());
                 }
             } else {
                 //loading full list of variants
@@ -432,7 +432,7 @@ class ArticleDetails extends \OxidEsales\Eshop\Application\Component\Widget\Widg
     {
         if ($this->_aMediaFiles === null) {
             $aMediaFiles = $this->getProduct()->getMediaUrls();
-            $this->_aMediaFiles = count($aMediaFiles) ? $aMediaFiles : false;
+            $this->_aMediaFiles = \count($aMediaFiles) ? $aMediaFiles : false;
         }
 
         return $this->_aMediaFiles;
@@ -760,7 +760,7 @@ class ArticleDetails extends \OxidEsales\Eshop\Application\Component\Widget\Widg
             $this->_dRatingValue = (double) 0;
             if ($this->isReviewActive() && ($oDetailsProduct = $this->getProduct())) {
                 $blShowVariantsReviews = \OxidEsales\Eshop\Core\Registry::getConfig()->getConfigParam('blShowVariantReviews');
-                $this->_dRatingValue = round($oDetailsProduct->getArticleRatingAverage($blShowVariantsReviews), 1);
+                $this->_dRatingValue = \round($oDetailsProduct->getArticleRatingAverage($blShowVariantsReviews), 1);
             }
         }
 
@@ -908,7 +908,7 @@ class ArticleDetails extends \OxidEsales\Eshop\Application\Component\Widget\Widg
     {
         $sSortingParameters = $this->getViewParameter('sorting');
         if ($sSortingParameters) {
-            list($sortBy, $sortOrder) = explode('|', $sSortingParameters);
+            list($sortBy, $sortOrder) = \explode('|', $sSortingParameters);
             if ((new SortingValidator())->isValid($sortBy, $sortOrder)) {
                 $this->setItemSorting($this->getSortIdent(), $sortBy, $sortOrder);
             }

--- a/source/Application/Component/Widget/CategoryTree.php
+++ b/source/Application/Component/Widget/CategoryTree.php
@@ -43,7 +43,7 @@ class CategoryTree extends \OxidEsales\Eshop\Application\Component\Widget\Widget
         parent::render();
 
         if ($sTpl = $this->getViewParameter("sWidgetType")) {
-            $sTemplateName = 'widget/' . basename($sTpl) . '/categorylist.tpl';
+            $sTemplateName = 'widget/' . \basename($sTpl) . '/categorylist.tpl';
             /** @var TemplateLoaderInterface $templateLoader */
             $templateLoader = $this->getContainer()->get('oxid_esales.templating.template.loader');
             if ($templateLoader->exists($sTemplateName)) {

--- a/source/Application/Component/Widget/Rating.php
+++ b/source/Application/Component/Widget/Rating.php
@@ -67,7 +67,7 @@ class Rating extends \OxidEsales\Eshop\Application\Component\Widget\WidgetContro
             $this->_dRatingValue = (double) 0;
             $dValue = $this->getViewParameter("dRatingValue");
             if ($dValue) {
-                $this->_dRatingValue = round($dValue, 1);
+                $this->_dRatingValue = \round($dValue, 1);
             }
         }
 

--- a/source/Application/Component/Widget/Review.php
+++ b/source/Application/Component/Widget/Review.php
@@ -48,7 +48,7 @@ class Review extends \OxidEsales\Eshop\Application\Component\Widget\WidgetContro
      */
     public function getReviewType()
     {
-        return strtolower($this->getViewParameter('type'));
+        return \strtolower($this->getViewParameter('type'));
     }
 
     /**

--- a/source/Application/Component/Widget/ServiceMenu.php
+++ b/source/Application/Component/Widget/ServiceMenu.php
@@ -42,7 +42,7 @@ class ServiceMenu extends \OxidEsales\Eshop\Application\Component\Widget\WidgetC
         $aCompareItems = $oCompare->getCompareItems();
 
         if ($blJson) {
-            $aCompareItems = json_encode($aCompareItems);
+            $aCompareItems = \json_encode($aCompareItems);
         }
 
         return $aCompareItems;

--- a/source/Application/Controller/AccountController.php
+++ b/source/Application/Controller/AccountController.php
@@ -207,12 +207,12 @@ class AccountController extends \OxidEsales\Eshop\Application\Controller\Fronten
             ($sourceClass = Registry::getConfig()->getRequestParameter("sourcecl")) &&
             $this->_oaComponents['oxcmp_user']->getLoginStatus() === USER_LOGIN_SUCCESS
         ) {
-            $redirectUrl = \OxidEsales\Eshop\Core\Registry::getConfig()->getShopUrl() . 'index.php?cl=' . rawurlencode($sourceClass);
+            $redirectUrl = \OxidEsales\Eshop\Core\Registry::getConfig()->getShopUrl() . 'index.php?cl=' . \rawurlencode($sourceClass);
 
             // building redirect link
             foreach ($this->getNavigationParams() as $key => $value) {
                 if ($value && $key != "sourcecl") {
-                    $redirectUrl .= '&' . rawurlencode($key) . "=" . rawurlencode($value);
+                    $redirectUrl .= '&' . \rawurlencode($key) . "=" . \rawurlencode($value);
                 }
             }
 
@@ -283,7 +283,7 @@ class AccountController extends \OxidEsales\Eshop\Application\Controller\Fronten
         if ($this->_sSearchParam === null) {
             $this->_sSearchParam = false;
             if ($this->getArticleId()) {
-                $this->_sSearchParam = rawurlencode(Registry::getConfig()->getRequestParameter('searchparam', true));
+                $this->_sSearchParam = \rawurlencode(Registry::getConfig()->getRequestParameter('searchparam', true));
             }
         }
 

--- a/source/Application/Controller/AccountDownloadsController.php
+++ b/source/Application/Controller/AccountDownloadsController.php
@@ -99,7 +99,7 @@ class AccountDownloadsController extends \OxidEsales\Eshop\Application\Controlle
             $sOrderTitleField = 'oxorderfiles__oxarticletitle';
             $sOrderArticleId = $oOrderFile->$sOrderArticleIdField->value;
             $oOrderArticles[$sOrderArticleId]['oxordernr'] = $oOrderFile->$sOrderNumberField->value;
-            $oOrderArticles[$sOrderArticleId]['oxorderdate'] = substr($oOrderFile->$sOrderDateField->value, 0, 16);
+            $oOrderArticles[$sOrderArticleId]['oxorderdate'] = \substr($oOrderFile->$sOrderDateField->value, 0, 16);
             $oOrderArticles[$sOrderArticleId]['oxarticletitle'] = $oOrderFile->$sOrderTitleField->value;
             $oOrderArticles[$sOrderArticleId]['oxorderfiles'][] = $oOrderFile;
         }

--- a/source/Application/Controller/AccountNoticeListController.php
+++ b/source/Application/Controller/AccountNoticeListController.php
@@ -107,12 +107,12 @@ class AccountNoticeListController extends \OxidEsales\Eshop\Application\Controll
     public function getSimilarProducts()
     {
         // similar products list
-        if ($this->_aSimilarProductList === null && count($this->getNoticeProductList())) {
+        if ($this->_aSimilarProductList === null && \count($this->getNoticeProductList())) {
             // just ensuring that next call will skip this check
             $this->_aSimilarProductList = false;
 
             // loading similar products
-            if ($oSimilarProd = current($this->getNoticeProductList())) {
+            if ($oSimilarProd = \current($this->getNoticeProductList())) {
                 $this->_aSimilarProductList = $oSimilarProd->getSimilarProducts();
             }
         }
@@ -131,8 +131,8 @@ class AccountNoticeListController extends \OxidEsales\Eshop\Application\Controll
             $this->_aSimilarRecommListIds = false;
 
             $aNoticeProdList = $this->getNoticeProductList();
-            if (is_array($aNoticeProdList) && count($aNoticeProdList)) {
-                $this->_aSimilarRecommListIds = array_keys($aNoticeProdList);
+            if (\is_array($aNoticeProdList) && \count($aNoticeProdList)) {
+                $this->_aSimilarRecommListIds = \array_keys($aNoticeProdList);
             }
         }
 

--- a/source/Application/Controller/AccountOrderController.php
+++ b/source/Application/Controller/AccountOrderController.php
@@ -91,7 +91,7 @@ class AccountOrderController extends \OxidEsales\Eshop\Application\Controller\Ac
                 $this->_iAllArtCnt = $oUser->getOrderCount();
                 if ($this->_iAllArtCnt && $this->_iAllArtCnt > 0) {
                     $this->_aOrderList = $oUser->getOrders($iNrofCatArticles, $this->getActPage());
-                    $this->_iCntPages = ceil($this->_iAllArtCnt / $iNrofCatArticles);
+                    $this->_iCntPages = \ceil($this->_iAllArtCnt / $iNrofCatArticles);
                 }
             }
         }

--- a/source/Application/Controller/AccountRecommlistController.php
+++ b/source/Application/Controller/AccountRecommlistController.php
@@ -97,7 +97,7 @@ class AccountRecommlistController extends \OxidEsales\Eshop\Application\Controll
             $this->_iAllArtCnt = $oUser->getRecommListsCount();
             $iNrofCatArticles = (int) \OxidEsales\Eshop\Core\Registry::getConfig()->getConfigParam('iNrofCatArticles');
             $iNrofCatArticles = $iNrofCatArticles ? $iNrofCatArticles : 10;
-            $this->_iCntPages = ceil($this->_iAllArtCnt / $iNrofCatArticles);
+            $this->_iCntPages = \ceil($this->_iAllArtCnt / $iNrofCatArticles);
         }
 
         return $this->_sThisTemplate;
@@ -232,9 +232,9 @@ class AccountRecommlistController extends \OxidEsales\Eshop\Application\Controll
                 $this->_sThisTemplate = 'page/account/recommendationedit.tpl';
             }
 
-            $sTitle = trim((string) Registry::getConfig()->getRequestParameter('recomm_title', true));
-            $sAuthor = trim((string) Registry::getConfig()->getRequestParameter('recomm_author', true));
-            $sText = trim((string) Registry::getConfig()->getRequestParameter('recomm_desc', true));
+            $sTitle = \trim((string) Registry::getConfig()->getRequestParameter('recomm_title', true));
+            $sAuthor = \trim((string) Registry::getConfig()->getRequestParameter('recomm_author', true));
+            $sText = \trim((string) Registry::getConfig()->getRequestParameter('recomm_desc', true));
 
             $oRecommList->oxrecommlists__oxtitle = new Field($sTitle);
             $oRecommList->oxrecommlists__oxauthor = new Field($sAuthor);

--- a/source/Application/Controller/AccountReviewController.php
+++ b/source/Application/Controller/AccountReviewController.php
@@ -207,7 +207,7 @@ class AccountReviewController extends \OxidEsales\Eshop\Application\Controller\A
      */
     private function getPagesCount()
     {
-        return ceil($this->getReviewAndRatingItemsCount() / $this->getItemsPerPage());
+        return \ceil($this->getReviewAndRatingItemsCount() / $this->getItemsPerPage());
     }
 
     /**
@@ -254,7 +254,7 @@ class AccountReviewController extends \OxidEsales\Eshop\Application\Controller\A
         $itemsCount,
         $offset
     ) {
-        return array_slice(
+        return \array_slice(
             $reviewAndRatingList,
             $offset,
             $itemsCount,

--- a/source/Application/Controller/AccountWishlistController.php
+++ b/source/Application/Controller/AccountWishlistController.php
@@ -189,7 +189,7 @@ class AccountWishlistController extends \OxidEsales\Eshop\Application\Controller
             $this->_aSimilarRecommListIds = false;
 
             $aWishProdList = $this->getWishProductList();
-            if (is_array($aWishProdList) && ($oSimilarProd = current($aWishProdList))) {
+            if (\is_array($aWishProdList) && ($oSimilarProd = \current($aWishProdList))) {
                 $this->_aSimilarRecommListIds = [$oSimilarProd->getId()];
             }
         }
@@ -209,7 +209,7 @@ class AccountWishlistController extends \OxidEsales\Eshop\Application\Controller
         }
 
         $aParams = Registry::getConfig()->getRequestParameter('editval', true);
-        if (is_array($aParams)) {
+        if (\is_array($aParams)) {
             $oUtilsView = Registry::getUtilsView();
             $oParams = (object) $aParams;
             $this->setEnteredData((object) Registry::getConfig()->getRequestParameter('editval'));

--- a/source/Application/Controller/Admin/ActionsGroupsAjax.php
+++ b/source/Application/Controller/Admin/ActionsGroupsAjax.php
@@ -78,8 +78,8 @@ class ActionsGroupsAjax extends \OxidEsales\Eshop\Application\Controller\Admin\L
         if (\OxidEsales\Eshop\Core\Registry::getConfig()->getRequestParameter('all')) {
             $sQ = $this->_addFilter("delete oxobject2action.* " . $this->_getQuery());
             \OxidEsales\Eshop\Core\DatabaseProvider::getDb()->Execute($sQ);
-        } elseif ($aRemoveGroups && is_array($aRemoveGroups)) {
-            $sRemoveGroups = implode(", ", \OxidEsales\Eshop\Core\DatabaseProvider::getDb()->quoteArray($aRemoveGroups));
+        } elseif ($aRemoveGroups && \is_array($aRemoveGroups)) {
+            $sRemoveGroups = \implode(", ", \OxidEsales\Eshop\Core\DatabaseProvider::getDb()->quoteArray($aRemoveGroups));
             $sQ = "delete from oxobject2action where oxobject2action.oxid in (" . $sRemoveGroups . ") ";
             \OxidEsales\Eshop\Core\DatabaseProvider::getDb()->Execute($sQ);
         }
@@ -101,7 +101,7 @@ class ActionsGroupsAjax extends \OxidEsales\Eshop\Application\Controller\Admin\L
         }
 
         $promotionAdded = false;
-        if ($soxId && $soxId != "-1" && is_array($aChosenGroup)) {
+        if ($soxId && $soxId != "-1" && \is_array($aChosenGroup)) {
             foreach ($aChosenGroup as $sChosenGroup) {
                 $oObject2Promotion = oxNew(\OxidEsales\Eshop\Core\Model\BaseModel::class);
                 $oObject2Promotion->init('oxobject2action');

--- a/source/Application/Controller/Admin/ActionsList.php
+++ b/source/Application/Controller/Admin/ActionsList.php
@@ -70,7 +70,7 @@ class ActionsList extends \OxidEsales\Eshop\Application\Controller\Admin\AdminLi
 
         // searching for empty oxfolder fields
         if ($sDisplayType) {
-            $sNow = date('Y-m-d H:i:s', \OxidEsales\Eshop\Core\Registry::getUtilsDate()->getTime());
+            $sNow = \date('Y-m-d H:i:s', \OxidEsales\Eshop\Core\Registry::getUtilsDate()->getTime());
 
             switch ($sDisplayType) {
                 case 1: // active

--- a/source/Application/Controller/Admin/ActionsMain.php
+++ b/source/Application/Controller/Admin/ActionsMain.php
@@ -38,15 +38,15 @@ class ActionsMain extends \OxidEsales\Eshop\Application\Controller\Admin\AdminDe
 
             $oOtherLang = $oAction->getAvailableInLangs();
             if (!isset($oOtherLang[$this->_iEditLang])) {
-                $oAction->loadInLang(key($oOtherLang), $soxId);
+                $oAction->loadInLang(\key($oOtherLang), $soxId);
             }
 
             $this->_aViewData["edit"] = $oAction;
 
             // remove already created languages
-            $aLang = array_diff(Registry::getLang()->getLanguageNames(), $oOtherLang);
+            $aLang = \array_diff(Registry::getLang()->getLanguageNames(), $oOtherLang);
 
-            if (count($aLang)) {
+            if (\count($aLang)) {
                 $this->_aViewData["posslang"] = $aLang;
             }
 

--- a/source/Application/Controller/Admin/ActionsMainAjax.php
+++ b/source/Application/Controller/Admin/ActionsMainAjax.php
@@ -154,8 +154,8 @@ class ActionsMainAjax extends \OxidEsales\Eshop\Application\Controller\Admin\Lis
         if (\OxidEsales\Eshop\Core\Registry::getConfig()->getRequestParameter('all')) {
             $sQ = parent::_addFilter("delete oxactions2article.* " . $this->_getQuery());
             \OxidEsales\Eshop\Core\DatabaseProvider::getDb()->Execute($sQ);
-        } elseif (is_array($aChosenArt)) {
-            $sChosenArticles = implode(", ", \OxidEsales\Eshop\Core\DatabaseProvider::getDb()->quoteArray($aChosenArt));
+        } elseif (\is_array($aChosenArt)) {
+            $sChosenArticles = \implode(", ", \OxidEsales\Eshop\Core\DatabaseProvider::getDb()->quoteArray($aChosenArt));
             $sQ = "delete from oxactions2article where oxactions2article.oxid in (" . $sChosenArticles . ") ";
             \OxidEsales\Eshop\Core\DatabaseProvider::getDb()->Execute($sQ);
         }
@@ -198,7 +198,7 @@ class ActionsMainAjax extends \OxidEsales\Eshop\Application\Controller\Admin\Lis
         $iSort = ((int) $database->getOne($sQ, $parameters)) + 1;
 
         $articleAdded = false;
-        if ($soxId && $soxId != "-1" && is_array($aArticles)) {
+        if ($soxId && $soxId != "-1" && \is_array($aArticles)) {
             $sShopId = $myConfig->getShopId();
             foreach ($aArticles as $sAdd) {
                 $oNewGroup = oxNew(\OxidEsales\Eshop\Core\Model\BaseModel::class);
@@ -249,7 +249,7 @@ class ActionsMainAjax extends \OxidEsales\Eshop\Application\Controller\Admin\Lis
         }
 
         //
-        if (($iKey = array_search(\OxidEsales\Eshop\Core\Registry::getConfig()->getRequestParameter('sortoxid'), $aIdx2Id)) !== false) {
+        if (($iKey = \array_search(\OxidEsales\Eshop\Core\Registry::getConfig()->getRequestParameter('sortoxid'), $aIdx2Id)) !== false) {
             $iDir = (\OxidEsales\Eshop\Core\Registry::getConfig()->getRequestParameter('direction') == 'up') ? ($iKey - 1) : ($iKey + 1);
             if (isset($aIdx2Id[$iDir])) {
                 // exchanging indexes

--- a/source/Application/Controller/Admin/ActionsOrderAjax.php
+++ b/source/Application/Controller/Admin/ActionsOrderAjax.php
@@ -84,7 +84,7 @@ class ActionsOrderAjax extends \OxidEsales\Eshop\Application\Controller\Admin\Li
         }
 
         //
-        if (($iKey = array_search(\OxidEsales\Eshop\Core\Registry::getConfig()->getRequestParameter('sortoxid'), $aIdx2Id)) !== false) {
+        if (($iKey = \array_search(\OxidEsales\Eshop\Core\Registry::getConfig()->getRequestParameter('sortoxid'), $aIdx2Id)) !== false) {
             $iDir = (\OxidEsales\Eshop\Core\Registry::getConfig()->getRequestParameter('direction') == 'up') ? ($iKey - 1) : ($iKey + 1);
             if (isset($aIdx2Id[$iDir])) {
                 // exchanging indexes

--- a/source/Application/Controller/Admin/AdminController.php
+++ b/source/Application/Controller/Admin/AdminController.php
@@ -189,7 +189,7 @@ class AdminController extends \OxidEsales\Eshop\Core\Controller\BaseController
 
         $oViewConf = $this->getViewConfig();
         $oViewConf->setViewConfigParam('selflink', \OxidEsales\Eshop\Core\Registry::getUtilsUrl()->processUrl($sURL . 'index.php?editlanguage=' . $this->_iEditLang, false));
-        $oViewConf->setViewConfigParam('ajaxlink', str_replace('&amp;', '&', \OxidEsales\Eshop\Core\Registry::getUtilsUrl()->processUrl($sURL . 'oxajax.php?editlanguage=' . $this->_iEditLang, false)));
+        $oViewConf->setViewConfigParam('ajaxlink', \str_replace('&amp;', '&', \OxidEsales\Eshop\Core\Registry::getUtilsUrl()->processUrl($sURL . 'oxajax.php?editlanguage=' . $this->_iEditLang, false)));
 
         // set language of admin backend
         $this->_aViewData['adminlang'] = $oLang->getTplLanguage();
@@ -264,16 +264,16 @@ class AdminController extends \OxidEsales\Eshop\Core\Controller\BaseController
         $myUtilsServer = \OxidEsales\Eshop\Core\Registry::getUtilsServer();
 
         // store navigation history
-        $aHistory = explode('|', $myUtilsServer->getOxCookie('oxidadminhistory'));
-        if (!is_array($aHistory)) {
+        $aHistory = \explode('|', $myUtilsServer->getOxCookie('oxidadminhistory'));
+        if (!\is_array($aHistory)) {
             $aHistory = [];
         }
 
-        if (!in_array($sNode, $aHistory)) {
+        if (!\in_array($sNode, $aHistory)) {
             $aHistory[] = $sNode;
         }
 
-        $myUtilsServer->setOxCookie('oxidadminhistory', implode('|', $aHistory));
+        $myUtilsServer->setOxCookie('oxidadminhistory', \implode('|', $aHistory));
     }
 
     /**
@@ -314,7 +314,7 @@ class AdminController extends \OxidEsales\Eshop\Core\Controller\BaseController
         $this->_aViewData['languages'] = $oLang->getLanguageArray($iLanguage);
 
         // setting maximum upload size
-        list($this->_aViewData['iMaxUploadFileSize'], $this->_aViewData['sMaxFormattedFileSize']) = $this->_getMaxUploadFileInfo(@ini_get("upload_max_filesize"));
+        list($this->_aViewData['iMaxUploadFileSize'], $this->_aViewData['sMaxFormattedFileSize']) = $this->_getMaxUploadFileInfo(@\ini_get("upload_max_filesize"));
 
         // "save-on-tab"
         if (!isset($this->_aViewData['updatelist'])) {
@@ -338,8 +338,8 @@ class AdminController extends \OxidEsales\Eshop\Core\Controller\BaseController
         $iMaxFileSize = $iMaxFileSize ? $iMaxFileSize : '2M';
 
         // processing config
-        $iMaxFileSize = trim($iMaxFileSize);
-        $sParam = strtolower($iMaxFileSize[strlen($iMaxFileSize) - 1]);
+        $iMaxFileSize = \trim($iMaxFileSize);
+        $sParam = \strtolower($iMaxFileSize[\strlen($iMaxFileSize) - 1]);
         switch ($sParam) {
             case 'g':
                 $iMaxFileSize *= 1024;
@@ -355,11 +355,11 @@ class AdminController extends \OxidEsales\Eshop\Core\Controller\BaseController
         $aMarkers = ['KB', 'MB', 'GB'];
         $sFormattedMaxSize = '';
 
-        $iSize = floor($iMaxFileSize / 1024);
-        while ($iSize && current($aMarkers)) {
-            $sFormattedMaxSize = $iSize . " " . current($aMarkers);
-            $iSize = floor($iSize / 1024);
-            next($aMarkers);
+        $iSize = \floor($iMaxFileSize / 1024);
+        while ($iSize && \current($aMarkers)) {
+            $sFormattedMaxSize = $iSize . " " . \current($aMarkers);
+            $iSize = \floor($iSize / 1024);
+            \next($aMarkers);
         }
 
         return [$iMaxFileSize, $sFormattedMaxSize];
@@ -454,7 +454,7 @@ class AdminController extends \OxidEsales\Eshop\Core\Controller\BaseController
 
         if (!empty($sCountryCode)) {
             $aLangIds = \OxidEsales\Eshop\Core\Registry::getLang()->getLanguageIds();
-            $iEnglishId = array_search("en", $aLangIds);
+            $iEnglishId = \array_search("en", $aLangIds);
             if (false !== $iEnglishId) {
                 $sViewName = getViewName("oxcountry", $iEnglishId);
                 $sQ = "select oxtitle from {$sViewName} where oxisoalpha2 = :oxisoalpha2";
@@ -476,7 +476,7 @@ class AdminController extends \OxidEsales\Eshop\Core\Controller\BaseController
             }
         }
 
-        return strtolower($sCountry);
+        return \strtolower($sCountry);
     }
 
     /**
@@ -490,7 +490,7 @@ class AdminController extends \OxidEsales\Eshop\Core\Controller\BaseController
         $session = \OxidEsales\Eshop\Core\Registry::getSession();
         return (bool) (
             $session->checkSessionChallenge()
-            && count(\OxidEsales\Eshop\Core\Registry::getUtilsServer()->getOxCookie())
+            && \count(\OxidEsales\Eshop\Core\Registry::getUtilsServer()->getOxCookie())
             && \OxidEsales\Eshop\Core\Registry::getUtils()->checkAccessRights()
         );
     }
@@ -516,7 +516,7 @@ class AdminController extends \OxidEsales\Eshop\Core\Controller\BaseController
      */
     public function getViewId()
     {
-        $viewId = is_null($this->viewId) ? strtolower($this->getControllerKey()) : $this->viewId;
+        $viewId = \is_null($this->viewId) ? \strtolower($this->getControllerKey()) : $this->viewId;
         return $this->getNavigation()->getClassId($viewId);
     }
 
@@ -598,9 +598,9 @@ class AdminController extends \OxidEsales\Eshop\Core\Controller\BaseController
      */
     protected function getControllerKey()
     {
-        $actualClass = get_class($this);
+        $actualClass = \get_class($this);
         $controllerKey = \OxidEsales\Eshop\Core\Registry::getControllerClassNameResolver()->getIdByClassName($actualClass);
-        if (is_null($controllerKey)) {
+        if (\is_null($controllerKey)) {
             //we might not have found a class key because class is a module chain extended class
             $controllerKey = \OxidEsales\Eshop\Core\Registry::getControllerClassNameResolver()->getIdByClassName($this->getShopParentClass());
         }
@@ -614,9 +614,9 @@ class AdminController extends \OxidEsales\Eshop\Core\Controller\BaseController
      */
     protected function getShopParentClass()
     {
-        $className = get_class($this); //actual class, might be shop class chain extended by module
+        $className = \get_class($this); //actual class, might be shop class chain extended by module
         while ($className && !\OxidEsales\Eshop\Core\NamespaceInformationProvider::classBelongsToShopUnifiedNamespace($className)) {
-            $className = get_parent_class($className);
+            $className = \get_parent_class($className);
         }
         return $className;
     }

--- a/source/Application/Controller/Admin/AdminDetailsController.php
+++ b/source/Application/Controller/Admin/AdminDetailsController.php
@@ -35,7 +35,7 @@ class AdminDetailsController extends \OxidEsales\Eshop\Application\Controller\Ad
         // generate help link
         $myConfig = \OxidEsales\Eshop\Core\Registry::getConfig();
         $sDir = $myConfig->getConfigParam('sShopDir') . '/documentation/admin';
-        if (is_dir($sDir)) {
+        if (\is_dir($sDir)) {
             $sDir = $myConfig->getConfigParam('sShopURL') . 'documentation/admin';
         } else {
             $languageId = $this->getDocumentationLanguageId();
@@ -102,7 +102,7 @@ class AdminDetailsController extends \OxidEsales\Eshop\Application\Controller\Ad
         // descriptions, which are filled dynamically
         if (!\OxidEsales\Eshop\Core\Registry::getConfig()->getConfigParam('bl_perfParseLongDescinSmarty')) {
             $aReplace = ['[{$shop->currenthomedir}]', '[{$oViewConf->getCurrentHomeDir()}]'];
-            $sValue = str_replace($aReplace, \OxidEsales\Eshop\Core\Registry::getConfig()->getCurrentShopURL(false), $sValue);
+            $sValue = \str_replace($aReplace, \OxidEsales\Eshop\Core\Registry::getConfig()->getCurrentShopURL(false), $sValue);
         }
 
         return $sValue;
@@ -231,7 +231,7 @@ class AdminDetailsController extends \OxidEsales\Eshop\Application\Controller\Ad
         $oRoot = oxNew(\OxidEsales\Eshop\Application\Model\Category::class);
         $oRoot->oxcategories__oxtitle = new Field('--');
 
-        $oCatTree->assign(array_merge(['' => $oRoot], $oCatTree->getArray()));
+        $oCatTree->assign(\array_merge(['' => $oRoot], $oCatTree->getArray()));
 
         // passing to view
         $this->_aViewData[$sTplVarName] = $oCatTree;
@@ -265,7 +265,7 @@ class AdminDetailsController extends \OxidEsales\Eshop\Application\Controller\Ad
         if ($sSelectedCatId) {
             // fixed parent category in select list
             foreach ($oCatTree as $oCategory) {
-                if (strcmp($oCategory->getId(), $sSelectedCatId) == 0) {
+                if (\strcmp($oCategory->getId(), $sSelectedCatId) == 0) {
                     $oCategory->selected = 1;
                     break;
                 }

--- a/source/Application/Controller/Admin/AdminListController.php
+++ b/source/Application/Controller/Admin/AdminListController.php
@@ -290,7 +290,7 @@ class AdminListController extends \OxidEsales\Eshop\Application\Controller\Admin
         if ($jumpToPage < 1) {
             $jumpToPage = 0;
         } elseif ($jumpToPage >= $this->_iListSize) {
-            $jumpToPage = floor($this->_iListSize / $adminListSize - 1) * $adminListSize;
+            $jumpToPage = \floor($this->_iListSize / $adminListSize - 1) * $adminListSize;
         }
 
         $this->_iCurrListPos = $this->_iOverPos = (int)$jumpToPage;
@@ -309,7 +309,7 @@ class AdminListController extends \OxidEsales\Eshop\Application\Controller\Admin
         // sorting
         $sortFields = $this->getListSorting();
 
-        if (is_array($sortFields) && count($sortFields)) {
+        if (\is_array($sortFields) && \count($sortFields)) {
             // only add order by at full sql not for count(*)
             $query .= ' order by ';
             $addSeparator = false;
@@ -329,7 +329,7 @@ class AdminListController extends \OxidEsales\Eshop\Application\Controller\Admin
                     $query .= ((($addSeparator) ? ', ' : '')) . \OxidEsales\Eshop\Core\DatabaseProvider::getDb()->quoteIdentifier($field);
 
                     //V oxActive field search always DESC
-                    if ($descending || $column == "oxactive" || strcasecmp($sortDirectory, 'desc') == 0) {
+                    if ($descending || $column == "oxactive" || \strcasecmp($sortDirectory, 'desc') == 0) {
                         $query .= ' desc ';
                     }
 
@@ -370,7 +370,7 @@ class AdminListController extends \OxidEsales\Eshop\Application\Controller\Admin
         $stringModifier = Str::getStr();
 
         //removing % symbols
-        $fieldValue = $stringModifier->preg_replace("/^%|%$/", "", trim($fieldValue));
+        $fieldValue = $stringModifier->preg_replace("/^%|%$/", "", \trim($fieldValue));
 
         return $stringModifier->preg_replace("/\s+/", " ", $fieldValue);
     }
@@ -423,10 +423,10 @@ class AdminListController extends \OxidEsales\Eshop\Application\Controller\Admin
      */
     protected function _prepareWhereQuery($whereQuery, $fullQuery) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
-        if (is_array($whereQuery) && count($whereQuery)) {
+        if (\is_array($whereQuery) && \count($whereQuery)) {
             $myUtilsString = \OxidEsales\Eshop\Core\Registry::getUtilsString();
             foreach ($whereQuery as $identifierName => $fieldValue) {
-                $fieldValue = trim($fieldValue);
+                $fieldValue = \trim($fieldValue);
 
                 //check if this is search string (contains % sign at beginning and end of string)
                 $isSearchValue = $this->_isSearchValue($fieldValue);
@@ -434,8 +434,8 @@ class AdminListController extends \OxidEsales\Eshop\Application\Controller\Admin
                 //removing % symbols
                 $fieldValue = $this->_processFilter($fieldValue);
 
-                if (strlen($fieldValue)) {
-                    $values = explode(' ', $fieldValue);
+                if (\strlen($fieldValue)) {
+                    $values = \explode(' ', $fieldValue);
 
                     //for each search field using AND action
                     $queryBoolAction = ' and (';
@@ -496,7 +496,7 @@ class AdminListController extends \OxidEsales\Eshop\Application\Controller\Admin
         if ($this->_aWhere === null && ($list = $this->getItemList())) {
             $this->_aWhere = [];
             $filter = $this->getListFilter();
-            if (is_array($filter)) {
+            if (\is_array($filter)) {
                 $listItem = $this->getItemListBaseObject();
                 $languageId = $listItem->isMultilang() ? $listItem->getLanguage() : \OxidEsales\Eshop\Core\Registry::getLang()->getBaseLanguage();
                 $localDateFormat = \OxidEsales\Eshop\Core\Registry::getConfig()->getConfigParam('sLocalDateFormat');
@@ -541,17 +541,17 @@ class AdminListController extends \OxidEsales\Eshop\Application\Controller\Admin
         $convertedObject = new \OxidEsales\Eshop\Core\Field();
         $convertedObject->setValue($value);
         if ($fieldType == "datetime") {
-            if (strlen($value) == 10 || strlen($value) == 22 || (strlen($value) == 19 && !stripos($value, "m"))) {
+            if (\strlen($value) == 10 || \strlen($value) == 22 || (\strlen($value) == 19 && !\stripos($value, "m"))) {
                 \OxidEsales\Eshop\Core\Registry::getUtilsDate()->convertDBDateTime($convertedObject, true);
             } else {
-                if (strlen($value) > 10) {
+                if (\strlen($value) > 10) {
                     return $this->_convertTime($value);
                 } else {
                     return $this->_convertDate($value);
                 }
             }
         } elseif ($fieldType == "date") {
-            if (strlen($value) == 10) {
+            if (\strlen($value) == 10) {
                 \OxidEsales\Eshop\Core\Registry::getUtilsDate()->convertDBDate($convertedObject, true);
             } else {
                 return $this->_convertDate($value);
@@ -610,14 +610,14 @@ class AdminListController extends \OxidEsales\Eshop\Application\Controller\Admin
      */
     protected function _convertTime($fullDate) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
-        $date = substr($fullDate, 0, 10);
+        $date = \substr($fullDate, 0, 10);
         $convertedObject = new \OxidEsales\Eshop\Core\Field();
         $convertedObject->setValue($date);
         \OxidEsales\Eshop\Core\Registry::getUtilsDate()->convertDBDate($convertedObject, true);
         $stringModifier = Str::getStr();
 
         // looking for time field
-        $time = substr($fullDate, 11);
+        $time = \substr($fullDate, 11);
         if ($stringModifier->preg_match("/([0-9]{2}):([0-9]{2}) ([AP]{1}[M]{1})$/", $time, $timeMatches)) {
             if ($timeMatches[3] == "PM") {
                 $intVal = (int)$timeMatches[1];
@@ -637,7 +637,7 @@ class AdminListController extends \OxidEsales\Eshop\Application\Controller\Admin
                 $time = $timeMatches[1];
             }
         } else {
-            $time = str_replace(".", ":", $time);
+            $time = \str_replace(".", ":", $time);
         }
 
         return $convertedObject->value . " " . $time;
@@ -655,8 +655,8 @@ class AdminListController extends \OxidEsales\Eshop\Application\Controller\Admin
         if ($this->_iListSize > $adminListSize) {
             // yes, we need to build the navigation object
             $pageNavigation = new stdClass();
-            $pageNavigation->pages = round((($this->_iListSize - 1) / $adminListSize) + 0.5, 0);
-            $pageNavigation->actpage = ($pageNavigation->actpage > $pageNavigation->pages) ? $pageNavigation->pages : round(
+            $pageNavigation->pages = \round((($this->_iListSize - 1) / $adminListSize) + 0.5, 0);
+            $pageNavigation->actpage = ($pageNavigation->actpage > $pageNavigation->pages) ? $pageNavigation->pages : \round(
                 ($this->_iCurrListPos / $adminListSize) + 0.5,
                 0
             );
@@ -717,7 +717,7 @@ class AdminListController extends \OxidEsales\Eshop\Application\Controller\Admin
         // determine not used space in List
         $listSizeToShow = $this->_iListSize - $this->_iCurrListPos;
         $adminListSize = $this->_getViewListSize();
-        $notUsed = $adminListSize - min($listSizeToShow, $adminListSize);
+        $notUsed = $adminListSize - \min($listSizeToShow, $adminListSize);
         $space = $notUsed * 15;
 
         if (!$showNavigation) {

--- a/source/Application/Controller/Admin/AdminlinksMain.php
+++ b/source/Application/Controller/Admin/AdminlinksMain.php
@@ -36,7 +36,7 @@ class AdminlinksMain extends \OxidEsales\Eshop\Application\Controller\Admin\Admi
             $oOtherLang = $oLinks->getAvailableInLangs();
             if (!isset($oOtherLang[$this->_iEditLang])) {
                 // echo "language entry doesn't exist! using: ".key($oOtherLang);
-                $oLinks->loadInLang(key($oOtherLang), $soxId);
+                $oLinks->loadInLang(\key($oOtherLang), $soxId);
             }
             $this->_aViewData["edit"] = $oLinks;
 
@@ -46,7 +46,7 @@ class AdminlinksMain extends \OxidEsales\Eshop\Application\Controller\Admin\Admi
             }
 
             // remove already created languages
-            $this->_aViewData["posslang"] = array_diff(\OxidEsales\Eshop\Core\Registry::getLang()->getLanguageNames(), $oOtherLang);
+            $this->_aViewData["posslang"] = \array_diff(\OxidEsales\Eshop\Core\Registry::getLang()->getLanguageNames(), $oOtherLang);
 
             foreach ($oOtherLang as $id => $language) {
                 $oLang = new stdClass();
@@ -84,16 +84,16 @@ class AdminlinksMain extends \OxidEsales\Eshop\Application\Controller\Admin\Admi
 
         // adds space to the end of URL description to keep new added links visible
         // if URL description left empty
-        if (isset($aParams['oxlinks__oxurldesc']) && strlen($aParams['oxlinks__oxurldesc']) == 0) {
+        if (isset($aParams['oxlinks__oxurldesc']) && \strlen($aParams['oxlinks__oxurldesc']) == 0) {
             $aParams['oxlinks__oxurldesc'] .= " ";
         }
 
         if (!$aParams['oxlinks__oxinsert']) {
             // sets default (?) date format to output
             // else if possible - changes date format to system compatible
-            $sDate = date(\OxidEsales\Eshop\Core\Registry::getLang()->translateString("simpleDateFormat"));
+            $sDate = \date(\OxidEsales\Eshop\Core\Registry::getLang()->translateString("simpleDateFormat"));
             if ($sDate == "simpleDateFormat") {
-                $aParams['oxlinks__oxinsert'] = date("Y-m-d");
+                $aParams['oxlinks__oxinsert'] = \date("Y-m-d");
             } else {
                 $aParams['oxlinks__oxinsert'] = $sDate;
             }

--- a/source/Application/Controller/Admin/ArticleAccessoriesAjax.php
+++ b/source/Application/Controller/Admin/ArticleAccessoriesAjax.php
@@ -139,8 +139,8 @@ class ArticleAccessoriesAjax extends \OxidEsales\Eshop\Application\Controller\Ad
         if (\OxidEsales\Eshop\Core\Registry::getConfig()->getRequestParameter('all')) {
             $sQ = $this->_addFilter("delete oxaccessoire2article.* " . $this->_getQuery());
             \OxidEsales\Eshop\Core\DatabaseProvider::getDb()->Execute($sQ);
-        } elseif (is_array($aChosenArt)) {
-            $sChosenArticles = implode(", ", \OxidEsales\Eshop\Core\DatabaseProvider::getDb()->quoteArray($aChosenArt));
+        } elseif (\is_array($aChosenArt)) {
+            $sChosenArticles = \implode(", ", \OxidEsales\Eshop\Core\DatabaseProvider::getDb()->quoteArray($aChosenArt));
             $sQ = "delete from oxaccessoire2article where oxaccessoire2article.oxid in ({$sChosenArticles}) ";
             \OxidEsales\Eshop\Core\DatabaseProvider::getDb()->Execute($sQ);
         }
@@ -161,7 +161,7 @@ class ArticleAccessoriesAjax extends \OxidEsales\Eshop\Application\Controller\Ad
             $aChosenArt = $this->_getAll(parent::_addFilter("select $sArtTable.oxid " . $this->_getQuery()));
         }
 
-        if ($oArticle->load($soxId) && $soxId && $soxId != "-1" && is_array($aChosenArt)) {
+        if ($oArticle->load($soxId) && $soxId && $soxId != "-1" && \is_array($aChosenArt)) {
             foreach ($aChosenArt as $sChosenArt) {
                 $oNewGroup = oxNew(\OxidEsales\Eshop\Core\Model\BaseModel::class);
                 $oNewGroup->init("oxaccessoire2article");
@@ -204,13 +204,13 @@ class ArticleAccessoriesAjax extends \OxidEsales\Eshop\Application\Controller\Ad
 
         $rebuildList = $this->rebuildAccessoriesSortIndexes($accessoriesList);
 
-        if (($selectedPosition = array_search($selectedIdForSort, $rebuildList)) !== false) {
+        if (($selectedPosition = \array_search($selectedIdForSort, $rebuildList)) !== false) {
             $selectedSortRecord = $accessoriesList->offsetGet($rebuildList[$selectedPosition]);
             $currentPosition = $selectedSortRecord->oxaccessoire2article__oxsort->value;
 
             // get current selected row sort position
 
-            if (($sortDirection == 'up' && $currentPosition > 0) || ($sortDirection == 'down' && $currentPosition < count($rebuildList) - 1)) {
+            if (($sortDirection == 'up' && $currentPosition > 0) || ($sortDirection == 'down' && $currentPosition < \count($rebuildList) - 1)) {
                 $newPosition = ($sortDirection == 'up') ? ($currentPosition - 1) : ($currentPosition + 1);
 
                 // exchanging indexes

--- a/source/Application/Controller/Admin/ArticleAttributeAjax.php
+++ b/source/Application/Controller/Admin/ArticleAttributeAjax.php
@@ -73,8 +73,8 @@ class ArticleAttributeAjax extends \OxidEsales\Eshop\Application\Controller\Admi
             $sO2AViewName = $this->_getViewName('oxobject2attribute');
             $sQ = $this->_addFilter("delete $sO2AViewName.* " . $this->_getQuery());
             \OxidEsales\Eshop\Core\DatabaseProvider::getDb()->Execute($sQ);
-        } elseif (is_array($aChosenArt)) {
-            $sChosenArticles = implode(", ", \OxidEsales\Eshop\Core\DatabaseProvider::getDb()->quoteArray($aChosenArt));
+        } elseif (\is_array($aChosenArt)) {
+            $sChosenArticles = \implode(", ", \OxidEsales\Eshop\Core\DatabaseProvider::getDb()->quoteArray($aChosenArt));
             $sQ = "delete from oxobject2attribute where oxobject2attribute.oxid in ({$sChosenArticles}) ";
             \OxidEsales\Eshop\Core\DatabaseProvider::getDb()->Execute($sQ);
         }
@@ -95,7 +95,7 @@ class ArticleAttributeAjax extends \OxidEsales\Eshop\Application\Controller\Admi
             $aAddCat = $this->_getAll($this->_addFilter("select $sAttrViewName.oxid " . $this->_getQuery()));
         }
 
-        if ($soxId && $soxId != "-1" && is_array($aAddCat)) {
+        if ($soxId && $soxId != "-1" && \is_array($aAddCat)) {
             foreach ($aAddCat as $sAdd) {
                 $oNew = oxNew(\OxidEsales\Eshop\Core\Model\BaseModel::class);
                 $oNew->init("oxobject2attribute");

--- a/source/Application/Controller/Admin/ArticleCrosssellingAjax.php
+++ b/source/Application/Controller/Admin/ArticleCrosssellingAjax.php
@@ -128,8 +128,8 @@ class ArticleCrosssellingAjax extends \OxidEsales\Eshop\Application\Controller\A
         if (\OxidEsales\Eshop\Core\Registry::getConfig()->getRequestParameter('all')) {
             $sQ = $this->_addFilter("delete oxobject2article.* " . $this->_getQuery());
             \OxidEsales\Eshop\Core\DatabaseProvider::getDb()->Execute($sQ);
-        } elseif (is_array($aChosenArt)) {
-            $sChosenArticles = implode(", ", \OxidEsales\Eshop\Core\DatabaseProvider::getDb()->quoteArray($aChosenArt));
+        } elseif (\is_array($aChosenArt)) {
+            $sChosenArticles = \implode(", ", \OxidEsales\Eshop\Core\DatabaseProvider::getDb()->quoteArray($aChosenArt));
             $sQ = "delete from oxobject2article where oxobject2article.oxid in (" . $sChosenArticles . ") ";
             \OxidEsales\Eshop\Core\DatabaseProvider::getDb()->Execute($sQ);
         }
@@ -150,7 +150,7 @@ class ArticleCrosssellingAjax extends \OxidEsales\Eshop\Application\Controller\A
         }
 
         $oArticle = oxNew(\OxidEsales\Eshop\Application\Model\Article::class);
-        if ($oArticle->load($soxId) && $soxId && $soxId != "-1" && is_array($aChosenArt)) {
+        if ($oArticle->load($soxId) && $soxId && $soxId != "-1" && \is_array($aChosenArt)) {
             foreach ($aChosenArt as $sAdd) {
                 $oNewGroup = oxNew(\OxidEsales\Eshop\Core\Model\BaseModel::class);
                 $oNewGroup->init('oxobject2article');

--- a/source/Application/Controller/Admin/ArticleExtend.php
+++ b/source/Application/Controller/Admin/ArticleExtend.php
@@ -55,7 +55,7 @@ class ArticleExtend extends \OxidEsales\Eshop\Application\Controller\Admin\Admin
             // load object in other languages
             $otherLang = $article->getAvailableInLangs();
             if (!isset($otherLang[$this->_iEditLang])) {
-                $article->loadInLang(key($otherLang), $oxId);
+                $article->loadInLang(\key($otherLang), $oxId);
             }
 
             foreach ($otherLang as $id => $language) {
@@ -106,7 +106,7 @@ class ArticleExtend extends \OxidEsales\Eshop\Application\Controller\Admin\Admin
 
         $aMyFile = \OxidEsales\Eshop\Core\Registry::getConfig()->getUploadedFile("myfile");
         $aMediaFile = \OxidEsales\Eshop\Core\Registry::getConfig()->getUploadedFile("mediaFile");
-        if (is_array($aMyFile['name']) && reset($aMyFile['name']) || $aMediaFile['name']) {
+        if (\is_array($aMyFile['name']) && \reset($aMyFile['name']) || $aMediaFile['name']) {
             $myConfig = \OxidEsales\Eshop\Core\Registry::getConfig();
             if ($myConfig->isDemoShop()) {
                 $oEx = oxNew(\OxidEsales\Eshop\Core\Exception\ExceptionToDisplay::class);
@@ -220,7 +220,7 @@ class ArticleExtend extends \OxidEsales\Eshop\Application\Controller\Admin\Admin
     public function updateMedia()
     {
         $aMediaUrls = \OxidEsales\Eshop\Core\Registry::getConfig()->getRequestParameter('aMediaUrls');
-        if (is_array($aMediaUrls)) {
+        if (\is_array($aMediaUrls)) {
             foreach ($aMediaUrls as $sMediaId => $aMediaParams) {
                 $oMedia = oxNew(\OxidEsales\Eshop\Application\Model\MediaUrl::class);
                 if ($oMedia->load($sMediaId)) {

--- a/source/Application/Controller/Admin/ArticleExtendAjax.php
+++ b/source/Application/Controller/Admin/ArticleExtendAjax.php
@@ -80,11 +80,11 @@ class ArticleExtendAjax extends \OxidEsales\Eshop\Application\Controller\Admin\L
     protected function _getDataFields($sQ) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $dataFields = parent::_getDataFields($sQ);
-        if (\OxidEsales\Eshop\Core\Registry::getConfig()->getRequestParameter('oxid') && is_array($dataFields) && count($dataFields)) {
+        if (\OxidEsales\Eshop\Core\Registry::getConfig()->getRequestParameter('oxid') && \is_array($dataFields) && \count($dataFields)) {
             // looking for smallest time value to mark record as main category ..
             $minimalPosition = null;
             $minimalValue = null;
-            reset($dataFields);
+            \reset($dataFields);
             foreach ($dataFields as $position => $fields) {
                 // already set ?
                 if ($fields['_3'] == '0') {
@@ -126,10 +126,10 @@ class ArticleExtendAjax extends \OxidEsales\Eshop\Application\Controller\Admin\L
         }
 
         // removing all
-        if (is_array($categoriesToRemove) && count($categoriesToRemove)) {
+        if (\is_array($categoriesToRemove) && \count($categoriesToRemove)) {
             $query = "delete from oxobject2category where oxobject2category.oxobjectid = :oxobjectid and ";
             $query = $this->updateQueryForRemovingArticleFromCategory($query);
-            $query .= " oxcatnid in (" . implode(', ', \OxidEsales\Eshop\Core\DatabaseProvider::getDb()->quoteArray($categoriesToRemove)) . ')';
+            $query .= " oxcatnid in (" . \implode(', ', \OxidEsales\Eshop\Core\DatabaseProvider::getDb()->quoteArray($categoriesToRemove)) . ')';
             $dataBase->Execute($query, [
                 ':oxobjectid' => $oxId
             ]);
@@ -163,7 +163,7 @@ class ArticleExtendAjax extends \OxidEsales\Eshop\Application\Controller\Admin\L
             $categoriesToAdd = $this->_getAll($this->_addFilter("select $categoriesTable.oxid " . $this->_getQuery()));
         }
 
-        if (isset($categoriesToAdd) && is_array($categoriesToAdd)) {
+        if (isset($categoriesToAdd) && \is_array($categoriesToAdd)) {
             // We force reading from master to prevent issues with slow replications or open transactions (see ESDEV-3804 and ESDEV-3822).
             $database = \OxidEsales\Eshop\Core\DatabaseProvider::getMaster();
 
@@ -178,10 +178,10 @@ class ArticleExtendAjax extends \OxidEsales\Eshop\Application\Controller\Admin\L
                     continue;
                 }
 
-                $objectToCategory->setId(md5($oxId . $sAdd . $shopId));
+                $objectToCategory->setId(\md5($oxId . $sAdd . $shopId));
                 $objectToCategory->oxobject2category__oxobjectid = new \OxidEsales\Eshop\Core\Field($oxId);
                 $objectToCategory->oxobject2category__oxcatnid = new \OxidEsales\Eshop\Core\Field($sAdd);
-                $objectToCategory->oxobject2category__oxtime = new \OxidEsales\Eshop\Core\Field(time());
+                $objectToCategory->oxobject2category__oxtime = new \OxidEsales\Eshop\Core\Field(\time());
 
                 $objectToCategory->save();
             }

--- a/source/Application/Controller/Admin/ArticleFiles.php
+++ b/source/Application/Controller/Admin/ArticleFiles.php
@@ -71,7 +71,7 @@ class ArticleFiles extends \OxidEsales\Eshop\Application\Controller\Admin\AdminD
 
         //update article files
         $aArticleFiles = \OxidEsales\Eshop\Core\Registry::getConfig()->getRequestParameter('article_files');
-        if (is_array($aArticleFiles)) {
+        if (\is_array($aArticleFiles)) {
             foreach ($aArticleFiles as $sArticleFileId => $aArticleFileUpdate) {
                 $oArticleFile = oxNew(\OxidEsales\Eshop\Application\Model\File::class);
                 $oArticleFile->load($sArticleFileId);
@@ -207,7 +207,7 @@ class ArticleFiles extends \OxidEsales\Eshop\Application\Controller\Admin\AdminD
      */
     protected function _processOptions($aParams) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
-        if (!is_array($aParams)) {
+        if (!\is_array($aParams)) {
             $aParams = [];
         }
 

--- a/source/Application/Controller/Admin/ArticleList.php
+++ b/source/Application/Controller/Admin/ArticleList.php
@@ -54,11 +54,11 @@ class ArticleList extends \OxidEsales\Eshop\Application\Controller\Admin\AdminLi
      */
     private function isArticleActive($sDateTime, $blUseTimeCheck, $oArticle)
     {
-        if (!is_bool($sDateTime) && isset($oArticle->oxarticles__oxactive) && $oArticle->oxarticles__oxactive->value === '1') {
+        if (!\is_bool($sDateTime) && isset($oArticle->oxarticles__oxactive) && $oArticle->oxarticles__oxactive->value === '1') {
             return true;
         } else {
             if (
-                !is_bool($sDateTime) && isset($oArticle->oxarticles__oxactivefrom) &&
+                !\is_bool($sDateTime) && isset($oArticle->oxarticles__oxactivefrom) &&
                 isset($oArticle->oxarticles__oxactiveto) && $blUseTimeCheck &&
                 $oArticle->oxarticles__oxactivefrom->value <= $sDateTime &&
                 $oArticle->oxarticles__oxactiveto->value >= $sDateTime
@@ -80,7 +80,7 @@ class ArticleList extends \OxidEsales\Eshop\Application\Controller\Admin\AdminLi
     {
         $myConfig = \OxidEsales\Eshop\Core\Registry::getConfig();
         $sPwrSearchFld = \OxidEsales\Eshop\Core\Registry::getConfig()->getRequestParameter("pwrsearchfld");
-        $sPwrSearchFld = $sPwrSearchFld ? strtolower($sPwrSearchFld) : "oxtitle";
+        $sPwrSearchFld = $sPwrSearchFld ? \strtolower($sPwrSearchFld) : "oxtitle";
 
         $sDateTime = $this->getServerDateTime();
         $blUseTimeCheck = $this->getConfig()->getConfigParam('blUseTimeCheck');
@@ -114,7 +114,7 @@ class ArticleList extends \OxidEsales\Eshop\Application\Controller\Admin\AdminLi
             $oArticle = $oList->getBaseObject();
         }
         $this->_aViewData["pwrsearchfields"] = $oArticle ? $this->getSearchFields() : null;
-        $this->_aViewData["pwrsearchfld"] = strtoupper($sPwrSearchFld);
+        $this->_aViewData["pwrsearchfld"] = \strtoupper($sPwrSearchFld);
 
         $aFilter = $this->getListFilter();
         if (isset($aFilter["oxarticles"][$sPwrSearchFld])) {
@@ -125,8 +125,8 @@ class ArticleList extends \OxidEsales\Eshop\Application\Controller\Admin\AdminLi
         $sValue = '';
 
         $sArtCat = \OxidEsales\Eshop\Core\Registry::getConfig()->getRequestParameter("art_category");
-        if ($sArtCat && strstr($sArtCat, "@@") !== false) {
-            list($sType, $sValue) = explode("@@", $sArtCat);
+        if ($sArtCat && \strstr($sArtCat, "@@") !== false) {
+            list($sType, $sValue) = \explode("@@", $sArtCat);
         }
         $this->_aViewData["art_category"] = $sArtCat;
 
@@ -159,7 +159,7 @@ class ArticleList extends \OxidEsales\Eshop\Application\Controller\Admin\AdminLi
         ];
         $oArticle = oxNew(\OxidEsales\Eshop\Application\Model\Article::class);
 
-        return array_diff($oArticle->getFieldNames(), $aSkipFields);
+        return \array_diff($oArticle->getFieldNames(), $aSkipFields);
     }
 
     /**
@@ -252,8 +252,8 @@ class ArticleList extends \OxidEsales\Eshop\Application\Controller\Admin\AdminLi
 
             $sType = false;
             $sArtCat = \OxidEsales\Eshop\Core\Registry::getConfig()->getRequestParameter("art_category");
-            if ($sArtCat && strstr($sArtCat, "@@") !== false) {
-                list($sType, $sValue) = explode("@@", $sArtCat);
+            if ($sArtCat && \strstr($sArtCat, "@@") !== false) {
+                list($sType, $sValue) = \explode("@@", $sArtCat);
             }
 
             switch ($sType) {

--- a/source/Application/Controller/Admin/ArticleMain.php
+++ b/source/Application/Controller/Admin/ArticleMain.php
@@ -61,7 +61,7 @@ class ArticleMain extends \OxidEsales\Eshop\Application\Controller\Admin\AdminDe
             $oOtherLang = $oArticle->getAvailableInLangs();
             if (!isset($oOtherLang[$this->_iEditLang])) {
                 // echo "language entry doesn't exist! using: ".key($oOtherLang);
-                $oArticle->loadInLang(key($oOtherLang), $sOxId);
+                $oArticle->loadInLang(\key($oOtherLang), $sOxId);
             }
 
             // variant handling
@@ -79,8 +79,8 @@ class ArticleMain extends \OxidEsales\Eshop\Application\Controller\Admin\AdminDe
             //hook for modules
             $oArticle = $this->customizeArticleInformation($oArticle);
 
-            $aLang = array_diff(\OxidEsales\Eshop\Core\Registry::getLang()->getLanguageNames(), $oOtherLang);
-            if (count($aLang)) {
+            $aLang = \array_diff(\OxidEsales\Eshop\Core\Registry::getLang()->getLanguageNames(), $oOtherLang);
+            if (\count($aLang)) {
                 $this->_aViewData["posslang"] = $aLang;
             }
 
@@ -172,7 +172,7 @@ class ArticleMain extends \OxidEsales\Eshop\Application\Controller\Admin\AdminDe
 
         //article number handling, warns for artnum duplicates
         if (
-            isset($aParams['oxarticles__oxartnum']) && strlen($aParams['oxarticles__oxartnum']) > 0 &&
+            isset($aParams['oxarticles__oxartnum']) && \strlen($aParams['oxarticles__oxartnum']) > 0 &&
             $oConfig->getConfigParam('blWarnOnSameArtNums') &&
             $oArticle->oxarticles__oxartnum->value != $aParams['oxarticles__oxartnum']
         ) {
@@ -187,7 +187,7 @@ class ArticleMain extends \OxidEsales\Eshop\Application\Controller\Admin\AdminDe
         $oArticle->setLanguage(0);
         //triming spaces from article title (M:876)
         if (isset($aParams['oxarticles__oxtitle'])) {
-            $aParams['oxarticles__oxtitle'] = trim($aParams['oxarticles__oxtitle']);
+            $aParams['oxarticles__oxtitle'] = \trim($aParams['oxarticles__oxtitle']);
         }
 
         $oArticle->assign($aParams);
@@ -221,12 +221,12 @@ class ArticleMain extends \OxidEsales\Eshop\Application\Controller\Admin\AdminDe
     {
         // TODO: the code below is redundant, optimize it, assignments should go smooth without conversions
         // hack, if editor screws up text, htmledit tends to do so
-        $sValue = str_replace('&amp;nbsp;', '&nbsp;', $sValue);
-        $sValue = str_replace('&amp;', '&', $sValue);
-        $sValue = str_replace('&quot;', '"', $sValue);
-        $sValue = str_replace('&lang=', '&amp;lang=', $sValue);
-        $sValue = str_replace('<p>&nbsp;</p>', '', $sValue);
-        $sValue = str_replace('<p>&nbsp; </p>', '', $sValue);
+        $sValue = \str_replace('&amp;nbsp;', '&nbsp;', $sValue);
+        $sValue = \str_replace('&amp;', '&', $sValue);
+        $sValue = \str_replace('&quot;', '"', $sValue);
+        $sValue = \str_replace('&lang=', '&amp;lang=', $sValue);
+        $sValue = \str_replace('<p>&nbsp;</p>', '', $sValue);
+        $sValue = \str_replace('<p>&nbsp; </p>', '', $sValue);
 
         return $sValue;
     }
@@ -300,7 +300,7 @@ class ArticleMain extends \OxidEsales\Eshop\Application\Controller\Admin\AdminDe
             }
 
             // setting oxinsert/oxtimestamp
-            $iNow = date('Y-m-d H:i:s', \OxidEsales\Eshop\Core\Registry::getUtilsDate()->getTime());
+            $iNow = \date('Y-m-d H:i:s', \OxidEsales\Eshop\Core\Registry::getUtilsDate()->getTime());
             $oArticle->oxarticles__oxinsert = new \OxidEsales\Eshop\Core\Field($iNow);
 
             // mantis#0001590: OXRATING and OXRATINGCNT not set to 0 when copying article
@@ -663,7 +663,7 @@ class ArticleMain extends \OxidEsales\Eshop\Application\Controller\Admin\AdminDe
                 }
             }
         }
-        if (count($aJumpList) > 1) {
+        if (\count($aJumpList) > 1) {
             $this->_aViewData["thisvariantlist"] = $aJumpList;
         }
     }
@@ -679,7 +679,7 @@ class ArticleMain extends \OxidEsales\Eshop\Application\Controller\Admin\AdminDe
     protected function _getTitle($oObj) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $sTitle = $oObj->oxarticles__oxtitle->value;
-        if (!strlen($sTitle)) {
+        if (!\strlen($sTitle)) {
             $sTitle = $oObj->oxarticles__oxvarselect->value;
         }
 

--- a/source/Application/Controller/Admin/ArticleReview.php
+++ b/source/Application/Controller/Admin/ArticleReview.php
@@ -87,7 +87,7 @@ class ArticleReview extends \OxidEsales\Eshop\Application\Controller\Admin\Admin
 
         $variantList = $article->getVariants();
 
-        if (\OxidEsales\Eshop\Core\Registry::getConfig()->getConfigParam('blShowVariantReviews') && count($variantList)) {
+        if (\OxidEsales\Eshop\Core\Registry::getConfig()->getConfigParam('blShowVariantReviews') && \count($variantList)) {
             // verifying rights
             foreach ($variantList as $variant) {
                 $query .= "or oxreviews.oxobjectid = " . $database->quote($variant->oxarticles__oxid->value) . " ";

--- a/source/Application/Controller/Admin/ArticleSelectionAjax.php
+++ b/source/Application/Controller/Admin/ArticleSelectionAjax.php
@@ -86,8 +86,8 @@ class ArticleSelectionAjax extends \OxidEsales\Eshop\Application\Controller\Admi
         if (\OxidEsales\Eshop\Core\Registry::getConfig()->getRequestParameter('all')) {
             $sQ = $this->_addFilter("delete oxobject2selectlist.* " . $this->_getQuery());
             \OxidEsales\Eshop\Core\DatabaseProvider::getDb()->Execute($sQ);
-        } elseif (is_array($aChosenArt)) {
-            $sChosenArticles = implode(", ", \OxidEsales\Eshop\Core\DatabaseProvider::getDb()->quoteArray($aChosenArt));
+        } elseif (\is_array($aChosenArt)) {
+            $sChosenArticles = \implode(", ", \OxidEsales\Eshop\Core\DatabaseProvider::getDb()->quoteArray($aChosenArt));
             $sQ = "delete from oxobject2selectlist " .
                   "where oxobject2selectlist.oxid in (" . $sChosenArticles . ") ";
             \OxidEsales\Eshop\Core\DatabaseProvider::getDb()->Execute($sQ);
@@ -113,7 +113,7 @@ class ArticleSelectionAjax extends \OxidEsales\Eshop\Application\Controller\Admi
             $aAddSel = $this->_getAll($this->_addFilter("select $sSLViewName.oxid " . $this->_getQuery()));
         }
 
-        if ($soxId && $soxId != "-1" && is_array($aAddSel)) {
+        if ($soxId && $soxId != "-1" && \is_array($aAddSel)) {
             // We force reading from master to prevent issues with slow replications or open transactions (see ESDEV-3804).
             $database = \OxidEsales\Eshop\Core\DatabaseProvider::getMaster();
             foreach ($aAddSel as $sAdd) {

--- a/source/Application/Controller/Admin/ArticleSeo.php
+++ b/source/Application/Controller/Admin/ArticleSeo.php
@@ -45,8 +45,8 @@ class ArticleSeo extends \OxidEsales\Eshop\Application\Controller\Admin\ObjectSe
             $iEndPos = $oStr->strpos($aData["oxparams"], "#");
             $sType = $oStr->substr($aData["oxparams"], 0, $iEndPos);
         } elseif ($aList = $this->getSelectionList()) {
-            reset($aList);
-            $sType = key($aList);
+            \reset($aList);
+            $sType = \key($aList);
         }
 
         return $sType;
@@ -71,8 +71,8 @@ class ArticleSeo extends \OxidEsales\Eshop\Application\Controller\Admin\ObjectSe
             $iEndPos = $oStr->strpos($aData["oxparams"], "#", $iStartPos + 1);
             $iLang = $oStr->substr($aData["oxparams"], $iEndPos + 1);
         } elseif ($aList = $this->getSelectionList()) {
-            $aList = reset($aList);
-            $iLang = key($aList);
+            $aList = \reset($aList);
+            $iLang = \key($aList);
         }
 
         return (int) $iLang;
@@ -95,7 +95,7 @@ class ArticleSeo extends \OxidEsales\Eshop\Application\Controller\Admin\ObjectSe
 
             $sId = $oStr->substr($aData["oxparams"], $iStartPos + 1, $iEndPos - $iLen);
         } elseif ($aList = $this->getSelectionList()) {
-            $oItem = reset($aList[$this->getActCatType()][$this->getActCatLang()]);
+            $oItem = \reset($aList[$this->getActCatType()][$this->getActCatLang()]);
 
             $sId = $oItem->getId();
         }
@@ -163,7 +163,7 @@ class ArticleSeo extends \OxidEsales\Eshop\Application\Controller\Admin\ObjectSe
         if ($oRs != false && $oRs->count() > 0) {
             while (!$oRs->EOF) {
                 $oCat = oxNew(\OxidEsales\Eshop\Application\Model\Category::class);
-                if ($oCat->loadInLang($iLang, current($oRs->fields))) {
+                if ($oCat->loadInLang($iLang, \current($oRs->fields))) {
                     if ($sMainCatId == $oCat->getId()) {
                         $sSuffix = \OxidEsales\Eshop\Core\Registry::getLang()->translateString('(main category)', $this->getEditLang());
                         $sTitleField = 'oxcategories__oxtitle';

--- a/source/Application/Controller/Admin/ArticleStock.php
+++ b/source/Application/Controller/Admin/ArticleStock.php
@@ -43,7 +43,7 @@ class ArticleStock extends \OxidEsales\Eshop\Application\Controller\Admin\AdminD
             $oOtherLang = $oArticle->getAvailableInLangs();
             if (!isset($oOtherLang[$this->_iEditLang])) {
                 // echo "language entry doesn't exist! using: ".key($oOtherLang);
-                $oArticle->loadInLang(key($oOtherLang), $soxId);
+                $oArticle->loadInLang(\key($oOtherLang), $soxId);
             }
 
             foreach ($oOtherLang as $id => $language) {
@@ -138,17 +138,17 @@ class ArticleStock extends \OxidEsales\Eshop\Application\Controller\Admin\AdminD
 
         $aParams = \OxidEsales\Eshop\Core\Registry::getConfig()->getRequestParameter("editval");
 
-        if (!is_array($aParams)) {
+        if (!\is_array($aParams)) {
             return;
         }
 
-        if (isset($aUpdateParams) && is_array($aUpdateParams)) {
-            $aParams = array_merge($aParams, $aUpdateParams);
+        if (isset($aUpdateParams) && \is_array($aUpdateParams)) {
+            $aParams = \array_merge($aParams, $aUpdateParams);
         }
 
         //replacing commas
         foreach ($aParams as $key => $sParam) {
-            $aParams[$key] = str_replace(",", ".", $sParam);
+            $aParams[$key] = \str_replace(",", ".", $sParam);
         }
 
         $aParams['oxprice2article__oxshopid'] = $myConfig->getShopID();
@@ -163,8 +163,8 @@ class ArticleStock extends \OxidEsales\Eshop\Application\Controller\Admin\AdminD
         }
 
         if (!$myConfig->getConfigParam('blAllowUnevenAmounts')) {
-            $aParams['oxprice2article__oxamount'] = round((string) $aParams['oxprice2article__oxamount']);
-            $aParams['oxprice2article__oxamountto'] = round((string) $aParams['oxprice2article__oxamountto']);
+            $aParams['oxprice2article__oxamount'] = \round((string) $aParams['oxprice2article__oxamount']);
+            $aParams['oxprice2article__oxamountto'] = \round((string) $aParams['oxprice2article__oxamountto']);
         }
 
         $dPrice = $aParams['price'];
@@ -181,9 +181,9 @@ class ArticleStock extends \OxidEsales\Eshop\Application\Controller\Admin\AdminD
             $oArticlePrice->$sType->value &&
             $oArticlePrice->oxprice2article__oxamount->value &&
             $oArticlePrice->oxprice2article__oxamountto->value &&
-            is_numeric($oArticlePrice->$sType->value) &&
-            is_numeric($oArticlePrice->oxprice2article__oxamount->value) &&
-            is_numeric($oArticlePrice->oxprice2article__oxamountto->value) &&
+            \is_numeric($oArticlePrice->$sType->value) &&
+            \is_numeric($oArticlePrice->oxprice2article__oxamount->value) &&
+            \is_numeric($oArticlePrice->oxprice2article__oxamountto->value) &&
             $oArticlePrice->oxprice2article__oxamount->value <= $oArticlePrice->oxprice2article__oxamountto->value
         ) {
             $oArticlePrice->save();
@@ -197,7 +197,7 @@ class ArticleStock extends \OxidEsales\Eshop\Application\Controller\Admin\AdminD
             ($aParams['price'] >= $oArticle->$sPriceField->value) &&
             ($aParams['pricetype'] == 'oxprice2article__oxaddabs')
         ) {
-            if (is_null($sOXID)) {
+            if (\is_null($sOXID)) {
                 $sOXID = $oArticlePrice->getId();
             }
             $this->_aViewData["errorscaleprice"][] = $sOXID;
@@ -210,7 +210,7 @@ class ArticleStock extends \OxidEsales\Eshop\Application\Controller\Admin\AdminD
     public function updateprices()
     {
         $aParams = \OxidEsales\Eshop\Core\Registry::getConfig()->getRequestParameter("updateval");
-        if (is_array($aParams)) {
+        if (\is_array($aParams)) {
             foreach ($aParams as $soxId => $aStockParams) {
                 $this->addprice($soxId, $aStockParams);
             }

--- a/source/Application/Controller/Admin/ArticleVariant.php
+++ b/source/Application/Controller/Admin/ArticleVariant.php
@@ -65,7 +65,7 @@ class ArticleVariant extends \OxidEsales\Eshop\Application\Controller\Admin\Admi
             $oOtherLang = $oArticle->getAvailableInLangs();
             if (!isset($oOtherLang[$this->_iEditLang])) {
                 // echo "language entry doesn't exist! using: ".key($oOtherLang);
-                $oArticle->loadInLang(key($oOtherLang), $soxId);
+                $oArticle->loadInLang(\key($oOtherLang), $soxId);
             }
 
             foreach ($oOtherLang as $id => $language) {
@@ -84,8 +84,8 @@ class ArticleVariant extends \OxidEsales\Eshop\Application\Controller\Admin\Admi
             }
             $this->_aViewData["editlanguage"] = $this->_iEditLang;
 
-            $aLang = array_diff(\OxidEsales\Eshop\Core\Registry::getLang()->getLanguageNames(), $oOtherLang);
-            if (count($aLang)) {
+            $aLang = \array_diff(\OxidEsales\Eshop\Core\Registry::getLang()->getLanguageNames(), $oOtherLang);
+            if (\count($aLang)) {
                 $this->_aViewData["posslang"] = $aLang;
             }
 
@@ -130,7 +130,7 @@ class ArticleVariant extends \OxidEsales\Eshop\Application\Controller\Admin\Admi
         }
 
         // checkbox handling
-        if (is_array($aParams) && !isset($aParams['oxarticles__oxactive'])) {
+        if (\is_array($aParams) && !isset($aParams['oxarticles__oxactive'])) {
             $aParams['oxarticles__oxactive'] = 0;
         }
 
@@ -168,7 +168,7 @@ class ArticleVariant extends \OxidEsales\Eshop\Application\Controller\Admin\Admi
      */
     protected function _isAnythingChanged($oProduct, $aData) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
-        if (!is_array($aData)) {
+        if (!\is_array($aData)) {
             return true;
         }
         foreach ($aData as $sKey => $sValue) {
@@ -210,7 +210,7 @@ class ArticleVariant extends \OxidEsales\Eshop\Application\Controller\Admin\Admi
     public function savevariants()
     {
         $aParams = \OxidEsales\Eshop\Core\Registry::getConfig()->getRequestParameter("editval");
-        if (is_array($aParams)) {
+        if (\is_array($aParams)) {
             foreach ($aParams as $soxId => $aVarParams) {
                 $this->savevariant($soxId, $aVarParams);
             }

--- a/source/Application/Controller/Admin/AttributeCategoryAjax.php
+++ b/source/Application/Controller/Admin/AttributeCategoryAjax.php
@@ -91,8 +91,8 @@ class AttributeCategoryAjax extends \OxidEsales\Eshop\Application\Controller\Adm
         if (\OxidEsales\Eshop\Core\Registry::getConfig()->getRequestParameter('all')) {
             $sQ = $this->_addFilter("delete oxcategory2attribute.* " . $this->_getQuery());
             \OxidEsales\Eshop\Core\DatabaseProvider::getDb()->Execute($sQ);
-        } elseif (is_array($aChosenCat)) {
-            $sChosenCategories = implode(", ", \OxidEsales\Eshop\Core\DatabaseProvider::getDb()->quoteArray($aChosenCat));
+        } elseif (\is_array($aChosenCat)) {
+            $sChosenCategories = \implode(", ", \OxidEsales\Eshop\Core\DatabaseProvider::getDb()->quoteArray($aChosenCat));
             $sQ = "delete from oxcategory2attribute where oxcategory2attribute.oxid in (" . $sChosenCategories . ") ";
             \OxidEsales\Eshop\Core\DatabaseProvider::getDb()->Execute($sQ);
         }
@@ -117,7 +117,7 @@ class AttributeCategoryAjax extends \OxidEsales\Eshop\Application\Controller\Adm
             $aAddCategory = $this->_getAll($this->_addFilter("select $sCatTable.oxid " . $this->_getQuery()));
         }
 
-        if ($oAttribute->load($soxId) && is_array($aAddCategory)) {
+        if ($oAttribute->load($soxId) && \is_array($aAddCategory)) {
             // We force reading from master to prevent issues with slow replications or open transactions (see ESDEV-3804 and ESDEV-3822).
             $database = \OxidEsales\Eshop\Core\DatabaseProvider::getMaster();
             foreach ($aAddCategory as $sAdd) {

--- a/source/Application/Controller/Admin/AttributeMain.php
+++ b/source/Application/Controller/Admin/AttributeMain.php
@@ -48,12 +48,12 @@ class AttributeMain extends \OxidEsales\Eshop\Application\Controller\Admin\Admin
             $oOtherLang = $oAttr->getAvailableInLangs();
             if (!isset($oOtherLang[$this->_iEditLang])) {
                 // echo "language entry doesn't exist! using: ".key($oOtherLang);
-                $oAttr->loadInLang(key($oOtherLang), $soxId);
+                $oAttr->loadInLang(\key($oOtherLang), $soxId);
             }
 
             // remove already created languages
-            $aLang = array_diff(\OxidEsales\Eshop\Core\Registry::getLang()->getLanguageNames(), $oOtherLang);
-            if (count($aLang)) {
+            $aLang = \array_diff(\OxidEsales\Eshop\Core\Registry::getLang()->getLanguageNames(), $oOtherLang);
+            if (\count($aLang)) {
                 $this->_aViewData["posslang"] = $aLang;
             }
 

--- a/source/Application/Controller/Admin/AttributeMainAjax.php
+++ b/source/Application/Controller/Admin/AttributeMainAjax.php
@@ -133,8 +133,8 @@ class AttributeMainAjax extends \OxidEsales\Eshop\Application\Controller\Admin\L
 
             $sQ = parent::_addFilter("delete $sO2AttributeView.* " . $this->_getQuery());
             \OxidEsales\Eshop\Core\DatabaseProvider::getDb()->Execute($sQ);
-        } elseif (is_array($aChosenCat)) {
-            $sChosenCategories = implode(", ", \OxidEsales\Eshop\Core\DatabaseProvider::getDb()->quoteArray($aChosenCat));
+        } elseif (\is_array($aChosenCat)) {
+            $sChosenCategories = \implode(", ", \OxidEsales\Eshop\Core\DatabaseProvider::getDb()->quoteArray($aChosenCat));
             $sQ = "delete from oxobject2attribute where oxobject2attribute.oxid in (" . $sChosenCategories . ") ";
             \OxidEsales\Eshop\Core\DatabaseProvider::getDb()->Execute($sQ);
         }
@@ -156,7 +156,7 @@ class AttributeMainAjax extends \OxidEsales\Eshop\Application\Controller\Admin\L
 
         $oAttribute = oxNew(\OxidEsales\Eshop\Application\Model\Attribute::class);
 
-        if ($oAttribute->load($soxId) && is_array($aAddArticle)) {
+        if ($oAttribute->load($soxId) && \is_array($aAddArticle)) {
             foreach ($aAddArticle as $sAdd) {
                 $oNewGroup = oxNew(\OxidEsales\Eshop\Core\Model\BaseModel::class);
                 $oNewGroup->init("oxobject2attribute");

--- a/source/Application/Controller/Admin/AttributeOrderAjax.php
+++ b/source/Application/Controller/Admin/AttributeOrderAjax.php
@@ -80,7 +80,7 @@ class AttributeOrderAjax extends \OxidEsales\Eshop\Application\Controller\Admin\
             $iSelCnt++;
         }
         //
-        if (($iKey = array_search(\OxidEsales\Eshop\Core\Registry::getConfig()->getRequestParameter('sortoxid'), $aIdx2Id)) !== false) {
+        if (($iKey = \array_search(\OxidEsales\Eshop\Core\Registry::getConfig()->getRequestParameter('sortoxid'), $aIdx2Id)) !== false) {
             $iDir = (\OxidEsales\Eshop\Core\Registry::getConfig()->getRequestParameter('direction') == 'up') ? ($iKey - 1) : ($iKey + 1);
             if (isset($aIdx2Id[$iDir])) {
                 // exchanging indexes

--- a/source/Application/Controller/Admin/CategoryList.php
+++ b/source/Application/Controller/Admin/CategoryList.php
@@ -89,7 +89,7 @@ class CategoryList extends \OxidEsales\Eshop\Application\Controller\Admin\AdminL
 
         $oCatTree->assign($aNewList);
         $aFilter = $this->getListFilter();
-        if (is_array($aFilter) && isset($aFilter["oxcategories"]["oxparentid"])) {
+        if (\is_array($aFilter) && isset($aFilter["oxcategories"]["oxparentid"])) {
             foreach ($oCatTree as $oCategory) {
                 if ($oCategory->oxcategories__oxid->value == $aFilter["oxcategories"]["oxparentid"]) {
                     $oCategory->selected = 1;

--- a/source/Application/Controller/Admin/CategoryMain.php
+++ b/source/Application/Controller/Admin/CategoryMain.php
@@ -63,12 +63,12 @@ class CategoryMain extends \OxidEsales\Eshop\Application\Controller\Admin\AdminD
             $oOtherLang = $oCategory->getAvailableInLangs();
             if (!isset($oOtherLang[$this->_iEditLang])) {
                 // echo "language entry doesn't exist! using: ".key($oOtherLang);
-                $oCategory->loadInLang(key($oOtherLang), $categoryId);
+                $oCategory->loadInLang(\key($oOtherLang), $categoryId);
             }
 
             // remove already created languages
-            $aLang = array_diff(\OxidEsales\Eshop\Core\Registry::getLang()->getLanguageNames(), $oOtherLang);
-            if (count($aLang)) {
+            $aLang = \array_diff(\OxidEsales\Eshop\Core\Registry::getLang()->getLanguageNames(), $oOtherLang);
+            if (\count($aLang)) {
                 $this->_aViewData["posslang"] = $aLang;
             }
 
@@ -124,9 +124,9 @@ class CategoryMain extends \OxidEsales\Eshop\Application\Controller\Admin\AdminD
         ];
         /** @var \OxidEsales\Eshop\Core\DbMetaDataHandler $oDbHandler */
         $oDbHandler = oxNew(\OxidEsales\Eshop\Core\DbMetaDataHandler::class);
-        $aFields = array_merge($oDbHandler->getMultilangFields('oxarticles'), array_keys($oDbHandler->getSinglelangFields('oxarticles', 0)));
-        $aFields = array_diff($aFields, $aSkipFields);
-        $aFields = array_unique($aFields);
+        $aFields = \array_merge($oDbHandler->getMultilangFields('oxarticles'), \array_keys($oDbHandler->getSinglelangFields('oxarticles', 0)));
+        $aFields = \array_diff($aFields, $aSkipFields);
+        $aFields = \array_unique($aFields);
 
         return $aFields;
     }
@@ -179,7 +179,7 @@ class CategoryMain extends \OxidEsales\Eshop\Application\Controller\Admin\AdminD
     protected function _processLongDesc($sValue) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         // workaround for firefox showing &lang= as &9001;= entity, mantis#0001272
-        return str_replace('&lang=', '&amp;lang=', $sValue);
+        return \str_replace('&lang=', '&amp;lang=', $sValue);
     }
 
     /**

--- a/source/Application/Controller/Admin/CategoryMainAjax.php
+++ b/source/Application/Controller/Admin/CategoryMainAjax.php
@@ -133,7 +133,7 @@ class CategoryMainAjax extends \OxidEsales\Eshop\Application\Controller\Admin\Li
                 $aArticles = $this->_getAll($this->_addFilter("select $sArticleTable.oxid " . $this->_getQuery()));
             }
 
-            if (is_array($aArticles)) {
+            if (\is_array($aArticles)) {
                 $sO2CView = $this->_getViewName('oxobject2category');
 
                 $oNew = oxNew(\OxidEsales\Eshop\Application\Model\Object2Category::class);
@@ -147,10 +147,10 @@ class CategoryMainAjax extends \OxidEsales\Eshop\Application\Controller\Admin\Li
                         continue;
                     }
 
-                    $oNew->oxobject2category__oxid = new \OxidEsales\Eshop\Core\Field($oNew->setId(md5($sAdd . $sCategoryID . $sShopID)));
+                    $oNew->oxobject2category__oxid = new \OxidEsales\Eshop\Core\Field($oNew->setId(\md5($sAdd . $sCategoryID . $sShopID)));
                     $oNew->oxobject2category__oxobjectid = new \OxidEsales\Eshop\Core\Field($sAdd);
                     $oNew->oxobject2category__oxcatnid = new \OxidEsales\Eshop\Core\Field($sCategoryID);
-                    $oNew->oxobject2category__oxtime = new \OxidEsales\Eshop\Core\Field(time());
+                    $oNew->oxobject2category__oxtime = new \OxidEsales\Eshop\Core\Field(\time());
 
                     $oNew->save();
 
@@ -236,7 +236,7 @@ class CategoryMainAjax extends \OxidEsales\Eshop\Application\Controller\Admin\Li
         }
 
         // adding
-        if (is_array($aArticles) && count($aArticles)) {
+        if (\is_array($aArticles) && \count($aArticles)) {
             $this->removeCategoryArticles($aArticles, $sCategoryID);
         }
 
@@ -258,7 +258,7 @@ class CategoryMainAjax extends \OxidEsales\Eshop\Application\Controller\Admin\Li
     protected function removeCategoryArticles($articles, $categoryID)
     {
         $db = \OxidEsales\Eshop\Core\DatabaseProvider::getDb();
-        $prodIds = implode(", ", \OxidEsales\Eshop\Core\DatabaseProvider::getDb()->quoteArray($articles));
+        $prodIds = \implode(", ", \OxidEsales\Eshop\Core\DatabaseProvider::getDb()->quoteArray($articles));
 
         $delete = "delete from oxobject2category ";
         $where = $this->getRemoveCategoryArticlesQueryFilter($categoryID, $prodIds);

--- a/source/Application/Controller/Admin/CategoryOrderAjax.php
+++ b/source/Application/Controller/Admin/CategoryOrderAjax.php
@@ -59,13 +59,13 @@ class CategoryOrderAjax extends \OxidEsales\Eshop\Application\Controller\Admin\L
         if ($sSynchOxid = \OxidEsales\Eshop\Core\Registry::getConfig()->getRequestParameter('synchoxid')) {
             $sQAdd = " from $sArtTable left join $sO2CView on $sArtTable.oxid=$sO2CView.oxobjectid where $sO2CView.oxcatnid = " . $oDb->quote($sSynchOxid);
             if ($aSkipArt = \OxidEsales\Eshop\Core\Registry::getSession()->getVariable('neworder_sess')) {
-                $sQAdd .= " and $sArtTable.oxid not in ( " . implode(", ", DatabaseProvider::getDb()->quoteArray($aSkipArt)) . " ) ";
+                $sQAdd .= " and $sArtTable.oxid not in ( " . \implode(", ", DatabaseProvider::getDb()->quoteArray($aSkipArt)) . " ) ";
             }
         } else {
             // which fields to load ?
             $sQAdd = " from $sArtTable where ";
             if ($aSkipArt = \OxidEsales\Eshop\Core\Registry::getSession()->getVariable('neworder_sess')) {
-                $sQAdd .= " $sArtTable.oxid in ( " . implode(", ", DatabaseProvider::getDb()->quoteArray($aSkipArt)) . " ) ";
+                $sQAdd .= " $sArtTable.oxid in ( " . \implode(", ", DatabaseProvider::getDb()->quoteArray($aSkipArt)) . " ) ";
             } else {
                 $sQAdd .= " 1 = 0 ";
             }
@@ -108,9 +108,9 @@ class CategoryOrderAjax extends \OxidEsales\Eshop\Application\Controller\Admin\L
         $soxId = \OxidEsales\Eshop\Core\Registry::getConfig()->getRequestParameter('oxid');
         $aSkipArt = \OxidEsales\Eshop\Core\Registry::getSession()->getVariable('neworder_sess');
 
-        if (is_array($aRemoveArt) && is_array($aSkipArt)) {
+        if (\is_array($aRemoveArt) && \is_array($aSkipArt)) {
             foreach ($aRemoveArt as $sRem) {
-                if (($iKey = array_search($sRem, $aSkipArt)) !== false) {
+                if (($iKey = \array_search($sRem, $aSkipArt)) !== false) {
                     unset($aSkipArt[$iKey]);
                 }
             }
@@ -122,9 +122,9 @@ class CategoryOrderAjax extends \OxidEsales\Eshop\Application\Controller\Admin\L
             // checking if all articles were moved from one
             $sSelect = "select 1 from $sArticleTable left join $sO2CView on $sArticleTable.oxid=$sO2CView.oxobjectid ";
             $sSelect .= "where $sO2CView.oxcatnid = :oxcatnid";
-            if (count($aSkipArt)) {
+            if (\count($aSkipArt)) {
                 $sSelect .= " and $sArticleTable.oxparentid = '' and $sArticleTable.oxid ";
-                $sSelect .= "not in ( " . implode(", ", DatabaseProvider::getDb()->quoteArray($aSkipArt)) . " ) ";
+                $sSelect .= "not in ( " . \implode(", ", DatabaseProvider::getDb()->quoteArray($aSkipArt)) . " ) ";
             }
 
             // simply echoing "1" if some items found, and 0 if nothing was found
@@ -144,14 +144,14 @@ class CategoryOrderAjax extends \OxidEsales\Eshop\Application\Controller\Admin\L
         $soxId = \OxidEsales\Eshop\Core\Registry::getConfig()->getRequestParameter('synchoxid');
 
         $aOrdArt = \OxidEsales\Eshop\Core\Registry::getSession()->getVariable('neworder_sess');
-        if (!is_array($aOrdArt)) {
+        if (!\is_array($aOrdArt)) {
             $aOrdArt = [];
         }
 
-        if (is_array($aAddArticle)) {
+        if (\is_array($aAddArticle)) {
             // storing newly ordered article seq.
             foreach ($aAddArticle as $sAdd) {
-                if (array_search($sAdd, $aOrdArt) === false) {
+                if (\array_search($sAdd, $aOrdArt) === false) {
                     $aOrdArt[] = $sAdd;
                 }
             }
@@ -163,7 +163,7 @@ class CategoryOrderAjax extends \OxidEsales\Eshop\Application\Controller\Admin\L
             // checking if all articles were moved from one
             $sSelect = "select 1 from $sArticleTable left join $sO2CView on $sArticleTable.oxid=$sO2CView.oxobjectid ";
             $sSelect .= "where $sO2CView.oxcatnid = :oxcatnid and $sArticleTable.oxparentid = '' and $sArticleTable.oxid ";
-            $sSelect .= "not in ( " . implode(", ", DatabaseProvider::getDb()->quoteArray($aOrdArt)) . " ) ";
+            $sSelect .= "not in ( " . \implode(", ", DatabaseProvider::getDb()->quoteArray($aOrdArt)) . " ) ";
 
             // simply echoing "1" if some items found, and 0 if nothing was found
             // We force reading from master to prevent issues with slow replications or open transactions (see ESDEV-3804).
@@ -191,9 +191,9 @@ class CategoryOrderAjax extends \OxidEsales\Eshop\Application\Controller\Admin\L
             $this->resetContentCache();
 
             $aNewOrder = \OxidEsales\Eshop\Core\Registry::getSession()->getVariable("neworder_sess");
-            if (is_array($aNewOrder) && count($aNewOrder)) {
+            if (\is_array($aNewOrder) && \count($aNewOrder)) {
                 $sO2CView = $this->_getViewName('oxobject2category');
-                $sSelect = "select * from $sO2CView where $sO2CView.oxcatnid = :oxcatnid and $sO2CView.oxobjectid in (" . implode(", ", DatabaseProvider::getDb()->quoteArray($aNewOrder)) . " )";
+                $sSelect = "select * from $sO2CView where $sO2CView.oxcatnid = :oxcatnid and $sO2CView.oxobjectid in (" . \implode(", ", DatabaseProvider::getDb()->quoteArray($aNewOrder)) . " )";
                 $oList = oxNew(\OxidEsales\Eshop\Core\Model\ListModel::class);
                 $oList->init("oxbase", "oxobject2category");
                 $oList->selectString($sSelect, [
@@ -202,7 +202,7 @@ class CategoryOrderAjax extends \OxidEsales\Eshop\Application\Controller\Admin\L
 
                 // setting new position
                 foreach ($oList as $oObj) {
-                    if (($iNewPos = array_search($oObj->oxobject2category__oxobjectid->value, $aNewOrder)) !== false) {
+                    if (($iNewPos = \array_search($oObj->oxobject2category__oxobjectid->value, $aNewOrder)) !== false) {
                         $oObj->oxobject2category__oxpos->setValue($iNewPos);
                         $oObj->save();
                     }

--- a/source/Application/Controller/Admin/ContentMain.php
+++ b/source/Application/Controller/Admin/ContentMain.php
@@ -46,12 +46,12 @@ class ContentMain extends \OxidEsales\Eshop\Application\Controller\Admin\AdminDe
             $oOtherLang = $oContent->getAvailableInLangs();
             if (!isset($oOtherLang[$this->_iEditLang])) {
                 // echo "language entry doesn't exist! using: ".key($oOtherLang);
-                $oContent->loadInLang(key($oOtherLang), $soxId);
+                $oContent->loadInLang(\key($oOtherLang), $soxId);
             }
 
             // remove already created languages
-            $aLang = array_diff(\OxidEsales\Eshop\Core\Registry::getLang()->getLanguageNames(), $oOtherLang);
-            if (count($aLang)) {
+            $aLang = \array_diff(\OxidEsales\Eshop\Core\Registry::getLang()->getLanguageNames(), $oOtherLang);
+            if (\count($aLang)) {
                 $this->_aViewData["posslang"] = $aLang;
             }
             foreach ($oOtherLang as $id => $language) {
@@ -223,7 +223,7 @@ class ContentMain extends \OxidEsales\Eshop\Application\Controller\Admin\AdminDe
         $blAllow = false;
 
         // null not allowed
-        if (!strlen($sIdent)) {
+        if (!\strlen($sIdent)) {
             $blAllow = true;
         // We force reading from master to prevent issues with slow replications or open transactions (see ESDEV-3804).
         } elseif (

--- a/source/Application/Controller/Admin/CountryList.php
+++ b/source/Application/Controller/Admin/CountryList.php
@@ -63,7 +63,7 @@ class CountryList extends \OxidEsales\Eshop\Application\Controller\Admin\AdminLi
     {
         $aListSorting = parent::getListSorting();
 
-        if (array_keys($aListSorting['oxcountry']) === ['oxactive']) {
+        if (\array_keys($aListSorting['oxcountry']) === ['oxactive']) {
             $aListSorting['oxcountry'][$this->_getSecondSortFieldName()] = 'asc';
         }
 

--- a/source/Application/Controller/Admin/CountryMain.php
+++ b/source/Application/Controller/Admin/CountryMain.php
@@ -42,13 +42,13 @@ class CountryMain extends \OxidEsales\Eshop\Application\Controller\Admin\AdminDe
             $oOtherLang = $oCountry->getAvailableInLangs();
             if (!isset($oOtherLang[$this->_iEditLang])) {
                 // echo "language entry doesn't exist! using: ".key($oOtherLang);
-                $oCountry->loadInLang(key($oOtherLang), $soxId);
+                $oCountry->loadInLang(\key($oOtherLang), $soxId);
             }
             $this->_aViewData["edit"] = $oCountry;
 
             // remove already created languages
-            $aLang = array_diff(\OxidEsales\Eshop\Core\Registry::getLang()->getLanguageNames(), $oOtherLang);
-            if (count($aLang)) {
+            $aLang = \array_diff(\OxidEsales\Eshop\Core\Registry::getLang()->getLanguageNames(), $oOtherLang);
+            if (\count($aLang)) {
                 $this->_aViewData["posslang"] = $aLang;
             }
 

--- a/source/Application/Controller/Admin/DeliveryArticlesAjax.php
+++ b/source/Application/Controller/Admin/DeliveryArticlesAjax.php
@@ -119,8 +119,8 @@ class DeliveryArticlesAjax extends \OxidEsales\Eshop\Application\Controller\Admi
         if (\OxidEsales\Eshop\Core\Registry::getConfig()->getRequestParameter('all')) {
             $sQ = parent::_addFilter("delete oxobject2delivery.* " . $this->_getQuery());
             \OxidEsales\Eshop\Core\DatabaseProvider::getDb()->Execute($sQ);
-        } elseif (is_array($aChosenArt)) {
-            $sQ = "delete from oxobject2delivery where oxobject2delivery.oxid in (" . implode(", ", \OxidEsales\Eshop\Core\DatabaseProvider::getDb()->quoteArray($aChosenArt)) . ") ";
+        } elseif (\is_array($aChosenArt)) {
+            $sQ = "delete from oxobject2delivery where oxobject2delivery.oxid in (" . \implode(", ", \OxidEsales\Eshop\Core\DatabaseProvider::getDb()->quoteArray($aChosenArt)) . ") ";
             \OxidEsales\Eshop\Core\DatabaseProvider::getDb()->Execute($sQ);
         }
     }
@@ -139,7 +139,7 @@ class DeliveryArticlesAjax extends \OxidEsales\Eshop\Application\Controller\Admi
             $aChosenArt = $this->_getAll($this->_addFilter("select $sArtTable.oxid " . $this->_getQuery()));
         }
 
-        if ($soxId && $soxId != "-1" && is_array($aChosenArt)) {
+        if ($soxId && $soxId != "-1" && \is_array($aChosenArt)) {
             foreach ($aChosenArt as $sChosenArt) {
                 $oObject2Delivery = oxNew(\OxidEsales\Eshop\Core\Model\BaseModel::class);
                 $oObject2Delivery->init('oxobject2delivery');

--- a/source/Application/Controller/Admin/DeliveryCategoriesAjax.php
+++ b/source/Application/Controller/Admin/DeliveryCategoriesAjax.php
@@ -65,7 +65,7 @@ class DeliveryCategoriesAjax extends \OxidEsales\Eshop\Application\Controller\Ad
                           "on {$sCatTable}.oxid=oxobject2delivery.oxobjectid " .
                           " where oxobject2delivery.oxdeliveryid = " . $oDb->quote($sSynchDelId) .
                           " and oxobject2delivery.oxtype = 'oxcategories' ";
-            if (stristr($sQAdd, 'where') === false) {
+            if (\stristr($sQAdd, 'where') === false) {
                 $sQAdd .= ' where ';
             } else {
                 $sQAdd .= ' and ';
@@ -87,8 +87,8 @@ class DeliveryCategoriesAjax extends \OxidEsales\Eshop\Application\Controller\Ad
         if (\OxidEsales\Eshop\Core\Registry::getConfig()->getRequestParameter('all')) {
             $sQ = $this->_addFilter("delete oxobject2delivery.* " . $this->_getQuery());
             \OxidEsales\Eshop\Core\DatabaseProvider::getDb()->Execute($sQ);
-        } elseif (is_array($aChosenCat)) {
-            $sChosenCategoriess = implode(", ", \OxidEsales\Eshop\Core\DatabaseProvider::getDb()->quoteArray($aChosenCat));
+        } elseif (\is_array($aChosenCat)) {
+            $sChosenCategoriess = \implode(", ", \OxidEsales\Eshop\Core\DatabaseProvider::getDb()->quoteArray($aChosenCat));
             $sQ = "delete from oxobject2delivery where oxobject2delivery.oxid in (" . $sChosenCategoriess . ") ";
             \OxidEsales\Eshop\Core\DatabaseProvider::getDb()->Execute($sQ);
         }

--- a/source/Application/Controller/Admin/DeliveryGroupsAjax.php
+++ b/source/Application/Controller/Admin/DeliveryGroupsAjax.php
@@ -79,8 +79,8 @@ class DeliveryGroupsAjax extends \OxidEsales\Eshop\Application\Controller\Admin\
         if (\OxidEsales\Eshop\Core\Registry::getConfig()->getRequestParameter('all')) {
             $sQ = $this->_addFilter("delete oxobject2delivery.* " . $this->_getQuery());
             \OxidEsales\Eshop\Core\DatabaseProvider::getDb()->Execute($sQ);
-        } elseif ($aRemoveGroups && is_array($aRemoveGroups)) {
-            $sRemoveGroups = implode(", ", \OxidEsales\Eshop\Core\DatabaseProvider::getDb()->quoteArray($aRemoveGroups));
+        } elseif ($aRemoveGroups && \is_array($aRemoveGroups)) {
+            $sRemoveGroups = \implode(", ", \OxidEsales\Eshop\Core\DatabaseProvider::getDb()->quoteArray($aRemoveGroups));
             $sQ = "delete from oxobject2delivery where oxobject2delivery.oxid in (" . $sRemoveGroups . ") ";
             \OxidEsales\Eshop\Core\DatabaseProvider::getDb()->Execute($sQ);
         }
@@ -100,7 +100,7 @@ class DeliveryGroupsAjax extends \OxidEsales\Eshop\Application\Controller\Admin\
             $aChosenCat = $this->_getAll($this->_addFilter("select $sGroupTable.oxid " . $this->_getQuery()));
         }
 
-        if ($soxId && $soxId != "-1" && is_array($aChosenCat)) {
+        if ($soxId && $soxId != "-1" && \is_array($aChosenCat)) {
             foreach ($aChosenCat as $sChosenCat) {
                 $oObject2Delivery = oxNew(\OxidEsales\Eshop\Core\Model\BaseModel::class);
                 $oObject2Delivery->init('oxobject2delivery');

--- a/source/Application/Controller/Admin/DeliveryMain.php
+++ b/source/Application/Controller/Admin/DeliveryMain.php
@@ -46,7 +46,7 @@ class DeliveryMain extends \OxidEsales\Eshop\Application\Controller\Admin\AdminD
             $oOtherLang = $oDelivery->getAvailableInLangs();
             if (!isset($oOtherLang[$this->_iEditLang])) {
                 // echo "language entry doesn't exist! using: ".key($oOtherLang);
-                $oDelivery->loadInLang(key($oOtherLang), $soxId);
+                $oDelivery->loadInLang(\key($oOtherLang), $soxId);
             }
 
             $this->_aViewData["edit"] = $oDelivery;
@@ -57,8 +57,8 @@ class DeliveryMain extends \OxidEsales\Eshop\Application\Controller\Admin\AdminD
             }
 
             // remove already created languages
-            $aLang = array_diff($oLang->getLanguageNames(), $oOtherLang);
-            if (count($aLang)) {
+            $aLang = \array_diff($oLang->getLanguageNames(), $oOtherLang);
+            if (\count($aLang)) {
                 $this->_aViewData["posslang"] = $aLang;
             }
 

--- a/source/Application/Controller/Admin/DeliveryMainAjax.php
+++ b/source/Application/Controller/Admin/DeliveryMainAjax.php
@@ -79,8 +79,8 @@ class DeliveryMainAjax extends \OxidEsales\Eshop\Application\Controller\Admin\Li
         if (\OxidEsales\Eshop\Core\Registry::getConfig()->getRequestParameter('all')) {
             $sQ = $this->_addFilter("delete oxobject2delivery.* " . $this->_getQuery());
             \OxidEsales\Eshop\Core\DatabaseProvider::getDb()->Execute($sQ);
-        } elseif (is_array($aChosenCntr)) {
-            $sQ = "delete from oxobject2delivery where oxobject2delivery.oxid in (" . implode(", ", \OxidEsales\Eshop\Core\DatabaseProvider::getDb()->quoteArray($aChosenCntr)) . ") ";
+        } elseif (\is_array($aChosenCntr)) {
+            $sQ = "delete from oxobject2delivery where oxobject2delivery.oxid in (" . \implode(", ", \OxidEsales\Eshop\Core\DatabaseProvider::getDb()->quoteArray($aChosenCntr)) . ") ";
             \OxidEsales\Eshop\Core\DatabaseProvider::getDb()->Execute($sQ);
         }
     }
@@ -99,7 +99,7 @@ class DeliveryMainAjax extends \OxidEsales\Eshop\Application\Controller\Admin\Li
             $aChosenCntr = $this->_getAll($this->_addFilter("select $sCountryTable.oxid " . $this->_getQuery()));
         }
 
-        if ($soxId && $soxId != "-1" && is_array($aChosenCntr)) {
+        if ($soxId && $soxId != "-1" && \is_array($aChosenCntr)) {
             foreach ($aChosenCntr as $sChosenCntr) {
                 $oObject2Delivery = oxNew(\OxidEsales\Eshop\Core\Model\BaseModel::class);
                 $oObject2Delivery->init('oxobject2delivery');

--- a/source/Application/Controller/Admin/DeliverySetCountryAjax.php
+++ b/source/Application/Controller/Admin/DeliverySetCountryAjax.php
@@ -81,8 +81,8 @@ class DeliverySetCountryAjax extends \OxidEsales\Eshop\Application\Controller\Ad
         if (\OxidEsales\Eshop\Core\Registry::getConfig()->getRequestParameter('all')) {
             $sQ = $this->_addFilter("delete oxobject2delivery.* " . $this->_getQuery());
             \OxidEsales\Eshop\Core\DatabaseProvider::getDb()->Execute($sQ);
-        } elseif (is_array($aChosenCntr)) {
-            $sChosenCountries = implode(", ", \OxidEsales\Eshop\Core\DatabaseProvider::getDb()->quoteArray($aChosenCntr));
+        } elseif (\is_array($aChosenCntr)) {
+            $sChosenCountries = \implode(", ", \OxidEsales\Eshop\Core\DatabaseProvider::getDb()->quoteArray($aChosenCntr));
             $sQ = "delete from oxobject2delivery where oxobject2delivery.oxid in (" . $sChosenCountries . ") ";
             \OxidEsales\Eshop\Core\DatabaseProvider::getDb()->Execute($sQ);
         }
@@ -102,7 +102,7 @@ class DeliverySetCountryAjax extends \OxidEsales\Eshop\Application\Controller\Ad
             $aChosenCntr = $this->_getAll($this->_addFilter("select $sCountryTable.oxid " . $this->_getQuery()));
         }
 
-        if ($soxId && $soxId != "-1" && is_array($aChosenCntr)) {
+        if ($soxId && $soxId != "-1" && \is_array($aChosenCntr)) {
             foreach ($aChosenCntr as $sChosenCntr) {
                 $oObject2Delivery = oxNew(\OxidEsales\Eshop\Core\Model\BaseModel::class);
                 $oObject2Delivery->init('oxobject2delivery');

--- a/source/Application/Controller/Admin/DeliverySetGroupsAjax.php
+++ b/source/Application/Controller/Admin/DeliverySetGroupsAjax.php
@@ -76,8 +76,8 @@ class DeliverySetGroupsAjax extends \OxidEsales\Eshop\Application\Controller\Adm
         if (\OxidEsales\Eshop\Core\Registry::getConfig()->getRequestParameter('all')) {
             $sQ = $this->_addFilter("delete oxobject2delivery.* " . $this->_getQuery());
             \OxidEsales\Eshop\Core\DatabaseProvider::getDb()->Execute($sQ);
-        } elseif ($aRemoveGroups && is_array($aRemoveGroups)) {
-            $sRemoveGroups = implode(", ", \OxidEsales\Eshop\Core\DatabaseProvider::getDb()->quoteArray($aRemoveGroups));
+        } elseif ($aRemoveGroups && \is_array($aRemoveGroups)) {
+            $sRemoveGroups = \implode(", ", \OxidEsales\Eshop\Core\DatabaseProvider::getDb()->quoteArray($aRemoveGroups));
             $sQ = "delete from oxobject2delivery where oxobject2delivery.oxid in (" . $sRemoveGroups . ") ";
             \OxidEsales\Eshop\Core\DatabaseProvider::getDb()->Execute($sQ);
         }
@@ -96,7 +96,7 @@ class DeliverySetGroupsAjax extends \OxidEsales\Eshop\Application\Controller\Adm
             $sGroupTable = $this->_getViewName('oxgroups');
             $aChosenCat = $this->_getAll($this->_addFilter("select $sGroupTable.oxid " . $this->_getQuery()));
         }
-        if ($soxId && $soxId != "-1" && is_array($aChosenCat)) {
+        if ($soxId && $soxId != "-1" && \is_array($aChosenCat)) {
             foreach ($aChosenCat as $sChosenCat) {
                 $oObject2Delivery = oxNew(\OxidEsales\Eshop\Core\Model\BaseModel::class);
                 $oObject2Delivery->init('oxobject2delivery');

--- a/source/Application/Controller/Admin/DeliverySetMain.php
+++ b/source/Application/Controller/Admin/DeliverySetMain.php
@@ -38,7 +38,7 @@ class DeliverySetMain extends \OxidEsales\Eshop\Application\Controller\Admin\Adm
 
             if (!isset($oOtherLang[$this->_iEditLang])) {
                 // echo "language entry doesn't exist! using: ".key($oOtherLang);
-                $odeliveryset->loadInLang(key($oOtherLang), $soxId);
+                $odeliveryset->loadInLang(\key($oOtherLang), $soxId);
             }
 
             $this->_aViewData["edit"] = $odeliveryset;
@@ -47,8 +47,8 @@ class DeliverySetMain extends \OxidEsales\Eshop\Application\Controller\Admin\Adm
                 $this->_aViewData['readonly'] = true;
             }
             // remove already created languages
-            $aLang = array_diff(\OxidEsales\Eshop\Core\Registry::getLang()->getLanguageNames(), $oOtherLang);
-            if (count($aLang)) {
+            $aLang = \array_diff(\OxidEsales\Eshop\Core\Registry::getLang()->getLanguageNames(), $oOtherLang);
+            if (\count($aLang)) {
                 $this->_aViewData["posslang"] = $aLang;
             }
 

--- a/source/Application/Controller/Admin/DeliverySetMainAjax.php
+++ b/source/Application/Controller/Admin/DeliverySetMainAjax.php
@@ -75,8 +75,8 @@ class DeliverySetMainAjax extends \OxidEsales\Eshop\Application\Controller\Admin
         if (\OxidEsales\Eshop\Core\Registry::getConfig()->getRequestParameter('all')) {
             $sQ = $this->_addFilter("delete oxdel2delset.* " . $this->_getQuery());
             \OxidEsales\Eshop\Core\DatabaseProvider::getDb()->Execute($sQ);
-        } elseif ($aRemoveGroups && is_array($aRemoveGroups)) {
-            $sQ = "delete from oxdel2delset where oxdel2delset.oxid in (" . implode(", ", \OxidEsales\Eshop\Core\DatabaseProvider::getDb()->quoteArray($aRemoveGroups)) . ") ";
+        } elseif ($aRemoveGroups && \is_array($aRemoveGroups)) {
+            $sQ = "delete from oxdel2delset where oxdel2delset.oxid in (" . \implode(", ", \OxidEsales\Eshop\Core\DatabaseProvider::getDb()->quoteArray($aRemoveGroups)) . ") ";
             \OxidEsales\Eshop\Core\DatabaseProvider::getDb()->Execute($sQ);
         }
     }
@@ -96,7 +96,7 @@ class DeliverySetMainAjax extends \OxidEsales\Eshop\Application\Controller\Admin
             $sDeliveryViewName = $this->_getViewName('oxdelivery');
             $aChosenSets = $this->_getAll($this->_addFilter("select $sDeliveryViewName.oxid " . $this->_getQuery()));
         }
-        if ($soxId && $soxId != "-1" && is_array($aChosenSets)) {
+        if ($soxId && $soxId != "-1" && \is_array($aChosenSets)) {
             // We force reading from master to prevent issues with slow replications or open transactions (see ESDEV-3804 and ESDEV-3822).
             $database = \OxidEsales\Eshop\Core\DatabaseProvider::getMaster();
             foreach ($aChosenSets as $sChosenSet) {

--- a/source/Application/Controller/Admin/DeliverySetPayment.php
+++ b/source/Application/Controller/Admin/DeliverySetPayment.php
@@ -38,7 +38,7 @@ class DeliverySetPayment extends \OxidEsales\Eshop\Application\Controller\Admin\
 
             if (!isset($oOtherLang[$this->_iEditLang])) {
                 // echo "language entry doesn't exist! using: ".key($oOtherLang);
-                $odeliveryset->setLanguage(key($oOtherLang));
+                $odeliveryset->setLanguage(\key($oOtherLang));
                 $odeliveryset->load($soxId);
             }
 

--- a/source/Application/Controller/Admin/DeliverySetPaymentAjax.php
+++ b/source/Application/Controller/Admin/DeliverySetPaymentAjax.php
@@ -74,8 +74,8 @@ class DeliverySetPaymentAjax extends \OxidEsales\Eshop\Application\Controller\Ad
         if (\OxidEsales\Eshop\Core\Registry::getConfig()->getRequestParameter('all')) {
             $sQ = $this->_addFilter("delete oxobject2payment.* " . $this->_getQuery());
             \OxidEsales\Eshop\Core\DatabaseProvider::getDb()->Execute($sQ);
-        } elseif (is_array($aChosenCntr)) {
-            $sQ = "delete from oxobject2payment where oxobject2payment.oxid in (" . implode(", ", \OxidEsales\Eshop\Core\DatabaseProvider::getDb()->quoteArray($aChosenCntr)) . ") ";
+        } elseif (\is_array($aChosenCntr)) {
+            $sQ = "delete from oxobject2payment where oxobject2payment.oxid in (" . \implode(", ", \OxidEsales\Eshop\Core\DatabaseProvider::getDb()->quoteArray($aChosenCntr)) . ") ";
             \OxidEsales\Eshop\Core\DatabaseProvider::getDb()->Execute($sQ);
         }
     }
@@ -95,7 +95,7 @@ class DeliverySetPaymentAjax extends \OxidEsales\Eshop\Application\Controller\Ad
             $sPayTable = $this->_getViewName('oxpayments');
             $aChosenSets = $this->_getAll($this->_addFilter("select $sPayTable.oxid " . $this->_getQuery()));
         }
-        if ($soxId && $soxId != "-1" && is_array($aChosenSets)) {
+        if ($soxId && $soxId != "-1" && \is_array($aChosenSets)) {
             // We force reading from master to prevent issues with slow replications or open transactions (see ESDEV-3804 and ESDEV-3822).
             $database = \OxidEsales\Eshop\Core\DatabaseProvider::getMaster();
             foreach ($aChosenSets as $sChosenSet) {

--- a/source/Application/Controller/Admin/DeliverySetRdfa.php
+++ b/source/Application/Controller/Admin/DeliverySetRdfa.php
@@ -82,7 +82,7 @@ class DeliverySetRdfa extends \OxidEsales\Eshop\Application\Controller\Admin\Pay
             $oDelivery = new stdClass();
             $oDelivery->name = $sName;
             $oDelivery->type = $iType;
-            $oDelivery->checked = in_array($sName, $aAssignedRDFaDeliveries);
+            $oDelivery->checked = \in_array($sName, $aAssignedRDFaDeliveries);
             $aRDFaDeliveries[] = $oDelivery;
         }
 

--- a/source/Application/Controller/Admin/DeliverySetUsersAjax.php
+++ b/source/Application/Controller/Admin/DeliverySetUsersAjax.php
@@ -101,8 +101,8 @@ class DeliverySetUsersAjax extends \OxidEsales\Eshop\Application\Controller\Admi
         if (\OxidEsales\Eshop\Core\Registry::getConfig()->getRequestParameter('all')) {
             $sQ = $this->_addFilter("delete oxobject2delivery.* " . $this->_getQuery());
             \OxidEsales\Eshop\Core\DatabaseProvider::getDb()->Execute($sQ);
-        } elseif ($aRemoveGroups && is_array($aRemoveGroups)) {
-            $sQ = "delete from oxobject2delivery where oxobject2delivery.oxid in (" . implode(", ", \OxidEsales\Eshop\Core\DatabaseProvider::getDb()->quoteArray($aRemoveGroups)) . ") ";
+        } elseif ($aRemoveGroups && \is_array($aRemoveGroups)) {
+            $sQ = "delete from oxobject2delivery where oxobject2delivery.oxid in (" . \implode(", ", \OxidEsales\Eshop\Core\DatabaseProvider::getDb()->quoteArray($aRemoveGroups)) . ") ";
             \OxidEsales\Eshop\Core\DatabaseProvider::getDb()->Execute($sQ);
         }
     }
@@ -120,7 +120,7 @@ class DeliverySetUsersAjax extends \OxidEsales\Eshop\Application\Controller\Admi
             $sUserTable = $this->_getViewName('oxuser');
             $aChosenUsr = $this->_getAll($this->_addFilter("select $sUserTable.oxid " . $this->_getQuery()));
         }
-        if ($soxId && $soxId != "-1" && is_array($aChosenUsr)) {
+        if ($soxId && $soxId != "-1" && \is_array($aChosenUsr)) {
             foreach ($aChosenUsr as $sChosenUsr) {
                 $oObject2Delivery = oxNew(\OxidEsales\Eshop\Core\Model\BaseModel::class);
                 $oObject2Delivery->init('oxobject2delivery');

--- a/source/Application/Controller/Admin/DeliveryUsersAjax.php
+++ b/source/Application/Controller/Admin/DeliveryUsersAjax.php
@@ -96,8 +96,8 @@ class DeliveryUsersAjax extends \OxidEsales\Eshop\Application\Controller\Admin\L
         if (\OxidEsales\Eshop\Core\Registry::getConfig()->getRequestParameter('all')) {
             $sQ = $this->_addFilter("delete oxobject2delivery.* " . $this->_getQuery());
             \OxidEsales\Eshop\Core\DatabaseProvider::getDb()->Execute($sQ);
-        } elseif ($aRemoveGroups && is_array($aRemoveGroups)) {
-            $sQ = "delete from oxobject2delivery where oxobject2delivery.oxid in (" . implode(", ", \OxidEsales\Eshop\Core\DatabaseProvider::getDb()->quoteArray($aRemoveGroups)) . ") ";
+        } elseif ($aRemoveGroups && \is_array($aRemoveGroups)) {
+            $sQ = "delete from oxobject2delivery where oxobject2delivery.oxid in (" . \implode(", ", \OxidEsales\Eshop\Core\DatabaseProvider::getDb()->quoteArray($aRemoveGroups)) . ") ";
             \OxidEsales\Eshop\Core\DatabaseProvider::getDb()->Execute($sQ);
         }
     }
@@ -116,7 +116,7 @@ class DeliveryUsersAjax extends \OxidEsales\Eshop\Application\Controller\Admin\L
             $aChosenUsr = $this->_getAll($this->_addFilter("select $sUserTable.oxid " . $this->_getQuery()));
         }
 
-        if ($soxId && $soxId != "-1" && is_array($aChosenUsr)) {
+        if ($soxId && $soxId != "-1" && \is_array($aChosenUsr)) {
             foreach ($aChosenUsr as $sChosenUsr) {
                 $oObject2Delivery = oxNew(\OxidEsales\Eshop\Core\Model\BaseModel::class);
                 $oObject2Delivery->init('oxobject2delivery');

--- a/source/Application/Controller/Admin/DiagnosticsMain.php
+++ b/source/Application/Controller/Admin/DiagnosticsMain.php
@@ -217,7 +217,7 @@ class DiagnosticsMain extends \OxidEsales\Eshop\Application\Controller\Admin\Adm
         $iLangId = $oLang->getTplLanguage();
         $sLangCode = $aLanguages[$iLangId]->abbr;
 
-        if (!array_key_exists($sLangCode, $aLinks)) {
+        if (!\array_key_exists($sLangCode, $aLinks)) {
             $sLangCode = "de";
         }
 

--- a/source/Application/Controller/Admin/DiscountArticlesAjax.php
+++ b/source/Application/Controller/Admin/DiscountArticlesAjax.php
@@ -92,7 +92,7 @@ class DiscountArticlesAjax extends \OxidEsales\Eshop\Application\Controller\Admi
             $sSubSelect = " select $sArticleTable.oxid from oxobject2discount, $sArticleTable where $sArticleTable.oxid=oxobject2discount.oxobjectid ";
             $sSubSelect .= " and oxobject2discount.oxdiscountid = " . $oDb->quote($sSynchOxid) . " and oxobject2discount.oxtype = 'oxarticles' ";
 
-            if (stristr($sQAdd, 'where') === false) {
+            if (\stristr($sQAdd, 'where') === false) {
                 $sQAdd .= ' where ';
             } else {
                 $sQAdd .= ' and ';
@@ -113,8 +113,8 @@ class DiscountArticlesAjax extends \OxidEsales\Eshop\Application\Controller\Admi
         if (\OxidEsales\Eshop\Core\Registry::getConfig()->getRequestParameter('all')) {
             $sQ = parent::_addFilter("delete oxobject2discount.* " . $this->_getQuery());
             \OxidEsales\Eshop\Core\DatabaseProvider::getDb()->execute($sQ);
-        } elseif (is_array($aChosenArt)) {
-            $sQ = "delete from oxobject2discount where oxobject2discount.oxid in (" . implode(", ", \OxidEsales\Eshop\Core\DatabaseProvider::getDb()->quoteArray($aChosenArt)) . ") ";
+        } elseif (\is_array($aChosenArt)) {
+            $sQ = "delete from oxobject2discount where oxobject2discount.oxid in (" . \implode(", ", \OxidEsales\Eshop\Core\DatabaseProvider::getDb()->quoteArray($aChosenArt)) . ") ";
             \OxidEsales\Eshop\Core\DatabaseProvider::getDb()->execute($sQ);
         }
     }
@@ -133,7 +133,7 @@ class DiscountArticlesAjax extends \OxidEsales\Eshop\Application\Controller\Admi
             $articleTable = $this->_getViewName('oxarticles');
             $articleIds = $this->_getAll(parent::_addFilter("select $articleTable.oxid " . $this->_getQuery()));
         }
-        if ($discountListId && $discountListId != self::NEW_DISCOUNT_LIST_ID && is_array($articleIds)) {
+        if ($discountListId && $discountListId != self::NEW_DISCOUNT_LIST_ID && \is_array($articleIds)) {
             foreach ($articleIds as $articleId) {
                 $this->addArticleToDiscount($discountListId, $articleId);
             }

--- a/source/Application/Controller/Admin/DiscountCategoriesAjax.php
+++ b/source/Application/Controller/Admin/DiscountCategoriesAjax.php
@@ -71,7 +71,7 @@ class DiscountCategoriesAjax extends \OxidEsales\Eshop\Application\Controller\Ad
                           "where {$sCategoryTable}.oxid=oxobject2discount.oxobjectid " .
                           " and oxobject2discount.oxdiscountid = " . $oDb->quote($sSynchId) .
                           " and oxobject2discount.oxtype = 'oxcategories' ";
-            if (stristr($sQAdd, 'where') === false) {
+            if (\stristr($sQAdd, 'where') === false) {
                 $sQAdd .= ' where ';
             } else {
                 $sQAdd .= ' and ';
@@ -93,8 +93,8 @@ class DiscountCategoriesAjax extends \OxidEsales\Eshop\Application\Controller\Ad
         if ($config->getRequestParameter('all')) {
             $query = $this->_addFilter("delete oxobject2discount.* " . $this->_getQuery());
             \OxidEsales\Eshop\Core\DatabaseProvider::getDb()->Execute($query);
-        } elseif (is_array($categoryIds)) {
-            $chosenCategories = implode(", ", \OxidEsales\Eshop\Core\DatabaseProvider::getDb()->quoteArray($categoryIds));
+        } elseif (\is_array($categoryIds)) {
+            $chosenCategories = \implode(", ", \OxidEsales\Eshop\Core\DatabaseProvider::getDb()->quoteArray($categoryIds));
             $query = "delete from oxobject2discount where oxobject2discount.oxid in (" . $chosenCategories . ") ";
             \OxidEsales\Eshop\Core\DatabaseProvider::getDb()->Execute($query);
         }
@@ -113,7 +113,7 @@ class DiscountCategoriesAjax extends \OxidEsales\Eshop\Application\Controller\Ad
             $categoryTable = $this->_getViewName('oxcategories');
             $categoryIds = $this->_getAll($this->_addFilter("select $categoryTable.oxid " . $this->_getQuery()));
         }
-        if ($discountId && $discountId != self::NEW_DISCOUNT_ID && is_array($categoryIds)) {
+        if ($discountId && $discountId != self::NEW_DISCOUNT_ID && \is_array($categoryIds)) {
             foreach ($categoryIds as $categoryId) {
                 $this->addCategoryToDiscount($discountId, $categoryId);
             }

--- a/source/Application/Controller/Admin/DiscountGroupsAjax.php
+++ b/source/Application/Controller/Admin/DiscountGroupsAjax.php
@@ -82,8 +82,8 @@ class DiscountGroupsAjax extends \OxidEsales\Eshop\Application\Controller\Admin\
         if ($config->getRequestParameter('all')) {
             $query = $this->_addFilter("delete oxobject2discount.* " . $this->_getQuery());
             \OxidEsales\Eshop\Core\DatabaseProvider::getDb()->Execute($query);
-        } elseif ($groupIds && is_array($groupIds)) {
-            $groupIdsQuoted = implode(", ", \OxidEsales\Eshop\Core\DatabaseProvider::getDb()->quoteArray($groupIds));
+        } elseif ($groupIds && \is_array($groupIds)) {
+            $groupIdsQuoted = \implode(", ", \OxidEsales\Eshop\Core\DatabaseProvider::getDb()->quoteArray($groupIds));
             $query = "delete from oxobject2discount where oxobject2discount.oxid in (" . $groupIdsQuoted . ") ";
             \OxidEsales\Eshop\Core\DatabaseProvider::getDb()->Execute($query);
         }
@@ -102,7 +102,7 @@ class DiscountGroupsAjax extends \OxidEsales\Eshop\Application\Controller\Admin\
             $groupTable = $this->_getViewName('oxgroups');
             $groupIds = $this->_getAll($this->_addFilter("select $groupTable.oxid " . $this->_getQuery()));
         }
-        if ($discountId && $discountId != self::NEW_DISCOUNT_ID && is_array($groupIds)) {
+        if ($discountId && $discountId != self::NEW_DISCOUNT_ID && \is_array($groupIds)) {
             foreach ($groupIds as $groupId) {
                 $object2Discount = oxNew(\OxidEsales\Eshop\Core\Model\BaseModel::class);
                 $object2Discount->init('oxobject2discount');

--- a/source/Application/Controller/Admin/DiscountItemAjax.php
+++ b/source/Application/Controller/Admin/DiscountItemAjax.php
@@ -90,7 +90,7 @@ class DiscountItemAjax extends \OxidEsales\Eshop\Application\Controller\Admin\Li
             $sSubSelect = " select $sArticleTable.oxid from $sDiscTable, $sArticleTable where $sArticleTable.oxid=$sDiscTable.oxitmartid ";
             $sSubSelect .= " and $sDiscTable.oxid = " . $oDb->quote($sSynchOxid);
 
-            if (stristr($sQAdd, 'where') === false) {
+            if (\stristr($sQAdd, 'where') === false) {
                 $sQAdd .= ' where ';
             } else {
                 $sQAdd .= ' and ';
@@ -108,11 +108,11 @@ class DiscountItemAjax extends \OxidEsales\Eshop\Application\Controller\Admin\Li
     {
         $soxId = \OxidEsales\Eshop\Core\Registry::getConfig()->getRequestParameter('oxid');
         $aChosenArt = $this->_getActionIds('oxdiscount.oxitmartid');
-        if (is_array($aChosenArt)) {
+        if (\is_array($aChosenArt)) {
             $sQ = "update oxdiscount set oxitmartid = '' where oxid = :oxid and oxitmartid = :oxitmartid";
             \OxidEsales\Eshop\Core\DatabaseProvider::getDb()->execute($sQ, [
                 ':oxid' => $soxId,
-                ':oxitmartid' => reset($aChosenArt)
+                ':oxitmartid' => \reset($aChosenArt)
             ]);
         }
     }
@@ -124,10 +124,10 @@ class DiscountItemAjax extends \OxidEsales\Eshop\Application\Controller\Admin\Li
     {
         $aChosenArt = $this->_getActionIds('oxarticles.oxid');
         $soxId = \OxidEsales\Eshop\Core\Registry::getConfig()->getRequestParameter('synchoxid');
-        if ($soxId && $soxId != "-1" && is_array($aChosenArt)) {
+        if ($soxId && $soxId != "-1" && \is_array($aChosenArt)) {
             $sQ = "update oxdiscount set oxitmartid = :oxitmartid where oxid = :oxid";
             \OxidEsales\Eshop\Core\DatabaseProvider::getDb()->execute($sQ, [
-                ':oxitmartid' => reset($aChosenArt),
+                ':oxitmartid' => \reset($aChosenArt),
                 ':oxid' => $soxId
             ]);
         }

--- a/source/Application/Controller/Admin/DiscountMain.php
+++ b/source/Application/Controller/Admin/DiscountMain.php
@@ -38,7 +38,7 @@ class DiscountMain extends \OxidEsales\Eshop\Application\Controller\Admin\AdminD
             $oOtherLang = $oDiscount->getAvailableInLangs();
             if (!isset($oOtherLang[$this->_iEditLang])) {
                 // echo "language entry doesn't exist! using: ".key($oOtherLang);
-                $oDiscount->loadInLang(key($oOtherLang), $sOxId);
+                $oDiscount->loadInLang(\key($oOtherLang), $sOxId);
             }
 
             $this->_aViewData["edit"] = $oDiscount;
@@ -49,9 +49,9 @@ class DiscountMain extends \OxidEsales\Eshop\Application\Controller\Admin\AdminD
             }
 
             // remove already created languages
-            $aLang = array_diff(\OxidEsales\Eshop\Core\Registry::getLang()->getLanguageNames(), $oOtherLang);
+            $aLang = \array_diff(\OxidEsales\Eshop\Core\Registry::getLang()->getLanguageNames(), $oOtherLang);
 
-            if (count($aLang)) {
+            if (\count($aLang)) {
                 $this->_aViewData["posslang"] = $aLang;
             }
 
@@ -148,7 +148,7 @@ class DiscountMain extends \OxidEsales\Eshop\Application\Controller\Admin\AdminD
             $newException->setMessage($exception->getMessage());
             $this->addTplParam('discount_title', $aParams['oxdiscount__oxtitle']);
 
-            if (false !== strpos($exception->getMessage(), 'DISCOUNT_ERROR_OXSORT')) {
+            if (false !== \strpos($exception->getMessage(), 'DISCOUNT_ERROR_OXSORT')) {
                 $messageArgument = \OxidEsales\Eshop\Core\Registry::getLang()->translateString('DISCOUNT_MAIN_SORT', \OxidEsales\Eshop\Core\Registry::getLang()->getTplLanguage(), true);
                 $newException->setMessageArgs($messageArgument);
             }

--- a/source/Application/Controller/Admin/DiscountMainAjax.php
+++ b/source/Application/Controller/Admin/DiscountMainAjax.php
@@ -76,8 +76,8 @@ class DiscountMainAjax extends \OxidEsales\Eshop\Application\Controller\Admin\Li
         if ($oConfig->getRequestParameter('all')) {
             $sQ = $this->_addFilter("delete oxobject2discount.* " . $this->_getQuery());
             \OxidEsales\Eshop\Core\DatabaseProvider::getDb()->Execute($sQ);
-        } elseif (is_array($aChosenCntr)) {
-            $sQ = "delete from oxobject2discount where oxobject2discount.oxid in (" . implode(", ", \OxidEsales\Eshop\Core\DatabaseProvider::getDb()->quoteArray($aChosenCntr)) . ") ";
+        } elseif (\is_array($aChosenCntr)) {
+            $sQ = "delete from oxobject2discount where oxobject2discount.oxid in (" . \implode(", ", \OxidEsales\Eshop\Core\DatabaseProvider::getDb()->quoteArray($aChosenCntr)) . ") ";
             \OxidEsales\Eshop\Core\DatabaseProvider::getDb()->Execute($sQ);
         }
     }
@@ -95,7 +95,7 @@ class DiscountMainAjax extends \OxidEsales\Eshop\Application\Controller\Admin\Li
             $sCountryTable = $this->_getViewName('oxcountry');
             $aChosenCntr = $this->_getAll($this->_addFilter("select $sCountryTable.oxid " . $this->_getQuery()));
         }
-        if ($soxId && $soxId != "-1" && is_array($aChosenCntr)) {
+        if ($soxId && $soxId != "-1" && \is_array($aChosenCntr)) {
             foreach ($aChosenCntr as $sChosenCntr) {
                 $oObject2Discount = oxNew(\OxidEsales\Eshop\Core\Model\BaseModel::class);
                 $oObject2Discount->init('oxobject2discount');

--- a/source/Application/Controller/Admin/DiscountUsersAjax.php
+++ b/source/Application/Controller/Admin/DiscountUsersAjax.php
@@ -98,8 +98,8 @@ class DiscountUsersAjax extends \OxidEsales\Eshop\Application\Controller\Admin\L
         if ($oConfig->getRequestParameter('all')) {
             $sQ = $this->_addFilter("delete oxobject2discount.* " . $this->_getQuery());
             \OxidEsales\Eshop\Core\DatabaseProvider::getDb()->Execute($sQ);
-        } elseif ($aRemoveGroups && is_array($aRemoveGroups)) {
-            $sQ = "delete from oxobject2discount where oxobject2discount.oxid in (" . implode(", ", \OxidEsales\Eshop\Core\DatabaseProvider::getDb()->quoteArray($aRemoveGroups)) . ") ";
+        } elseif ($aRemoveGroups && \is_array($aRemoveGroups)) {
+            $sQ = "delete from oxobject2discount where oxobject2discount.oxid in (" . \implode(", ", \OxidEsales\Eshop\Core\DatabaseProvider::getDb()->quoteArray($aRemoveGroups)) . ") ";
             \OxidEsales\Eshop\Core\DatabaseProvider::getDb()->Execute($sQ);
         }
     }
@@ -117,7 +117,7 @@ class DiscountUsersAjax extends \OxidEsales\Eshop\Application\Controller\Admin\L
             $sUserTable = $this->_getViewName('oxuser');
             $aChosenUsr = $this->_getAll($this->_addFilter("select $sUserTable.oxid " . $this->_getQuery()));
         }
-        if ($soxId && $soxId != "-1" && is_array($aChosenUsr)) {
+        if ($soxId && $soxId != "-1" && \is_array($aChosenUsr)) {
             foreach ($aChosenUsr as $sChosenUsr) {
                 $oObject2Discount = oxNew(\OxidEsales\Eshop\Core\Model\BaseModel::class);
                 $oObject2Discount->init('oxobject2discount');

--- a/source/Application/Controller/Admin/DynamicExportBaseController.php
+++ b/source/Application/Controller/Admin/DynamicExportBaseController.php
@@ -15,9 +15,9 @@ use OxidEsales\Eshop\Core\Str;
 /**
  * Error constants
  */
-DEFINE("ERR_SUCCESS", -2);
-DEFINE("ERR_GENERAL", -1);
-DEFINE("ERR_FILEIO", 1);
+\DEFINE("ERR_SUCCESS", -2);
+\DEFINE("ERR_GENERAL", -1);
+\DEFINE("ERR_FILEIO", 1);
 
 /**
  * DynExportBase framework class encapsulating a method for defining implementation class.
@@ -134,7 +134,7 @@ class DynamicExportBaseController extends \OxidEsales\Eshop\Application\Controll
         parent::render();
 
         // assign all member variables to template
-        $aClassVars = get_object_vars($this);
+        $aClassVars = \get_object_vars($this);
         foreach ($aClassVars as $name => $value) {
             $this->_aViewData[$name] = $value;
         }
@@ -168,14 +168,14 @@ class DynamicExportBaseController extends \OxidEsales\Eshop\Application\Controll
     public function start()
     {
         // delete file, if its already there
-        $this->fpFile = @fopen($this->_sFilePath, "w");
+        $this->fpFile = @\fopen($this->_sFilePath, "w");
         if (!isset($this->fpFile) || !$this->fpFile) {
             // we do have an error !
             $this->stop(ERR_FILEIO);
         } else {
             $this->_aViewData['refresh'] = 0;
             $this->_aViewData['iStart'] = 0;
-            fclose($this->fpFile);
+            \fclose($this->fpFile);
 
             // prepare it
             $iEnd = $this->prepareExport();
@@ -219,8 +219,8 @@ class DynamicExportBaseController extends \OxidEsales\Eshop\Application\Controll
     public function write($sLine)
     {
         $sLine = $this->removeSID($sLine);
-        $sLine = str_replace(["\r\n", "\n"], "", $sLine);
-        fwrite($this->fpFile, $sLine . "\r\n");
+        $sLine = \str_replace(["\r\n", "\n"], "", $sLine);
+        \fwrite($this->fpFile, $sLine . "\r\n");
     }
 
     /**
@@ -231,7 +231,7 @@ class DynamicExportBaseController extends \OxidEsales\Eshop\Application\Controll
         $blContinue = true;
         $iExportedItems = 0;
 
-        $this->fpFile = @fopen($this->_sFilePath, "a");
+        $this->fpFile = @\fopen($this->_sFilePath, "a");
         if (!isset($this->fpFile) || !$this->fpFile) {
             // we do have an error !
             $this->stop(ERR_FILEIO);
@@ -255,7 +255,7 @@ class DynamicExportBaseController extends \OxidEsales\Eshop\Application\Controll
                 $this->_aViewData['iStart'] = $i;
                 $this->_aViewData['iExpItems'] = $iExportedItems;
             }
-            fclose($this->fpFile);
+            \fclose($this->fpFile);
         }
     }
 
@@ -299,11 +299,11 @@ class DynamicExportBaseController extends \OxidEsales\Eshop\Application\Controll
         $sSid = $session->getId();
 
         // remove sid from link
-        $sOutput = str_replace("sid={$sSid}/", "", $sInput);
-        $sOutput = str_replace("sid/{$sSid}/", "", $sOutput);
-        $sOutput = str_replace("sid={$sSid}&amp;", "", $sOutput);
-        $sOutput = str_replace("sid={$sSid}&", "", $sOutput);
-        $sOutput = str_replace("sid={$sSid}", "", $sOutput);
+        $sOutput = \str_replace("sid={$sSid}/", "", $sInput);
+        $sOutput = \str_replace("sid/{$sSid}/", "", $sOutput);
+        $sOutput = \str_replace("sid={$sSid}&amp;", "", $sOutput);
+        $sOutput = \str_replace("sid={$sSid}&", "", $sOutput);
+        $sOutput = \str_replace("sid={$sSid}", "", $sOutput);
 
         return $sOutput;
     }
@@ -320,14 +320,14 @@ class DynamicExportBaseController extends \OxidEsales\Eshop\Application\Controll
     public function shrink($sInput, $iMaxSize, $blRemoveNewline = true)
     {
         if ($blRemoveNewline) {
-            $sInput = str_replace("\r\n", " ", $sInput);
-            $sInput = str_replace("\n", " ", $sInput);
+            $sInput = \str_replace("\r\n", " ", $sInput);
+            $sInput = \str_replace("\n", " ", $sInput);
         }
 
-        $sInput = str_replace("\t", "    ", $sInput);
+        $sInput = \str_replace("\t", "    ", $sInput);
 
         // remove html entities, remove html tags
-        $sInput = $this->_unHTMLEntities(strip_tags($sInput));
+        $sInput = $this->_unHTMLEntities(\strip_tags($sInput));
 
         $oStr = Str::getStr();
         if ($oStr->strlen($sInput) > $iMaxSize - 3) {
@@ -422,7 +422,7 @@ class DynamicExportBaseController extends \OxidEsales\Eshop\Application\Controll
     {
         $sInput = \OxidEsales\Eshop\Core\Registry::getUtilsString()->prepareCSVField($sInput);
 
-        return str_replace(["&nbsp;", "&euro;", "|"], [" ", "", ""], $sInput);
+        return \str_replace(["&nbsp;", "&euro;", "|"], [" ", "", ""], $sInput);
     }
 
     /**
@@ -434,11 +434,11 @@ class DynamicExportBaseController extends \OxidEsales\Eshop\Application\Controll
      */
     public function prepareXML($sInput)
     {
-        $sOutput = str_replace("&", "&amp;", $sInput);
-        $sOutput = str_replace("\"", "&quot;", $sOutput);
-        $sOutput = str_replace(">", "&gt;", $sOutput);
-        $sOutput = str_replace("<", "&lt;", $sOutput);
-        $sOutput = str_replace("'", "&apos;", $sOutput);
+        $sOutput = \str_replace("&", "&amp;", $sInput);
+        $sOutput = \str_replace("\"", "&quot;", $sOutput);
+        $sOutput = \str_replace(">", "&gt;", $sOutput);
+        $sOutput = \str_replace("<", "&lt;", $sOutput);
+        $sOutput = \str_replace("'", "&apos;", $sOutput);
 
         return $sOutput;
     }
@@ -549,9 +549,9 @@ class DynamicExportBaseController extends \OxidEsales\Eshop\Application\Controll
      */
     protected function _unHtmlEntities($sInput) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
-        $aTransTbl = array_flip(get_html_translation_table(HTML_ENTITIES));
+        $aTransTbl = \array_flip(\get_html_translation_table(HTML_ENTITIES));
 
-        return strtr($sInput, $aTransTbl);
+        return \strtr($sInput, $aTransTbl);
     }
 
     /**
@@ -564,7 +564,7 @@ class DynamicExportBaseController extends \OxidEsales\Eshop\Application\Controll
     {
         // table name must not start with any digit
         $session = \OxidEsales\Eshop\Core\Registry::getSession();
-        return "tmp_" . str_replace("0", "", md5($session->getId()));
+        return "tmp_" . \str_replace("0", "", \md5($session->getId()));
     }
 
     /**
@@ -580,7 +580,7 @@ class DynamicExportBaseController extends \OxidEsales\Eshop\Application\Controll
         $sTableCharset = "";
 
         //if MySQL >= 4.1.0 set charsets and collations
-        if (version_compare($sMysqlVersion, '4.1.0', '>=') > 0) {
+        if (\version_compare($sMysqlVersion, '4.1.0', '>=') > 0) {
             $oDB = \OxidEsales\Eshop\Core\DatabaseProvider::getDb(\OxidEsales\Eshop\Core\DatabaseProvider::FETCH_MODE_ASSOC);
             $oRs = $oDB->select("SHOW FULL COLUMNS FROM `oxarticles` WHERE field like 'OXID'");
             if (isset($oRs->fields['Collation']) && ($sMysqlCollation = $oRs->fields['Collation'])) {
@@ -627,7 +627,7 @@ class DynamicExportBaseController extends \OxidEsales\Eshop\Application\Controll
     protected function _getCatAdd($aChosenCat) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $sCatAdd = null;
-        if (is_array($aChosenCat) && count($aChosenCat)) {
+        if (\is_array($aChosenCat) && \count($aChosenCat)) {
             $oDB = \OxidEsales\Eshop\Core\DatabaseProvider::getDb();
             $sCatAdd = " and ( ";
             $blSep = false;
@@ -690,7 +690,7 @@ class DynamicExportBaseController extends \OxidEsales\Eshop\Application\Controll
 
         // add minimum stock value
         if (\OxidEsales\Eshop\Core\Registry::getConfig()->getConfigParam('blUseStock') && ($dMinStock = \OxidEsales\Eshop\Core\Registry::getConfig()->getRequestParameter("sExportMinStock"))) {
-            $dMinStock = str_replace([";", " ", "/", "'"], "", $dMinStock);
+            $dMinStock = \str_replace([";", " ", "/", "'"], "", $dMinStock);
             $insertQuery .= " and {$sArticleTable}.oxstock >= " . $oDB->quote($dMinStock);
         }
 
@@ -743,16 +743,16 @@ class DynamicExportBaseController extends \OxidEsales\Eshop\Application\Controll
         \OxidEsales\Eshop\Core\Registry::getSession()->deleteVariable("sExportDelCost");
         $dDelCost = \OxidEsales\Eshop\Core\Registry::getConfig()->getRequestParameter("sExportDelCost");
         if (isset($dDelCost)) {
-            $dDelCost = str_replace([";", " ", "/", "'"], "", $dDelCost);
-            $dDelCost = str_replace(",", ".", $dDelCost);
+            $dDelCost = \str_replace([";", " ", "/", "'"], "", $dDelCost);
+            $dDelCost = \str_replace(",", ".", $dDelCost);
             \OxidEsales\Eshop\Core\Registry::getSession()->setVariable("sExportDelCost", $dDelCost);
         }
 
         \OxidEsales\Eshop\Core\Registry::getSession()->deleteVariable("sExportMinPrice");
         $dMinPrice = \OxidEsales\Eshop\Core\Registry::getConfig()->getRequestParameter("sExportMinPrice");
         if (isset($dMinPrice)) {
-            $dMinPrice = str_replace([";", " ", "/", "'"], "", $dMinPrice);
-            $dMinPrice = str_replace(",", ".", $dMinPrice);
+            $dMinPrice = \str_replace([";", " ", "/", "'"], "", $dMinPrice);
+            $dMinPrice = \str_replace(",", ".", $dMinPrice);
             \OxidEsales\Eshop\Core\Registry::getSession()->setVariable("sExportMinPrice", $dMinPrice);
         }
 
@@ -760,7 +760,7 @@ class DynamicExportBaseController extends \OxidEsales\Eshop\Application\Controll
         \OxidEsales\Eshop\Core\Registry::getSession()->deleteVariable("sExportCampaign");
         $sCampaign = \OxidEsales\Eshop\Core\Registry::getConfig()->getRequestParameter("sExportCampaign");
         if (isset($sCampaign)) {
-            $sCampaign = str_replace([";", " ", "/", "'"], "", $sCampaign);
+            $sCampaign = \str_replace([";", " ", "/", "'"], "", $sCampaign);
             \OxidEsales\Eshop\Core\Registry::getSession()->setVariable("sExportCampaign", $sCampaign);
         }
 
@@ -844,7 +844,7 @@ class DynamicExportBaseController extends \OxidEsales\Eshop\Application\Controll
 
         // find deepest
         $aIds = $oArticle->getCategoryIds();
-        if (is_array($aIds) && count($aIds)) {
+        if (\is_array($aIds) && \count($aIds)) {
             if ($aCatLvlCache = $this->_loadRootCats()) {
                 $sIdMax = null;
                 $dMaxLvl = 0;

--- a/source/Application/Controller/Admin/GenericExportDo.php
+++ b/source/Application/Controller/Admin/GenericExportDo.php
@@ -99,10 +99,10 @@ class GenericExportDo extends \OxidEsales\Eshop\Application\Controller\Admin\Dyn
     {
         $sLine = $this->removeSID($sLine);
 
-        $sLine = str_replace(["\r\n", "\n"], "", $sLine);
-        $sLine = str_replace("<br>", "\n", $sLine);
+        $sLine = \str_replace(["\r\n", "\n"], "", $sLine);
+        $sLine = \str_replace("<br>", "\n", $sLine);
 
-        fwrite($this->fpFile, $sLine . "\n");
+        \fwrite($this->fpFile, $sLine . "\n");
     }
 
     /**

--- a/source/Application/Controller/Admin/GenericImportMain.php
+++ b/source/Application/Controller/Admin/GenericImportMain.php
@@ -154,7 +154,7 @@ class GenericImportMain extends \OxidEsales\Eshop\Application\Controller\Admin\A
 
         if ($navigationStep == 1) {
             $this->_aViewData['aImportTables'] = $genericImport->getImportObjectsList();
-            asort($this->_aViewData['aImportTables']);
+            \asort($this->_aViewData['aImportTables']);
             $this->_resetUploadedCsvData();
         }
 
@@ -170,8 +170,8 @@ class GenericImportMain extends \OxidEsales\Eshop\Application\Controller\Admin\A
     protected function _deleteCsvFile() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $sPath = $this->_getUploadedCsvFilePath();
-        if (is_file($sPath)) {
-            @unlink($sPath);
+        if (\is_file($sPath)) {
+            @\unlink($sPath);
         }
     }
 
@@ -218,9 +218,9 @@ class GenericImportMain extends \OxidEsales\Eshop\Application\Controller\Admin\A
         $iMaxLineLength = 8192;
 
         //getting first row
-        if (($rFile = @fopen($sPath, "r")) !== false) {
-            $aRow = fgetcsv($rFile, $iMaxLineLength, $this->_getCsvFieldsTerminator(), $this->_getCsvFieldsEncolser());
-            fclose($rFile);
+        if (($rFile = @\fopen($sPath, "r")) !== false) {
+            $aRow = \fgetcsv($rFile, $iMaxLineLength, $this->_getCsvFieldsTerminator(), $this->_getCsvFieldsEncolser());
+            \fclose($rFile);
         }
 
         return $aRow;
@@ -299,8 +299,8 @@ class GenericImportMain extends \OxidEsales\Eshop\Application\Controller\Admin\A
         $oConfig = \OxidEsales\Eshop\Core\Registry::getConfig();
         $aFile = $oConfig->getUploadedFile('csvfile');
         if (isset($aFile['name']) && $aFile['name']) {
-            $this->_sCsvFilePath = $oConfig->getConfigParam('sCompileDir') . basename($aFile['tmp_name']);
-            move_uploaded_file($aFile['tmp_name'], $this->_sCsvFilePath);
+            $this->_sCsvFilePath = $oConfig->getConfigParam('sCompileDir') . \basename($aFile['tmp_name']);
+            \move_uploaded_file($aFile['tmp_name'], $this->_sCsvFilePath);
             \OxidEsales\Eshop\Core\Registry::getSession()->setVariable('sCsvFilePath', $this->_sCsvFilePath);
 
             return $this->_sCsvFilePath;
@@ -366,7 +366,7 @@ class GenericImportMain extends \OxidEsales\Eshop\Application\Controller\Admin\A
     private function setErrorToView($invalidData)
     {
         $error = oxNew(\OxidEsales\Eshop\Core\DisplayError::class);
-        $error->setFormatParameters(htmlspecialchars($invalidData));
+        $error->setFormatParameters(\htmlspecialchars($invalidData));
         $error->setMessage("SHOP_CONFIG_ERROR_INVALID_VALUE");
         \OxidEsales\Eshop\Core\Registry::getUtilsView()->addErrorToDisplay($error);
     }

--- a/source/Application/Controller/Admin/LanguageList.php
+++ b/source/Application/Controller/Admin/LanguageList.php
@@ -107,10 +107,10 @@ class LanguageList extends \OxidEsales\Eshop\Application\Controller\Admin\AdminL
             $aLanguages[$sKey]->sort = $aLangParams[$sOxId]["sort"];
         }
 
-        if (is_array($aLangParams)) {
+        if (\is_array($aLangParams)) {
             $aSorting = $this->getListSorting();
 
-            if (is_array($aSorting)) {
+            if (\is_array($aSorting)) {
                 foreach ($aSorting as $aFieldSorting) {
                     foreach ($aFieldSorting as $sField => $sDir) {
                         $this->_sDefSortField = $sField;
@@ -125,7 +125,7 @@ class LanguageList extends \OxidEsales\Eshop\Application\Controller\Admin\AdminL
                 }
             }
 
-            uasort($aLanguages, [$this, '_sortLanguagesCallback']);
+            \uasort($aLanguages, [$this, '_sortLanguagesCallback']);
         }
 
         return $aLanguages;
@@ -144,8 +144,8 @@ class LanguageList extends \OxidEsales\Eshop\Application\Controller\Admin\AdminL
     protected function _sortLanguagesCallback($oLang1, $oLang2) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $sSortParam = $this->_sDefSortField;
-        $sVal1 = is_string($oLang1->$sSortParam) ? strtolower($oLang1->$sSortParam) : $oLang1->$sSortParam;
-        $sVal2 = is_string($oLang2->$sSortParam) ? strtolower($oLang2->$sSortParam) : $oLang2->$sSortParam;
+        $sVal1 = \is_string($oLang1->$sSortParam) ? \strtolower($oLang1->$sSortParam) : $oLang1->$sSortParam;
+        $sVal2 = \is_string($oLang2->$sSortParam) ? \strtolower($oLang2->$sSortParam) : $oLang2->$sSortParam;
 
         if ($this->_sDefSortOrder == 'asc') {
             return ($sVal1 < $sVal2) ? -1 : 1;

--- a/source/Application/Controller/Admin/LanguageMain.php
+++ b/source/Application/Controller/Admin/LanguageMain.php
@@ -226,7 +226,7 @@ class LanguageMain extends \OxidEsales\Eshop\Application\Controller\Admin\AdminD
         $aLangData['sslUrls'] = \OxidEsales\Eshop\Core\Registry::getConfig()->getConfigParam('aLanguageSSLURLs');
 
         // empty languages parameters array - creating new one with default values
-        if (!is_array($aLangData['params'])) {
+        if (!\is_array($aLangData['params'])) {
             $aLangData['params'] = $this->_assignDefaultLangParams($aLangData['lang']);
         }
 
@@ -242,19 +242,19 @@ class LanguageMain extends \OxidEsales\Eshop\Application\Controller\Admin\AdminD
      */
     protected function _updateAbbervation($sOldId, $sNewId) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
-        foreach (array_keys($this->_aLangData) as $sTypeKey) {
-            if (is_array($this->_aLangData[$sTypeKey]) && count($this->_aLangData[$sTypeKey]) > 0) {
+        foreach (\array_keys($this->_aLangData) as $sTypeKey) {
+            if (\is_array($this->_aLangData[$sTypeKey]) && \count($this->_aLangData[$sTypeKey]) > 0) {
                 if ($sTypeKey == 'urls' || $sTypeKey == 'sslUrls') {
                     continue;
                 }
 
-                $aKeys = array_keys($this->_aLangData[$sTypeKey]);
-                $aValues = array_values($this->_aLangData[$sTypeKey]);
+                $aKeys = \array_keys($this->_aLangData[$sTypeKey]);
+                $aValues = \array_values($this->_aLangData[$sTypeKey]);
                 //find and replace key
-                $iReplaceId = array_search($sOldId, $aKeys);
+                $iReplaceId = \array_search($sOldId, $aKeys);
                 $aKeys[$iReplaceId] = $sNewId;
 
-                $this->_aLangData[$sTypeKey] = array_combine($aKeys, $aValues);
+                $this->_aLangData[$sTypeKey] = \array_combine($aKeys, $aValues);
             }
         }
     }
@@ -270,7 +270,7 @@ class LanguageMain extends \OxidEsales\Eshop\Application\Controller\Admin\AdminD
         $aSslUrls = [];
         $aLanguages = [];
 
-        uasort($this->_aLangData['params'], [$this, '_sortLangParamsByBaseIdCallback']);
+        \uasort($this->_aLangData['params'], [$this, '_sortLangParamsByBaseIdCallback']);
 
         foreach ($this->_aLangData['params'] as $sAbbr => $aParams) {
             $iId = (int) $aParams['baseId'];
@@ -297,7 +297,7 @@ class LanguageMain extends \OxidEsales\Eshop\Application\Controller\Admin\AdminD
         $aParams = [];
         $iBaseId = 0;
 
-        foreach (array_keys($aLanguages) as $sOxId) {
+        foreach (\array_keys($aLanguages) as $sOxId) {
             $aParams[$sOxId]['baseId'] = $iBaseId;
             $aParams[$sOxId]['active'] = 1;
             $aParams[$sOxId]['sort'] = $iBaseId + 1;
@@ -334,8 +334,8 @@ class LanguageMain extends \OxidEsales\Eshop\Application\Controller\Admin\AdminD
         }
 
         $iNewId = 0;
-        sort($aBaseId);
-        $iTotal = count($aBaseId);
+        \sort($aBaseId);
+        $iTotal = \count($aBaseId);
 
         //getting first available id
         while ($iNewId <= $iTotal) {
@@ -359,7 +359,7 @@ class LanguageMain extends \OxidEsales\Eshop\Application\Controller\Admin\AdminD
     {
         $myConfig = \OxidEsales\Eshop\Core\Registry::getConfig();
 
-        $sDir = dirname($myConfig->getTranslationsDir('lang.php', $sOxId));
+        $sDir = \dirname($myConfig->getTranslationsDir('lang.php', $sOxId));
 
         if (empty($sDir)) {
             $oEx = oxNew(\OxidEsales\Eshop\Core\Exception\ExceptionToDisplay::class);
@@ -426,9 +426,9 @@ class LanguageMain extends \OxidEsales\Eshop\Application\Controller\Admin\AdminD
      */
     protected function _checkLangExists($sAbbr) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
-        $aAbbrs = array_keys($this->_aLangData['lang']);
+        $aAbbrs = \array_keys($this->_aLangData['lang']);
 
-        return in_array($sAbbr, $aAbbrs);
+        return \in_array($sAbbr, $aAbbrs);
     }
 
     /**
@@ -496,9 +496,9 @@ class LanguageMain extends \OxidEsales\Eshop\Application\Controller\Admin\AdminD
     protected function checkAbbreviationAllowedCharacters($abbreviation)
     {
         $pattern = '/^[a-zA-Z0-9_]*$/';
-        $result = preg_match($pattern, $abbreviation);
+        $result = \preg_match($pattern, $abbreviation);
         if ($result === false) {
-            throw new \Exception(preg_last_error(), $pattern, $abbreviation);
+            throw new \Exception(\preg_last_error(), $pattern, $abbreviation);
         }
 
         return (bool) $result;
@@ -528,14 +528,14 @@ class LanguageMain extends \OxidEsales\Eshop\Application\Controller\Admin\AdminD
         $blValid = true;
         $configValidator = $this->getNoJsValidator();
         foreach ($aLanguageData as $mLanguageDataParameters) {
-            if (is_array($mLanguageDataParameters)) {
+            if (\is_array($mLanguageDataParameters)) {
                 // Recursion till we gonna have a string.
                 $blDeepResult = $this->isValidLanguageData($mLanguageDataParameters);
                 $blValid = $blDeepResult === false ? $blDeepResult : $blValid;
             } elseif (!$configValidator->isValid($mLanguageDataParameters)) {
                 $blValid = false;
                 $error = oxNew(\OxidEsales\Eshop\Core\DisplayError::class);
-                $error->setFormatParameters(htmlspecialchars($mLanguageDataParameters));
+                $error->setFormatParameters(\htmlspecialchars($mLanguageDataParameters));
                 $error->setMessage("SHOP_CONFIG_ERROR_INVALID_VALUE");
                 \OxidEsales\Eshop\Core\Registry::getUtilsView()->addErrorToDisplay($error);
             }
@@ -549,7 +549,7 @@ class LanguageMain extends \OxidEsales\Eshop\Application\Controller\Admin\AdminD
      */
     protected function getNoJsValidator()
     {
-        if (is_null($this->noJsValidator)) {
+        if (\is_null($this->noJsValidator)) {
             $this->noJsValidator = oxNew(\OxidEsales\Eshop\Core\NoJsValidator::class);
         }
 

--- a/source/Application/Controller/Admin/ListComponentAjax.php
+++ b/source/Application/Controller/Admin/ListComponentAjax.php
@@ -169,7 +169,7 @@ class ListComponentAjax extends \OxidEsales\Eshop\Core\Base
     {
         $aVisibleNames = $this->_getVisibleColNames();
         $iCol = \OxidEsales\Eshop\Core\Registry::getConfig()->getRequestParameter('sort');
-        $iCol = $iCol ? ((int) str_replace('_', '', $iCol)) : 0;
+        $iCol = $iCol ? ((int) \str_replace('_', '', $iCol)) : 0;
         $iCol = (!isset($aVisibleNames[$iCol])) ? 0 : $iCol;
 
         return $iCol;
@@ -232,9 +232,9 @@ class ListComponentAjax extends \OxidEsales\Eshop\Core\Base
         $aVisibleCols = [];
 
         // user defined some cols to load ?
-        if (is_array($aUserCols)) {
+        if (\is_array($aUserCols)) {
             foreach ($aUserCols as $iKey => $sCol) {
-                $iCol = (int) str_replace('_', '', $sCol);
+                $iCol = (int) \str_replace('_', '', $sCol);
                 if (isset($aColNames[$iCol]) && !$aColNames[$iCol][4]) {
                     $aVisibleCols[$iCol] = $aColNames[$iCol];
                 }
@@ -242,7 +242,7 @@ class ListComponentAjax extends \OxidEsales\Eshop\Core\Base
         }
 
         // no user defined valid cols ? setting defauls ..
-        if (!count($aVisibleCols)) {
+        if (!\count($aVisibleCols)) {
             foreach ($aColNames as $sName => $aCol) {
                 // visible ?
                 if ($aCol[1] && !$aColNames[$sName][4]) {
@@ -372,7 +372,7 @@ class ListComponentAjax extends \OxidEsales\Eshop\Core\Base
         $sQ = '';
         $oConfig = \OxidEsales\Eshop\Core\Registry::getConfig();
         $aFilter = $oConfig->getRequestParameter('aFilter');
-        if (is_array($aFilter) && count($aFilter)) {
+        if (\is_array($aFilter) && \count($aFilter)) {
             $aCols = $this->_getVisibleColNames();
             $oDb = \OxidEsales\Eshop\Core\DatabaseProvider::getDb();
             $oStr = Str::getStr();
@@ -383,14 +383,14 @@ class ListComponentAjax extends \OxidEsales\Eshop\Core\Base
                     continue;
                 }
 
-                $iCol = (int) str_replace('_', '', $sCol);
+                $iCol = (int) \str_replace('_', '', $sCol);
                 if (isset($aCols[$iCol])) {
                     if ($sQ) {
                         $sQ .= ' and ';
                     }
 
                     // escaping special characters
-                    $sValue = str_replace(['%', '_'], ['\%', '\_'], $sValue);
+                    $sValue = \str_replace(['%', '_'], ['\%', '\_'], $sValue);
 
                     // possibility to search in the middle ..
                     $sValue = $oStr->preg_replace('/^\*/', '%', $sValue);
@@ -415,7 +415,7 @@ class ListComponentAjax extends \OxidEsales\Eshop\Core\Base
     protected function _addFilter($sQ) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         if ($sQ && ($sFilter = $this->_getFilter())) {
-            $sQ .= ((stristr($sQ, 'where') === false) ? 'where' : ' and ') . $sFilter;
+            $sQ .= ((\stristr($sQ, 'where') === false) ? 'where' : ' and ') . $sFilter;
         }
 
         return $sQ;
@@ -452,7 +452,7 @@ class ListComponentAjax extends \OxidEsales\Eshop\Core\Base
     protected function _getSortDir() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $sDir = \OxidEsales\Eshop\Core\Registry::getConfig()->getRequestParameter('dir');
-        if (!in_array($sDir, $this->_aPosDir)) {
+        if (!\in_array($sDir, $this->_aPosDir)) {
             $sDir = $this->_aPosDir[0];
         }
 
@@ -512,7 +512,7 @@ class ListComponentAjax extends \OxidEsales\Eshop\Core\Base
      */
     protected function _outputResponse($aData) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
-        $this->_output(json_encode($aData));
+        $this->_output(\json_encode($aData));
     }
 
     /**
@@ -595,7 +595,7 @@ class ListComponentAjax extends \OxidEsales\Eshop\Core\Base
             return;
         }
 
-        if (!is_array($aArtIds)) {
+        if (!\is_array($aArtIds)) {
             $aArtIds = [$aArtIds];
         }
 

--- a/source/Application/Controller/Admin/LoginController.php
+++ b/source/Application/Controller/Admin/LoginController.php
@@ -40,7 +40,7 @@ class LoginController extends \OxidEsales\Eshop\Application\Controller\Admin\Adm
         $myConfig = \OxidEsales\Eshop\Core\Registry::getConfig();
 
         // automatically redirect to SSL login
-        if (!$myConfig->isSsl() && strpos($myConfig->getConfigParam('sAdminSSLURL'), 'https://') === 0) {
+        if (!$myConfig->isSsl() && \strpos($myConfig->getConfigParam('sAdminSSLURL'), 'https://') === 0) {
             \OxidEsales\Eshop\Core\Registry::getUtils()->redirect($myConfig->getConfigParam('sAdminSSLURL'), false, 302);
         }
 
@@ -149,22 +149,22 @@ class LoginController extends \OxidEsales\Eshop\Application\Controller\Admin\Adm
             $aProfiles = \OxidEsales\Eshop\Core\Registry::getSession()->getVariable("aAdminProfiles");
             if ($aProfiles && isset($aProfiles[$sProfile])) {
                 // setting cookie to store last locally used profile
-                $myUtilsServer->setOxCookie("oxidadminprofile", $sProfile . "@" . implode("@", $aProfiles[$sProfile]), time() + 31536000, "/");
+                $myUtilsServer->setOxCookie("oxidadminprofile", $sProfile . "@" . \implode("@", $aProfiles[$sProfile]), \time() + 31536000, "/");
                 \OxidEsales\Eshop\Core\Registry::getSession()->setVariable("profile", $aProfiles[$sProfile]);
             }
         } else {
             //deleting cookie info, as setting profile to default
-            $myUtilsServer->setOxCookie("oxidadminprofile", "", time() - 3600, "/");
+            $myUtilsServer->setOxCookie("oxidadminprofile", "", \time() - 3600, "/");
         }
 
         // languages
         $iLang = \OxidEsales\Eshop\Core\Registry::getConfig()->getRequestParameter("chlanguage");
         $aLanguages = \OxidEsales\Eshop\Core\Registry::getLang()->getAdminTplLanguageArray();
         if (!isset($aLanguages[$iLang])) {
-            $iLang = key($aLanguages);
+            $iLang = \key($aLanguages);
         }
 
-        $myUtilsServer->setOxCookie("oxidadminlanguage", $aLanguages[$iLang]->abbr, time() + 31536000, "/");
+        $myUtilsServer->setOxCookie("oxidadminlanguage", $aLanguages[$iLang]->abbr, \time() + 31536000, "/");
 
         //P
         //\OxidEsales\Eshop\Core\Registry::getSession()->setVariable( "blAdminTemplateLanguage", $iLang );
@@ -222,6 +222,6 @@ class LoginController extends \OxidEsales\Eshop\Application\Controller\Admin\Adm
      */
     protected function _getBrowserLanguage() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
-        return strtolower(substr($_SERVER['HTTP_ACCEPT_LANGUAGE'], 0, 2));
+        return \strtolower(\substr($_SERVER['HTTP_ACCEPT_LANGUAGE'], 0, 2));
     }
 }

--- a/source/Application/Controller/Admin/ManufacturerMain.php
+++ b/source/Application/Controller/Admin/ManufacturerMain.php
@@ -35,7 +35,7 @@ class ManufacturerMain extends \OxidEsales\Eshop\Application\Controller\Admin\Ad
 
             $oOtherLang = $oManufacturer->getAvailableInLangs();
             if (!isset($oOtherLang[$this->_iEditLang])) {
-                $oManufacturer->loadInLang(key($oOtherLang), $soxId);
+                $oManufacturer->loadInLang(\key($oOtherLang), $soxId);
             }
             $this->_aViewData["edit"] = $oManufacturer;
 
@@ -48,8 +48,8 @@ class ManufacturerMain extends \OxidEsales\Eshop\Application\Controller\Admin\Ad
             }
 
             // remove already created languages
-            $aLang = array_diff(\OxidEsales\Eshop\Core\Registry::getLang()->getLanguageNames(), $oOtherLang);
-            if (count($aLang)) {
+            $aLang = \array_diff(\OxidEsales\Eshop\Core\Registry::getLang()->getLanguageNames(), $oOtherLang);
+            if (\count($aLang)) {
                 $this->_aViewData["posslang"] = $aLang;
             }
 

--- a/source/Application/Controller/Admin/ManufacturerMainAjax.php
+++ b/source/Application/Controller/Admin/ManufacturerMainAjax.php
@@ -119,7 +119,7 @@ class ManufacturerMainAjax extends \OxidEsales\Eshop\Application\Controller\Admi
             $articleIds = $this->_getAll($this->_addFilter("select $articleViewTable.oxid " . $this->_getQuery()));
         }
 
-        if (is_array($articleIds) && !empty($articleIds)) {
+        if (\is_array($articleIds) && !empty($articleIds)) {
             $query = $this->formManufacturerRemovalQuery($articleIds);
             \OxidEsales\Eshop\Core\DatabaseProvider::getDb()->execute($query);
 
@@ -139,7 +139,7 @@ class ManufacturerMainAjax extends \OxidEsales\Eshop\Application\Controller\Admi
         return "
           UPDATE oxarticles
           SET oxmanufacturerid = null
-          WHERE oxid IN ( " . implode(", ", \OxidEsales\Eshop\Core\DatabaseProvider::getDb()->quoteArray($articlesToRemove)) . ") ";
+          WHERE oxid IN ( " . \implode(", ", \OxidEsales\Eshop\Core\DatabaseProvider::getDb()->quoteArray($articlesToRemove)) . ") ";
     }
 
     /**
@@ -157,7 +157,7 @@ class ManufacturerMainAjax extends \OxidEsales\Eshop\Application\Controller\Admi
             $articleIds = $this->_getAll($this->_addFilter("select $articleViewName.oxid " . $this->_getQuery()));
         }
 
-        if ($manufacturerId && $manufacturerId != "-1" && is_array($articleIds)) {
+        if ($manufacturerId && $manufacturerId != "-1" && \is_array($articleIds)) {
             $database = \OxidEsales\Eshop\Core\DatabaseProvider::getDb();
 
             $query = $this->formArticleToManufacturerAdditionQuery($manufacturerId, $articleIds);
@@ -181,6 +181,6 @@ class ManufacturerMainAjax extends \OxidEsales\Eshop\Application\Controller\Admi
         return "
             UPDATE oxarticles
             SET oxmanufacturerid = " . $database->quote($manufacturerId) . "
-            WHERE oxid IN ( " . implode(", ", $database->quoteArray($articlesToAdd)) . " )";
+            WHERE oxid IN ( " . \implode(", ", $database->quoteArray($articlesToAdd)) . " )";
     }
 }

--- a/source/Application/Controller/Admin/ModuleConfiguration.php
+++ b/source/Application/Controller/Admin/ModuleConfiguration.php
@@ -112,12 +112,12 @@ class ModuleConfiguration extends \OxidEsales\Eshop\Application\Controller\Admin
 
         $aDbVariables = $this->loadConfVars($oConfig->getShopId(), $this->_getModuleForConfigVars());
 
-        if (is_array($aModuleSettings)) {
+        if (\is_array($aModuleSettings)) {
             foreach ($aModuleSettings as $aValue) {
                 $sName = $aValue["name"];
                 $sType = $aValue["type"];
                 $sValue = null;
-                if (is_null($oConfig->getConfigParam($sName))) {
+                if (\is_null($oConfig->getConfigParam($sName))) {
                     switch ($aValue["type"]) {
                         case "arr":
                             $sValue = $this->_arrayToMultiline($aValue["value"]);
@@ -126,7 +126,7 @@ class ModuleConfiguration extends \OxidEsales\Eshop\Application\Controller\Admin
                             $sValue = $this->_aarrayToMultiline($aValue["value"]);
                             break;
                         case "bool":
-                            $sValue = filter_var($aValue["value"], FILTER_VALIDATE_BOOLEAN);
+                            $sValue = \filter_var($aValue["value"], FILTER_VALIDATE_BOOLEAN);
                             break;
                         default:
                             $sValue = $aValue["value"];
@@ -232,7 +232,7 @@ class ModuleConfiguration extends \OxidEsales\Eshop\Application\Controller\Admin
                             $value = $this->_multilineToArray($value);
                         }
                         if ($moduleSetting->getType() === 'bool') {
-                            $value = filter_var($value, FILTER_VALIDATE_BOOLEAN);
+                            $value = \filter_var($value, FILTER_VALIDATE_BOOLEAN);
                         }
                         $moduleSetting->setValue($value);
                     }
@@ -294,7 +294,7 @@ class ModuleConfiguration extends \OxidEsales\Eshop\Application\Controller\Admin
                         $value = $this->_aarrayToMultiline($setting->getValue());
                         break;
                     case 'bool':
-                        $value = filter_var($setting->getValue(), FILTER_VALIDATE_BOOLEAN);
+                        $value = \filter_var($setting->getValue(), FILTER_VALIDATE_BOOLEAN);
                         break;
                     default:
                         $value = $setting->getValue();

--- a/source/Application/Controller/Admin/ModuleList.php
+++ b/source/Application/Controller/Admin/ModuleList.php
@@ -67,8 +67,8 @@ class ModuleList extends \OxidEsales\Eshop\Application\Controller\Admin\AdminLis
      */
     private function sortModulesByTitleAlphabetically(array $modules): array
     {
-        usort($modules, function ($a, $b) {
-            return strcmp($a->getTitle(), $b->getTitle());
+        \usort($modules, function ($a, $b) {
+            return \strcmp($a->getTitle(), $b->getTitle());
         });
 
         return $modules;

--- a/source/Application/Controller/Admin/ModuleMain.php
+++ b/source/Application/Controller/Admin/ModuleMain.php
@@ -39,8 +39,8 @@ class ModuleMain extends \OxidEsales\Eshop\Application\Controller\Admin\AdminDet
                 $iLang = \OxidEsales\Eshop\Core\Registry::getLang()->getTplLanguage();
 
                 $this->_aViewData["oModule"] = $oModule;
-                $this->_aViewData["sModuleName"] = basename($oModule->getInfo("title", $iLang));
-                $this->_aViewData["sModuleId"] = str_replace("/", "_", $oModule->getModulePath());
+                $this->_aViewData["sModuleName"] = \basename($oModule->getInfo("title", $iLang));
+                $this->_aViewData["sModuleId"] = \str_replace("/", "_", $oModule->getModulePath());
             } else {
                 \OxidEsales\Eshop\Core\Registry::getUtilsView()->addErrorToDisplay(new \OxidEsales\Eshop\Core\Exception\StandardException('EXCEPTION_MODULE_NOT_LOADED'));
             }

--- a/source/Application/Controller/Admin/ModuleSortList.php
+++ b/source/Application/Controller/Admin/ModuleSortList.php
@@ -42,7 +42,7 @@ class ModuleSortList extends \OxidEsales\Eshop\Application\Controller\Admin\Admi
 
         $sanitizedExtendClass = [];
         foreach ($classExtensionsChain as $extendedClass => $classChain) {
-            $sanitizedKey = str_replace("\\", self::BACKSLASH_REPLACEMENT, $extendedClass);
+            $sanitizedKey = \str_replace("\\", self::BACKSLASH_REPLACEMENT, $extendedClass);
             $sanitizedExtendClass[$sanitizedKey] = $classChain;
         }
 
@@ -66,7 +66,7 @@ class ModuleSortList extends \OxidEsales\Eshop\Application\Controller\Admin\Admi
      */
     public function save()
     {
-        $classExtensionsChainFromRequest = json_decode(
+        $classExtensionsChainFromRequest = \json_decode(
             Registry::getRequest()->getRequestEscapedParameter('aModules'),
             true
         );
@@ -116,7 +116,7 @@ class ModuleSortList extends \OxidEsales\Eshop\Application\Controller\Admin\Admi
         $sanitizedClassExtensionsChain = [];
 
         foreach ($chain as $key => $value) {
-            $sanitizedKey = str_replace(self::BACKSLASH_REPLACEMENT, "\\", $key);
+            $sanitizedKey = \str_replace(self::BACKSLASH_REPLACEMENT, "\\", $key);
             $sanitizedClassExtensionsChain[$sanitizedKey] = $value;
         }
 

--- a/source/Application/Controller/Admin/NavigationController.php
+++ b/source/Application/Controller/Admin/NavigationController.php
@@ -33,12 +33,12 @@ class NavigationController extends \OxidEsales\Eshop\Application\Controller\Admi
         $myUtilsServer = Registry::getUtilsServer();
 
         $sItem = Registry::getConfig()->getRequestParameter("item");
-        $sItem = $sItem ? basename($sItem) : false;
+        $sItem = $sItem ? \basename($sItem) : false;
         if (!$sItem) {
             $sItem = "nav_frame.tpl";
             $aFavorites = Registry::getConfig()->getRequestParameter("favorites");
-            if (is_array($aFavorites)) {
-                $myUtilsServer->setOxCookie('oxidadminfavorites', implode('|', $aFavorites));
+            if (\is_array($aFavorites)) {
+                $myUtilsServer->setOxCookie('oxidadminfavorites', \implode('|', $aFavorites));
             }
         } else {
             $oNavTree = $this->getNavigation();
@@ -61,16 +61,16 @@ class NavigationController extends \OxidEsales\Eshop\Application\Controller\Admi
             }
 
             // favorite navigation
-            $aFavorites = explode('|', $myUtilsServer->getOxCookie('oxidadminfavorites'));
+            $aFavorites = \explode('|', $myUtilsServer->getOxCookie('oxidadminfavorites'));
 
-            if (is_array($aFavorites) && count($aFavorites)) {
+            if (\is_array($aFavorites) && \count($aFavorites)) {
                 $this->_aViewData["menufavorites"] = $oNavTree->getListNodes($aFavorites);
                 $this->_aViewData["aFavorites"] = $aFavorites;
             }
 
             // history navigation
-            $aHistory = explode('|', $myUtilsServer->getOxCookie('oxidadminhistory'));
-            if (is_array($aHistory) && count($aHistory)) {
+            $aHistory = \explode('|', $myUtilsServer->getOxCookie('oxidadminhistory'));
+            if (\is_array($aHistory) && \count($aHistory)) {
                 $this->_aViewData["menuhistory"] = $oNavTree->getListNodes($aHistory);
             }
 
@@ -179,13 +179,13 @@ class NavigationController extends \OxidEsales\Eshop\Application\Controller\Admi
 
 
         // check if setup dir is deleted
-        if (file_exists(Registry::getConfig()->getConfigParam('sShopDir') . '/Setup/index.php')) {
+        if (\file_exists(Registry::getConfig()->getConfigParam('sShopDir') . '/Setup/index.php')) {
             $messages['warning'] .= ((!empty($messages['warning'])) ? "<br>" : '') . Registry::getLang()->translateString('SETUP_DIRNOTDELETED_WARNING');
         }
 
         // check if config file is writable
         $sConfPath = Registry::getConfig()->getConfigParam('sShopDir') . "/config.inc.php";
-        if (!is_readable($sConfPath) || is_writable($sConfPath)) {
+        if (!\is_readable($sConfPath) || \is_writable($sConfPath)) {
             $messages['warning'] .= ((!empty($messages['warning'])) ? "<br>" : '') . Registry::getLang()->translateString('SETUP_CONFIGPERMISSIONS_WARNING');
         }
 
@@ -205,8 +205,8 @@ class NavigationController extends \OxidEsales\Eshop\Application\Controller\Admi
         $latestVersion = Registry::getUtilsFile()->readRemoteFileAsString($query);
         if ($latestVersion) {
             $currentVersion = Registry::getConfig()->getVersion();
-            if (version_compare($currentVersion, $latestVersion, '<')) {
-                return sprintf(
+            if (\version_compare($currentVersion, $latestVersion, '<')) {
+                return \sprintf(
                     Registry::getLang()->translateString('NAVIGATION_NEW_VERSION_AVAILABLE'),
                     $currentVersion,
                     $latestVersion

--- a/source/Application/Controller/Admin/NavigationTree.php
+++ b/source/Application/Controller/Admin/NavigationTree.php
@@ -109,14 +109,14 @@ class NavigationTree extends \OxidEsales\Eshop\Core\Base
         $domFile->preserveWhiteSpace = false;
         if (!@$domFile->load($menuFile)) {
             $merge = true;
-        } elseif (is_readable($menuFile) && ($xml = @file_get_contents($menuFile))) {
+        } elseif (\is_readable($menuFile) && ($xml = @\file_get_contents($menuFile))) {
             // looking for non supported character encoding
             if (Str::getStr()->preg_match("/encoding\=(.*)\?\>/", $xml, $matches) !== 0) {
                 if (isset($matches[1])) {
-                    $currEncoding = trim($matches[1], "\"");
-                    if (!in_array(strtolower($currEncoding), $this->_aSupportedExpathXmlEncodings)) {
-                        $xml = str_replace($matches[1], "\"UTF-8\"", $xml);
-                        $xml = iconv($currEncoding, "UTF-8", $xml);
+                    $currEncoding = \trim($matches[1], "\"");
+                    if (!\in_array(\strtolower($currEncoding), $this->_aSupportedExpathXmlEncodings)) {
+                        $xml = \str_replace($matches[1], "\"UTF-8\"", $xml);
+                        $xml = \iconv($currEncoding, "UTF-8", $xml);
                     }
                 }
             }
@@ -146,7 +146,7 @@ class NavigationTree extends \OxidEsales\Eshop\Core\Base
         foreach (['url', 'link'] as $attrType) {
             foreach ($xPath->query("//OXMENU//*[@$attrType]") as $node) {
                 $localUrl = $node->getAttribute($attrType);
-                if (strpos($localUrl, 'index.php?') === 0) {
+                if (\strpos($localUrl, 'index.php?') === 0) {
                     $localUrl = $str->preg_replace('#^index.php\?#', $url, $localUrl);
                     $node->setAttribute($attrType, $localUrl);
                 }
@@ -168,7 +168,7 @@ class NavigationTree extends \OxidEsales\Eshop\Core\Base
         foreach ($nodeList as $node) {
             // only allowed modules/user rights or so
             if (($req = $node->getAttribute('rights'))) {
-                $perms = explode(',', $req);
+                $perms = \explode(',', $req);
                 foreach ($perms as $perm) {
                     if ($perm && !$this->_hasRights($perm)) {
                         $node->parentNode->removeChild($node);
@@ -176,7 +176,7 @@ class NavigationTree extends \OxidEsales\Eshop\Core\Base
                 }
                 // not allowed modules/user rights or so
             } elseif (($noReq = $node->getAttribute('norights'))) {
-                $perms = explode(',', $noReq);
+                $perms = \explode(',', $noReq);
                 foreach ($perms as $perm) {
                     if ($perm && $this->_hasRights($perm)) {
                         $node->parentNode->removeChild($node);
@@ -200,7 +200,7 @@ class NavigationTree extends \OxidEsales\Eshop\Core\Base
         foreach ($nodeList as $node) {
             // allowed only for groups
             if (($req = $node->getAttribute('group'))) {
-                $perms = explode(',', $req);
+                $perms = \explode(',', $req);
                 foreach ($perms as $perm) {
                     if ($perm && !$this->_hasGroup($perm)) {
                         $node->parentNode->removeChild($node);
@@ -208,7 +208,7 @@ class NavigationTree extends \OxidEsales\Eshop\Core\Base
                 }
                 // not allowed for groups
             } elseif (($noReq = $node->getAttribute('nogroup'))) {
-                $perms = explode(',', $noReq);
+                $perms = \explode(',', $noReq);
                 foreach ($perms as $perm) {
                     if ($perm && $this->_hasGroup($perm)) {
                         $node->parentNode->removeChild($node);
@@ -407,14 +407,14 @@ class NavigationTree extends \OxidEsales\Eshop\Core\Base
         $path = getShopBasePath();
         $moduleList = oxNew(\OxidEsales\Eshop\Core\Module\ModuleList::class);
         $activeModuleInfo = $moduleList->getActiveModuleInfo();
-        if (is_array($activeModuleInfo)) {
+        if (\is_array($activeModuleInfo)) {
             foreach ($activeModuleInfo as $modulePath) {
                 $fullPath = $path . "modules/" . $modulePath;
                 // missing file/folder?
-                if (is_dir($fullPath)) {
+                if (\is_dir($fullPath)) {
                     // including menu file
                     $menuFile = $fullPath . "/menu.xml";
-                    if (file_exists($menuFile) && is_readable($menuFile)) {
+                    if (\file_exists($menuFile) && \is_readable($menuFile)) {
                         $filesToLoad[] = $menuFile;
                     }
                 }
@@ -448,7 +448,7 @@ class NavigationTree extends \OxidEsales\Eshop\Core\Base
         if ($this->_oInitialDom === null) {
             $myOxUtlis = \OxidEsales\Eshop\Core\Registry::getUtils();
 
-            if (is_array($filesToLoad = $this->_getMenuFiles())) {
+            if (\is_array($filesToLoad = $this->_getMenuFiles())) {
                 // now checking if xml files are newer than cached file
                 $reload = false;
                 $templateLanguageCode = $this->getTemplateLanguageCode();
@@ -457,9 +457,9 @@ class NavigationTree extends \OxidEsales\Eshop\Core\Base
                 $cacheName = 'menu_' . $templateLanguageCode . $shopId . '_xml';
                 $cacheFile = $myOxUtlis->getCacheFilePath($cacheName);
                 $cacheContents = $myOxUtlis->fromFileCache($cacheName);
-                if ($cacheContents && file_exists($cacheFile) && ($cacheModTime = filemtime($cacheFile))) {
+                if ($cacheContents && \file_exists($cacheFile) && ($cacheModTime = \filemtime($cacheFile))) {
                     foreach ($filesToLoad as $dynPath) {
-                        if ($cacheModTime < filemtime($dynPath)) {
+                        if ($cacheModTime < \filemtime($dynPath)) {
                             $reload = true;
                         }
                     }
@@ -535,7 +535,7 @@ class NavigationTree extends \OxidEsales\Eshop\Core\Base
     public function getListNodes($nodes)
     {
         $xPath = new DOMXPath($this->getDomXml());
-        $nodeList = $xPath->query("//SUBMENU[@cl='" . implode("' or @cl='", $nodes) . "']");
+        $nodeList = $xPath->query("//SUBMENU[@cl='" . \implode("' or @cl='", $nodes) . "']");
 
         return ($nodeList->length) ? $nodeList : null;
     }
@@ -621,9 +621,9 @@ class NavigationTree extends \OxidEsales\Eshop\Core\Base
         $myConfig = \OxidEsales\Eshop\Core\Registry::getConfig();
 
         if (($adminSslUrl = $myConfig->getConfigParam('sAdminSSLURL'))) {
-            $url = trim($adminSslUrl, '/');
+            $url = \trim($adminSslUrl, '/');
         } else {
-            $url = trim($myConfig->getConfigParam('sShopURL'), '/') . '/admin';
+            $url = \trim($myConfig->getConfigParam('sShopURL'), '/') . '/admin';
         }
 
         return \OxidEsales\Eshop\Core\Registry::getUtilsUrl()->processUrl("{$url}/index.php", false);

--- a/source/Application/Controller/Admin/NewsletterSelectionAjax.php
+++ b/source/Application/Controller/Admin/NewsletterSelectionAjax.php
@@ -73,8 +73,8 @@ class NewsletterSelectionAjax extends \OxidEsales\Eshop\Application\Controller\A
         if (\OxidEsales\Eshop\Core\Registry::getConfig()->getRequestParameter('all')) {
             $sQ = $this->_addFilter("delete oxobject2group.* " . $this->_getQuery());
             \OxidEsales\Eshop\Core\DatabaseProvider::getDb()->Execute($sQ);
-        } elseif ($aRemoveGroups && is_array($aRemoveGroups)) {
-            $sQ = "delete from oxobject2group where oxobject2group.oxid in (" . implode(", ", \OxidEsales\Eshop\Core\DatabaseProvider::getDb()->quoteArray($aRemoveGroups)) . ") ";
+        } elseif ($aRemoveGroups && \is_array($aRemoveGroups)) {
+            $sQ = "delete from oxobject2group where oxobject2group.oxid in (" . \implode(", ", \OxidEsales\Eshop\Core\DatabaseProvider::getDb()->quoteArray($aRemoveGroups)) . ") ";
             \OxidEsales\Eshop\Core\DatabaseProvider::getDb()->Execute($sQ);
         }
     }
@@ -91,7 +91,7 @@ class NewsletterSelectionAjax extends \OxidEsales\Eshop\Application\Controller\A
             $sGroupTable = $this->_getViewName('oxgroups');
             $aAddGroups = $this->_getAll($this->_addFilter("select $sGroupTable.oxid " . $this->_getQuery()));
         }
-        if ($soxId && $soxId != "-1" && is_array($aAddGroups)) {
+        if ($soxId && $soxId != "-1" && \is_array($aAddGroups)) {
             foreach ($aAddGroups as $sAddgroup) {
                 $oNewGroup = oxNew(\OxidEsales\Eshop\Application\Model\Object2Group::class);
                 $oNewGroup->oxobject2group__oxobjectid = new \OxidEsales\Eshop\Core\Field($soxId);

--- a/source/Application/Controller/Admin/NewsletterSend.php
+++ b/source/Application/Controller/Admin/NewsletterSend.php
@@ -127,7 +127,7 @@ class NewsletterSend extends \OxidEsales\Eshop\Application\Controller\Admin\News
             }
         }
 
-        $iSend = $iSendCnt + (ceil($iStart / $iMaxCnt) - 1) * $iMaxCnt;
+        $iSend = $iSendCnt + (\ceil($iStart / $iMaxCnt) - 1) * $iMaxCnt;
         $iSend = $iSend > $iUserCount ? $iUserCount : $iSend;
 
         $this->_aViewData["iStart"] = $iStart;

--- a/source/Application/Controller/Admin/ObjectSeo.php
+++ b/source/Application/Controller/Admin/ObjectSeo.php
@@ -32,7 +32,7 @@ class ObjectSeo extends \OxidEsales\Eshop\Application\Controller\Admin\AdminDeta
             if ($oObject->load($this->getEditObjectId())) {
                 $oOtherLang = $oObject->getAvailableInLangs();
                 if (!isset($oOtherLang[$iLang])) {
-                    $oObject->loadInLang(key($oOtherLang), $this->getEditObjectId());
+                    $oObject->loadInLang(\key($oOtherLang), $this->getEditObjectId());
                 }
                 $this->_aViewData['edit'] = $oObject;
             }
@@ -85,8 +85,8 @@ class ObjectSeo extends \OxidEsales\Eshop\Application\Controller\Admin\AdminDeta
                 $aSeoData['oxseourl'],
                 $this->_getSeoEntryType(),
                 $aSeoData['oxfixed'],
-                trim($aSeoData['oxkeywords']),
-                trim($aSeoData['oxdescription']),
+                \trim($aSeoData['oxkeywords']),
+                \trim($aSeoData['oxdescription']),
                 $this->processParam($aSeoData['oxparams']),
                 true,
                 $this->_getAltSeoEntryId()
@@ -106,7 +106,7 @@ class ObjectSeo extends \OxidEsales\Eshop\Application\Controller\Admin\AdminDeta
     {
         $sParams = null;
         if (isset($aSeoData['oxparams'])) {
-            if (preg_match('/([a-z]*#)?(?<objectseo>[a-z0-9]+)(#[0-9])?/i', $aSeoData['oxparams'], $aMatches)) {
+            if (\preg_match('/([a-z]*#)?(?<objectseo>[a-z0-9]+)(#[0-9])?/i', $aSeoData['oxparams'], $aMatches)) {
                 $sQuotedObjectSeoId = \OxidEsales\Eshop\Core\DatabaseProvider::getDb()->quote($aMatches['objectseo']);
                 $sParams = "oxparams = {$sQuotedObjectSeoId}";
             }

--- a/source/Application/Controller/Admin/OrderAddress.php
+++ b/source/Application/Controller/Admin/OrderAddress.php
@@ -65,12 +65,12 @@ class OrderAddress extends \OxidEsales\Eshop\Application\Controller\Admin\AdminD
 
         foreach ($aData as $sName => $sValue) {
             // if field type matches..
-            if (strpos($sName, $sTypeToProcess) !== false) {
+            if (\strpos($sName, $sTypeToProcess) !== false) {
                 // storing which fields must be unset..
                 $aFields[] = $sName;
 
                 // ignoring whats need to be ignored and testing values
-                if (!in_array($sName, $aIgnore) && $sValue) {
+                if (!\in_array($sName, $aIgnore) && $sValue) {
                     // something was found - means leaving as is..
                     $blEmpty = false;
                     break;

--- a/source/Application/Controller/Admin/OrderArticle.php
+++ b/source/Application/Controller/Admin/OrderArticle.php
@@ -260,7 +260,7 @@ class OrderArticle extends \OxidEsales\Eshop\Application\Controller\Admin\AdminD
         $aOrderArticles = \OxidEsales\Eshop\Core\Registry::getConfig()->getRequestParameter('aOrderArticles');
 
         $oOrder = oxNew(\OxidEsales\Eshop\Application\Model\Order::class);
-        if (is_array($aOrderArticles) && $oOrder->load($this->getEditObjectId())) {
+        if (\is_array($aOrderArticles) && $oOrder->load($this->getEditObjectId())) {
             $myConfig = \OxidEsales\Eshop\Core\Registry::getConfig();
             $oOrderArticles = $oOrder->getOrderArticles(true);
 

--- a/source/Application/Controller/Admin/OrderList.php
+++ b/source/Application/Controller/Admin/OrderList.php
@@ -51,8 +51,8 @@ class OrderList extends \OxidEsales\Eshop\Application\Controller\Admin\AdminList
         $folders = \OxidEsales\Eshop\Core\Registry::getConfig()->getConfigParam('aOrderfolder');
         $folder = \OxidEsales\Eshop\Core\Registry::getConfig()->getRequestParameter("folder");
         // first display new orders
-        if (!$folder && is_array($folders)) {
-            $names = array_keys($folders);
+        if (!$folder && \is_array($folders)) {
+            $names = \array_keys($folders);
             $folder = $names[0];
         }
 
@@ -129,8 +129,8 @@ class OrderList extends \OxidEsales\Eshop\Application\Controller\Admin\AdminList
         // Searching for empty oxfolder fields
         if ($folder && $folder != '-1') {
             $query .= " and ( oxorder.oxfolder = " . $database->quote($folder) . " )";
-        } elseif (!$folder && is_array($folders)) {
-            $folderNames = array_keys($folders);
+        } elseif (!$folder && \is_array($folders)) {
+            $folderNames = \array_keys($folders);
             $query .= " and ( oxorder.oxfolder = " . $database->quote($folderNames[0]) . " )";
         }
 
@@ -151,7 +151,7 @@ class OrderList extends \OxidEsales\Eshop\Application\Controller\Admin\AdminList
         $database = \OxidEsales\Eshop\Core\DatabaseProvider::getDb();
 
         $searchQuery = \OxidEsales\Eshop\Core\Registry::getConfig()->getRequestParameter('addsearch');
-        $searchQuery = trim($searchQuery);
+        $searchQuery = \trim($searchQuery);
         $searchField = \OxidEsales\Eshop\Core\Registry::getConfig()->getRequestParameter('addsearchfld');
 
         if ($searchQuery) {
@@ -166,7 +166,7 @@ class OrderList extends \OxidEsales\Eshop\Application\Controller\Admin\AdminList
                     $queryPart = "oxorder where oxorder.oxpaid like " . $database->quote("%{$searchQuery}%") . " and ";
                     break;
             }
-            $query = str_replace('oxorder where', $queryPart, $query);
+            $query = \str_replace('oxorder where', $queryPart, $query);
         }
 
         return $query;

--- a/source/Application/Controller/Admin/OrderMain.php
+++ b/source/Application/Controller/Admin/OrderMain.php
@@ -79,7 +79,7 @@ class OrderMain extends \OxidEsales\Eshop\Application\Controller\Admin\AdminDeta
             $this->_aViewData["aVouchers"] = $oOrder->getVoucherNrList();
         }
 
-        $this->_aViewData["sNowValue"] = date("Y-m-d H:i:s", \OxidEsales\Eshop\Core\Registry::getUtilsDate()->getTime());
+        $this->_aViewData["sNowValue"] = \date("Y-m-d H:i:s", \OxidEsales\Eshop\Core\Registry::getUtilsDate()->getTime());
 
         return "order_main.tpl";
     }
@@ -102,11 +102,11 @@ class OrderMain extends \OxidEsales\Eshop\Application\Controller\Admin\AdminDeta
         }
 
         $needOrderRecalculate = false;
-        if (is_array($aParams)) {
+        if (\is_array($aParams)) {
             foreach ($aParams as $parameter => $value) {
                 //parameter changes for not whitelisted parameters trigger order recalculation
                 $orderField = $oOrder->$parameter;
-                if (($value != $orderField->value) && !in_array($parameter, $this->fieldsTriggerNoOrderRecalculation)) {
+                if (($value != $orderField->value) && !\in_array($parameter, $this->fieldsTriggerNoOrderRecalculation)) {
                     $needOrderRecalculate = true;
                     continue;
                 }
@@ -163,7 +163,7 @@ class OrderMain extends \OxidEsales\Eshop\Application\Controller\Admin\AdminDeta
         $oOrder = oxNew(\OxidEsales\Eshop\Application\Model\Order::class);
         if ($oOrder->load($soxId)) {
             // #632A
-            $oOrder->oxorder__oxsenddate = new \OxidEsales\Eshop\Core\Field(date("Y-m-d H:i:s", \OxidEsales\Eshop\Core\Registry::getUtilsDate()->getTime()));
+            $oOrder->oxorder__oxsenddate = new \OxidEsales\Eshop\Core\Field(\date("Y-m-d H:i:s", \OxidEsales\Eshop\Core\Registry::getUtilsDate()->getTime()));
             $oOrder->save();
 
             // #1071C

--- a/source/Application/Controller/Admin/OrderOverview.php
+++ b/source/Application/Controller/Admin/OrderOverview.php
@@ -99,10 +99,10 @@ class OrderOverview extends \OxidEsales\Eshop\Application\Controller\Admin\Admin
      */
     public function makeValidFileName($sFilename)
     {
-        $sFilename = preg_replace('/[\s]+/', '_', $sFilename);
-        $sFilename = preg_replace('/[^a-zA-Z0-9_\.-]/', '', $sFilename);
+        $sFilename = \preg_replace('/[\s]+/', '_', $sFilename);
+        $sFilename = \preg_replace('/[^a-zA-Z0-9_\.-]/', '', $sFilename);
 
-        return str_replace(' ', '_', $sFilename);
+        return \str_replace(' ', '_', $sFilename);
     }
 
     /**
@@ -112,7 +112,7 @@ class OrderOverview extends \OxidEsales\Eshop\Application\Controller\Admin\Admin
     {
         $oOrder = oxNew(\OxidEsales\Eshop\Application\Model\Order::class);
         if ($oOrder->load($this->getEditObjectId())) {
-            $oOrder->oxorder__oxsenddate = new \OxidEsales\Eshop\Core\Field(date("Y-m-d H:i:s", \OxidEsales\Eshop\Core\Registry::getUtilsDate()->getTime()));
+            $oOrder->oxorder__oxsenddate = new \OxidEsales\Eshop\Core\Field(\date("Y-m-d H:i:s", \OxidEsales\Eshop\Core\Registry::getUtilsDate()->getTime()));
             $oOrder->save();
 
             // #1071C

--- a/source/Application/Controller/Admin/PaymentCountry.php
+++ b/source/Application/Controller/Admin/PaymentCountry.php
@@ -41,13 +41,13 @@ class PaymentCountry extends \OxidEsales\Eshop\Application\Controller\Admin\Admi
             $oOtherLang = $oPayment->getAvailableInLangs();
             if (!isset($oOtherLang[$this->_iEditLang])) {
                 // echo "language entry doesn't exist! using: ".key($oOtherLang);
-                $oPayment->loadInLang(key($oOtherLang), $soxId);
+                $oPayment->loadInLang(\key($oOtherLang), $soxId);
             }
             $this->_aViewData["edit"] = $oPayment;
 
             // remove already created languages
-            $aLang = array_diff(\OxidEsales\Eshop\Core\Registry::getLang()->getLanguageNames(), $oOtherLang);
-            if (count($aLang)) {
+            $aLang = \array_diff(\OxidEsales\Eshop\Core\Registry::getLang()->getLanguageNames(), $oOtherLang);
+            if (\count($aLang)) {
                 $this->_aViewData["posslang"] = $aLang;
             }
 
@@ -76,7 +76,7 @@ class PaymentCountry extends \OxidEsales\Eshop\Application\Controller\Admin\Admi
     {
         $sOxId = $this->getEditObjectId();
         $aChosenCntr = \OxidEsales\Eshop\Core\Registry::getConfig()->getRequestParameter("allcountries");
-        if (isset($sOxId) && $sOxId != "-1" && is_array($aChosenCntr)) {
+        if (isset($sOxId) && $sOxId != "-1" && \is_array($aChosenCntr)) {
             foreach ($aChosenCntr as $sChosenCntr) {
                 $oObject2Payment = oxNew(\OxidEsales\Eshop\Core\Model\BaseModel::class);
                 $oObject2Payment->init('oxobject2payment');
@@ -95,7 +95,7 @@ class PaymentCountry extends \OxidEsales\Eshop\Application\Controller\Admin\Admi
     {
         $sOxId = $this->getEditObjectId();
         $aChosenCntr = \OxidEsales\Eshop\Core\Registry::getConfig()->getRequestParameter("countries");
-        if (isset($sOxId) && $sOxId != "-1" && is_array($aChosenCntr)) {
+        if (isset($sOxId) && $sOxId != "-1" && \is_array($aChosenCntr)) {
             foreach ($aChosenCntr as $sChosenCntr) {
                 $oObject2Payment = oxNew(\OxidEsales\Eshop\Core\Model\BaseModel::class);
                 $oObject2Payment->init('oxobject2payment');

--- a/source/Application/Controller/Admin/PaymentCountryAjax.php
+++ b/source/Application/Controller/Admin/PaymentCountryAjax.php
@@ -80,7 +80,7 @@ class PaymentCountryAjax extends \OxidEsales\Eshop\Application\Controller\Admin\
             $sCountryTable = $this->_getViewName('oxcountry');
             $aChosenCntr = $this->_getAll($this->_addFilter("select $sCountryTable.oxid " . $this->_getQuery()));
         }
-        if ($soxId && $soxId != "-1" && is_array($aChosenCntr)) {
+        if ($soxId && $soxId != "-1" && \is_array($aChosenCntr)) {
             foreach ($aChosenCntr as $sChosenCntr) {
                 $oObject2Payment = oxNew(\OxidEsales\Eshop\Core\Model\BaseModel::class);
                 $oObject2Payment->init('oxobject2payment');
@@ -101,8 +101,8 @@ class PaymentCountryAjax extends \OxidEsales\Eshop\Application\Controller\Admin\
         if (\OxidEsales\Eshop\Core\Registry::getConfig()->getRequestParameter('all')) {
             $sQ = $this->_addFilter("delete oxobject2payment.* " . $this->_getQuery());
             \OxidEsales\Eshop\Core\DatabaseProvider::getDb()->Execute($sQ);
-        } elseif (is_array($aChosenCntr)) {
-            $sQ = "delete from oxobject2payment where oxobject2payment.oxid in (" . implode(", ", \OxidEsales\Eshop\Core\DatabaseProvider::getDb()->quoteArray($aChosenCntr)) . ") ";
+        } elseif (\is_array($aChosenCntr)) {
+            $sQ = "delete from oxobject2payment where oxobject2payment.oxid in (" . \implode(", ", \OxidEsales\Eshop\Core\DatabaseProvider::getDb()->quoteArray($aChosenCntr)) . ") ";
             \OxidEsales\Eshop\Core\DatabaseProvider::getDb()->Execute($sQ);
         }
     }

--- a/source/Application/Controller/Admin/PaymentMain.php
+++ b/source/Application/Controller/Admin/PaymentMain.php
@@ -46,13 +46,13 @@ class PaymentMain extends \OxidEsales\Eshop\Application\Controller\Admin\AdminDe
             $oOtherLang = $oPayment->getAvailableInLangs();
             if (!isset($oOtherLang[$this->_iEditLang])) {
                 // echo "language entry doesn't exist! using: ".key($oOtherLang);
-                $oPayment->loadInLang(key($oOtherLang), $soxId);
+                $oPayment->loadInLang(\key($oOtherLang), $soxId);
             }
             $this->_aViewData["edit"] = $oPayment;
 
             // remove already created languages
-            $aLang = array_diff(\OxidEsales\Eshop\Core\Registry::getLang()->getLanguageNames(), $oOtherLang);
-            if (count($aLang)) {
+            $aLang = \array_diff(\OxidEsales\Eshop\Core\Registry::getLang()->getLanguageNames(), $oOtherLang);
+            if (\count($aLang)) {
                 $this->_aViewData["posslang"] = $aLang;
             }
 
@@ -114,11 +114,11 @@ class PaymentMain extends \OxidEsales\Eshop\Application\Controller\Admin\AdminDe
         if (empty($aRules)) {
             $this->_aViewData["noticeoxaddsumrules"] = 1;
         }
-        $oPayment->oxpayments__oxaddsumrules = new \OxidEsales\Eshop\Core\Field(array_sum($aRules));
+        $oPayment->oxpayments__oxaddsumrules = new \OxidEsales\Eshop\Core\Field(\array_sum($aRules));
 
 
         //#708
-        if (!is_array($this->_aFieldArray)) {
+        if (!\is_array($this->_aFieldArray)) {
             $this->_aFieldArray = \OxidEsales\Eshop\Core\Registry::getUtils()->assignValuesFromText($oPayment->oxpayments__oxvaldesc->value);
         }
 
@@ -174,7 +174,7 @@ class PaymentMain extends \OxidEsales\Eshop\Application\Controller\Admin\AdminDe
             $aDelFields = \OxidEsales\Eshop\Core\Registry::getConfig()->getRequestParameter("aFields");
             $this->_aFieldArray = \OxidEsales\Eshop\Core\Registry::getUtils()->assignValuesFromText($oPayment->oxpayments__oxvaldesc->value);
 
-            if (is_array($aDelFields) && count($aDelFields)) {
+            if (\is_array($aDelFields) && \count($aDelFields)) {
                 foreach ($aDelFields as $sDelField) {
                     foreach ($this->_aFieldArray as $sKey => $oField) {
                         if ($oField->name == $sDelField) {

--- a/source/Application/Controller/Admin/PaymentMainAjax.php
+++ b/source/Application/Controller/Admin/PaymentMainAjax.php
@@ -83,8 +83,8 @@ class PaymentMainAjax extends \OxidEsales\Eshop\Application\Controller\Admin\Lis
         if (\OxidEsales\Eshop\Core\Registry::getConfig()->getRequestParameter('all')) {
             $sQ = $this->_addFilter("delete oxobject2group.* " . $this->_getQuery());
             \OxidEsales\Eshop\Core\DatabaseProvider::getDb()->Execute($sQ);
-        } elseif ($aRemoveGroups && is_array($aRemoveGroups)) {
-            $sRemoveGroups = implode(", ", \OxidEsales\Eshop\Core\DatabaseProvider::getDb()->quoteArray($aRemoveGroups));
+        } elseif ($aRemoveGroups && \is_array($aRemoveGroups)) {
+            $sRemoveGroups = \implode(", ", \OxidEsales\Eshop\Core\DatabaseProvider::getDb()->quoteArray($aRemoveGroups));
             $sQ = "delete from oxobject2group where oxobject2group.oxid in (" . $sRemoveGroups . ") ";
             \OxidEsales\Eshop\Core\DatabaseProvider::getDb()->Execute($sQ);
         }
@@ -102,7 +102,7 @@ class PaymentMainAjax extends \OxidEsales\Eshop\Application\Controller\Admin\Lis
             $sGroupTable = $this->_getViewName('oxgroups');
             $aAddGroups = $this->_getAll($this->_addFilter("select $sGroupTable.oxid " . $this->_getQuery()));
         }
-        if ($soxId && $soxId != "-1" && is_array($aAddGroups)) {
+        if ($soxId && $soxId != "-1" && \is_array($aAddGroups)) {
             foreach ($aAddGroups as $sAddgroup) {
                 $oNewGroup = oxNew(\OxidEsales\Eshop\Application\Model\Object2Group::class);
                 $oNewGroup->oxobject2group__oxobjectid = new \OxidEsales\Eshop\Core\Field($soxId);

--- a/source/Application/Controller/Admin/PaymentRdfa.php
+++ b/source/Application/Controller/Admin/PaymentRdfa.php
@@ -80,7 +80,7 @@ class PaymentRdfa extends \OxidEsales\Eshop\Application\Controller\Admin\AdminDe
             $oPayment = new stdClass();
             $oPayment->name = $sName;
             $oPayment->type = $iType;
-            $oPayment->checked = in_array($sName, $aAssignedRDFaPayments);
+            $oPayment->checked = \in_array($sName, $aAssignedRDFaPayments);
             $aRDFaPayments[] = $oPayment;
         }
 

--- a/source/Application/Controller/Admin/PriceAlarmList.php
+++ b/source/Application/Controller/Admin/PriceAlarmList.php
@@ -67,12 +67,12 @@ class PriceAlarmList extends \OxidEsales\Eshop\Application\Controller\Admin\Admi
 
         // updating price fields values for correct search in DB
         if (isset($this->_aWhere[$sViewName . '.oxprice'])) {
-            $sPriceParam = (double) str_replace(['%', ','], ['', '.'], $this->_aWhere[$sViewName . '.oxprice']);
+            $sPriceParam = (double) \str_replace(['%', ','], ['', '.'], $this->_aWhere[$sViewName . '.oxprice']);
             $this->_aWhere[$sViewName . '.oxprice'] = '%' . $sPriceParam . '%';
         }
 
         if (isset($this->_aWhere[$sArtViewName . '.oxprice'])) {
-            $sPriceParam = (double) str_replace(['%', ','], ['', '.'], $this->_aWhere[$sArtViewName . '.oxprice']);
+            $sPriceParam = (double) \str_replace(['%', ','], ['', '.'], $this->_aWhere[$sArtViewName . '.oxprice']);
             $this->_aWhere[$sArtViewName . '.oxprice'] = '%' . $sPriceParam . '%';
         }
 

--- a/source/Application/Controller/Admin/PriceAlarmMain.php
+++ b/source/Application/Controller/Admin/PriceAlarmMain.php
@@ -62,7 +62,7 @@ class PriceAlarmMain extends \OxidEsales\Eshop\Application\Controller\Admin\Admi
             $oLetter = new stdClass();
             $aParams = \OxidEsales\Eshop\Core\Registry::getConfig()->getRequestParameter("editval");
             if (isset($aParams['oxpricealarm__oxlongdesc']) && $aParams['oxpricealarm__oxlongdesc']) {
-                $oLetter->oxpricealarm__oxlongdesc = new \OxidEsales\Eshop\Core\Field(stripslashes($aParams['oxpricealarm__oxlongdesc']), \OxidEsales\Eshop\Core\Field::T_RAW);
+                $oLetter->oxpricealarm__oxlongdesc = new \OxidEsales\Eshop\Core\Field(\stripslashes($aParams['oxpricealarm__oxlongdesc']), \OxidEsales\Eshop\Core\Field::T_RAW);
             } else {
                 $oEmail = oxNew(\OxidEsales\Eshop\Core\Email::class);
                 $sDesc = $oEmail->sendPricealarmToCustomer($oPricealarm->oxpricealarm__oxemail->value, $oPricealarm, null, true);
@@ -96,7 +96,7 @@ class PriceAlarmMain extends \OxidEsales\Eshop\Application\Controller\Admin\Admi
             $oPricealarm->load($sOxid);
 
             $aParams = \OxidEsales\Eshop\Core\Registry::getConfig()->getRequestParameter("editval");
-            $sMailBody = isset($aParams['oxpricealarm__oxlongdesc']) ? stripslashes($aParams['oxpricealarm__oxlongdesc']) : '';
+            $sMailBody = isset($aParams['oxpricealarm__oxlongdesc']) ? \stripslashes($aParams['oxpricealarm__oxlongdesc']) : '';
             if ($sMailBody) {
                 $sMailBody = \OxidEsales\Eshop\Core\Registry::getUtilsView()->parseThroughSmarty($sMailBody, $oPricealarm->getId());
             }
@@ -108,7 +108,7 @@ class PriceAlarmMain extends \OxidEsales\Eshop\Application\Controller\Admin\Admi
 
             // setting result message
             if ($blSuccess) {
-                $oPricealarm->oxpricealarm__oxsended->setValue(date("Y-m-d H:i:s"));
+                $oPricealarm->oxpricealarm__oxsended->setValue(\date("Y-m-d H:i:s"));
                 $oPricealarm->save();
                 $blError = false;
             }

--- a/source/Application/Controller/Admin/PriceAlarmSend.php
+++ b/source/Application/Controller/Admin/PriceAlarmSend.php
@@ -37,7 +37,7 @@ class PriceAlarmSend extends \OxidEsales\Eshop\Application\Controller\Admin\Admi
 
         $config = \OxidEsales\Eshop\Core\Registry::getConfig();
 
-        ini_set("session.gc_maxlifetime", 36000);
+        \ini_set("session.gc_maxlifetime", 36000);
 
         $start = (int) $config->getRequestParameter("iStart");
         $limit = $config->getConfigParam('iCntofMails');
@@ -164,7 +164,7 @@ class PriceAlarmSend extends \OxidEsales\Eshop\Application\Controller\Admin\Admi
         $language->setTplLanguage($oldLanguageId);
 
         if ($success) {
-            $alarm->oxpricealarm__oxsended = new \OxidEsales\Eshop\Core\Field(date("Y-m-d H:i:s"));
+            $alarm->oxpricealarm__oxsended = new \OxidEsales\Eshop\Core\Field(\date("Y-m-d H:i:s"));
             $alarm->save();
         }
     }

--- a/source/Application/Controller/Admin/SelectListMain.php
+++ b/source/Application/Controller/Admin/SelectListMain.php
@@ -11,14 +11,14 @@ use oxRegistry;
 use oxField;
 use stdClass;
 
-if (!defined('ERR_SUCCESS')) {
-    DEFINE("ERR_SUCCESS", 1);
+if (!\defined('ERR_SUCCESS')) {
+    \DEFINE("ERR_SUCCESS", 1);
 }
-if (!defined('ERR_REQUIREDMISSING')) {
-    DEFINE("ERR_REQUIREDMISSING", -1);
+if (!\defined('ERR_REQUIREDMISSING')) {
+    \DEFINE("ERR_REQUIREDMISSING", -1);
 }
-if (!defined('ERR_POSOUTOFBOUNDS')) {
-    DEFINE("ERR_POSOUTOFBOUNDS", -2);
+if (!\defined('ERR_POSOUTOFBOUNDS')) {
+    \DEFINE("ERR_POSOUTOFBOUNDS", -2);
 }
 
 /**
@@ -59,7 +59,7 @@ class SelectListMain extends \OxidEsales\Eshop\Application\Controller\Admin\Admi
             $oAttr->loadInLang($this->_iEditLang, $sOxId);
 
             $aFieldList = $oAttr->getFieldList();
-            if (is_array($aFieldList)) {
+            if (\is_array($aFieldList)) {
                 foreach ($aFieldList as $key => $oField) {
                     if ($oField->priceUnit == '%') {
                         $oField->price = $oField->fprice;
@@ -70,7 +70,7 @@ class SelectListMain extends \OxidEsales\Eshop\Application\Controller\Admin\Admi
             $oOtherLang = $oAttr->getAvailableInLangs();
             if (!isset($oOtherLang[$this->_iEditLang])) {
                 // echo "language entry doesn't exist! using: ".key($oOtherLang);
-                $oAttr->loadInLang(key($oOtherLang), $sOxId);
+                $oAttr->loadInLang(\key($oOtherLang), $sOxId);
             }
             $this->_aViewData["edit"] = $oAttr;
 
@@ -80,8 +80,8 @@ class SelectListMain extends \OxidEsales\Eshop\Application\Controller\Admin\Admi
             }
 
             // remove already created languages
-            $aLang = array_diff(\OxidEsales\Eshop\Core\Registry::getLang()->getLanguageNames(), $oOtherLang);
-            if (count($aLang)) {
+            $aLang = \array_diff(\OxidEsales\Eshop\Core\Registry::getLang()->getLanguageNames(), $oOtherLang);
+            if (\count($aLang)) {
                 $this->_aViewData["posslang"] = $aLang;
             }
 
@@ -141,7 +141,7 @@ class SelectListMain extends \OxidEsales\Eshop\Application\Controller\Admin\Admi
         $oAttr->assign($aParams);
 
         //#708
-        if (!is_array($this->aFieldArray)) {
+        if (!\is_array($this->aFieldArray)) {
             $this->aFieldArray = \OxidEsales\Eshop\Core\Registry::getUtils()->assignValuesFromText($oAttr->oxselectlist__oxvaldesc->getRawValue());
         }
         // build value
@@ -149,7 +149,7 @@ class SelectListMain extends \OxidEsales\Eshop\Application\Controller\Admin\Admi
         foreach ($this->aFieldArray as $oField) {
             $oAttr->oxselectlist__oxvaldesc->setValue($oAttr->oxselectlist__oxvaldesc->getRawValue() . $oField->name, \OxidEsales\Eshop\Core\Field::T_RAW);
             if (isset($oField->price) && $oField->price) {
-                $oAttr->oxselectlist__oxvaldesc->setValue($oAttr->oxselectlist__oxvaldesc->getRawValue() . "!P!" . trim(str_replace(",", ".", $oField->price)), \OxidEsales\Eshop\Core\Field::T_RAW);
+                $oAttr->oxselectlist__oxvaldesc->setValue($oAttr->oxselectlist__oxvaldesc->getRawValue() . "!P!" . \trim(\str_replace(",", ".", $oField->price)), \OxidEsales\Eshop\Core\Field::T_RAW);
                 if ($oField->priceUnit == '%') {
                     $oAttr->oxselectlist__oxvaldesc->setValue($oAttr->oxselectlist__oxvaldesc->getRawValue() . '%', \OxidEsales\Eshop\Core\Field::T_RAW);
                 }
@@ -218,7 +218,7 @@ class SelectListMain extends \OxidEsales\Eshop\Application\Controller\Admin\Admi
             $aDelFields = \OxidEsales\Eshop\Core\Registry::getConfig()->getRequestParameter("aFields");
             $this->aFieldArray = \OxidEsales\Eshop\Core\Registry::getUtils()->assignValuesFromText($oSelectlist->oxselectlist__oxvaldesc->getRawValue());
 
-            if (is_array($aDelFields) && count($aDelFields)) {
+            if (\is_array($aDelFields) && \count($aDelFields)) {
                 foreach ($aDelFields as $sDelField) {
                     $sDel = $this->parseFieldName($sDelField);
                     foreach ($this->aFieldArray as $sKey => $oField) {
@@ -287,7 +287,7 @@ class SelectListMain extends \OxidEsales\Eshop\Application\Controller\Admin\Admi
         }
 
         $aChangeFields = \OxidEsales\Eshop\Core\Registry::getConfig()->getRequestParameter("aFields");
-        if (is_array($aChangeFields) && count($aChangeFields)) {
+        if (\is_array($aChangeFields) && \count($aChangeFields)) {
             $oSelectlist = oxNew(\OxidEsales\Eshop\Application\Model\SelectList::class);
             if ($oSelectlist->loadInLang($this->_iEditLang, $this->getEditObjectId())) {
                 $this->aFieldArray = \OxidEsales\Eshop\Core\Registry::getUtils()->assignValuesFromText($oSelectlist->oxselectlist__oxvaldesc->getRawValue());
@@ -323,11 +323,11 @@ class SelectListMain extends \OxidEsales\Eshop\Application\Controller\Admin\Admi
      */
     protected function _rearrangeFields($oField, $iPos) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
-        if (!isset($this->aFieldArray) || !is_array($this->aFieldArray)) {
+        if (!isset($this->aFieldArray) || !\is_array($this->aFieldArray)) {
             return true;
         }
 
-        $iFieldCount = count($this->aFieldArray);
+        $iFieldCount = \count($this->aFieldArray);
         if ($iPos < 0 || $iPos >= $iFieldCount) {
             \OxidEsales\Eshop\Core\Registry::getSession()->setVariable("iErrorCode", ERR_POSOUTOFBOUNDS);
 
@@ -378,7 +378,7 @@ class SelectListMain extends \OxidEsales\Eshop\Application\Controller\Admin\Admi
      */
     public function parseFieldName($sInput)
     {
-        $aInput = explode('__@@', $sInput, 3);
+        $aInput = \explode('__@@', $sInput, 3);
 
         return $aInput[1];
     }

--- a/source/Application/Controller/Admin/SelectListMainAjax.php
+++ b/source/Application/Controller/Admin/SelectListMainAjax.php
@@ -110,8 +110,8 @@ class SelectListMainAjax extends \OxidEsales\Eshop\Application\Controller\Admin\
         if (\OxidEsales\Eshop\Core\Registry::getConfig()->getRequestParameter('all')) {
             $sQ = parent::_addFilter("delete oxobject2selectlist.* " . $this->_getQuery());
             \OxidEsales\Eshop\Core\DatabaseProvider::getDb()->Execute($sQ);
-        } elseif (is_array($aChosenArt)) {
-            $sQ = "delete from oxobject2selectlist where oxobject2selectlist.oxid in (" . implode(", ", \OxidEsales\Eshop\Core\DatabaseProvider::getDb()->quoteArray($aChosenArt)) . ") ";
+        } elseif (\is_array($aChosenArt)) {
+            $sQ = "delete from oxobject2selectlist where oxobject2selectlist.oxid in (" . \implode(", ", \OxidEsales\Eshop\Core\DatabaseProvider::getDb()->quoteArray($aChosenArt)) . ") ";
             \OxidEsales\Eshop\Core\DatabaseProvider::getDb()->Execute($sQ);
         }
     }
@@ -131,7 +131,7 @@ class SelectListMainAjax extends \OxidEsales\Eshop\Application\Controller\Admin\
             $aAddArticle = $this->_getAll(parent::_addFilter("select $sArtTable.oxid " . $this->_getQuery()));
         }
 
-        if ($soxId && $soxId != "-1" && is_array($aAddArticle)) {
+        if ($soxId && $soxId != "-1" && \is_array($aAddArticle)) {
             // We force reading from master to prevent issues with slow replications or open transactions (see ESDEV-3804 and ESDEV-3822).
             $database = \OxidEsales\Eshop\Core\DatabaseProvider::getMaster();
             foreach ($aAddArticle as $sAdd) {

--- a/source/Application/Controller/Admin/SelectListOrderAjax.php
+++ b/source/Application/Controller/Admin/SelectListOrderAjax.php
@@ -84,7 +84,7 @@ class SelectListOrderAjax extends \OxidEsales\Eshop\Application\Controller\Admin
         }
 
         //
-        if (($iKey = array_search(\OxidEsales\Eshop\Core\Registry::getConfig()->getRequestParameter('sortoxid'), $aIdx2Id)) !== false) {
+        if (($iKey = \array_search(\OxidEsales\Eshop\Core\Registry::getConfig()->getRequestParameter('sortoxid'), $aIdx2Id)) !== false) {
             $iDir = (\OxidEsales\Eshop\Core\Registry::getConfig()->getRequestParameter('direction') == 'up') ? ($iKey - 1) : ($iKey + 1);
             if (isset($aIdx2Id[$iDir])) {
                 // exchanging indexes

--- a/source/Application/Controller/Admin/ShopConfiguration.php
+++ b/source/Application/Controller/Admin/ShopConfiguration.php
@@ -90,9 +90,9 @@ class ShopConfiguration extends \OxidEsales\Eshop\Application\Controller\Admin\A
         // #251A passing country list
         $countryList = oxNew(\OxidEsales\Eshop\Application\Model\CountryList::class);
         $countryList->loadActiveCountries(\OxidEsales\Eshop\Core\Registry::getLang()->getObjectTplLanguage());
-        if (isset($confVars['arr']["aHomeCountry"]) && count($confVars['arr']["aHomeCountry"]) && count($countryList)) {
+        if (isset($confVars['arr']["aHomeCountry"]) && \count($confVars['arr']["aHomeCountry"]) && \count($countryList)) {
             foreach ($countryList as $sCountryId => $oCountry) {
-                if (in_array($oCountry->oxcountry__oxid->value, $confVars['arr']["aHomeCountry"])) {
+                if (\in_array($oCountry->oxcountry__oxid->value, $confVars['arr']["aHomeCountry"])) {
                     $countryList[$sCountryId]->selected = "1";
                 }
             }
@@ -101,7 +101,7 @@ class ShopConfiguration extends \OxidEsales\Eshop\Application\Controller\Admin\A
         $this->_aViewData["countrylist"] = $countryList;
 
         // checking if cUrl is enabled
-        $this->_aViewData["blCurlIsActive"] = (!function_exists('curl_init')) ? false : true;
+        $this->_aViewData["blCurlIsActive"] = (!\function_exists('curl_init')) ? false : true;
 
         /** @var ContactFormBridgeInterface $contactFormBridge */
         $contactFormBridge = $this->getContainer()->get(ContactFormBridgeInterface::class);
@@ -143,14 +143,14 @@ class ShopConfiguration extends \OxidEsales\Eshop\Application\Controller\Admin\A
         foreach ($this->_aConfParams as $existingConfigType => $existingConfigName) {
             $requestValue = \OxidEsales\Eshop\Core\Registry::getConfig()
                 ->getRequestParameter($existingConfigName, true);
-            if (is_array($requestValue)) {
+            if (\is_array($requestValue)) {
                 foreach ($requestValue as $configName => $newConfigValue) {
                     $oldValue = $config->getConfigParam($configName);
                     if ($newConfigValue !== $oldValue) {
-                        $sValueToValidate = is_array($newConfigValue) ? join(', ', $newConfigValue) : $newConfigValue;
+                        $sValueToValidate = \is_array($newConfigValue) ? \join(', ', $newConfigValue) : $newConfigValue;
                         if (!$configValidator->isValid($sValueToValidate)) {
                             $error = oxNew(\OxidEsales\Eshop\Core\DisplayError::class);
-                            $error->setFormatParameters(htmlspecialchars($sValueToValidate));
+                            $error->setFormatParameters(\htmlspecialchars($sValueToValidate));
                             $error->setMessage("SHOP_CONFIG_ERROR_INVALID_VALUE");
                             \OxidEsales\Eshop\Core\Registry::getUtilsView()->addErrorToDisplay($error);
                             continue;
@@ -274,7 +274,7 @@ class ShopConfiguration extends \OxidEsales\Eshop\Application\Controller\Admin\A
     {
         switch ($type) {
             case "select":
-                return array_map('trim', explode('|', $constraint));
+                return \array_map('trim', \explode('|', $constraint));
                 break;
         }
         return null;
@@ -293,7 +293,7 @@ class ShopConfiguration extends \OxidEsales\Eshop\Application\Controller\Admin\A
     {
         switch ($type) {
             case "select":
-                return implode('|', array_map('trim', $constraint));
+                return \implode('|', \array_map('trim', $constraint));
                 break;
         }
         return '';
@@ -324,24 +324,24 @@ class ShopConfiguration extends \OxidEsales\Eshop\Application\Controller\Admin\A
             case "num":
             case "int":
                 $data = $str->htmlentities($value);
-                if (in_array($name, $this->_aParseFloat)) {
-                    $data = str_replace(',', '.', $data);
+                if (\in_array($name, $this->_aParseFloat)) {
+                    $data = \str_replace(',', '.', $data);
                 }
                 break;
 
             case "arr":
-                if (in_array($name, $this->_aSkipMultiline)) {
-                    $data = unserialize($value);
+                if (\in_array($name, $this->_aSkipMultiline)) {
+                    $data = \unserialize($value);
                 } else {
-                    $data = $str->htmlentities($this->_arrayToMultiline(unserialize($value)));
+                    $data = $str->htmlentities($this->_arrayToMultiline(\unserialize($value)));
                 }
                 break;
 
             case "aarr":
-                if (in_array($name, $this->_aSkipMultiline)) {
-                    $data = unserialize($value);
+                if (\in_array($name, $this->_aSkipMultiline)) {
+                    $data = \unserialize($value);
                 } else {
-                    $data = $str->htmlentities($this->_aarrayToMultiline(unserialize($value)));
+                    $data = $str->htmlentities($this->_aarrayToMultiline(\unserialize($value)));
                 }
                 break;
         }
@@ -371,13 +371,13 @@ class ShopConfiguration extends \OxidEsales\Eshop\Application\Controller\Admin\A
             case "str":
             case "select":
             case "int":
-                if (in_array($name, $this->_aParseFloat)) {
-                    $data = str_replace(',', '.', $data);
+                if (\in_array($name, $this->_aParseFloat)) {
+                    $data = \str_replace(',', '.', $data);
                 }
                 break;
 
             case "arr":
-                if (!is_array($value)) {
+                if (!\is_array($value)) {
                     $data = $this->_multilineToArray($value);
                 }
                 break;
@@ -400,7 +400,7 @@ class ShopConfiguration extends \OxidEsales\Eshop\Application\Controller\Admin\A
      */
     protected function _arrayToMultiline($input) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
-        return implode("\n", (array) $input);
+        return \implode("\n", (array) $input);
     }
 
     /**
@@ -413,10 +413,10 @@ class ShopConfiguration extends \OxidEsales\Eshop\Application\Controller\Admin\A
      */
     protected function _multilineToArray($multiline) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
-        $array = explode("\n", $multiline);
-        if (is_array($array)) {
+        $array = \explode("\n", $multiline);
+        if (\is_array($array)) {
             foreach ($array as $key => $value) {
-                $array[$key] = trim($value);
+                $array[$key] = \trim($value);
                 if ($array[$key] == "") {
                     unset($array[$key]);
                 }
@@ -436,7 +436,7 @@ class ShopConfiguration extends \OxidEsales\Eshop\Application\Controller\Admin\A
      */
     protected function _aarrayToMultiline($input) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
-        if (is_array($input)) {
+        if (\is_array($input)) {
             $multiline = '';
             foreach ($input as $key => $value) {
                 if ($multiline) {
@@ -461,12 +461,12 @@ class ShopConfiguration extends \OxidEsales\Eshop\Application\Controller\Admin\A
     {
         $string = Str::getStr();
         $array = [];
-        $lines = explode("\n", $multiline);
+        $lines = \explode("\n", $multiline);
         foreach ($lines as $line) {
-            $line = trim($line);
+            $line = \trim($line);
             if ($line != "" && $string->preg_match("/(.+)=>(.+)/", $line, $regs)) {
-                $key = trim($regs[1]);
-                $value = trim($regs[2]);
+                $key = \trim($regs[1]);
+                $value = \trim($regs[2]);
                 if ($key != "" && $value != "") {
                     $array[$key] = $value;
                 }
@@ -502,8 +502,8 @@ class ShopConfiguration extends \OxidEsales\Eshop\Application\Controller\Admin\A
         $module = $this->_getModuleForConfigVars();
         $config = $this->getConfig();
         $preparedConfigValue = $this->_serializeConfVar($existingConfigType, $configName, $configValue);
-        if (strpos($module, 'module:') !== false) {
-            $moduleId = explode(':', $module)[1];
+        if (\strpos($module, 'module:') !== false) {
+            $moduleId = \explode(':', $module)[1];
             $moduleSettingBridge = ContainerFactory::getInstance()
                 ->getContainer()
                 ->get(ModuleSettingBridgeInterface::class);

--- a/source/Application/Controller/Admin/ShopLicense.php
+++ b/source/Application/Controller/Admin/ShopLicense.php
@@ -105,7 +105,7 @@ class ShopLicense extends \OxidEsales\Eshop\Application\Controller\Admin\ShopCon
     {
         $curl = oxNew(Curl::class);
         $curl->setMethod("POST");
-        $curl->setUrl(sprintf('%s/%s', $url, $this->getLanguageAbbreviation()));
+        $curl->setUrl(\sprintf('%s/%s', $url, $this->getLanguageAbbreviation()));
         $curl->setParameters(["myversion" => Registry::getConfig()->getVersion()]);
         $curl->setOption(
             Curl::CONNECT_TIMEOUT_OPTION,
@@ -132,24 +132,24 @@ class ShopLicense extends \OxidEsales\Eshop\Application\Controller\Admin\ShopCon
     private function displayErrorMessage(string $message)
     {
         Registry::getUtilsView()->addErrorToDisplay(
-            sprintf(
+            \sprintf(
                 '%s! %s.',
                 Registry::getLang()->translateString('ADMIN_SETTINGS_LICENSE_VERSION_FETCH_INFO_ERROR'),
-                sprintf(Registry::getLang()->translateString('CURL_EXECUTE_ERROR'), $message)
+                \sprintf(Registry::getLang()->translateString('CURL_EXECUTE_ERROR'), $message)
             )
         );
     }
 
     private function insertUpdateLinkIntoResponse(string $response): string
     {
-        $response = strip_tags($response, "<br>, <b>");
-        $result = explode("<br>", $response);
-        if (!isset($result[5]) || !strstr($result[5], "update")) {
+        $response = \strip_tags($response, "<br>, <b>");
+        $result = \explode("<br>", $response);
+        if (!isset($result[5]) || !\strstr($result[5], "update")) {
             return $response;
         }
         /** URL is set through i18n (lang file) */
         $sUpdateLink = Registry::getLang()->translateString("VERSION_UPDATE_LINK");
         $result[5] = "<a id='linkToUpdate' href='$sUpdateLink' target='_blank'>" . $result[5] . "</a>";
-        return implode("<br>", $result);
+        return \implode("<br>", $result);
     }
 }

--- a/source/Application/Controller/Admin/ShopMain.php
+++ b/source/Application/Controller/Admin/ShopMain.php
@@ -111,7 +111,7 @@ class ShopMain extends \OxidEsales\Eshop\Application\Controller\Admin\AdminDetai
         }
 
         if ($parameters['oxshops__oxsmtp']) {
-            $parameters['oxshops__oxsmtp'] = trim($parameters['oxshops__oxsmtp']);
+            $parameters['oxshops__oxsmtp'] = \trim($parameters['oxshops__oxsmtp']);
         }
 
         $shop->setLanguage(0);
@@ -171,7 +171,7 @@ class ShopMain extends \OxidEsales\Eshop\Application\Controller\Admin\AdminDetai
         //adding non copable multishop field options
         $multiShopTables = \OxidEsales\Eshop\Core\Registry::getConfig()->getConfigParam('aMultiShopTables');
         foreach ($multiShopTables as $multishopTable) {
-            $nonCopyVars[] = 'blMallInherit_' . strtolower($multishopTable);
+            $nonCopyVars[] = 'blMallInherit_' . \strtolower($multishopTable);
         }
 
         return $nonCopyVars;
@@ -198,7 +198,7 @@ class ShopMain extends \OxidEsales\Eshop\Application\Controller\Admin\AdminDetai
         if ($shopConfiguration != false && $shopConfiguration->count() > 0) {
             while (!$shopConfiguration->EOF) {
                 $configName = $shopConfiguration->fields[0];
-                if (!in_array($configName, $nonCopyVars)) {
+                if (!\in_array($configName, $nonCopyVars)) {
                     $newId = $utilsObject->generateUID();
                     $insertNewConfigQuery =
                         "insert into oxconfig (oxid, oxshopid, oxvarname, oxvartype, oxvarvalue, oxmodule)
@@ -219,7 +219,7 @@ class ShopMain extends \OxidEsales\Eshop\Application\Controller\Admin\AdminDetai
         $inheritAll = $shop->oxshops__oxisinherited->value ? "true" : "false";
         $multiShopTables = $config->getConfigParam('aMultiShopTables');
         foreach ($multiShopTables as $multishopTable) {
-            $config->saveShopConfVar("bool", 'blMallInherit_' . strtolower($multishopTable), $inheritAll, $shop->oxshops__oxid->value);
+            $config->saveShopConfVar("bool", 'blMallInherit_' . \strtolower($multishopTable), $inheritAll, $shop->oxshops__oxid->value);
         }
     }
 

--- a/source/Application/Controller/Admin/ShopRdfa.php
+++ b/source/Application/Controller/Admin/ShopRdfa.php
@@ -67,7 +67,7 @@ class ShopRdfa extends \OxidEsales\Eshop\Application\Controller\Admin\ShopConfig
         $aCustomersConf = \OxidEsales\Eshop\Core\Registry::getConfig()->getShopConfVar("aRDFaCustomers");
         if (isset($aCustomersConf)) {
             foreach ($this->_aCustomers as $sCustomer => $iValue) {
-                $aCustomers[$sCustomer] = (in_array($sCustomer, $aCustomersConf)) ? 1 : 0;
+                $aCustomers[$sCustomer] = (\in_array($sCustomer, $aCustomersConf)) ? 1 : 0;
             }
         } else {
             $aCustomers = [];
@@ -85,15 +85,15 @@ class ShopRdfa extends \OxidEsales\Eshop\Application\Controller\Admin\ShopConfig
     {
         $aParams = \OxidEsales\Eshop\Core\Registry::getConfig()->getRequestParameter("aSubmitUrl");
         if ($aParams['url']) {
-            $sNotificationUrl = "http://gr-notify.appspot.com/submit?uri=" . urlencode($aParams['url']) . "&agent=oxid";
+            $sNotificationUrl = "http://gr-notify.appspot.com/submit?uri=" . \urlencode($aParams['url']) . "&agent=oxid";
             if ($aParams['email']) {
-                $sNotificationUrl .= "&contact=" . urlencode($aParams['email']);
+                $sNotificationUrl .= "&contact=" . \urlencode($aParams['email']);
             }
             $aHeaders = $this->getHttpResponseCode($sNotificationUrl);
-            if (substr($aHeaders[2], -4) === "True") {
+            if (\substr($aHeaders[2], -4) === "True") {
                 $this->_aViewData["submitMessage"] = 'SHOP_RDFA_SUBMITED_SUCCESSFULLY';
             } else {
-                \OxidEsales\Eshop\Core\Registry::getUtilsView()->addErrorToDisplay(substr($aHeaders[3], strpos($aHeaders[3], ":") + 2));
+                \OxidEsales\Eshop\Core\Registry::getUtilsView()->addErrorToDisplay(\substr($aHeaders[3], \strpos($aHeaders[3], ":") + 2));
             }
         } else {
             \OxidEsales\Eshop\Core\Registry::getUtilsView()->addErrorToDisplay('SHOP_RDFA_MESSAGE_NOURL');
@@ -111,6 +111,6 @@ class ShopRdfa extends \OxidEsales\Eshop\Application\Controller\Admin\ShopConfig
      */
     public function getHttpResponseCode($sURL)
     {
-        return get_headers($sURL);
+        return \get_headers($sURL);
     }
 }

--- a/source/Application/Controller/Admin/ShopSeo.php
+++ b/source/Application/Controller/Admin/ShopSeo.php
@@ -67,7 +67,7 @@ class ShopSeo extends \OxidEsales\Eshop\Application\Controller\Admin\ShopConfigu
         $sActObject = null;
         if ($this->_sActSeoObject) {
             $sActObject = $this->_sActSeoObject;
-        } elseif (is_array($aStatUrl = \OxidEsales\Eshop\Core\Registry::getConfig()->getRequestParameter('aStaticUrl'))) {
+        } elseif (\is_array($aStatUrl = \OxidEsales\Eshop\Core\Registry::getConfig()->getRequestParameter('aStaticUrl'))) {
             $sActObject = $aStatUrl['oxseo__oxobjectid'];
         }
 
@@ -107,7 +107,7 @@ class ShopSeo extends \OxidEsales\Eshop\Application\Controller\Admin\ShopConfigu
             $oShop->save();
 
             // saving static url changes
-            if (is_array($aStaticUrl = \OxidEsales\Eshop\Core\Registry::getConfig()->getRequestParameter('aStaticUrl'))) {
+            if (\is_array($aStaticUrl = \OxidEsales\Eshop\Core\Registry::getConfig()->getRequestParameter('aStaticUrl'))) {
                 $this->_sActSeoObject = \OxidEsales\Eshop\Core\Registry::getSeoEncoder()->encodeStaticUrls($this->_processUrls($aStaticUrl), $oShop->getId(), $this->_iEditLang);
             }
         }
@@ -127,7 +127,7 @@ class ShopSeo extends \OxidEsales\Eshop\Application\Controller\Admin\ShopConfigu
             $aUrls['oxseo__oxstdurl'] = $this->_cleanupUrl($aUrls['oxseo__oxstdurl']);
         }
 
-        if (isset($aUrls['oxseo__oxseourl']) && is_array($aUrls['oxseo__oxseourl'])) {
+        if (isset($aUrls['oxseo__oxseourl']) && \is_array($aUrls['oxseo__oxseourl'])) {
             foreach ($aUrls['oxseo__oxseourl'] as $iPos => $sUrl) {
                 $aUrls['oxseo__oxseourl'][$iPos] = $this->_cleanupUrl($sUrl);
             }
@@ -147,13 +147,13 @@ class ShopSeo extends \OxidEsales\Eshop\Application\Controller\Admin\ShopConfigu
     protected function _cleanupUrl($sUrl) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         // replacing &amp; to & or removing double &&
-        while ((stripos($sUrl, '&amp;') !== false) || (stripos($sUrl, '&&') !== false)) {
-            $sUrl = str_replace('&amp;', '&', $sUrl);
-            $sUrl = str_replace('&&', '&', $sUrl);
+        while ((\stripos($sUrl, '&amp;') !== false) || (\stripos($sUrl, '&&') !== false)) {
+            $sUrl = \str_replace('&amp;', '&', $sUrl);
+            $sUrl = \str_replace('&&', '&', $sUrl);
         }
 
         // converting & to &amp;
-        return str_replace('&', '&amp;', $sUrl);
+        return \str_replace('&', '&amp;', $sUrl);
     }
 
     /**
@@ -170,7 +170,7 @@ class ShopSeo extends \OxidEsales\Eshop\Application\Controller\Admin\ShopConfigu
     public function deleteStaticUrl()
     {
         $aStaticUrl = \OxidEsales\Eshop\Core\Registry::getConfig()->getRequestParameter('aStaticUrl');
-        if (is_array($aStaticUrl)) {
+        if (\is_array($aStaticUrl)) {
             $sObjectid = $aStaticUrl['oxseo__oxobjectid'];
             if ($sObjectid && $sObjectid != '-1') {
                 $this->deleteStaticUrlFromDb($sObjectid);

--- a/source/Application/Controller/Admin/SystemInfoController.php
+++ b/source/Application/Controller/Admin/SystemInfoController.php
@@ -34,11 +34,11 @@ class SystemInfoController extends \OxidEsales\Eshop\Application\Controller\Admi
         $blisMallAdmin = $oAuthUser->oxuser__oxrights->value == "malladmin";
 
         if ($blisMallAdmin && !$myConfig->isDemoShop()) {
-            $aClassVars = get_object_vars($myConfig);
+            $aClassVars = \get_object_vars($myConfig);
             $aSystemInfo = [];
             $aSystemInfo['pkg.info'] = $myConfig->getPackageInfo();
             foreach ($aClassVars as $name => $value) {
-                if (gettype($value) == "object") {
+                if (\gettype($value) == "object") {
                     continue;
                 }
 
@@ -46,8 +46,8 @@ class SystemInfoController extends \OxidEsales\Eshop\Application\Controller\Admi
                     continue;
                 }
 
-                $value = var_export($value, true);
-                $value = str_replace("\n", "<br>", $value);
+                $value = \var_export($value, true);
+                $value = \str_replace("\n", "<br>", $value);
                 $aSystemInfo[$name] = $value;
                 //echo( "$name = $value <br>");
             }
@@ -59,12 +59,12 @@ class SystemInfoController extends \OxidEsales\Eshop\Application\Controller\Admi
                 "aSystemInfo" => $aSystemInfo
             ];
 
-            ob_start();
+            \ob_start();
             echo $this->getRenderer()->renderTemplate("systeminfo.tpl", $context);
             echo("<br><br>");
 
-            phpinfo();
-            $sMessage = ob_get_clean();
+            \phpinfo();
+            $sMessage = \ob_get_clean();
 
             \OxidEsales\Eshop\Core\Registry::getUtils()->showMessageAndExit($sMessage);
         } else {
@@ -92,7 +92,7 @@ class SystemInfoController extends \OxidEsales\Eshop\Application\Controller\Admi
      */
     protected function isClassVariableVisible($varName)
     {
-        return !in_array($varName, [
+        return !\in_array($varName, [
             'oDB',
             'dbUser',
             'dbPwd',

--- a/source/Application/Controller/Admin/ThemeConfiguration.php
+++ b/source/Application/Controller/Admin/ThemeConfiguration.php
@@ -92,7 +92,7 @@ class ThemeConfiguration extends \OxidEsales\Eshop\Application\Controller\Admin\
 
         foreach ($this->_aConfParams as $sType => $sParam) {
             $aConfVars = $myConfig->getRequestParameter($sParam);
-            if (is_array($aConfVars)) {
+            if (\is_array($aConfVars)) {
                 foreach ($aConfVars as $sName => $sValue) {
                     $myConfig->saveShopConfVar(
                         $sType,

--- a/source/Application/Controller/Admin/ToolsList.php
+++ b/source/Application/Controller/Admin/ToolsList.php
@@ -50,15 +50,15 @@ class ToolsList extends \OxidEsales\Eshop\Application\Controller\Admin\AdminList
             $sUpdateSQL = \OxidEsales\Eshop\Core\Registry::getConfig()->getRequestParameter("updatesql");
             $sUpdateSQLFile = $this->_processFiles();
 
-            if ($sUpdateSQLFile && strlen($sUpdateSQLFile) > 0) {
-                if (isset($sUpdateSQL) && strlen($sUpdateSQL)) {
+            if ($sUpdateSQLFile && \strlen($sUpdateSQLFile) > 0) {
+                if (isset($sUpdateSQL) && \strlen($sUpdateSQL)) {
                     $sUpdateSQL .= ";\r\n" . $sUpdateSQLFile;
                 } else {
                     $sUpdateSQL = $sUpdateSQLFile;
                 }
             }
 
-            $sUpdateSQL = trim(stripslashes($sUpdateSQL));
+            $sUpdateSQL = \trim(\stripslashes($sUpdateSQL));
             $oStr = Str::getStr();
             $iLen = $oStr->strlen($sUpdateSQL);
             if ($this->_prepareSQL($sUpdateSQL, $iLen)) {
@@ -69,16 +69,16 @@ class ToolsList extends \OxidEsales\Eshop\Application\Controller\Admin\AdminList
                 $aQErrorMessages = [];
                 $aQErrorNumbers = [];
 
-                if (!empty($aQueries) && is_array($aQueries)) {
+                if (!empty($aQueries) && \is_array($aQueries)) {
                     $blStop = false;
                     $oDB = \OxidEsales\Eshop\Core\DatabaseProvider::getDb();
                     $iQueriesCounter = 0;
-                    for ($i = 0; $i < count($aQueries); $i++) {
+                    for ($i = 0; $i < \count($aQueries); $i++) {
                         $sUpdateSQL = $aQueries[$i];
-                        $sUpdateSQL = trim($sUpdateSQL);
+                        $sUpdateSQL = \trim($sUpdateSQL);
 
                         if ($oStr->strlen($sUpdateSQL) > 0) {
-                            $aPassedQueries[$iQueriesCounter] = nl2br($oStr->htmlentities($sUpdateSQL));
+                            $aPassedQueries[$iQueriesCounter] = \nl2br($oStr->htmlentities($sUpdateSQL));
                             if ($oStr->strlen($aPassedQueries[$iQueriesCounter]) > 200) {
                                 $aPassedQueries[$iQueriesCounter] = $oStr->substr($aPassedQueries[$iQueriesCounter], 0, 200) . "...";
                             }
@@ -132,23 +132,23 @@ class ToolsList extends \OxidEsales\Eshop\Application\Controller\Admin\AdminList
             foreach ($_FILES['myfile']['name'] as $key => $value) {
                 $aSource = $_FILES['myfile']['tmp_name'];
                 $sSource = $aSource[$key];
-                $value = strtolower($value);
+                $value = \strtolower($value);
                 // add type to name
-                $aFilename = explode(".", $value);
+                $aFilename = \explode(".", $value);
 
                 //hack?
 
                 $aBadFiles = ["php", 'php4', 'php5', "jsp", "cgi", "cmf", "exe"];
 
-                if (in_array($aFilename[1], $aBadFiles)) {
+                if (\in_array($aFilename[1], $aBadFiles)) {
                     \OxidEsales\Eshop\Core\Registry::getUtils()->showMessageAndExit("File didn't pass our allowed files filter.");
                 }
 
                 //reading SQL dump file
-                if (filesize($sSource) > 0) {
-                    $rHandle = fopen($sSource, "r");
-                    $sContents = fread($rHandle, filesize($sSource));
-                    fclose($rHandle);
+                if (\filesize($sSource) > 0) {
+                    $rHandle = \fopen($sSource, "r");
+                    $sContents = \fread($rHandle, \filesize($sSource));
+                    \fclose($rHandle);
 
                     //reading only one SQL dump file
                     return $sContents;
@@ -178,10 +178,10 @@ class ToolsList extends \OxidEsales\Eshop\Application\Controller\Admin\AdminList
 
         //removing "mysqldump" application comments
         while ($oStr->preg_match("/^\-\-.*\n/", $sSQL)) {
-            $sSQL = trim($oStr->preg_replace("/^\-\-.*\n/", "", $sSQL));
+            $sSQL = \trim($oStr->preg_replace("/^\-\-.*\n/", "", $sSQL));
         }
         while ($oStr->preg_match("/\n\-\-.*\n/", $sSQL)) {
-            $sSQL = trim($oStr->preg_replace("/\n\-\-.*\n/", "\n", $sSQL));
+            $sSQL = \trim($oStr->preg_replace("/\n\-\-.*\n/", "\n", $sSQL));
         }
 
         for ($iPos = 0; $iPos < $iSQLlen; ++$iPos) {
@@ -218,7 +218,7 @@ class ToolsList extends \OxidEsales\Eshop\Application\Controller\Admin\AdminList
             } elseif ($sChar == ";") {
                 // delimiter found, appending query array
                 $this->aSQLs[] = $oStr->substr($sSQL, 0, $iPos);
-                $sSQL = ltrim($oStr->substr($sSQL, min($iPos + 1, $iSQLlen)));
+                $sSQL = \ltrim($oStr->substr($sSQL, \min($iPos + 1, $iSQLlen)));
                 $iSQLlen = $oStr->strlen($sSQL);
                 if ($iSQLlen) {
                     $iPos = -1;
@@ -236,12 +236,12 @@ class ToolsList extends \OxidEsales\Eshop\Application\Controller\Admin\AdminList
                     : $oStr->strpos(' ' . $sSQL, "\015", $iPos + 2);
                 if (!$iCommEnd) {
                     if ($iCommStart > 0) {
-                        $this->aSQLs[] = trim($oStr->substr($sSQL, 0, $iCommStart));
+                        $this->aSQLs[] = \trim($oStr->substr($sSQL, 0, $iCommStart));
                     }
 
                     return true;
                 } else {
-                    $sSQL = $oStr->substr($sSQL, 0, $iCommStart) . ltrim($oStr->substr($sSQL, $iCommEnd));
+                    $sSQL = $oStr->substr($sSQL, 0, $iCommStart) . \ltrim($oStr->substr($sSQL, $iCommEnd));
                     $iSQLlen = $oStr->strlen($sSQL);
                     $iPos--;
                 }

--- a/source/Application/Controller/Admin/UserGroupMain.php
+++ b/source/Application/Controller/Admin/UserGroupMain.php
@@ -37,15 +37,15 @@ class UserGroupMain extends \OxidEsales\Eshop\Application\Controller\Admin\Admin
             $oOtherLang = $oGroup->getAvailableInLangs();
             if (!isset($oOtherLang[$this->_iEditLang])) {
                 // echo "language entry doesn't exist! using: ".key($oOtherLang);
-                $oGroup->loadInLang(key($oOtherLang), $soxId);
+                $oGroup->loadInLang(\key($oOtherLang), $soxId);
             }
 
             $this->_aViewData["edit"] = $oGroup;
 
             // remove already created languages
-            $aLang = array_diff(\OxidEsales\Eshop\Core\Registry::getLang()->getLanguageNames(), $oOtherLang);
+            $aLang = \array_diff(\OxidEsales\Eshop\Core\Registry::getLang()->getLanguageNames(), $oOtherLang);
 
-            if (count($aLang)) {
+            if (\count($aLang)) {
                 $this->_aViewData["posslang"] = $aLang;
             }
 

--- a/source/Application/Controller/Admin/UserGroupMainAjax.php
+++ b/source/Application/Controller/Admin/UserGroupMainAjax.php
@@ -97,8 +97,8 @@ class UserGroupMainAjax extends \OxidEsales\Eshop\Application\Controller\Admin\L
         if (\OxidEsales\Eshop\Core\Registry::getConfig()->getRequestParameter('all')) {
             $sQ = $this->_addFilter("delete oxobject2group.* " . $this->_getQuery());
             \OxidEsales\Eshop\Core\DatabaseProvider::getDb()->Execute($sQ);
-        } elseif ($aRemoveGroups && is_array($aRemoveGroups)) {
-            $sQ = "delete from oxobject2group where oxobject2group.oxid in (" . implode(", ", \OxidEsales\Eshop\Core\DatabaseProvider::getDb()->quoteArray($aRemoveGroups)) . ") ";
+        } elseif ($aRemoveGroups && \is_array($aRemoveGroups)) {
+            $sQ = "delete from oxobject2group where oxobject2group.oxid in (" . \implode(", ", \OxidEsales\Eshop\Core\DatabaseProvider::getDb()->quoteArray($aRemoveGroups)) . ") ";
             \OxidEsales\Eshop\Core\DatabaseProvider::getDb()->Execute($sQ);
         }
     }
@@ -115,7 +115,7 @@ class UserGroupMainAjax extends \OxidEsales\Eshop\Application\Controller\Admin\L
             $sUserTable = $this->_getViewName('oxuser');
             $aAddUsers = $this->_getAll($this->_addFilter("select $sUserTable.oxid " . $this->_getQuery()));
         }
-        if ($soxId && $soxId != "-1" && is_array($aAddUsers)) {
+        if ($soxId && $soxId != "-1" && \is_array($aAddUsers)) {
             foreach ($aAddUsers as $sAdduser) {
                 $oNewGroup = oxNew(\OxidEsales\Eshop\Application\Model\Object2Group::class);
                 $oNewGroup->oxobject2group__oxobjectid = new \OxidEsales\Eshop\Core\Field($sAdduser);

--- a/source/Application/Controller/Admin/UserList.php
+++ b/source/Application/Controller/Admin/UserList.php
@@ -105,7 +105,7 @@ class UserList extends \OxidEsales\Eshop\Application\Controller\Admin\AdminListC
         $query = parent::_prepareWhereQuery($whereQuery, $fullQuery);
 
         if ($nameWhere) {
-            $values = explode(' ', $name);
+            $values = \explode(' ', $name);
             $query .= ' and (';
             $queryBoolAction = '';
             $utilsString = \OxidEsales\Eshop\Core\Registry::getUtilsString();

--- a/source/Application/Controller/Admin/UserMain.php
+++ b/source/Application/Controller/Admin/UserMain.php
@@ -41,13 +41,13 @@ class UserMain extends \OxidEsales\Eshop\Application\Controller\Admin\AdminDetai
         $oLang = \OxidEsales\Eshop\Core\Registry::getLang();
         $iTplLang = $oLang->getTplLanguage();
 
-        $iPos = count($aUserRights);
+        $iPos = \count($aUserRights);
         $aUserRights[$iPos] = new stdClass();
         $aUserRights[$iPos]->name = $oLang->translateString("user", $iTplLang);
         $aUserRights[$iPos]->id = "user";
 
         if ($blisMallAdmin) {
-            $iPos = count($aUserRights);
+            $iPos = \count($aUserRights);
             $aUserRights[$iPos] = new stdClass();
             $aUserRights[$iPos]->id = "malladmin";
             $aUserRights[$iPos]->name = $oLang->translateString("Admin", $iTplLang);
@@ -64,7 +64,7 @@ class UserMain extends \OxidEsales\Eshop\Application\Controller\Admin\AdminDetai
 
             if (!($oUser->oxuser__oxrights->value == "malladmin" && !$blisMallAdmin)) {
                 // generate selected right
-                reset($aUserRights);
+                \reset($aUserRights);
                 foreach ($aUserRights as $val) {
                     if ($val->id == $oUser->oxuser__oxrights->value) {
                         $val->selected = 1;

--- a/source/Application/Controller/Admin/UserMainAjax.php
+++ b/source/Application/Controller/Admin/UserMainAjax.php
@@ -72,8 +72,8 @@ class UserMainAjax extends \OxidEsales\Eshop\Application\Controller\Admin\ListCo
         if (\OxidEsales\Eshop\Core\Registry::getConfig()->getRequestParameter('all')) {
             $sQ = $this->_addFilter("delete oxobject2group.* " . $this->_getQuery());
             \OxidEsales\Eshop\Core\DatabaseProvider::getDb()->Execute($sQ);
-        } elseif ($aRemoveGroups && is_array($aRemoveGroups)) {
-            $sQ = "delete from oxobject2group where oxobject2group.oxid in (" . implode(", ", \OxidEsales\Eshop\Core\DatabaseProvider::getDb()->quoteArray($aRemoveGroups)) . ") ";
+        } elseif ($aRemoveGroups && \is_array($aRemoveGroups)) {
+            $sQ = "delete from oxobject2group where oxobject2group.oxid in (" . \implode(", ", \OxidEsales\Eshop\Core\DatabaseProvider::getDb()->quoteArray($aRemoveGroups)) . ") ";
             \OxidEsales\Eshop\Core\DatabaseProvider::getDb()->Execute($sQ);
         }
     }
@@ -90,7 +90,7 @@ class UserMainAjax extends \OxidEsales\Eshop\Application\Controller\Admin\ListCo
             $sGroupTable = $this->_getViewName('oxgroups');
             $aAddGroups = $this->_getAll($this->_addFilter("select $sGroupTable.oxid " . $this->_getQuery()));
         }
-        if ($soxId && $soxId != "-1" && is_array($aAddGroups)) {
+        if ($soxId && $soxId != "-1" && \is_array($aAddGroups)) {
             foreach ($aAddGroups as $sAddgroup) {
                 $oNewGroup = oxNew(\OxidEsales\Eshop\Application\Model\Object2Group::class);
                 $oNewGroup->oxobject2group__oxobjectid = new \OxidEsales\Eshop\Core\Field($soxId);

--- a/source/Application/Controller/Admin/VendorMain.php
+++ b/source/Application/Controller/Admin/VendorMain.php
@@ -36,7 +36,7 @@ class VendorMain extends \OxidEsales\Eshop\Application\Controller\Admin\AdminDet
             $oOtherLang = $oVendor->getAvailableInLangs();
             if (!isset($oOtherLang[$this->_iEditLang])) {
                 // echo "language entry doesn't exist! using: ".key($oOtherLang);
-                $oVendor->loadInLang(key($oOtherLang), $soxId);
+                $oVendor->loadInLang(\key($oOtherLang), $soxId);
             }
             $this->_aViewData["edit"] = $oVendor;
 
@@ -49,8 +49,8 @@ class VendorMain extends \OxidEsales\Eshop\Application\Controller\Admin\AdminDet
             }
 
             // remove already created languages
-            $aLang = array_diff(\OxidEsales\Eshop\Core\Registry::getLang()->getLanguageNames(), $oOtherLang);
-            if (count($aLang)) {
+            $aLang = \array_diff(\OxidEsales\Eshop\Core\Registry::getLang()->getLanguageNames(), $oOtherLang);
+            if (\count($aLang)) {
                 $this->_aViewData["posslang"] = $aLang;
             }
 

--- a/source/Application/Controller/Admin/VendorMainAjax.php
+++ b/source/Application/Controller/Admin/VendorMainAjax.php
@@ -115,7 +115,7 @@ class VendorMainAjax extends \OxidEsales\Eshop\Application\Controller\Admin\List
             $aRemoveArt = $this->_getAll($this->_addFilter("select $sArtTable.oxid " . $this->_getQuery()));
         }
 
-        if (is_array($aRemoveArt)) {
+        if (\is_array($aRemoveArt)) {
             $sSelect = "update oxarticles set oxvendorid = null where "
                 . $this->onVendorActionArticleUpdateConditions($aRemoveArt);
             \OxidEsales\Eshop\Core\DatabaseProvider::getDb()->Execute($sSelect);
@@ -141,7 +141,7 @@ class VendorMainAjax extends \OxidEsales\Eshop\Application\Controller\Admin\List
             $aAddArticle = $this->_getAll($this->_addFilter("select $sArtTable.oxid " . $this->_getQuery()));
         }
 
-        if ($soxId && $soxId != "-1" && is_array($aAddArticle)) {
+        if ($soxId && $soxId != "-1" && \is_array($aAddArticle)) {
             $oDb = \OxidEsales\Eshop\Core\DatabaseProvider::getDb();
             $sSelect = "update oxarticles set oxvendorid = " . $oDb->quote($soxId) . " where "
                 . $this->onVendorActionArticleUpdateConditions($aAddArticle);
@@ -162,7 +162,7 @@ class VendorMainAjax extends \OxidEsales\Eshop\Application\Controller\Admin\List
      */
     protected function onVendorActionArticleUpdateConditions($articleIds)
     {
-        return 'oxid in (' . implode(", ", \OxidEsales\Eshop\Core\DatabaseProvider::getDb()->quoteArray($articleIds)) . ')';
+        return 'oxid in (' . \implode(", ", \OxidEsales\Eshop\Core\DatabaseProvider::getDb()->quoteArray($articleIds)) . ')';
     }
 
     /**

--- a/source/Application/Controller/Admin/VoucherSerieExport.php
+++ b/source/Application/Controller/Admin/VoucherSerieExport.php
@@ -88,7 +88,7 @@ class VoucherSerieExport extends \OxidEsales\Eshop\Application\Controller\Admin\
         $sSessionFileName = \OxidEsales\Eshop\Core\Registry::getSession()->getVariable("sExportFileName");
         if (!$sSessionFileName) {
             $session = \OxidEsales\Eshop\Core\Registry::getSession();
-            $sSessionFileName = md5($session->getId() . \OxidEsales\Eshop\Core\Registry::getUtilsObject()->generateUId());
+            $sSessionFileName = \md5($session->getId() . \OxidEsales\Eshop\Core\Registry::getUtilsObject()->generateUId());
             \OxidEsales\Eshop\Core\Registry::getSession()->setVariable("sExportFileName", $sSessionFileName);
         }
 
@@ -118,8 +118,8 @@ class VoucherSerieExport extends \OxidEsales\Eshop\Application\Controller\Admin\
         $oUtils->setHeader("Content-Disposition: attachment; filename=vouchers.csv");
         $oUtils->setHeader("Content-Type: application/csv");
         $sFile = $this->_getExportFilePath();
-        if (file_exists($sFile) && is_readable($sFile)) {
-            readfile($sFile);
+        if (\file_exists($sFile) && \is_readable($sFile)) {
+            \readfile($sFile);
         }
         $oUtils->showMessageAndExit("");
     }
@@ -131,7 +131,7 @@ class VoucherSerieExport extends \OxidEsales\Eshop\Application\Controller\Admin\
     {
         $blContinue = true;
 
-        $this->fpFile = @fopen($this->_sFilePath, "a");
+        $this->fpFile = @\fopen($this->_sFilePath, "a");
         if (!isset($this->fpFile) || !$this->fpFile) {
             // we do have an error !
             $this->stop(ERR_FILEIO);
@@ -139,7 +139,7 @@ class VoucherSerieExport extends \OxidEsales\Eshop\Application\Controller\Admin\
             // file is open
             $iStart = \OxidEsales\Eshop\Core\Registry::getConfig()->getRequestParameter("iStart");
             if (!$iStart) {
-                ftruncate($this->fpFile, 0);
+                \ftruncate($this->fpFile, 0);
             }
 
             if (($iExportedItems = $this->exportVouchers($iStart)) === false) {
@@ -154,7 +154,7 @@ class VoucherSerieExport extends \OxidEsales\Eshop\Application\Controller\Admin\
                 $this->_aViewData['iStart'] = $iStart + $iExportedItems;
                 $this->_aViewData['iExpItems'] = $iStart + $iExportedItems;
             }
-            fclose($this->fpFile);
+            \fclose($this->fpFile);
         }
     }
 
@@ -188,7 +188,7 @@ class VoucherSerieExport extends \OxidEsales\Eshop\Application\Controller\Admin\
 
             // writing vouchers..
             while (!$rs->EOF) {
-                $this->write(current($rs->fields));
+                $this->write(\current($rs->fields));
                 $iExported++;
                 $rs->fetchRow();
             }
@@ -205,7 +205,7 @@ class VoucherSerieExport extends \OxidEsales\Eshop\Application\Controller\Admin\
     public function write($sLine)
     {
         if ($sLine) {
-            fwrite($this->fpFile, $sLine . "\n");
+            \fwrite($this->fpFile, $sLine . "\n");
         }
     }
 }

--- a/source/Application/Controller/Admin/VoucherSerieGenerate.php
+++ b/source/Application/Controller/Admin/VoucherSerieGenerate.php
@@ -75,7 +75,7 @@ class VoucherSerieGenerate extends \OxidEsales\Eshop\Application\Controller\Admi
      */
     public function generateVoucher($iCnt)
     {
-        $iAmount = abs((int) \OxidEsales\Eshop\Core\Registry::getSession()->getVariable("voucherAmount"));
+        $iAmount = \abs((int) \OxidEsales\Eshop\Core\Registry::getSession()->getVariable("voucherAmount"));
 
         // creating new vouchers
         if ($iCnt < $iAmount && ($oVoucherSerie = $this->_getVoucherSerie())) {

--- a/source/Application/Controller/Admin/VoucherSerieGroupsAjax.php
+++ b/source/Application/Controller/Admin/VoucherSerieGroupsAjax.php
@@ -73,8 +73,8 @@ class VoucherSerieGroupsAjax extends \OxidEsales\Eshop\Application\Controller\Ad
         if (\OxidEsales\Eshop\Core\Registry::getConfig()->getRequestParameter('all')) {
             $sQ = $this->_addFilter("delete oxobject2group.* " . $this->_getQuery());
             \OxidEsales\Eshop\Core\DatabaseProvider::getDb()->Execute($sQ);
-        } elseif ($aRemoveGroups && is_array($aRemoveGroups)) {
-            $sQ = "delete from oxobject2group where oxobject2group.oxid in (" . implode(", ", \OxidEsales\Eshop\Core\DatabaseProvider::getDb()->quoteArray($aRemoveGroups)) . ") ";
+        } elseif ($aRemoveGroups && \is_array($aRemoveGroups)) {
+            $sQ = "delete from oxobject2group where oxobject2group.oxid in (" . \implode(", ", \OxidEsales\Eshop\Core\DatabaseProvider::getDb()->quoteArray($aRemoveGroups)) . ") ";
             \OxidEsales\Eshop\Core\DatabaseProvider::getDb()->Execute($sQ);
         }
     }
@@ -92,7 +92,7 @@ class VoucherSerieGroupsAjax extends \OxidEsales\Eshop\Application\Controller\Ad
             $sGroupTable = $this->_getViewName('oxgroups');
             $aChosenCat = $this->_getAll($this->_addFilter("select $sGroupTable.oxid " . $this->_getQuery()));
         }
-        if ($soxId && $soxId != "-1" && is_array($aChosenCat)) {
+        if ($soxId && $soxId != "-1" && \is_array($aChosenCat)) {
             foreach ($aChosenCat as $sChosenCat) {
                 $oNewGroup = oxNew(\OxidEsales\Eshop\Application\Model\Object2Group::class);
                 $oNewGroup->oxobject2group__oxobjectid = new \OxidEsales\Eshop\Core\Field($soxId);

--- a/source/Application/Controller/Admin/VoucherSerieMain.php
+++ b/source/Application/Controller/Admin/VoucherSerieMain.php
@@ -99,7 +99,7 @@ class VoucherSerieMain extends \OxidEsales\Eshop\Application\Controller\Admin\Dy
             return;
         }
 
-        $aSerieParams["oxvoucherseries__oxdiscount"] = abs($aSerieParams["oxvoucherseries__oxdiscount"]);
+        $aSerieParams["oxvoucherseries__oxdiscount"] = \abs($aSerieParams["oxvoucherseries__oxdiscount"]);
 
         $oVoucherSerie->assign($aSerieParams);
         $oVoucherSerie->save();
@@ -154,7 +154,7 @@ class VoucherSerieMain extends \OxidEsales\Eshop\Application\Controller\Admin\Dy
      */
     public function start()
     {
-        $sVoucherNr = trim(\OxidEsales\Eshop\Core\Registry::getConfig()->getRequestParameter("voucherNr"));
+        $sVoucherNr = \trim(\OxidEsales\Eshop\Core\Registry::getConfig()->getRequestParameter("voucherNr"));
         $bRandomNr = \OxidEsales\Eshop\Core\Registry::getConfig()->getRequestParameter("randomVoucherNr");
         $controllerId = \OxidEsales\Eshop\Core\Registry::getConfig()->getRequestControllerId();
 
@@ -170,7 +170,7 @@ class VoucherSerieMain extends \OxidEsales\Eshop\Application\Controller\Admin\Dy
 
         // saving export info
         \OxidEsales\Eshop\Core\Registry::getSession()->setVariable("voucherid", \OxidEsales\Eshop\Core\Registry::getConfig()->getRequestParameter("voucherid"));
-        \OxidEsales\Eshop\Core\Registry::getSession()->setVariable("voucherAmount", abs((int) \OxidEsales\Eshop\Core\Registry::getConfig()->getRequestParameter("voucherAmount")));
+        \OxidEsales\Eshop\Core\Registry::getSession()->setVariable("voucherAmount", \abs((int) \OxidEsales\Eshop\Core\Registry::getConfig()->getRequestParameter("voucherAmount")));
         \OxidEsales\Eshop\Core\Registry::getSession()->setVariable("randomVoucherNr", $bRandomNr);
         \OxidEsales\Eshop\Core\Registry::getSession()->setVariable("voucherNr", $sVoucherNr);
     }

--- a/source/Application/Controller/Admin/WrappingMain.php
+++ b/source/Application/Controller/Admin/WrappingMain.php
@@ -37,7 +37,7 @@ class WrappingMain extends \OxidEsales\Eshop\Application\Controller\Admin\AdminD
             $oOtherLang = $oWrapping->getAvailableInLangs();
             if (!isset($oOtherLang[$this->_iEditLang])) {
                 // echo "language entry doesn't exist! using: ".key($oOtherLang);
-                $oWrapping->loadInLang(key($oOtherLang), $soxId);
+                $oWrapping->loadInLang(\key($oOtherLang), $soxId);
             }
             $this->_aViewData["edit"] = $oWrapping;
 
@@ -47,8 +47,8 @@ class WrappingMain extends \OxidEsales\Eshop\Application\Controller\Admin\AdminD
             }
 
             // remove already created languages
-            $aLang = array_diff(\OxidEsales\Eshop\Core\Registry::getLang()->getLanguageNames(), $oOtherLang);
-            if (count($aLang)) {
+            $aLang = \array_diff(\OxidEsales\Eshop\Core\Registry::getLang()->getLanguageNames(), $oOtherLang);
+            if (\count($aLang)) {
                 $this->_aViewData["posslang"] = $aLang;
             }
 

--- a/source/Application/Controller/ArticleDetailsController.php
+++ b/source/Application/Controller/ArticleDetailsController.php
@@ -273,7 +273,7 @@ class ArticleDetailsController extends \OxidEsales\Eshop\Application\Controller\
         }
 
         if (($templateName = Registry::getConfig()->getRequestParameter('tpl'))) {
-            $this->_sThisTemplate = 'custom/' . basename($templateName);
+            $this->_sThisTemplate = 'custom/' . \basename($templateName);
         }
 
         parent::render();
@@ -352,16 +352,16 @@ class ArticleDetailsController extends \OxidEsales\Eshop\Application\Controller\
     {
         if (!$keywords) {
             $article = $this->getProduct();
-            $keywords = trim($this->getTitle());
+            $keywords = \trim($this->getTitle());
 
             if ($categoryTree = $this->getCategoryTree()) {
                 foreach ($categoryTree->getPath() as $category) {
-                    $keywords .= ", " . trim($category->oxcategories__oxtitle->value);
+                    $keywords .= ", " . \trim($category->oxcategories__oxtitle->value);
                 }
             }
 
             // Adding search keys info
-            if ($searchKeys = trim($article->oxarticles__oxsearchkeys->value)) {
+            if ($searchKeys = \trim($article->oxarticles__oxsearchkeys->value)) {
                 $keywords .= ", " . $searchKeys;
             }
 
@@ -404,7 +404,7 @@ class ArticleDetailsController extends \OxidEsales\Eshop\Application\Controller\
                 }
             }
 
-            if (($reviewText = trim((string) \OxidEsales\Eshop\Core\Registry::getConfig()->getRequestParameter('rvw_txt', true)))) {
+            if (($reviewText = \trim((string) \OxidEsales\Eshop\Core\Registry::getConfig()->getRequestParameter('rvw_txt', true)))) {
                 $review = oxNew(\OxidEsales\Eshop\Application\Model\Review::class);
                 $review->oxreviews__oxobjectid = new Field($article->getId());
                 $review->oxreviews__oxtype = new Field('oxarticle');
@@ -434,7 +434,7 @@ class ArticleDetailsController extends \OxidEsales\Eshop\Application\Controller\
             return;
         }
 
-        $recommendationText = trim((string) \OxidEsales\Eshop\Core\Registry::getConfig()->getRequestParameter('recomm_txt'));
+        $recommendationText = \trim((string) \OxidEsales\Eshop\Core\Registry::getConfig()->getRequestParameter('recomm_txt'));
         $recommendationListId = \OxidEsales\Eshop\Core\Registry::getConfig()->getRequestParameter('recomm');
         $articleId = $this->getProduct()->getId();
 
@@ -1021,7 +1021,7 @@ class ArticleDetailsController extends \OxidEsales\Eshop\Application\Controller\
             $normalizedRating = [];
             $value = ((4 * ($article->oxarticles__oxrating->value - $minRating) / ($maxRating - $minRating))) + 1;
             $normalizedRating["count"] = $count;
-            $normalizedRating["value"] = round($value, 2);
+            $normalizedRating["value"] = \round($value, 2);
 
             return $normalizedRating;
         }
@@ -1044,8 +1044,8 @@ class ArticleDetailsController extends \OxidEsales\Eshop\Application\Controller\
             $from = \OxidEsales\Eshop\Core\Registry::getUtilsDate()->getTime();
 
             $through = $from + ($days * 24 * 60 * 60);
-            $validity["from"] = date('Y-m-d\TH:i:s', $from) . "Z";
-            $validity["through"] = date('Y-m-d\TH:i:s', $through) . "Z";
+            $validity["from"] = \date('Y-m-d\TH:i:s', $from) . "Z";
+            $validity["through"] = \date('Y-m-d\TH:i:s', $through) . "Z";
 
             return $validity;
         }
@@ -1240,11 +1240,11 @@ class ArticleDetailsController extends \OxidEsales\Eshop\Application\Controller\
     public function getSortingParameters()
     {
         $sorting = $this->getSorting($this->getSortIdent());
-        if (!is_array($sorting)) {
+        if (!\is_array($sorting)) {
             return null;
         }
 
-        return implode('|', $sorting);
+        return \implode('|', $sorting);
     }
 
     /**
@@ -1309,7 +1309,7 @@ class ArticleDetailsController extends \OxidEsales\Eshop\Application\Controller\
         $selfLink = $this->getViewConfig()->getSelfLink();
         $sessionToken = Registry::getSession()->getVariable('sess_stoken');
 
-        $searchPath['title'] = sprintf($translatedString, $this->getSearchParamForHtml());
+        $searchPath['title'] = \sprintf($translatedString, $this->getSearchParamForHtml());
         $searchPath['link'] = $selfLink . 'stoken=' . $sessionToken . "&amp;cl=search&amp;" .
             "searchparam=" . $this->getSearchParamForHtml();
 

--- a/source/Application/Controller/ArticleListController.php
+++ b/source/Application/Controller/ArticleListController.php
@@ -152,7 +152,7 @@ class ArticleListController extends \OxidEsales\Eshop\Application\Controller\Fro
         $listDisplayType = $this->_getListDisplayType();
         $parentViewId = parent::generateViewId();
 
-        return md5(
+        return \md5(
             $parentViewId . '|' . $categoryId . '|' . $activePage . '|' . $articlesPerPage . '|' . $listDisplayType
         );
     }
@@ -395,7 +395,7 @@ class ArticleListController extends \OxidEsales\Eshop\Application\Controller\Fro
             $this->_iAllArtCnt = $articleList->loadCategoryArticles($activeCategoryId, $sessionFilter);
         }
 
-        $this->_iCntPages = ceil($this->_iAllArtCnt / $numberOfCategoryArticles);
+        $this->_iCntPages = \ceil($this->_iAllArtCnt / $numberOfCategoryArticles);
 
         return $articleList;
     }
@@ -439,7 +439,7 @@ class ArticleListController extends \OxidEsales\Eshop\Application\Controller\Fro
     {
         $listDisplayType = Registry::getSession()->getVariable('ldtype');
 
-        if (is_null($listDisplayType)) {
+        if (\is_null($listDisplayType)) {
             $listDisplayType = Registry::getConfig()->getConfigParam('sDefaultListDisplayType');
         }
 
@@ -472,7 +472,7 @@ class ArticleListController extends \OxidEsales\Eshop\Application\Controller\Fro
             $this->_sCatPathString = false;
 
             //fetching category path
-            if (is_array($categoryTreePath = $this->getCatTreePath())) {
+            if (\is_array($categoryTreePath = $this->getCatTreePath())) {
                 $stringModifier = Str::getStr();
                 $this->_sCatPathString = '';
                 foreach ($categoryTreePath as $category) {
@@ -523,7 +523,7 @@ class ArticleListController extends \OxidEsales\Eshop\Application\Controller\Fro
         $description = $str->cleanStr($description);
         $description = $str->htmlspecialchars($description);
 
-        return trim($description);
+        return \trim($description);
     }
 
     /**
@@ -563,10 +563,10 @@ class ArticleListController extends \OxidEsales\Eshop\Application\Controller\Fro
         //formatting description tag
         $category = $this->getActiveCategory();
 
-        $additionalText = (($category instanceof Category)) ? trim($category->getLongDesc()) : '';
+        $additionalText = (($category instanceof Category)) ? \trim($category->getLongDesc()) : '';
 
         $articleList = $this->getArticleList();
-        if (!$additionalText && count($articleList)) {
+        if (!$additionalText && \count($articleList)) {
             foreach ($articleList as $article) {
                 if ($additionalText) {
                     $additionalText .= ', ';
@@ -576,7 +576,7 @@ class ArticleListController extends \OxidEsales\Eshop\Application\Controller\Fro
         }
 
         if (!$meta) {
-            $meta = trim($this->_getCatPathString());
+            $meta = \trim($this->_getCatPathString());
         }
 
         if ($meta) {
@@ -605,25 +605,25 @@ class ArticleListController extends \OxidEsales\Eshop\Application\Controller\Fro
 
             if ($categoryTree = $this->getCategoryTree()) {
                 foreach ($categoryTree->getPath() as $category) {
-                    $keywordsList[] = trim($category->oxcategories__oxtitle->value);
+                    $keywordsList[] = \trim($category->oxcategories__oxtitle->value);
                 }
             }
 
             $subCategories = $activeCategory->getSubCats();
-            if (is_array($subCategories)) {
+            if (\is_array($subCategories)) {
                 foreach ($subCategories as $subCategory) {
                     $keywordsList[] = $subCategory->oxcategories__oxtitle->value;
                 }
             }
 
-            if (count($keywordsList) > 0) {
-                $keywords = implode(", ", $keywordsList);
+            if (\count($keywordsList) > 0) {
+                $keywords = \implode(", ", $keywordsList);
             }
         }
 
         $keywords = parent::_prepareMetaDescription($keywords, -1, $removeDuplicatedWords);
 
-        return trim($keywords);
+        return \trim($keywords);
     }
 
     /**
@@ -640,12 +640,12 @@ class ArticleListController extends \OxidEsales\Eshop\Application\Controller\Fro
         $maxTextLength = 60;
         $text = '';
 
-        if (count($articleList = $this->getArticleList())) {
+        if (\count($articleList = $this->getArticleList())) {
             $stringModifier = Str::getStr();
             foreach ($articleList as $article) {
                 /** @var \OxidEsales\Eshop\Application\Model\Article $article */
                 $description = $stringModifier->strip_tags(
-                    trim($stringModifier->strtolower($article->getLongDescription()->value))
+                    \trim($stringModifier->strtolower($article->getLongDescription()->value))
                 );
 
                 //removing dots from string (they are not cleaned up during general string cleanup)
@@ -656,7 +656,7 @@ class ArticleListController extends \OxidEsales\Eshop\Application\Controller\Fro
                     $description = $stringModifier->substr(
                         $midText,
                         0,
-                        ($stringModifier->strlen($midText) - $stringModifier->strpos(strrev($midText), ' '))
+                        ($stringModifier->strlen($midText) - $stringModifier->strpos(\strrev($midText), ' '))
                     );
                 }
                 if ($text) {
@@ -687,7 +687,7 @@ class ArticleListController extends \OxidEsales\Eshop\Application\Controller\Fro
     public function getTemplateName()
     {
         // assign template name
-        if (($templateName = basename(Registry::getConfig()->getRequestParameter('tpl')))) {
+        if (($templateName = \basename(Registry::getConfig()->getRequestParameter('tpl')))) {
             $this->_sThisTemplate = 'custom/' . $templateName;
         } elseif (($category = $this->getActiveCategory()) && $category->oxcategories__oxtemplate->value) {
             $this->_sThisTemplate = $category->oxcategories__oxtemplate->value;
@@ -818,7 +818,7 @@ class ArticleListController extends \OxidEsales\Eshop\Application\Controller\Fro
 
         if (($category = $this->getActiveCategory())) {
             $attributes = $category->getAttributes();
-            if (count($attributes)) {
+            if (\count($attributes)) {
                 $this->_aAttributes = $attributes;
             }
         }
@@ -836,7 +836,7 @@ class ArticleListController extends \OxidEsales\Eshop\Application\Controller\Fro
         if ($this->_aArticleList === null) {
             if ($category = $this->getActiveCategory()) {
                 $articleList = $this->_loadArticles($category);
-                if (count($articleList)) {
+                if (\count($articleList)) {
                     $this->_aArticleList = $articleList;
                 }
             }

--- a/source/Application/Controller/BasketController.php
+++ b/source/Application/Controller/BasketController.php
@@ -145,7 +145,7 @@ class BasketController extends \OxidEsales\Eshop\Application\Controller\Frontend
             $this->_oFirstBasketProduct = false;
 
             $aBasketArticles = $this->getBasketArticles();
-            if (is_array($aBasketArticles) && $oProduct = reset($aBasketArticles)) {
+            if (\is_array($aBasketArticles) && $oProduct = \reset($aBasketArticles)) {
                 $this->_oFirstBasketProduct = $oProduct;
             }
         }
@@ -408,7 +408,7 @@ class BasketController extends \OxidEsales\Eshop\Application\Controller\Frontend
      */
     protected function _setWrappingInfo($oBasket, $aWrapping) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
-        if (is_array($aWrapping) && count($aWrapping)) {
+        if (\is_array($aWrapping) && \count($aWrapping)) {
             foreach ($oBasket->getContents() as $sKey => $oBasketItem) {
                 if (isset($aWrapping[$sKey])) {
                     $oBasketItem->setWrapping($aWrapping[$sKey]);

--- a/source/Application/Controller/ClearCookiesController.php
+++ b/source/Application/Controller/ClearCookiesController.php
@@ -46,14 +46,14 @@ class ClearCookiesController extends \OxidEsales\Eshop\Application\Controller\Fr
     {
         $oUtilsServer = Registry::getUtilsServer();
         if (isset($_SERVER['HTTP_COOKIE'])) {
-            $aCookies = explode(';', $_SERVER['HTTP_COOKIE']);
+            $aCookies = \explode(';', $_SERVER['HTTP_COOKIE']);
             foreach ($aCookies as $sCookie) {
-                $sRawCookie = explode('=', $sCookie);
-                $oUtilsServer->setOxCookie(trim($sRawCookie[0]), '', time() - 10000, '/');
+                $sRawCookie = \explode('=', $sCookie);
+                $oUtilsServer->setOxCookie(\trim($sRawCookie[0]), '', \time() - 10000, '/');
             }
         }
-        $oUtilsServer->setOxCookie('language', '', time() - 10000, '/');
-        $oUtilsServer->setOxCookie('displayedCookiesNotification', '', time() - 10000, '/');
+        $oUtilsServer->setOxCookie('language', '', \time() - 10000, '/');
+        $oUtilsServer->setOxCookie('displayedCookiesNotification', '', \time() - 10000, '/');
 
         $this->dispatchEvent(new AllCookiesRemovedEvent());
     }

--- a/source/Application/Controller/CompareController.php
+++ b/source/Application/Controller/CompareController.php
@@ -204,7 +204,7 @@ class CompareController extends \OxidEsales\Eshop\Application\Controller\Fronten
         if ($this->_iCompItemsCnt === null) {
             $this->_iCompItemsCnt = 0;
             if ($aItems = $this->getCompareItems()) {
-                $this->_iCompItemsCnt = count($aItems);
+                $this->_iCompItemsCnt = \count($aItems);
             }
         }
 
@@ -220,7 +220,7 @@ class CompareController extends \OxidEsales\Eshop\Application\Controller\Fronten
     {
         if ($this->_aCompItems === null) {
             $aItems = Registry::getSession()->getVariable('aFiltcompproducts');
-            if (is_array($aItems) && count($aItems)) {
+            if (\is_array($aItems) && \count($aItems)) {
                 $this->_aCompItems = $aItems;
             }
         }
@@ -271,11 +271,11 @@ class CompareController extends \OxidEsales\Eshop\Application\Controller\Fronten
             if (($aItems = $this->getCompareItems())) {
                 // counts how many pages
                 $oList = oxNew(\OxidEsales\Eshop\Application\Model\ArticleList::class);
-                $oList->loadIds(array_keys($aItems));
+                $oList->loadIds(\array_keys($aItems));
 
                 // cut page articles
                 if ($this->_iArticlesPerPage > 0) {
-                    $this->_iCntPages = ceil($oList->count() / $this->_iArticlesPerPage);
+                    $this->_iCntPages = \ceil($oList->count() / $this->_iArticlesPerPage);
                     $aItems = $this->_removeArticlesFromPage($aItems, $oList);
                 }
 
@@ -296,7 +296,7 @@ class CompareController extends \OxidEsales\Eshop\Application\Controller\Fronten
         if ($this->_oAttributeList === null) {
             $this->_oAttributeList = false;
             if ($oArtList = $this->getCompArtList()) {
-                $aProductIds = array_keys($oArtList);
+                $aProductIds = \array_keys($oArtList);
                 foreach ($oArtList as $oArticle) {
                     if ($oArticle->getParentId()) {
                         $aProductIds[] = $oArticle->getParentId();
@@ -323,7 +323,7 @@ class CompareController extends \OxidEsales\Eshop\Application\Controller\Fronten
             $this->_aSimilarRecommListIds = false;
 
             if ($oArtList = $this->getCompArtList()) {
-                $this->_aSimilarRecommListIds = array_keys($oArtList);
+                $this->_aSimilarRecommListIds = \array_keys($oArtList);
             }
         }
 
@@ -359,8 +359,8 @@ class CompareController extends \OxidEsales\Eshop\Application\Controller\Fronten
         //#1106S $aItems changed to $oList.
         //2006-08-10 Alfonsas, compare arrows fixed, array position is very important here, preserve it.
         $aListKeys = $oList->arrayKeys();
-        $aItemKeys = array_keys($aItems);
-        $aKeys = array_intersect($aItemKeys, $aListKeys);
+        $aItemKeys = \array_keys($aItems);
+        $aKeys = \array_intersect($aItemKeys, $aListKeys);
         $aNewItems = [];
         $iActPage = $this->getActPage();
         $maxPageIndex = $this->_iArticlesPerPage * $iActPage + $this->_iArticlesPerPage;
@@ -406,7 +406,7 @@ class CompareController extends \OxidEsales\Eshop\Application\Controller\Fronten
 
             // hide arrow if article is last in the list
             $oNewList[$sOxid]->hideNext = false;
-            if (($iActPage + 1) == $this->_iCntPages && $iCnt == count($aItems)) {
+            if (($iActPage + 1) == $this->_iCntPages && $iCnt == \count($aItems)) {
                 $oNewList[$sOxid]->hideNext = true;
             }
         }

--- a/source/Application/Controller/ContentController.php
+++ b/source/Application/Controller/ContentController.php
@@ -170,7 +170,7 @@ class ContentController extends \OxidEsales\Eshop\Application\Controller\Fronten
     {
         return !(
             $this->isEnabledPrivateSales() &&
-            !$this->getUser() && !in_array($sContentIdent, $this->_aPsAllowedContents)
+            !$this->getUser() && !\in_array($sContentIdent, $this->_aPsAllowedContents)
         );
     }
 
@@ -341,7 +341,7 @@ class ContentController extends \OxidEsales\Eshop\Application\Controller\Fronten
 
         if ($sTplName) {
             // security fix so that you cant access files from outside template dir
-            $sTplName = basename($sTplName);
+            $sTplName = \basename($sTplName);
 
             //checking if it is template name, not content id
             if (!Str::getStr()->preg_match("/\.tpl$/", $sTplName)) {
@@ -526,8 +526,8 @@ class ContentController extends \OxidEsales\Eshop\Application\Controller\Fronten
         $iFrom = \OxidEsales\Eshop\Core\Registry::getUtilsDate()->getTime();
         $iThrough = $iFrom + ($iDays * 24 * 60 * 60);
         $oPriceValidity = [];
-        $oPriceValidity['validfrom'] = date('Y-m-d\TH:i:s', $iFrom) . "Z";
-        $oPriceValidity['validthrough'] = date('Y-m-d\TH:i:s', $iThrough) . "Z";
+        $oPriceValidity['validfrom'] = \date('Y-m-d\TH:i:s', $iFrom) . "Z";
+        $oPriceValidity['validthrough'] = \date('Y-m-d\TH:i:s', $iThrough) . "Z";
 
         return $oPriceValidity;
     }

--- a/source/Application/Controller/ExceptionErrorController.php
+++ b/source/Application/Controller/ExceptionErrorController.php
@@ -32,7 +32,7 @@ class ExceptionErrorController extends \OxidEsales\Eshop\Application\Controller\
         //add all exceptions to display
         $aErrors = $this->_getErrors();
 
-        if (is_array($aErrors) && count($aErrors)) {
+        if (\is_array($aErrors) && \count($aErrors)) {
             \OxidEsales\Eshop\Core\Registry::getUtilsView()->passAllErrorsToView($aViewData, $aErrors);
         }
 

--- a/source/Application/Controller/FrontendController.php
+++ b/source/Application/Controller/FrontendController.php
@@ -31,9 +31,9 @@ use oxViewConfig;
 use stdClass;
 
 // view indexing state for search engines:
-define('VIEW_INDEXSTATE_INDEX', 0); //  index without limitations
-define('VIEW_INDEXSTATE_NOINDEXNOFOLLOW', 1); //  no index / no follow
-define('VIEW_INDEXSTATE_NOINDEXFOLLOW', 2); //  no index / follow
+\define('VIEW_INDEXSTATE_INDEX', 0); //  index without limitations
+\define('VIEW_INDEXSTATE_NOINDEXNOFOLLOW', 1); //  no index / no follow
+\define('VIEW_INDEXSTATE_NOINDEXFOLLOW', 2); //  no index / follow
 
 /**
  * Base view class.
@@ -456,10 +456,10 @@ class FrontendController extends \OxidEsales\Eshop\Core\Controller\BaseControlle
     protected function _getComponentNames() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         if (self::$_aCollectedComponentNames === null) {
-            self::$_aCollectedComponentNames = array_merge($this->_aComponentNames, $this->_aUserComponentNames);
+            self::$_aCollectedComponentNames = \array_merge($this->_aComponentNames, $this->_aUserComponentNames);
 
             if (($userComponentNames = \OxidEsales\Eshop\Core\Registry::getConfig()->getConfigParam('aUserComponentNames'))) {
-                self::$_aCollectedComponentNames = array_merge(self::$_aCollectedComponentNames, $userComponentNames);
+                self::$_aCollectedComponentNames = \array_merge(self::$_aCollectedComponentNames, $userComponentNames);
             }
 
             if (Registry::getConfig()->getRequestParameter('_force_no_basket_cmp')) {
@@ -468,7 +468,7 @@ class FrontendController extends \OxidEsales\Eshop\Core\Controller\BaseControlle
         }
 
         // resetting array pointer
-        reset(self::$_aCollectedComponentNames);
+        \reset(self::$_aCollectedComponentNames);
 
         return self::$_aCollectedComponentNames;
     }
@@ -496,7 +496,7 @@ class FrontendController extends \OxidEsales\Eshop\Core\Controller\BaseControlle
                 if (\OxidEsales\Eshop\Core\Registry::getConfig()->getConfigParam('blSeoLogging')) {
                     $shopId = \OxidEsales\Eshop\Core\Registry::getConfig()->getShopId();
                     $languageId = \OxidEsales\Eshop\Core\Registry::getLang()->getBaseLanguage();
-                    $id = md5(strtolower($requestUrl) . $shopId . $languageId);
+                    $id = \md5(\strtolower($requestUrl) . $shopId . $languageId);
 
                     // logging "not found" url
                     $database = \OxidEsales\Eshop\Core\DatabaseProvider::getDb();
@@ -537,7 +537,7 @@ class FrontendController extends \OxidEsales\Eshop\Core\Controller\BaseControlle
                     $this->_oaComponents[$componentName]->init();
 
                     // executing only is view does not have action method
-                    if (!method_exists($this, $this->getFncName())) {
+                    if (!\method_exists($this, $this->getFncName())) {
                         $this->_oaComponents[$componentName]->executeFunction($this->getFncName());
                     }
                 }
@@ -590,11 +590,11 @@ class FrontendController extends \OxidEsales\Eshop\Core\Controller\BaseControlle
         }
 
         // #0002866: external global viewID addition
-        if (function_exists('customGetViewId')) {
+        if (\function_exists('customGetViewId')) {
             $externalViewId = customGetViewId();
 
             if ($externalViewId !== null) {
-                $viewId .= '|' . md5(serialize($externalViewId));
+                $viewId .= '|' . \md5(\serialize($externalViewId));
             }
         }
 
@@ -731,7 +731,7 @@ class FrontendController extends \OxidEsales\Eshop\Core\Controller\BaseControlle
                 $this->_sListDisplayType = \OxidEsales\Eshop\Core\Registry::getConfig()->getConfigParam('sDefaultListDisplayType');
             }
 
-            $this->_sListDisplayType = in_array((string) $this->_sListDisplayType, $this->_aListDisplayTypes) ?
+            $this->_sListDisplayType = \in_array((string) $this->_sListDisplayType, $this->_aListDisplayTypes) ?
                 $this->_sListDisplayType : 'infogrid';
 
             // writing to session
@@ -857,7 +857,7 @@ class FrontendController extends \OxidEsales\Eshop\Core\Controller\BaseControlle
      */
     public function addRssFeed($title, $url, $key = null)
     {
-        if (!is_array($this->_aRssLinks)) {
+        if (!\is_array($this->_aRssLinks)) {
             $this->_aRssLinks = [];
         }
 
@@ -970,9 +970,9 @@ class FrontendController extends \OxidEsales\Eshop\Core\Controller\BaseControlle
     public function getListOrderBy()
     {
         //if column is with table name split it
-        $columns = explode('.', $this->_sListOrderBy);
+        $columns = \explode('.', $this->_sListOrderBy);
 
-        if (is_array($columns) && count($columns) > 1) {
+        if (\is_array($columns) && \count($columns) > 1) {
             return $columns[1];
         }
 
@@ -1131,7 +1131,7 @@ class FrontendController extends \OxidEsales\Eshop\Core\Controller\BaseControlle
     {
         if ($this->_iCompItemsCnt === null) {
             $items = Registry::getSession()->getVariable('aFiltcompproducts');
-            $this->_iCompItemsCnt = is_array($items) ? count($items) : 0;
+            $this->_iCompItemsCnt = \is_array($items) ? \count($items) : 0;
         }
 
         return $this->_iCompItemsCnt;
@@ -1216,7 +1216,7 @@ class FrontendController extends \OxidEsales\Eshop\Core\Controller\BaseControlle
                 $numbersOfCategoryArticles = $config->getConfigParam('aNrofCatArticles');
         }
 
-        if (!is_array($numbersOfCategoryArticles) || !isset($numbersOfCategoryArticles[0])) {
+        if (!\is_array($numbersOfCategoryArticles) || !isset($numbersOfCategoryArticles[0])) {
             $numbersOfCategoryArticles = [$numberOfCategoryArticles];
             $config->setConfigParam('aNrofCatArticles', $numbersOfCategoryArticles);
         } else {
@@ -1228,14 +1228,14 @@ class FrontendController extends \OxidEsales\Eshop\Core\Controller\BaseControlle
         $session = Registry::getSession();
         if (($articlesPerPage = (int) Registry::getConfig()->getRequestParameter('_artperpage'))) {
             // M45 Possibility to push any "Show articles per page" number parameter
-            $numberOfCategoryArticles = (in_array($articlesPerPage, $numbersOfCategoryArticles))
+            $numberOfCategoryArticles = (\in_array($articlesPerPage, $numbersOfCategoryArticles))
                 ? $articlesPerPage
                 : $numberOfCategoryArticles;
             $viewConfig->setViewConfigParam('iartPerPage', $numberOfCategoryArticles);
             $session->setVariable('_artperpage', $numberOfCategoryArticles);
-        } elseif (($sessArtPerPage = $session->getVariable('_artperpage')) && is_numeric($sessArtPerPage)) {
+        } elseif (($sessArtPerPage = $session->getVariable('_artperpage')) && \is_numeric($sessArtPerPage)) {
             // M45 Possibility to push any "Show articles per page" number parameter
-            $numberOfCategoryArticles = (in_array($sessArtPerPage, $numbersOfCategoryArticles))
+            $numberOfCategoryArticles = (\in_array($sessArtPerPage, $numbersOfCategoryArticles))
                 ? $sessArtPerPage
                 : $numberOfCategoryArticles;
             $viewConfig->setViewConfigParam('iartPerPage', $numberOfCategoryArticles);
@@ -1294,13 +1294,13 @@ class FrontendController extends \OxidEsales\Eshop\Core\Controller\BaseControlle
             }
 
             // some special cases
-            $meta = str_replace(' ,', ',', $meta);
+            $meta = \str_replace(' ,', ',', $meta);
             $pattern = ["/,[\s\+\-\*]*,/", "/\s+,/"];
             $meta = $stringModifier->preg_replace($pattern, ',', $meta);
             $meta = Registry::getUtilsString()->minimizeTruncateString($meta, $length);
             $meta = $stringModifier->htmlspecialchars($meta);
 
-            return trim($meta);
+            return \trim($meta);
         }
     }
 
@@ -1321,7 +1321,7 @@ class FrontendController extends \OxidEsales\Eshop\Core\Controller\BaseControlle
             $string = $this->_removeDuplicatedWords($string, \OxidEsales\Eshop\Core\Registry::getConfig()->getConfigParam('aSkipTags'));
         }
 
-        return trim($string);
+        return \trim($string);
     }
 
     /**
@@ -1336,32 +1336,32 @@ class FrontendController extends \OxidEsales\Eshop\Core\Controller\BaseControlle
     protected function _removeDuplicatedWords($input, $skipTags = []) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $stringModifier = Str::getStr();
-        if (is_array($input)) {
-            $input = implode(" ", $input);
+        if (\is_array($input)) {
+            $input = \implode(" ", $input);
         }
 
         // removing some usually met characters..
-        $input = $stringModifier->preg_replace("/[" . preg_quote($this->_sRemoveMetaChars, "/") . "]/", " ", $input);
+        $input = $stringModifier->preg_replace("/[" . \preg_quote($this->_sRemoveMetaChars, "/") . "]/", " ", $input);
 
         // splitting by word
         $strings = $stringModifier->preg_split("/[\s,]+/", $input);
 
-        if ($count = count($skipTags)) {
+        if ($count = \count($skipTags)) {
             for ($num = 0; $num < $count; $num++) {
                 $skipTags[$num] = $stringModifier->strtolower($skipTags[$num]);
             }
         }
-        $count = count($strings);
+        $count = \count($strings);
         for ($num = 0; $num < $count; $num++) {
             $strings[$num] = $stringModifier->strtolower($strings[$num]);
             // removing in admin defined strings
-            if (!$strings[$num] || in_array($strings[$num], $skipTags)) {
+            if (!$strings[$num] || \in_array($strings[$num], $skipTags)) {
                 unset($strings[$num]);
             }
         }
 
         // duplicates
-        return implode(', ', array_unique($strings));
+        return \implode(', ', \array_unique($strings));
     }
 
     /**
@@ -1392,7 +1392,7 @@ class FrontendController extends \OxidEsales\Eshop\Core\Controller\BaseControlle
         $params['searchcnid'] = $config->getRequestParameter('searchcnid');
         $params['searchmanufacturer'] = $config->getRequestParameter('searchmanufacturer');
 
-        $params = array_merge($params, $this->getViewConfig()->getAdditionalNavigationParameters());
+        $params = \array_merge($params, $this->getViewConfig()->getAdditionalNavigationParameters());
 
         return $params;
     }
@@ -1448,11 +1448,11 @@ class FrontendController extends \OxidEsales\Eshop\Core\Controller\BaseControlle
     public function getSortingSql($ident)
     {
         $sorting = $this->getSorting($ident);
-        if (is_array($sorting)) {
+        if (\is_array($sorting)) {
             $sortDir = isset($sorting['sortdir']) ? $sorting['sortdir'] : '';
             if ($this->isAllowedSortingOrder($sortDir)) {
                 $sortBy = \OxidEsales\Eshop\Core\DatabaseProvider::getDb()->quoteIdentifier($sorting['sortby']);
-                return trim($sortBy . ' ' . $sortDir);
+                return \trim($sortBy . ' ' . $sortDir);
             }
         }
     }
@@ -1498,9 +1498,9 @@ class FrontendController extends \OxidEsales\Eshop\Core\Controller\BaseControlle
         $titleParts[] = $this->getTitleSuffix();
         $titleParts[] = $this->getTitlePageSuffix();
 
-        $titleParts = array_filter($titleParts);
+        $titleParts = \array_filter($titleParts);
 
-        return implode(' | ', $titleParts);
+        return \implode(' | ', $titleParts);
     }
 
 
@@ -1535,18 +1535,18 @@ class FrontendController extends \OxidEsales\Eshop\Core\Controller\BaseControlle
                 break;
             case 'search':
                 $result .= "&amp;listtype={$listType}";
-                if ($searchParamForLink = rawurlencode($config->getRequestParameter('searchparam', true))) {
+                if ($searchParamForLink = \rawurlencode($config->getRequestParameter('searchparam', true))) {
                     $result .= "&amp;searchparam={$searchParamForLink}";
                 }
 
                 if (($var = $config->getRequestParameter('searchcnid', true))) {
-                    $result .= '&amp;searchcnid=' . rawurlencode(rawurldecode($var));
+                    $result .= '&amp;searchcnid=' . \rawurlencode(\rawurldecode($var));
                 }
                 if (($var = $config->getRequestParameter('searchvendor', true))) {
-                    $result .= '&amp;searchvendor=' . rawurlencode(rawurldecode($var));
+                    $result .= '&amp;searchvendor=' . \rawurlencode(\rawurldecode($var));
                 }
                 if (($var = $config->getRequestParameter('searchmanufacturer', true))) {
-                    $result .= '&amp;searchmanufacturer=' . rawurlencode(rawurldecode($var));
+                    $result .= '&amp;searchmanufacturer=' . \rawurlencode(\rawurldecode($var));
                 }
                 break;
         }
@@ -1650,7 +1650,7 @@ class FrontendController extends \OxidEsales\Eshop\Core\Controller\BaseControlle
             'deleteReviewAndRating',
         ];
 
-        if (in_array($function, $forbiddenFunctions)) {
+        if (\in_array($function, $forbiddenFunctions)) {
             $function = '';
         }
 
@@ -1669,11 +1669,11 @@ class FrontendController extends \OxidEsales\Eshop\Core\Controller\BaseControlle
             $url .= "&amp;anid={$value}";
         }
 
-        if ($value = basename(Registry::getConfig()->getRequestParameter('page'))) {
+        if ($value = \basename(Registry::getConfig()->getRequestParameter('page'))) {
             $url .= "&amp;page={$value}";
         }
 
-        if ($value = basename(Registry::getConfig()->getRequestParameter('tpl'))) {
+        if ($value = \basename(Registry::getConfig()->getRequestParameter('tpl'))) {
             $url .= "&amp;tpl={$value}";
         }
 
@@ -1689,7 +1689,7 @@ class FrontendController extends \OxidEsales\Eshop\Core\Controller\BaseControlle
         }
 
         // #1184M - specialchar search
-        if ($value = rawurlencode(Registry::getConfig()->getRequestParameter('searchparam', true))) {
+        if ($value = \rawurlencode(Registry::getConfig()->getRequestParameter('searchparam', true))) {
             $url .= "&amp;searchparam={$value}";
         }
 
@@ -1733,7 +1733,7 @@ class FrontendController extends \OxidEsales\Eshop\Core\Controller\BaseControlle
 
         // #921 S
         $forbiddenFunctions = ['tobasket', 'login_noredirect', 'addVoucher'];
-        if (in_array($function, $forbiddenFunctions)) {
+        if (\in_array($function, $forbiddenFunctions)) {
             $function = '';
         }
 
@@ -1742,11 +1742,11 @@ class FrontendController extends \OxidEsales\Eshop\Core\Controller\BaseControlle
         if ($function) {
             $url .= "&amp;fnc={$function}";
         }
-        if ($value = basename(Registry::getConfig()->getRequestParameter('page'))) {
+        if ($value = \basename(Registry::getConfig()->getRequestParameter('page'))) {
             $url .= "&amp;page={$value}";
         }
 
-        if ($value = basename(Registry::getConfig()->getRequestParameter('tpl'))) {
+        if ($value = \basename(Registry::getConfig()->getRequestParameter('tpl'))) {
             $url .= "&amp;tpl={$value}";
         }
 
@@ -1886,7 +1886,7 @@ class FrontendController extends \OxidEsales\Eshop\Core\Controller\BaseControlle
     public function getTitle()
     {
         $language = \OxidEsales\Eshop\Core\Registry::getLang();
-        $translationName = 'PAGE_TITLE_' . strtoupper(\OxidEsales\Eshop\Core\Registry::getConfig()->getActiveView()->getClassName());
+        $translationName = 'PAGE_TITLE_' . \strtoupper(\OxidEsales\Eshop\Core\Registry::getConfig()->getActiveView()->getClassName());
         $translated = $language->translateString($translationName, \OxidEsales\Eshop\Core\Registry::getLang()->getBaseLanguage(), false);
 
         return $translationName == $translated ? null : $translated;
@@ -1950,24 +1950,24 @@ class FrontendController extends \OxidEsales\Eshop\Core\Controller\BaseControlle
             $this->_sAdditionalParams .= 'cl=' . \OxidEsales\Eshop\Core\Registry::getConfig()->getTopActiveView()->getClassName();
 
             // #1834M - special char search
-            $searchParamForLink = rawurlencode(Registry::getConfig()->getRequestParameter('searchparam', true));
+            $searchParamForLink = \rawurlencode(Registry::getConfig()->getRequestParameter('searchparam', true));
             if (isset($searchParamForLink)) {
                 $this->_sAdditionalParams .= "&amp;searchparam={$searchParamForLink}";
             }
             if (($value = Registry::getConfig()->getRequestParameter('searchcnid'))) {
-                $this->_sAdditionalParams .= '&amp;searchcnid=' . rawurlencode(rawurldecode($value));
+                $this->_sAdditionalParams .= '&amp;searchcnid=' . \rawurlencode(\rawurldecode($value));
             }
             if (($value = Registry::getConfig()->getRequestParameter('searchvendor'))) {
-                $this->_sAdditionalParams .= '&amp;searchvendor=' . rawurlencode(rawurldecode($value));
+                $this->_sAdditionalParams .= '&amp;searchvendor=' . \rawurlencode(\rawurldecode($value));
             }
             if (($value = Registry::getConfig()->getRequestParameter('searchmanufacturer'))) {
-                $this->_sAdditionalParams .= '&amp;searchmanufacturer=' . rawurlencode(rawurldecode($value));
+                $this->_sAdditionalParams .= '&amp;searchmanufacturer=' . \rawurlencode(\rawurldecode($value));
             }
             if (($value = Registry::getConfig()->getRequestParameter('cnid'))) {
-                $this->_sAdditionalParams .= '&amp;cnid=' . rawurlencode(rawurldecode($value));
+                $this->_sAdditionalParams .= '&amp;cnid=' . \rawurlencode(\rawurldecode($value));
             }
             if (($value = Registry::getConfig()->getRequestParameter('mnid'))) {
-                $this->_sAdditionalParams .= '&amp;mnid=' . rawurlencode(rawurldecode($value));
+                $this->_sAdditionalParams .= '&amp;mnid=' . \rawurlencode(\rawurldecode($value));
             }
 
             $this->_sAdditionalParams .= $this->getViewConfig()->getAdditionalParameters();
@@ -1999,16 +1999,16 @@ class FrontendController extends \OxidEsales\Eshop\Core\Controller\BaseControlle
     protected function _addPageNrParam($url, $page, $languageId = null) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         if ($page) {
-            if ((strpos($url, 'pgNr='))) {
-                $url = preg_replace('/pgNr=[0-9]*/', 'pgNr=' . $page, $url);
+            if ((\strpos($url, 'pgNr='))) {
+                $url = \preg_replace('/pgNr=[0-9]*/', 'pgNr=' . $page, $url);
             } else {
-                $url .= ((strpos($url, '?') === false) ? '?' : '&amp;') . 'pgNr=' . $page;
+                $url .= ((\strpos($url, '?') === false) ? '?' : '&amp;') . 'pgNr=' . $page;
             }
         } else {
-            $url = preg_replace('/pgNr=[0-9]*/', '', $url);
-            $url = preg_replace('/\&amp\;\&amp\;/', '&amp;', $url);
-            $url = preg_replace('/\?\&amp\;/', '?', $url);
-            $url = preg_replace('/\&amp\;$/', '', $url);
+            $url = \preg_replace('/pgNr=[0-9]*/', '', $url);
+            $url = \preg_replace('/\&amp\;\&amp\;/', '&amp;', $url);
+            $url = \preg_replace('/\?\&amp\;/', '?', $url);
+            $url = \preg_replace('/\&amp\;$/', '', $url);
         }
 
         return $url;
@@ -2068,7 +2068,7 @@ class FrontendController extends \OxidEsales\Eshop\Core\Controller\BaseControlle
             $finishNo = $pageNavigation->NrOfPages;
         } else {
             $tmpVal = $positionCount - 3;
-            $tmpVal2 = floor(($positionCount - 4) / 2);
+            $tmpVal2 = \floor(($positionCount - 4) / 2);
 
             // actual page is at the start
             if ($pageNavigation->actPage <= $tmpVal) {
@@ -2121,7 +2121,7 @@ class FrontendController extends \OxidEsales\Eshop\Core\Controller\BaseControlle
      */
     public function render()
     {
-        foreach (array_keys($this->_oaComponents) as $componentName) {
+        foreach (\array_keys($this->_oaComponents) as $componentName) {
             $this->_aViewData[$componentName] = $this->_oaComponents[$componentName]->render();
         }
 
@@ -2198,7 +2198,7 @@ class FrontendController extends \OxidEsales\Eshop\Core\Controller\BaseControlle
         if ($this->_oActVendor === null) {
             $this->_oActVendor = false;
             $vendorId = \OxidEsales\Eshop\Core\Registry::getConfig()->getRequestParameter('cnid');
-            $vendorId = $vendorId ? str_replace('v_', '', $vendorId) : $vendorId;
+            $vendorId = $vendorId ? \str_replace('v_', '', $vendorId) : $vendorId;
             $vendor = oxNew(\OxidEsales\Eshop\Application\Model\Vendor::class);
             if ($vendor->load($vendorId)) {
                 $this->_oActVendor = $vendor;
@@ -2589,8 +2589,8 @@ class FrontendController extends \OxidEsales\Eshop\Core\Controller\BaseControlle
 
             // passing must-be-filled-fields info
             $mustFillFields = \OxidEsales\Eshop\Core\Registry::getConfig()->getConfigParam('aMustFillFields');
-            if (is_array($mustFillFields)) {
-                $this->_aMustFillFields = array_flip($mustFillFields);
+            if (\is_array($mustFillFields)) {
+                $this->_aMustFillFields = \array_flip($mustFillFields);
             }
         }
 
@@ -2709,8 +2709,8 @@ class FrontendController extends \OxidEsales\Eshop\Core\Controller\BaseControlle
         }
         $this->_blShowPromotions = false;
         if (oxNew(\OxidEsales\Eshop\Application\Model\ActionList::class)->areAnyActivePromotions()) {
-            $this->_blShowPromotions = (count($this->getPromoFinishedList()) + count($this->getPromoCurrentList()) +
-                                        count($this->getPromoFutureList())) > 0;
+            $this->_blShowPromotions = (\count($this->getPromoFinishedList()) + \count($this->getPromoCurrentList()) +
+                                        \count($this->getPromoFutureList())) > 0;
         }
 
         return $this->_blShowPromotions;
@@ -3041,7 +3041,7 @@ class FrontendController extends \OxidEsales\Eshop\Core\Controller\BaseControlle
      */
     private function isAllowedSortingOrder($sortOrder)
     {
-        $allowedSortOrders = array_merge((new SortingValidator())->getSortingOrders(), ['']);
-        return in_array(strtolower($sortOrder), $allowedSortOrders);
+        $allowedSortOrders = \array_merge((new SortingValidator())->getSortingOrders(), ['']);
+        return \in_array(\strtolower($sortOrder), $allowedSortOrders);
     }
 }

--- a/source/Application/Controller/InviteController.php
+++ b/source/Application/Controller/InviteController.php
@@ -109,7 +109,7 @@ class InviteController extends \OxidEsales\Eshop\Application\Controller\AccountC
 
         $aParams = Registry::getConfig()->getRequestParameter('editval', true);
         $oUser = $this->getUser();
-        if (!is_array($aParams) || !$oUser) {
+        if (!\is_array($aParams) || !$oUser) {
             return;
         }
 
@@ -131,7 +131,7 @@ class InviteController extends \OxidEsales\Eshop\Application\Controller\AccountC
                 }
 
                 //counting entered eMails
-                if (count($aParams[$sFieldName]) < 1) {
+                if (\count($aParams[$sFieldName]) < 1) {
                     $oUtilsView->addErrorToDisplay('ERROR_MESSAGE_COMPLETE_FIELDS_CORRECTLY');
 
                     return;

--- a/source/Application/Controller/ManufacturerListController.php
+++ b/source/Application/Controller/ManufacturerListController.php
@@ -153,7 +153,7 @@ class ManufacturerListController extends \OxidEsales\Eshop\Application\Controlle
         $this->_iAllArtCnt = $oArtList->loadManufacturerArticles($sManufacturerId, $oManufacturer);
 
         // counting pages
-        $this->_iCntPages = ceil($this->_iAllArtCnt / $iNrofCatArticles);
+        $this->_iCntPages = \ceil($this->_iAllArtCnt / $iNrofCatArticles);
 
         return [$oArtList, $this->_iAllArtCnt];
     }

--- a/source/Application/Controller/NewsletterController.php
+++ b/source/Application/Controller/NewsletterController.php
@@ -170,7 +170,7 @@ class NewsletterController extends \OxidEsales\Eshop\Application\Controller\Fron
         // user exists ?
         $oUser = oxNew(\OxidEsales\Eshop\Application\Model\User::class);
         if ($oUser->load(Registry::getConfig()->getRequestParameter('uid'))) {
-            $sConfirmCode = md5($oUser->oxuser__oxusername->value . $oUser->oxuser__oxpasssalt->value);
+            $sConfirmCode = \md5($oUser->oxuser__oxusername->value . $oUser->oxuser__oxpasssalt->value);
             // is confirm code ok?
             if (Registry::getConfig()->getRequestParameter('confirm') == $sConfirmCode) {
                 $oUser->getNewsSubscription()->setOptInStatus(1);
@@ -254,8 +254,8 @@ class NewsletterController extends \OxidEsales\Eshop\Application\Controller\Fron
         if ($this->_sHomeCountryId === null) {
             $this->_sHomeCountryId = false;
             $aHomeCountry = \OxidEsales\Eshop\Core\Registry::getConfig()->getConfigParam('aHomeCountry');
-            if (is_array($aHomeCountry)) {
-                $this->_sHomeCountryId = current($aHomeCountry);
+            if (\is_array($aHomeCountry)) {
+                $this->_sHomeCountryId = \current($aHomeCountry);
             }
         }
 

--- a/source/Application/Controller/OrderController.php
+++ b/source/Application/Controller/OrderController.php
@@ -524,14 +524,14 @@ class OrderController extends \OxidEsales\Eshop\Application\Controller\FrontendC
                 break;
             case ($iSuccess === \OxidEsales\Eshop\Application\Model\Order::ORDER_STATE_ORDEREXISTS):
                 break; // reload blocker activ
-            case (is_numeric($iSuccess) && $iSuccess > 3):
+            case (\is_numeric($iSuccess) && $iSuccess > 3):
                 Registry::getSession()->setVariable('payerror', $iSuccess);
                 $sNextStep = 'payment?payerror=' . $iSuccess;
                 break;
-            case (!is_numeric($iSuccess) && $iSuccess):
+            case (!\is_numeric($iSuccess) && $iSuccess):
                 //instead of error code getting error text and setting payerror to -1
                 Registry::getSession()->setVariable('payerror', -1);
-                $iSuccess = urlencode($iSuccess);
+                $iSuccess = \urlencode($iSuccess);
                 $sNextStep = 'payment?payerror=-1&payerrortext=' . $iSuccess;
                 break;
             default:

--- a/source/Application/Controller/OxidStartController.php
+++ b/source/Application/Controller/OxidStartController.php
@@ -43,7 +43,7 @@ class OxidStartController extends \OxidEsales\Eshop\Application\Controller\Front
         $errorNumber = \OxidEsales\Eshop\Core\Registry::getConfig()->getRequestParameter('execerror');
         $templates = $this->getErrorTemplates();
 
-        if (array_key_exists($errorNumber, $templates)) {
+        if (\array_key_exists($errorNumber, $templates)) {
             return $templates[$errorNumber];
         } else {
             return 'message/err_unknown.tpl';

--- a/source/Application/Controller/PaymentController.php
+++ b/source/Application/Controller/PaymentController.php
@@ -384,7 +384,7 @@ class PaymentController extends \OxidEsales\Eshop\Application\Controller\Fronten
             $this->_iAllSetsCnt = 0;
 
             if ($this->getPaymentList()) {
-                $this->_iAllSetsCnt = count($this->_aAllSets);
+                $this->_iAllSetsCnt = \count($this->_aAllSets);
             }
         }
 
@@ -400,7 +400,7 @@ class PaymentController extends \OxidEsales\Eshop\Application\Controller\Fronten
      */
     protected function _setValues(&$aPaymentList, $oBasket = null) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
-        if (is_array($aPaymentList)) {
+        if (\is_array($aPaymentList)) {
             foreach ($aPaymentList as $oPayment) {
                 $oPayment->calculate($oBasket);
                 $oPayment->aDynValues = $oPayment->getDynValues();
@@ -539,8 +539,8 @@ class PaymentController extends \OxidEsales\Eshop\Application\Controller\Fronten
             // #646
             $oPaymentList = $this->getPaymentList();
             if (isset($oPaymentList) && $oPaymentList && !isset($oPaymentList[$sCheckedId])) {
-                end($oPaymentList);
-                $sCheckedId = key($oPaymentList);
+                \end($oPaymentList);
+                $sCheckedId = \key($oPaymentList);
             }
             $this->_sCheckedPaymentId = $sCheckedId;
         }
@@ -559,7 +559,7 @@ class PaymentController extends \OxidEsales\Eshop\Application\Controller\Fronten
             $this->_iPaymentCnt = false;
 
             if ($oPaymentList = $this->getPaymentList()) {
-                $this->_iPaymentCnt = count($oPaymentList);
+                $this->_iPaymentCnt = \count($oPaymentList);
             }
         }
 
@@ -577,7 +577,7 @@ class PaymentController extends \OxidEsales\Eshop\Application\Controller\Fronten
      */
     protected function _checkArrValuesEmpty($aData, $aKeys) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
-        if (!is_array($aKeys) || count($aKeys) < 1) {
+        if (!\is_array($aKeys) || \count($aKeys) < 1) {
             return false;
         }
 

--- a/source/Application/Controller/RecommListController.php
+++ b/source/Application/Controller/RecommListController.php
@@ -139,7 +139,7 @@ class RecommListController extends \OxidEsales\Eshop\Application\Controller\Arti
         if ($oList && $oList->count()) {
             $iNrofCatArticles = (int) \OxidEsales\Eshop\Core\Registry::getConfig()->getConfigParam('iNrofCatArticles');
             $iNrofCatArticles = $iNrofCatArticles ? $iNrofCatArticles : 10;
-            $this->_iCntPages = ceil($this->_iAllArtCnt / $iNrofCatArticles);
+            $this->_iCntPages = \ceil($this->_iAllArtCnt / $iNrofCatArticles);
         }
         // processing list articles
         $this->_processListArticles();
@@ -184,7 +184,7 @@ class RecommListController extends \OxidEsales\Eshop\Application\Controller\Arti
     {
         $sAddParams = parent::getAddSeoUrlParams();
         if ($sParam = Registry::getConfig()->getRequestParameter("searchrecomm", true)) {
-            $sAddParams .= "&amp;searchrecomm=" . rawurlencode($sParam);
+            $sAddParams .= "&amp;searchrecomm=" . \rawurlencode($sParam);
         }
 
         return $sAddParams;
@@ -223,7 +223,7 @@ class RecommListController extends \OxidEsales\Eshop\Application\Controller\Arti
                 }
             }
 
-            if (($sReviewText = trim((string) Registry::getConfig()->getRequestParameter('rvw_txt', true)))) {
+            if (($sReviewText = \trim((string) Registry::getConfig()->getRequestParameter('rvw_txt', true)))) {
                 $oReview = oxNew(\OxidEsales\Eshop\Application\Model\Review::class);
                 $oReview->oxreviews__oxobjectid = new Field($oRecommList->getId());
                 $oReview->oxreviews__oxtype = new Field('oxrecommlist');
@@ -359,7 +359,7 @@ class RecommListController extends \OxidEsales\Eshop\Application\Controller\Arti
         if ($this->_dRatingValue === null) {
             $this->_dRatingValue = (double) 0;
             if ($this->isReviewActive() && ($oActiveRecommList = $this->getActiveRecommList())) {
-                $this->_dRatingValue = round($oActiveRecommList->oxrecommlists__oxrating->value, 1);
+                $this->_dRatingValue = \round($oActiveRecommList->oxrecommlists__oxrating->value, 1);
             }
         }
 
@@ -437,7 +437,7 @@ class RecommListController extends \OxidEsales\Eshop\Application\Controller\Arti
 
         if ($sSearchParam = $this->getRecommSearch()) {
             $shopHomeURL = \OxidEsales\Eshop\Core\Registry::getConfig()->getShopHomeUrl();
-            $sUrl = $shopHomeURL . "cl=recommlist&amp;searchrecomm=" . rawurlencode($sSearchParam);
+            $sUrl = $shopHomeURL . "cl=recommlist&amp;searchrecomm=" . \rawurlencode($sSearchParam);
             $sTitle = $oLang->translateString('RECOMMLIST_SEARCH') . ' "' . $sSearchParam . '"';
 
             $aPath[1] = oxNew(\OxidEsales\Eshop\Application\Model\Category::class);
@@ -515,7 +515,7 @@ class RecommListController extends \OxidEsales\Eshop\Application\Controller\Arti
         }
 
         if ($sSearch = $this->getRecommSearch()) {
-            $sAddParams .= "&amp;searchrecomm=" . rawurlencode($sSearch);
+            $sAddParams .= "&amp;searchrecomm=" . \rawurlencode($sSearch);
         }
 
         return $sAddParams;
@@ -537,7 +537,7 @@ class RecommListController extends \OxidEsales\Eshop\Application\Controller\Arti
         }
         $sSearch = Registry::getConfig()->getRequestParameter('searchrecomm');
         if ($sSearch) {
-            $sLink .= ((strpos($sLink, '?') === false) ? '?' : '&amp;') . "searchrecomm={$sSearch}";
+            $sLink .= ((\strpos($sLink, '?') === false) ? '?' : '&amp;') . "searchrecomm={$sSearch}";
         }
 
         return $sLink;

--- a/source/Application/Controller/ReviewController.php
+++ b/source/Application/Controller/ReviewController.php
@@ -176,7 +176,7 @@ class ReviewController extends \OxidEsales\Eshop\Application\Controller\ArticleD
                 // load only lists which we show on screen
                 $iNrofCatArticles = \OxidEsales\Eshop\Core\Registry::getConfig()->getConfigParam('iNrofCatArticles');
                 $iNrofCatArticles = $iNrofCatArticles ? $iNrofCatArticles : 10;
-                $this->_iCntPages = ceil($this->_iAllArtCnt / $iNrofCatArticles);
+                $this->_iCntPages = \ceil($this->_iAllArtCnt / $iNrofCatArticles);
             }
             // END deprecated
         }
@@ -221,7 +221,7 @@ class ReviewController extends \OxidEsales\Eshop\Application\Controller\ArticleD
                     }
                 }
 
-                if (($sReviewText = trim((string) Registry::getConfig()->getRequestParameter('rvw_txt', true)))) {
+                if (($sReviewText = \trim((string) Registry::getConfig()->getRequestParameter('rvw_txt', true)))) {
                     $oReview = oxNew(\OxidEsales\Eshop\Application\Model\Review::class);
                     $oReview->oxreviews__oxobjectid = new Field($oActObject->getId());
                     $oReview->oxreviews__oxtype = new Field($sType);

--- a/source/Application/Controller/SearchController.php
+++ b/source/Application/Controller/SearchController.php
@@ -149,17 +149,17 @@ class SearchController extends \OxidEsales\Eshop\Application\Controller\Frontend
 
         // #1184M - special char search
         $oConfig = \OxidEsales\Eshop\Core\Registry::getConfig();
-        $sSearchParamForQuery = trim($oConfig->getRequestParameter('searchparam', true));
+        $sSearchParamForQuery = \trim($oConfig->getRequestParameter('searchparam', true));
 
         // searching in category ?
-        $sInitialSearchCat = $this->_sSearchCatId = rawurldecode($oConfig->getRequestParameter('searchcnid'));
+        $sInitialSearchCat = $this->_sSearchCatId = \rawurldecode($oConfig->getRequestParameter('searchcnid'));
 
         // searching in vendor #671
-        $sInitialSearchVendor = rawurldecode($oConfig->getRequestParameter('searchvendor'));
+        $sInitialSearchVendor = \rawurldecode($oConfig->getRequestParameter('searchvendor'));
 
         // searching in Manufacturer #671
         $sManufacturerParameter = $oConfig->getRequestParameter('searchmanufacturer');
-        $sInitialSearchManufacturer = $this->_sSearchManufacturer = rawurldecode($sManufacturerParameter);
+        $sInitialSearchManufacturer = $this->_sSearchManufacturer = \rawurldecode($sManufacturerParameter);
 
         $this->_blEmptySearch = false;
         if (!$sSearchParamForQuery && !$sInitialSearchCat && !$sInitialSearchVendor && !$sInitialSearchManufacturer) {
@@ -202,7 +202,7 @@ class SearchController extends \OxidEsales\Eshop\Application\Controller\Frontend
 
         $iNrofCatArticles = (int) $myConfig->getConfigParam('iNrofCatArticles');
         $iNrofCatArticles = $iNrofCatArticles ? $iNrofCatArticles : 1;
-        $this->_iCntPages = ceil($this->_iAllArtCnt / $iNrofCatArticles);
+        $this->_iCntPages = \ceil($this->_iAllArtCnt / $iNrofCatArticles);
     }
 
     /**
@@ -266,18 +266,18 @@ class SearchController extends \OxidEsales\Eshop\Application\Controller\Frontend
         $oConfig = \OxidEsales\Eshop\Core\Registry::getConfig();
 
         if ($sParam = $oConfig->getRequestParameter('searchparam', true)) {
-            $sAddParams .= "&amp;searchparam=" . rawurlencode($sParam);
+            $sAddParams .= "&amp;searchparam=" . \rawurlencode($sParam);
         }
 
         if ($sParam = $oConfig->getRequestParameter('searchcnid')) {
             $sAddParams .= "&amp;searchcnid=$sParam";
         }
 
-        if ($sParam = rawurldecode($oConfig->getRequestParameter('searchvendor'))) {
+        if ($sParam = \rawurldecode($oConfig->getRequestParameter('searchvendor'))) {
             $sAddParams .= "&amp;searchvendor=$sParam";
         }
 
-        if ($sParam = rawurldecode($oConfig->getRequestParameter('searchmanufacturer'))) {
+        if ($sParam = \rawurldecode($oConfig->getRequestParameter('searchmanufacturer'))) {
             $sAddParams .= "&amp;searchmanufacturer=$sParam";
         }
 
@@ -294,7 +294,7 @@ class SearchController extends \OxidEsales\Eshop\Application\Controller\Frontend
     {
         if ($this->_blSearchClass === null) {
             $this->_blSearchClass = false;
-            if ('search' == strtolower(\OxidEsales\Eshop\Core\Registry::getConfig()->getRequestControllerId())) {
+            if ('search' == \strtolower(\OxidEsales\Eshop\Core\Registry::getConfig()->getRequestControllerId())) {
                 $this->_blSearchClass = true;
             }
         }
@@ -370,7 +370,7 @@ class SearchController extends \OxidEsales\Eshop\Application\Controller\Frontend
         if ($this->_sSearchParam === null) {
             $this->_sSearchParam = false;
             if ($this->_isSearchClass()) {
-                $this->_sSearchParam = rawurlencode(\OxidEsales\Eshop\Core\Registry::getConfig()->getRequestParameter('searchparam', true));
+                $this->_sSearchParam = \rawurlencode(\OxidEsales\Eshop\Core\Registry::getConfig()->getRequestParameter('searchparam', true));
             }
         }
 
@@ -387,7 +387,7 @@ class SearchController extends \OxidEsales\Eshop\Application\Controller\Frontend
         if ($this->_sSearchCatId === null) {
             $this->_sSearchCatId = false;
             if ($this->_isSearchClass()) {
-                $this->_sSearchCatId = rawurldecode(\OxidEsales\Eshop\Core\Registry::getConfig()->getRequestParameter('searchcnid'));
+                $this->_sSearchCatId = \rawurldecode(\OxidEsales\Eshop\Core\Registry::getConfig()->getRequestParameter('searchcnid'));
             }
         }
 
@@ -405,7 +405,7 @@ class SearchController extends \OxidEsales\Eshop\Application\Controller\Frontend
             $this->_sSearchVendor = false;
             if ($this->_isSearchClass()) {
                 // searching in vendor #671
-                $this->_sSearchVendor = rawurldecode(\OxidEsales\Eshop\Core\Registry::getConfig()->getRequestParameter('searchvendor'));
+                $this->_sSearchVendor = \rawurldecode(\OxidEsales\Eshop\Core\Registry::getConfig()->getRequestParameter('searchvendor'));
             }
         }
 
@@ -424,7 +424,7 @@ class SearchController extends \OxidEsales\Eshop\Application\Controller\Frontend
             if ($this->_isSearchClass()) {
                 // searching in Manufacturer #671
                 $sManufacturerParameter = \OxidEsales\Eshop\Core\Registry::getConfig()->getRequestParameter('searchmanufacturer');
-                $this->_sSearchManufacturer = rawurldecode($sManufacturerParameter);
+                $this->_sSearchManufacturer = \rawurldecode($sManufacturerParameter);
             }
         }
 

--- a/source/Application/Controller/TemplateController.php
+++ b/source/Application/Controller/TemplateController.php
@@ -26,7 +26,7 @@ class TemplateController extends \OxidEsales\Eshop\Application\Controller\Fronte
         parent::render();
 
         // security fix so that you cant access files from outside template dir
-        $sTplName = basename((string) \OxidEsales\Eshop\Core\Registry::getConfig()->getRequestParameter("tpl"));
+        $sTplName = \basename((string) \OxidEsales\Eshop\Core\Registry::getConfig()->getRequestParameter("tpl"));
         if ($sTplName) {
             $sTplName = 'custom/' . $sTplName;
         }

--- a/source/Application/Controller/TextEditorHandler.php
+++ b/source/Application/Controller/TextEditorHandler.php
@@ -56,10 +56,10 @@ class TextEditorHandler
      */
     public function renderPlainTextEditor($width, $height, $objectValue, $fieldName)
     {
-        if (strpos($width, '%') === false) {
+        if (\strpos($width, '%') === false) {
             $width .= 'px';
         }
-        if (strpos($height, '%') === false) {
+        if (\strpos($height, '%') === false) {
             $height .= 'px';
         }
 

--- a/source/Application/Controller/ThankYouController.php
+++ b/source/Application/Controller/ThankYouController.php
@@ -170,7 +170,7 @@ class ThankYouController extends \OxidEsales\Eshop\Application\Controller\Fronte
         if ($this->_aLastProducts === null) {
             $this->_aLastProducts = false;
             // 5th order step
-            $aBasketContents = array_values($this->getBasket()->getContents());
+            $aBasketContents = \array_values($this->getBasket()->getContents());
             if ($oBasketItem = $aBasketContents[0]) {
                 if ($oProduct = $oBasketItem->getArticle(false)) {
                     $this->_aLastProducts = $oProduct->getCustomerAlsoBoughtThisProducts();

--- a/source/Application/Controller/UserController.php
+++ b/source/Application/Controller/UserController.php
@@ -180,7 +180,7 @@ class UserController extends \OxidEsales\Eshop\Application\Controller\FrontendCo
             $this->_blNewsSubscribed = $isSubscribedToNews;
         }
 
-        if (is_null($this->_blNewsSubscribed)) {
+        if (\is_null($this->_blNewsSubscribed)) {
             $this->_blNewsSubscribed = false;
         }
 

--- a/source/Application/Controller/VendorListController.php
+++ b/source/Application/Controller/VendorListController.php
@@ -150,7 +150,7 @@ class VendorListController extends \OxidEsales\Eshop\Application\Controller\Arti
         $this->_iAllArtCnt = $oArtList->loadVendorArticles($sVendorId, $oVendor);
 
         // counting pages
-        $this->_iCntPages = ceil($this->_iAllArtCnt / $iNrOfCatArticles);
+        $this->_iCntPages = \ceil($this->_iAllArtCnt / $iNrOfCatArticles);
 
         return [$oArtList, $this->_iAllArtCnt];
     }

--- a/source/Application/Controller/WrappingController.php
+++ b/source/Application/Controller/WrappingController.php
@@ -118,7 +118,7 @@ class WrappingController extends \OxidEsales\Eshop\Application\Controller\Fronte
             $session = \OxidEsales\Eshop\Core\Registry::getSession();
             $oBasket = $session->getBasket();
             // setting wrapping info
-            if (is_array($aWrapping) && count($aWrapping)) {
+            if (\is_array($aWrapping) && \count($aWrapping)) {
                 foreach ($oBasket->getContents() as $sKey => $oBasketItem) {
                     // wrapping ?
                     if (isset($aWrapping[$sKey])) {

--- a/source/Application/Model/ActionList.php
+++ b/source/Application/Model/ActionList.php
@@ -30,14 +30,14 @@ class ActionList extends \OxidEsales\Eshop\Core\Model\ListModel
     public function loadFinishedByCount($iCount)
     {
         $sViewName = $this->getBaseObject()->getViewName();
-        $sDate = date('Y-m-d H:i:s', \OxidEsales\Eshop\Core\Registry::getUtilsDate()->getTime());
+        $sDate = \date('Y-m-d H:i:s', \OxidEsales\Eshop\Core\Registry::getUtilsDate()->getTime());
 
         $oDb = \OxidEsales\Eshop\Core\DatabaseProvider::getDb();
         $sQ = "select * from {$sViewName} where oxtype=2 and oxactive=1 and oxshopid='" . \OxidEsales\Eshop\Core\Registry::getConfig()->getShopId() . "' and oxactiveto>0 and oxactiveto < " . $oDb->quote($sDate) . "
                " . $this->_getUserGroupFilter() . "
                order by oxactiveto desc, oxactivefrom desc limit " . (int) $iCount;
         $this->selectString($sQ);
-        $this->_aArray = array_reverse($this->_aArray, true);
+        $this->_aArray = \array_reverse($this->_aArray, true);
     }
 
     /**
@@ -48,8 +48,8 @@ class ActionList extends \OxidEsales\Eshop\Core\Model\ListModel
     public function loadFinishedByTimespan($iTimespan)
     {
         $sViewName = $this->getBaseObject()->getViewName();
-        $sDateTo = date('Y-m-d H:i:s', \OxidEsales\Eshop\Core\Registry::getUtilsDate()->getTime());
-        $sDateFrom = date('Y-m-d H:i:s', \OxidEsales\Eshop\Core\Registry::getUtilsDate()->getTime() - $iTimespan);
+        $sDateTo = \date('Y-m-d H:i:s', \OxidEsales\Eshop\Core\Registry::getUtilsDate()->getTime());
+        $sDateFrom = \date('Y-m-d H:i:s', \OxidEsales\Eshop\Core\Registry::getUtilsDate()->getTime() - $iTimespan);
         $oDb = \OxidEsales\Eshop\Core\DatabaseProvider::getDb();
         $sQ = "select * from {$sViewName} where oxtype=2 and oxactive=1 and oxshopid='" . \OxidEsales\Eshop\Core\Registry::getConfig()->getShopId() . "' and oxactiveto < " . $oDb->quote($sDateTo) . " and oxactiveto > " . $oDb->quote($sDateFrom) . "
                " . $this->_getUserGroupFilter() . "
@@ -63,7 +63,7 @@ class ActionList extends \OxidEsales\Eshop\Core\Model\ListModel
     public function loadCurrent()
     {
         $sViewName = $this->getBaseObject()->getViewName();
-        $sDate = date('Y-m-d H:i:s', \OxidEsales\Eshop\Core\Registry::getUtilsDate()->getTime());
+        $sDate = \date('Y-m-d H:i:s', \OxidEsales\Eshop\Core\Registry::getUtilsDate()->getTime());
         $oDb = \OxidEsales\Eshop\Core\DatabaseProvider::getDb();
         $sQ = "select * from {$sViewName} where oxtype=2 and oxactive=1 and oxshopid='" . \OxidEsales\Eshop\Core\Registry::getConfig()->getShopId() . "' and (oxactiveto > " . $oDb->quote($sDate) . " or oxactiveto=0) and oxactivefrom != 0 and oxactivefrom < " . $oDb->quote($sDate) . "
                " . $this->_getUserGroupFilter() . "
@@ -79,7 +79,7 @@ class ActionList extends \OxidEsales\Eshop\Core\Model\ListModel
     public function loadFutureByCount($iCount)
     {
         $sViewName = $this->getBaseObject()->getViewName();
-        $sDate = date('Y-m-d H:i:s', \OxidEsales\Eshop\Core\Registry::getUtilsDate()->getTime());
+        $sDate = \date('Y-m-d H:i:s', \OxidEsales\Eshop\Core\Registry::getUtilsDate()->getTime());
         $oDb = \OxidEsales\Eshop\Core\DatabaseProvider::getDb();
         $sQ = "select * from {$sViewName} where oxtype=2 and oxactive=1 and oxshopid='" . \OxidEsales\Eshop\Core\Registry::getConfig()->getShopId() . "' and (oxactiveto > " . $oDb->quote($sDate) . " or oxactiveto=0) and oxactivefrom > " . $oDb->quote($sDate) . "
                " . $this->_getUserGroupFilter() . "
@@ -95,8 +95,8 @@ class ActionList extends \OxidEsales\Eshop\Core\Model\ListModel
     public function loadFutureByTimespan($iTimespan)
     {
         $sViewName = $this->getBaseObject()->getViewName();
-        $sDate = date('Y-m-d H:i:s', \OxidEsales\Eshop\Core\Registry::getUtilsDate()->getTime());
-        $sDateTo = date('Y-m-d H:i:s', \OxidEsales\Eshop\Core\Registry::getUtilsDate()->getTime() + $iTimespan);
+        $sDate = \date('Y-m-d H:i:s', \OxidEsales\Eshop\Core\Registry::getUtilsDate()->getTime());
+        $sDateTo = \date('Y-m-d H:i:s', \OxidEsales\Eshop\Core\Registry::getUtilsDate()->getTime() + $iTimespan);
         $oDb = \OxidEsales\Eshop\Core\DatabaseProvider::getDb();
         $sQ = "select * from {$sViewName} where oxtype=2 and oxactive=1 and oxshopid='" . \OxidEsales\Eshop\Core\Registry::getConfig()->getShopId() . "' and (oxactiveto > " . $oDb->quote($sDate) . " or oxactiveto=0) and oxactivefrom > " . $oDb->quote($sDate) . " and oxactivefrom < " . $oDb->quote($sDateTo) . "
                " . $this->_getUserGroupFilter() . "
@@ -120,13 +120,13 @@ class ActionList extends \OxidEsales\Eshop\Core\Model\ListModel
 
         $aIds = [];
         // checking for current session user which gives additional restrictions for user itself, users group and country
-        if ($oUser && count($aGroupIds = $oUser->getUserGroups())) {
+        if ($oUser && \count($aGroupIds = $oUser->getUserGroups())) {
             foreach ($aGroupIds as $oGroup) {
                 $aIds[] = $oGroup->getId();
             }
         }
 
-        $sGroupSql = count($aIds) ? "EXISTS(select oxobject2action.oxid from oxobject2action where oxobject2action.oxactionid=$sTable.OXID and oxobject2action.oxclass='oxgroups' and oxobject2action.OXOBJECTID in (" . implode(', ', \OxidEsales\Eshop\Core\DatabaseProvider::getDb()->quoteArray($aIds)) . ") )" : '0';
+        $sGroupSql = \count($aIds) ? "EXISTS(select oxobject2action.oxid from oxobject2action where oxobject2action.oxactionid=$sTable.OXID and oxobject2action.oxclass='oxgroups' and oxobject2action.OXOBJECTID in (" . \implode(', ', \OxidEsales\Eshop\Core\DatabaseProvider::getDb()->quoteArray($aIds)) . ") )" : '0';
         return " and (
             select
                 if(EXISTS(select 1 from oxobject2action, $sGroupTable where $sGroupTable.oxid=oxobject2action.oxobjectid and oxobject2action.oxactionid=$sTable.OXID and oxobject2action.oxclass='oxgroups' LIMIT 1),

--- a/source/Application/Model/Actions.php
+++ b/source/Application/Model/Actions.php
@@ -118,7 +118,7 @@ class Actions extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel
     public function getTimeLeft()
     {
         $iNow = \OxidEsales\Eshop\Core\Registry::getUtilsDate()->getTime();
-        $iFrom = strtotime($this->oxactions__oxactiveto->value);
+        $iFrom = \strtotime($this->oxactions__oxactiveto->value);
 
         return $iFrom - $iNow;
     }
@@ -131,7 +131,7 @@ class Actions extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel
     public function getTimeUntilStart()
     {
         $iNow = \OxidEsales\Eshop\Core\Registry::getUtilsDate()->getTime();
-        $iFrom = strtotime($this->oxactions__oxactivefrom->value);
+        $iFrom = \strtotime($this->oxactions__oxactivefrom->value);
 
         return $iFrom - $iNow;
     }
@@ -141,10 +141,10 @@ class Actions extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel
      */
     public function start()
     {
-        $this->oxactions__oxactivefrom = new \OxidEsales\Eshop\Core\Field(date('Y-m-d H:i:s', \OxidEsales\Eshop\Core\Registry::getUtilsDate()->getTime()));
+        $this->oxactions__oxactivefrom = new \OxidEsales\Eshop\Core\Field(\date('Y-m-d H:i:s', \OxidEsales\Eshop\Core\Registry::getUtilsDate()->getTime()));
         if ($this->oxactions__oxactiveto->value && ($this->oxactions__oxactiveto->value != '0000-00-00 00:00:00')) {
             $iNow = \OxidEsales\Eshop\Core\Registry::getUtilsDate()->getTime();
-            $iTo = strtotime($this->oxactions__oxactiveto->value);
+            $iTo = \strtotime($this->oxactions__oxactiveto->value);
             if ($iNow > $iTo) {
                 $this->oxactions__oxactiveto = new \OxidEsales\Eshop\Core\Field('0000-00-00 00:00:00');
             }
@@ -157,7 +157,7 @@ class Actions extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel
      */
     public function stop()
     {
-        $this->oxactions__oxactiveto = new \OxidEsales\Eshop\Core\Field(date('Y-m-d H:i:s', \OxidEsales\Eshop\Core\Registry::getUtilsDate()->getTime()));
+        $this->oxactions__oxactiveto = new \OxidEsales\Eshop\Core\Field(\date('Y-m-d H:i:s', \OxidEsales\Eshop\Core\Registry::getUtilsDate()->getTime()));
         $this->save();
     }
 
@@ -178,13 +178,13 @@ class Actions extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel
             return false;
         }
         $iNow = \OxidEsales\Eshop\Core\Registry::getUtilsDate()->getTime();
-        $iFrom = strtotime($this->oxactions__oxactivefrom->value);
+        $iFrom = \strtotime($this->oxactions__oxactivefrom->value);
         if ($iNow < $iFrom) {
             return false;
         }
 
         if ($this->oxactions__oxactiveto->value != '0000-00-00 00:00:00') {
-            $iTo = strtotime($this->oxactions__oxactiveto->value);
+            $iTo = \strtotime($this->oxactions__oxactiveto->value);
             if ($iNow > $iTo) {
                 return false;
             }

--- a/source/Application/Model/Address.php
+++ b/source/Application/Model/Address.php
@@ -39,7 +39,7 @@ class Address extends \OxidEsales\Eshop\Core\Model\BaseModel
      */
     protected function _getStateObject() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
-        if (is_null($this->_oStateObject)) {
+        if (\is_null($this->_oStateObject)) {
             $this->_oStateObject = oxNew(\OxidEsales\Eshop\Application\Model\State::class);
         }
 
@@ -85,7 +85,7 @@ class Address extends \OxidEsales\Eshop\Core\Model\BaseModel
         }
         $sAddress .= "$sStreet $sStreetNr, $sCity";
 
-        return trim($sAddress);
+        return \trim($sAddress);
     }
 
     /**
@@ -95,7 +95,7 @@ class Address extends \OxidEsales\Eshop\Core\Model\BaseModel
      */
     public function getEncodedDeliveryAddress()
     {
-        return md5($this->_getMergedAddressFields());
+        return \md5($this->_getMergedAddressFields());
     }
 
     /**
@@ -120,7 +120,7 @@ class Address extends \OxidEsales\Eshop\Core\Model\BaseModel
     {
         $oState = $this->_getStateObject();
 
-        if (is_null($sId)) {
+        if (\is_null($sId)) {
             $sId = $this->getStateId();
         }
 

--- a/source/Application/Model/Article.php
+++ b/source/Application/Model/Article.php
@@ -15,12 +15,12 @@ use OxidEsales\Eshop\Core\Str;
 use oxList;
 
 // defining supported link types
-define('OXARTICLE_LINKTYPE_CATEGORY', 0);
-define('OXARTICLE_LINKTYPE_VENDOR', 1);
-define('OXARTICLE_LINKTYPE_MANUFACTURER', 2);
-define('OXARTICLE_LINKTYPE_PRICECATEGORY', 3);
+\define('OXARTICLE_LINKTYPE_CATEGORY', 0);
+\define('OXARTICLE_LINKTYPE_VENDOR', 1);
+\define('OXARTICLE_LINKTYPE_MANUFACTURER', 2);
+\define('OXARTICLE_LINKTYPE_PRICECATEGORY', 3);
 // @deprecated since v5.3 (2016-06-17); Listmania will be moved to an own module.
-define('OXARTICLE_LINKTYPE_RECOMM', 5);
+\define('OXARTICLE_LINKTYPE_RECOMM', 5);
 // END deprecated
 
 /**
@@ -478,7 +478,7 @@ class Article extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
      */
     public function __construct($aParams = null)
     {
-        if ($aParams && is_array($aParams)) {
+        if ($aParams && \is_array($aParams)) {
             foreach ($aParams as $sParam => $mValue) {
                 $this->$sParam = $mValue;
             }
@@ -1061,7 +1061,7 @@ class Article extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
         }
 
         // active ?
-        $sNow = date('Y-m-d H:i:s');
+        $sNow = \date('Y-m-d H:i:s');
         if (
             !$this->oxarticles__oxactive->value &&
             (
@@ -1261,7 +1261,7 @@ class Article extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
     public function getArticleRatingAverage($blIncludeVariants = false)
     {
         if (!$blIncludeVariants) {
-            return round($this->oxarticles__oxrating->value, 1);
+            return \round($this->oxarticles__oxrating->value, 1);
         } else {
             $oRating = oxNew(\OxidEsales\Eshop\Application\Model\Rating::class);
 
@@ -1304,8 +1304,8 @@ class Article extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
         // showing variant reviews ..
         if (\OxidEsales\Eshop\Core\Registry::getConfig()->getConfigParam('blShowVariantReviews')) {
             $aAdd = $this->getVariantIds();
-            if (is_array($aAdd)) {
-                $aIds = array_merge($aIds, $aAdd);
+            if (\is_array($aAdd)) {
+                $aIds = \array_merge($aIds, $aAdd);
             }
         }
 
@@ -1387,8 +1387,8 @@ class Article extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
 
         $aList = $this->_getSimList($sAttribs, $iCnt);
 
-        if (count($aList)) {
-            uasort($aList, function ($a, $b) {
+        if (\count($aList)) {
+            \uasort($aList, function ($a, $b) {
                 if ($a->cnt == $b->cnt) {
                     return 0;
                 }
@@ -1444,7 +1444,7 @@ class Article extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
 
         if ($this->_oAmountPriceInfo === null) {
             $this->_oAmountPriceInfo = [];
-            if (count(($aAmPriceList = $this->_getAmountPriceList()->getArray()))) {
+            if (\count(($aAmPriceList = $this->_getAmountPriceList()->getArray()))) {
                 $this->_oAmountPriceInfo = $this->_fillAmountPriceList($aAmPriceList);
             }
         }
@@ -1588,7 +1588,7 @@ class Article extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
     public function getSelections($iLimit = null, $aFilter = null)
     {
         $sId = $this->getId() . ((int) $iLimit);
-        if (!array_key_exists($sId, self::$_aSelections)) {
+        if (!\array_key_exists($sId, self::$_aSelections)) {
             $oDb = \OxidEsales\Eshop\Core\DatabaseProvider::getDb();
             $sSLViewName = getViewName('oxselectlist');
 
@@ -1689,7 +1689,7 @@ class Article extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
         if (($sId = $this->getId())) {
             $oBaseObj = $oVariants->getBaseObject();
 
-            if (is_null($sLanguage)) {
+            if (\is_null($sLanguage)) {
                 $oBaseObj->setLanguage(\OxidEsales\Eshop\Core\Registry::getLang()->getBaseLanguage());
             } else {
                 $oBaseObj->setLanguage($sLanguage);
@@ -1781,7 +1781,7 @@ class Article extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
             $sSql = $this->getSqlForPriceCategories();
             $aPriceCategoryIds = $this->_selectCategoryIds($sSql, 'oxid');
 
-            self::$_aArticleCats[$sArticleId] = array_unique(array_merge($aCategoryIds, $aPriceCategoryIds));
+            self::$_aArticleCats[$sArticleId] = \array_unique(\array_merge($aCategoryIds, $aPriceCategoryIds));
         }
 
         return self::$_aArticleCats[$sArticleId];
@@ -1891,7 +1891,7 @@ class Article extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
      */
     public function inCategory($sCatNid)
     {
-        return in_array($sCatNid, $this->getCategoryIds());
+        return \in_array($sCatNid, $this->getCategoryIds());
     }
 
     /**
@@ -2426,7 +2426,7 @@ class Article extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
      */
     public function onChange($action = null, $articleId = null, $parentArticleId = null)
     {
-        $this->actionType = !is_null($action) ? $action : $this->actionType;
+        $this->actionType = !\is_null($action) ? $action : $this->actionType;
         $myConfig = \OxidEsales\Eshop\Core\Registry::getConfig();
 
         if (!isset($articleId)) {
@@ -2539,7 +2539,7 @@ class Article extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
                 }
             }
             if (!$myConfig->getConfigParam('blAllowUnevenAmounts')) {
-                $iOnStock = floor($iOnStock);
+                $iOnStock = \floor($iOnStock);
             }
         }
         if (\OxidEsales\Eshop\Core\Registry::getConfig()->getConfigParam('blPsBasketReservationEnabled')) {
@@ -2722,7 +2722,7 @@ class Article extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
 
         $sUrl = $this->_aSeoUrls[$iLang][$iLinkType];
         if (isset($this->_aSeoAddParams[$iLang])) {
-            $sUrl .= ((strpos($sUrl . $this->_aSeoAddParams[$iLang], '?') === false) ? '?' : '&amp;') . $this->_aSeoAddParams[$iLang];
+            $sUrl .= ((\strpos($sUrl . $this->_aSeoAddParams[$iLang], '?') === false) ? '?' : '&amp;') . $this->_aSeoAddParams[$iLang];
         }
 
         return $sUrl;
@@ -2925,7 +2925,7 @@ class Article extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
 
                 $this->_sToBasketLink .= '&amp;fnc=tobasket&amp;aid=' . $this->getId() . '&amp;anid=' . $this->getId();
 
-                if ($sTpl = basename(\OxidEsales\Eshop\Core\Registry::getConfig()->getRequestParameter('tpl'))) {
+                if ($sTpl = \basename(\OxidEsales\Eshop\Core\Registry::getConfig()->getRequestParameter('tpl'))) {
                     $this->_sToBasketLink .= '&amp;tpl=' . $sTpl;
                 }
             }
@@ -2983,7 +2983,7 @@ class Article extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
     public function getRestockDate()
     {
         $restockDate = $this->getFieldData('oxdelivery');
-        if ($restockDate >= date('Y-m-d')) {
+        if ($restockDate >= \date('Y-m-d')) {
             return Registry::getUtilsDate()->formatDBDate($restockDate);
         }
 
@@ -3103,7 +3103,7 @@ class Article extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
         if ($iIndex) {
             $sImgName = false;
             if (!$this->_isFieldEmpty("oxarticles__oxpic" . $iIndex)) {
-                $sImgName = basename($this->{"oxarticles__oxpic$iIndex"}->value);
+                $sImgName = \basename($this->{"oxarticles__oxpic$iIndex"}->value);
             }
 
             $sSize = \OxidEsales\Eshop\Core\Registry::getConfig()->getConfigParam('aDetailImageSizes');
@@ -3126,13 +3126,13 @@ class Article extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
         $sImgName = false;
         $sDirname = "product/1/";
         if ($iIndex && !$this->_isFieldEmpty("oxarticles__oxpic{$iIndex}")) {
-            $sImgName = basename($this->{"oxarticles__oxpic$iIndex"}->value);
+            $sImgName = \basename($this->{"oxarticles__oxpic$iIndex"}->value);
             $sDirname = "product/{$iIndex}/";
         } elseif (!$this->_isFieldEmpty("oxarticles__oxicon")) {
-            $sImgName = basename($this->oxarticles__oxicon->value);
+            $sImgName = \basename($this->oxarticles__oxicon->value);
             $sDirname = "product/icon/";
         } elseif (!$this->_isFieldEmpty("oxarticles__oxpic1")) {
-            $sImgName = basename($this->oxarticles__oxpic1->value);
+            $sImgName = \basename($this->oxarticles__oxpic1->value);
         }
 
         $sSize = \OxidEsales\Eshop\Core\Registry::getConfig()->getConfigParam('sIconsize');
@@ -3154,10 +3154,10 @@ class Article extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
         $sImgName = false;
         $sDirname = "product/1/";
         if (!$this->_isFieldEmpty("oxarticles__oxthumb")) {
-            $sImgName = basename($this->oxarticles__oxthumb->value);
+            $sImgName = \basename($this->oxarticles__oxthumb->value);
             $sDirname = "product/thumb/";
         } elseif (!$this->_isFieldEmpty("oxarticles__oxpic1")) {
-            $sImgName = basename($this->oxarticles__oxpic1->value);
+            $sImgName = \basename($this->oxarticles__oxpic1->value);
         }
 
         $sSize = \OxidEsales\Eshop\Core\Registry::getConfig()->getConfigParam('sThumbnailsize');
@@ -3176,7 +3176,7 @@ class Article extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
     {
         $iIndex = (int) $iIndex;
         if ($iIndex > 0 && !$this->_isFieldEmpty("oxarticles__oxpic" . $iIndex)) {
-            $sImgName = basename($this->{"oxarticles__oxpic" . $iIndex}->value);
+            $sImgName = \basename($this->{"oxarticles__oxpic" . $iIndex}->value);
             $sSize = \OxidEsales\Eshop\Core\Registry::getConfig()->getConfigParam("sZoomImageSize");
 
             return \OxidEsales\Eshop\Core\Registry::getPictureHandler()->getProductPicUrl(
@@ -3210,7 +3210,7 @@ class Article extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
             $oDiscountList = \OxidEsales\Eshop\Core\Registry::get(\OxidEsales\Eshop\Application\Model\DiscountList::class);
             $aDiscounts = $oDiscountList->getArticleDiscounts($this, $this->getArticleUser());
 
-            reset($aDiscounts);
+            \reset($aDiscounts);
             foreach ($aDiscounts as $oDiscount) {
                 $oPrice->setDiscount($oDiscount->getAddSum(), $oDiscount->getAddSumType());
             }
@@ -3465,11 +3465,11 @@ class Article extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
     public function getMasterZoomPictureUrl($iIndex)
     {
         $sPicUrl = false;
-        $sPicName = basename($this->{"oxarticles__oxpic" . $iIndex}->value);
+        $sPicName = \basename($this->{"oxarticles__oxpic" . $iIndex}->value);
 
         if ($sPicName && $sPicName != "nopic.jpg") {
             $sPicUrl = \OxidEsales\Eshop\Core\Registry::getConfig()->getPictureUrl("master/product/" . $iIndex . "/" . $sPicName);
-            if (!$sPicUrl || basename($sPicUrl) == "nopic.jpg") {
+            if (!$sPicUrl || \basename($sPicUrl) == "nopic.jpg") {
                 $sPicUrl = false;
             }
         }
@@ -3627,7 +3627,7 @@ class Article extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
             }
 
             //if we have variants, but all variants are incative means article may be non buyable (depends on config option)
-            if (!$config->getConfigParam('blVariantParentBuyable') && count($variants) == 0 && $this->_blHasVariants) {
+            if (!$config->getConfigParam('blVariantParentBuyable') && \count($variants) == 0 && $this->_blHasVariants) {
                 $this->_blNotBuyable = true;
             }
         }
@@ -3651,7 +3651,7 @@ class Article extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
         $aReturn = [];
 
         foreach ($aResult as $aValue) {
-            $aValue = array_change_key_case($aValue, CASE_LOWER);
+            $aValue = \array_change_key_case($aValue, CASE_LOWER);
 
             $aReturn[] = $aValue[$field];
         }
@@ -3724,7 +3724,7 @@ class Article extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
             $oDiscountList = \OxidEsales\Eshop\Core\Registry::get(\OxidEsales\Eshop\Application\Model\DiscountList::class);
             $aDiscounts = $oDiscountList->getArticleDiscounts($this, $this->getArticleUser());
 
-            reset($aDiscounts);
+            \reset($aDiscounts);
             foreach ($aDiscounts as $oDiscount) {
                 $oPrice->setDiscount($oDiscount->getAddSum(), $oDiscount->getAddSumType());
             }
@@ -3789,7 +3789,7 @@ class Article extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
      */
     protected function _saveArtLongDesc() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
-        if (in_array("oxlongdesc", $this->_aSkipSaveFields)) {
+        if (\in_array("oxlongdesc", $this->_aSkipSaveFields)) {
             return;
         }
 
@@ -3815,14 +3815,14 @@ class Article extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
             }
 
             foreach ($aObjFields as $sKey => $sValue) {
-                if (preg_match('/^oxlongdesc(_(\d{1,2}))?$/', $sKey)) {
+                if (\preg_match('/^oxlongdesc(_(\d{1,2}))?$/', $sKey)) {
                     $sField = $this->_getFieldLongName($sKey);
 
                     if (isset($this->$sField)) {
                         $sLongDesc = null;
                         if ($this->$sField instanceof \OxidEsales\Eshop\Core\Field) {
                             $sLongDesc = $this->$sField->getRawValue();
-                        } elseif (is_object($this->$sField)) {
+                        } elseif (\is_object($this->$sField)) {
                             $sLongDesc = $this->$sField->value;
                         }
                         if (isset($sLongDesc)) {
@@ -3868,7 +3868,7 @@ class Article extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
     {
         foreach ($aItemDiscounts as $sKey => $oDiscount) {
             // add prices of the same discounts
-            if (array_key_exists($sKey, $aDiscounts)) {
+            if (\array_key_exists($sKey, $aDiscounts)) {
                 $aDiscounts[$sKey]->dDiscount += $oDiscount->dDiscount;
             } else {
                 $aDiscounts[$sKey] = $oDiscount;
@@ -4026,7 +4026,7 @@ class Article extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
             ]);
             if ($oRs != false && $oRs->count() > 0) {
                 while (!$oRs->EOF) {
-                    $aSelect[] = reset($oRs->fields);
+                    $aSelect[] = \reset($oRs->fields);
                     $oRs->fetchRow();
                 }
             }
@@ -4105,10 +4105,10 @@ class Article extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
             ':oxobjectid' => $this->getId(),
             ':oxparentid' => $this->getParentId()
         ]);
-        if (is_array($aAttributeIds) && count($aAttributeIds)) {
-            $aAttributeIds = array_unique($aAttributeIds);
-            $iCnt = count($aAttributeIds);
-            $sAttributeSql .= 't1.oxattrid IN ( ' . implode(',', $oDb->quoteArray($aAttributeIds)) . ') ';
+        if (\is_array($aAttributeIds) && \count($aAttributeIds)) {
+            $aAttributeIds = \array_unique($aAttributeIds);
+            $iCnt = \count($aAttributeIds);
+            $sAttributeSql .= 't1.oxattrid IN ( ' . \implode(',', $oDb->quoteArray($aAttributeIds)) . ') ';
         }
     }
 
@@ -4130,7 +4130,7 @@ class Article extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
             $iAttrPercent = 0.70;
         }
         // #1137V iAttributesPercent = 100 doesn't work
-        $iHitMin = ceil($iCnt * $iAttrPercent);
+        $iHitMin = \ceil($iCnt * $iAttrPercent);
 
         $aExcludeIds = [];
         $aExcludeIds[] = $this->getId();
@@ -4141,7 +4141,7 @@ class Article extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
         // we do not use lists here as we don't need this overhead right now
         $sSelect = "select oxobjectid from oxobject2attribute as t1 where
                     ( $sAttributeSql )
-                    and t1.oxobjectid NOT IN (" . implode(', ', \OxidEsales\Eshop\Core\DatabaseProvider::getDb()->quoteArray($aExcludeIds)) . ")
+                    and t1.oxobjectid NOT IN (" . \implode(', ', \OxidEsales\Eshop\Core\DatabaseProvider::getDb()->quoteArray($aExcludeIds)) . ")
                     group by t1.oxobjectid having count(*) >= :minhit LIMIT 0, 20";
 
         return \OxidEsales\Eshop\Core\DatabaseProvider::getDb()->getCol($sSelect, [
@@ -4161,11 +4161,11 @@ class Article extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
     protected function _generateSimListSearchStr($sArticleTable, $aList) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $sFieldList = $this->getSelectFields();
-        $aList = array_slice($aList, 0, \OxidEsales\Eshop\Core\Registry::getConfig()->getConfigParam('iNrofSimilarArticles'));
+        $aList = \array_slice($aList, 0, \OxidEsales\Eshop\Core\Registry::getConfig()->getConfigParam('iNrofSimilarArticles'));
 
         $sSearch = "select $sFieldList from $sArticleTable where " . $this->getSqlActiveSnippet() . "  and $sArticleTable.oxissearch = 1 and $sArticleTable.oxid in ( ";
 
-        $sSearch .= implode(',', \OxidEsales\Eshop\Core\DatabaseProvider::getDb()->quoteArray($aList)) . ')';
+        $sSearch .= \implode(',', \OxidEsales\Eshop\Core\DatabaseProvider::getDb()->quoteArray($aList)) . ')';
 
         // #524A -- randomizing articles in attribute list
         $sSearch .= ' order by rand() ';
@@ -4231,7 +4231,7 @@ class Article extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
             and oxid != :oxid ", $params);
         if ($oRs != false && $oRs->count() > 0) {
             while (!$oRs->EOF) {
-                $sIn .= ", " . $oDb->quote(current($oRs->fields)) . " ";
+                $sIn .= ", " . $oDb->quote(\current($oRs->fields)) . " ";
                 $oRs->fetchRow();
             }
         }
@@ -4350,7 +4350,7 @@ class Article extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
     {
         $mValue = $this->$sFieldName->value;
 
-        if (is_null($mValue)) {
+        if (\is_null($mValue)) {
             return true;
         }
 
@@ -4361,19 +4361,19 @@ class Article extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
         // certain fields with zero value treat as empty
         $aZeroValueFields = ['oxarticles__oxprice', 'oxarticles__oxvat', 'oxarticles__oxunitquantity'];
 
-        if (!$mValue && in_array($sFieldName, $aZeroValueFields)) {
+        if (!$mValue && \in_array($sFieldName, $aZeroValueFields)) {
             return true;
         }
 
 
-        if (!strcmp($mValue, '0000-00-00 00:00:00') || !strcmp($mValue, '0000-00-00')) {
+        if (!\strcmp($mValue, '0000-00-00 00:00:00') || !\strcmp($mValue, '0000-00-00')) {
             return true;
         }
 
-        $sFieldName = strtolower($sFieldName);
+        $sFieldName = \strtolower($sFieldName);
 
         if (
-            $sFieldName == 'oxarticles__oxicon' && (strpos($mValue, "nopic_ico.jpg") !== false || strpos(
+            $sFieldName == 'oxarticles__oxicon' && (\strpos($mValue, "nopic_ico.jpg") !== false || \strpos(
                 $mValue,
                 "nopic.jpg"
             ) !== false)
@@ -4382,11 +4382,11 @@ class Article extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
         }
 
         if (
-            strpos($mValue, "nopic.jpg") !== false && ($sFieldName == 'oxarticles__oxthumb' || substr(
+            \strpos($mValue, "nopic.jpg") !== false && ($sFieldName == 'oxarticles__oxthumb' || \substr(
                 $sFieldName,
                 0,
                 17
-            ) == 'oxarticles__oxpic' || substr($sFieldName, 0, 18) == 'oxarticles__oxzoom')
+            ) == 'oxarticles__oxpic' || \substr($sFieldName, 0, 18) == 'oxarticles__oxzoom')
         ) {
             return true;
         }
@@ -4413,12 +4413,12 @@ class Article extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
         // assigning only these which parent article has
         if ($oParentArticle->$sCopyFieldName != null) {
             // only overwrite database values
-            if (substr($sCopyFieldName, 0, 12) != 'oxarticles__') {
+            if (\substr($sCopyFieldName, 0, 12) != 'oxarticles__') {
                 return;
             }
 
             //do not copy certain fields
-            if (in_array($sCopyFieldName, $this->_aNonCopyParentFields)) {
+            if (\in_array($sCopyFieldName, $this->_aNonCopyParentFields)) {
                 return;
             }
 
@@ -4444,10 +4444,10 @@ class Article extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
      */
     protected function _isImageField($sFieldName) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
-        return (stristr($sFieldName, '_oxthumb') || stristr($sFieldName, '_oxicon') || stristr(
+        return (\stristr($sFieldName, '_oxthumb') || \stristr($sFieldName, '_oxicon') || \stristr(
             $sFieldName,
             '_oxzoom'
-        ) || stristr($sFieldName, '_oxpic'));
+        ) || \stristr($sFieldName, '_oxpic'));
     }
 
     /**
@@ -4495,7 +4495,7 @@ class Article extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
 
         // #1125 A. must round (using floor()) value taken from database and cast to int
         if (!$myConfig->getConfigParam('blAllowUnevenAmounts') && !$this->isAdmin()) {
-            $this->oxarticles__oxstock = new \OxidEsales\Eshop\Core\Field((int) floor($this->oxarticles__oxstock->value));
+            $this->oxarticles__oxstock = new \OxidEsales\Eshop\Core\Field((int) \floor($this->oxarticles__oxstock->value));
         }
         //GREEN light
         $this->_iStockStatus = 0;
@@ -4612,9 +4612,9 @@ class Article extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
     protected function _insert() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         // set oxinsert
-        $sNow = date('Y-m-d H:i:s', \OxidEsales\Eshop\Core\Registry::getUtilsDate()->getTime());
+        $sNow = \date('Y-m-d H:i:s', \OxidEsales\Eshop\Core\Registry::getUtilsDate()->getTime());
         $this->oxarticles__oxinsert = new \OxidEsales\Eshop\Core\Field($sNow);
-        if (!is_object($this->oxarticles__oxsubclass) || $this->oxarticles__oxsubclass->value == '') {
+        if (!\is_object($this->oxarticles__oxsubclass) || $this->oxarticles__oxsubclass->value == '') {
             $this->oxarticles__oxsubclass = new \OxidEsales\Eshop\Core\Field('oxarticle');
         }
 
@@ -4947,7 +4947,7 @@ class Article extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
      */
     protected function _hasMasterImage($iIndex) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
-        $sPicName = basename($this->{"oxarticles__oxpic" . $iIndex}->value);
+        $sPicName = \basename($this->{"oxarticles__oxpic" . $iIndex}->value);
 
         if ($sPicName == "nopic.jpg" || $sPicName == "") {
             return false;
@@ -5054,9 +5054,9 @@ class Article extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
 
         $blEnterNetPrice = \OxidEsales\Eshop\Core\Registry::getConfig()->getConfigParam('blEnterNetPrice');
         if ($blCalculationModeNetto && !$blEnterNetPrice) {
-            $dPrice = round(\OxidEsales\Eshop\Core\Price::brutto2Netto($dPrice, $dVat), $oCurrency->decimal);
+            $dPrice = \round(\OxidEsales\Eshop\Core\Price::brutto2Netto($dPrice, $dVat), $oCurrency->decimal);
         } elseif (!$blCalculationModeNetto && $blEnterNetPrice) {
-            $dPrice = round(\OxidEsales\Eshop\Core\Price::netto2Brutto($dPrice, $dVat), $oCurrency->decimal);
+            $dPrice = \round(\OxidEsales\Eshop\Core\Price::netto2Brutto($dPrice, $dVat), $oCurrency->decimal);
         }
 
         return $dPrice;
@@ -5120,7 +5120,7 @@ class Article extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
         if ($this->_dVarMinPrice === null) {
             $dPrice = $this->_getShopVarMinPrice();
 
-            if (is_null($dPrice)) {
+            if (\is_null($dPrice)) {
                 $sPriceSuffix = $this->_getUserPriceSufix();
                 if ($sPriceSuffix === '') {
                     $dPrice = $this->oxarticles__oxvarminprice->value;
@@ -5159,7 +5159,7 @@ class Article extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
         if ($this->_dVarMaxPrice === null) {
             $dPrice = $this->_getShopVarMaxPrice();
 
-            if (is_null($dPrice)) {
+            if (\is_null($dPrice)) {
                 $sPriceSuffix = $this->_getUserPriceSufix();
                 if ($sPriceSuffix === '') {
                     $dPrice = $this->oxarticles__oxvarmaxprice->value;
@@ -5249,11 +5249,11 @@ class Article extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
 
         foreach ($this->_getCopyParentFields() as $sField) {
             $sValue = isset($this->$sField->value) ? $this->$sField->value : 0;
-            $sSqlSets[] = '`' . str_replace('oxarticles__', '', $sField) . '` = ' . $oDb->quote($sValue);
+            $sSqlSets[] = '`' . \str_replace('oxarticles__', '', $sField) . '` = ' . $oDb->quote($sValue);
         }
 
         $sSql = "UPDATE `oxarticles` SET ";
-        $sSql .= implode(', ', $sSqlSets) . '';
+        $sSql .= \implode(', ', $sSqlSets) . '';
         $sSql .= " WHERE `oxparentid` = :oxparentid";
 
         return $oDb->execute($sSql, [':oxparentid' => $this->getId()]);

--- a/source/Application/Model/ArticleList.php
+++ b/source/Application/Model/ArticleList.php
@@ -83,7 +83,7 @@ class ArticleList extends \OxidEsales\Eshop\Core\Model\ListModel
         if ($aArticlesIds = $session->getVariable('aHistoryArticles')) {
             return $aArticlesIds;
         } elseif ($sArticlesIds = \OxidEsales\Eshop\Core\Registry::getUtilsServer()->getOxCookie('aHistoryArticles')) {
-            return explode('|', $sArticlesIds);
+            return \explode('|', $sArticlesIds);
         }
     }
 
@@ -100,7 +100,7 @@ class ArticleList extends \OxidEsales\Eshop\Core\Model\ListModel
             // clean cookie, if session started
             \OxidEsales\Eshop\Core\Registry::getUtilsServer()->setOxCookie('aHistoryArticles', '');
         } else {
-            \OxidEsales\Eshop\Core\Registry::getUtilsServer()->setOxCookie('aHistoryArticles', implode('|', $aArticlesIds));
+            \OxidEsales\Eshop\Core\Registry::getUtilsServer()->setOxCookie('aHistoryArticles', \implode('|', $aArticlesIds));
         }
     }
 
@@ -117,20 +117,20 @@ class ArticleList extends \OxidEsales\Eshop\Core\Model\ListModel
         $aHistoryArticles[] = $sArtId;
 
         // removing duplicates
-        $aHistoryArticles = array_unique($aHistoryArticles);
-        if (count($aHistoryArticles) > ($iCnt + 1)) {
-            array_shift($aHistoryArticles);
+        $aHistoryArticles = \array_unique($aHistoryArticles);
+        if (\count($aHistoryArticles) > ($iCnt + 1)) {
+            \array_shift($aHistoryArticles);
         }
 
         $this->setHistoryArticles($aHistoryArticles);
 
         //remove current article and return array
         //asignment =, not ==
-        if (($iCurrentArt = array_search($sArtId, $aHistoryArticles)) !== false) {
+        if (($iCurrentArt = \array_search($sArtId, $aHistoryArticles)) !== false) {
             unset($aHistoryArticles[$iCurrentArt]);
         }
 
-        $aHistoryArticles = array_values($aHistoryArticles);
+        $aHistoryArticles = \array_values($aHistoryArticles);
         $this->loadIds($aHistoryArticles);
         $this->sortByIds($aHistoryArticles);
     }
@@ -142,8 +142,8 @@ class ArticleList extends \OxidEsales\Eshop\Core\Model\ListModel
      */
     public function sortByIds($aIds)
     {
-        $this->_aOrderMap = array_flip($aIds);
-        uksort($this->_aArray, [$this, '_sortByOrderMapCallback']);
+        $this->_aOrderMap = \array_flip($aIds);
+        \uksort($this->_aArray, [$this, '_sortByOrderMapCallback']);
     }
 
     /**
@@ -273,12 +273,12 @@ class ArticleList extends \OxidEsales\Eshop\Core\Model\ListModel
     public function loadActionArticles($sActionID, $iLimit = null)
     {
         // Performance
-        if (!trim($sActionID)) {
+        if (!\trim($sActionID)) {
             return;
         }
 
         $sShopID = Registry::getConfig()->getShopId();
-        $sActionID = strtolower($sActionID);
+        $sActionID = \strtolower($sActionID);
 
         //echo $sSelect;
         $oBaseObject = $this->getBaseObject();
@@ -468,7 +468,7 @@ class ArticleList extends \OxidEsales\Eshop\Core\Model\ListModel
         $sSelect = $this->_getArticleSelect($sRecommId, $sArticlesFilter);
 
         $sArtView = getViewName('oxarticles');
-        $sPartial = substr($sSelect, strpos($sSelect, ' from '));
+        $sPartial = \substr($sSelect, \strpos($sSelect, ' from '));
         $sSelect = "select distinct $sArtView.oxid $sPartial ";
 
         $this->_createIdListFromSql($sSelect);
@@ -653,7 +653,7 @@ class ArticleList extends \OxidEsales\Eshop\Core\Model\ListModel
      */
     public function loadIds($aIds)
     {
-        if (!count($aIds)) {
+        if (!\count($aIds)) {
             $this->clear();
 
             return;
@@ -663,7 +663,7 @@ class ArticleList extends \OxidEsales\Eshop\Core\Model\ListModel
         $sArticleTable = $oBaseObject->getViewName();
         $sArticleFields = $oBaseObject->getSelectFields();
 
-        $oxIdsSql = implode(',', \OxidEsales\Eshop\Core\DatabaseProvider::getDb()->quoteArray($aIds));
+        $oxIdsSql = \implode(',', \OxidEsales\Eshop\Core\DatabaseProvider::getDb()->quoteArray($aIds));
 
         $sSelect = "select $sArticleFields from $sArticleTable ";
         $sSelect .= "where $sArticleTable.oxid in ( " . $oxIdsSql . " ) and ";
@@ -681,7 +681,7 @@ class ArticleList extends \OxidEsales\Eshop\Core\Model\ListModel
      */
     public function loadOrderArticles($aOrders)
     {
-        if (!count($aOrders)) {
+        if (!\count($aOrders)) {
             $this->clear();
 
             return;
@@ -694,17 +694,17 @@ class ArticleList extends \OxidEsales\Eshop\Core\Model\ListModel
         $oBaseObject = $this->getBaseObject();
         $sArticleTable = $oBaseObject->getViewName();
         $sArticleFields = $oBaseObject->getSelectFields();
-        $sArticleFields = str_replace("`$sArticleTable`.`oxid`", "`oxorderarticles`.`oxartid` AS `oxid`", $sArticleFields);
+        $sArticleFields = \str_replace("`$sArticleTable`.`oxid`", "`oxorderarticles`.`oxartid` AS `oxid`", $sArticleFields);
 
         $sSelect = "SELECT $sArticleFields FROM oxorderarticles ";
         $sSelect .= "left join $sArticleTable on oxorderarticles.oxartid = $sArticleTable.oxid ";
-        $sSelect .= "WHERE oxorderarticles.oxorderid IN ( '" . implode("','", $aOrdersIds) . "' ) ";
+        $sSelect .= "WHERE oxorderarticles.oxorderid IN ( '" . \implode("','", $aOrdersIds) . "' ) ";
         $sSelect .= "order by $sArticleTable.oxid ";
 
         $this->selectString($sSelect);
 
         // not active or not available products must not have button "tobasket"
-        $sNow = date('Y-m-d H:i:s');
+        $sNow = \date('Y-m-d H:i:s');
         foreach ($this as $oArticle) {
             if (
                 !$oArticle->oxarticles__oxactive->value &&
@@ -725,7 +725,7 @@ class ArticleList extends \OxidEsales\Eshop\Core\Model\ListModel
      */
     public function loadStockRemindProducts($aBasketContents)
     {
-        if (is_array($aBasketContents) && count($aBasketContents)) {
+        if (\is_array($aBasketContents) && \count($aBasketContents)) {
             $oDb = \OxidEsales\Eshop\Core\DatabaseProvider::getDb();
             foreach ($aBasketContents as $oBasketItem) {
                 $aArtIds[] = $oDb->quote($oBasketItem->getProductId());
@@ -737,13 +737,13 @@ class ArticleList extends \OxidEsales\Eshop\Core\Model\ListModel
             $sTable = $oBaseObject->getViewName();
 
             // fetching actual db stock state and reminder status
-            $sQ = "select {$sFieldNames} from {$sTable} where {$sTable}.oxid in ( " . implode(",", $aArtIds) . " ) and
+            $sQ = "select {$sFieldNames} from {$sTable} where {$sTable}.oxid in ( " . \implode(",", $aArtIds) . " ) and
                           oxremindactive = '1' and oxstock <= oxremindamount";
             $this->selectString($sQ);
 
             // updating stock reminder state
             if ($this->count()) {
-                $sQ = "update {$sTable} set oxremindactive = '2' where :tableName in ( " . implode(",", $aArtIds) . " ) and
+                $sQ = "update {$sTable} set oxremindactive = '2' where :tableName in ( " . \implode(",", $aArtIds) . " ) and
                               oxremindactive = '1' and oxstock <= oxremindamount";
                 $oDb->execute($sQ, [':tableName' => $sTable . '.oxid']);
             }
@@ -793,7 +793,7 @@ class ArticleList extends \OxidEsales\Eshop\Core\Model\ListModel
 
             $database->startTransaction();
             try {
-                $sCurrUpdateTime = date("Y-m-d H:i:s", \OxidEsales\Eshop\Core\Registry::getUtilsDate()->getTime());
+                $sCurrUpdateTime = \date("Y-m-d H:i:s", \OxidEsales\Eshop\Core\Registry::getUtilsDate()->getTime());
 
                 // Collect article id's for later recalculation.
                 $sQ = "SELECT `oxid` FROM `oxarticles`
@@ -818,7 +818,7 @@ class ArticleList extends \OxidEsales\Eshop\Core\Model\ListModel
             }
 
             // recalculate oxvarminprice and oxvarmaxprice for parent
-            if (is_array($aUpdatedArticleIds)) {
+            if (\is_array($aUpdatedArticleIds)) {
                 foreach ($aUpdatedArticleIds as $sArticleId) {
                     $oArticle = oxNew(\OxidEsales\Eshop\Application\Model\Article::class);
                     $oArticle->load($sArticleId);
@@ -843,7 +843,7 @@ class ArticleList extends \OxidEsales\Eshop\Core\Model\ListModel
         $rs = \OxidEsales\Eshop\Core\DatabaseProvider::getDb(\OxidEsales\Eshop\Core\DatabaseProvider::FETCH_MODE_ASSOC)->select($sSql);
         if ($rs != false && $rs->count() > 0) {
             while (!$rs->EOF) {
-                $rs->fields = array_change_key_case($rs->fields, CASE_LOWER);
+                $rs->fields = \array_change_key_case($rs->fields, CASE_LOWER);
                 $this[$rs->fields['oxid']] = $rs->fields['oxid']; //only the oxid
                 $rs->fetchRow();
             }
@@ -911,14 +911,14 @@ class ArticleList extends \OxidEsales\Eshop\Core\Model\ListModel
                 if ($sIds) {
                     $sIds .= ', ';
                 }
-                $sIds .= \OxidEsales\Eshop\Core\DatabaseProvider::getDb()->quote(current($aArt));
+                $sIds .= \OxidEsales\Eshop\Core\DatabaseProvider::getDb()->quote(\current($aArt));
             }
 
             if ($sIds) {
                 $sFilterSql = " and $sArticleTable.oxid in ( $sIds ) ";
             }
             // bug fix #0001695: if no articles found return false
-        } elseif (!(current($aFilter) == '' && count(array_unique($aFilter)) == 1)) {
+        } elseif (!(\current($aFilter) == '' && \count(\array_unique($aFilter)) == 1)) {
             $sFilterSql = " and false ";
         }
 
@@ -1009,7 +1009,7 @@ class ArticleList extends \OxidEsales\Eshop\Core\Model\ListModel
     protected function _getSearchSelect($sSearchString) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         // check if it has string at all
-        if (!$sSearchString || !str_replace(' ', '', $sSearchString)) {
+        if (!$sSearchString || !\str_replace(' ', '', $sSearchString)) {
             return '';
         }
 
@@ -1017,7 +1017,7 @@ class ArticleList extends \OxidEsales\Eshop\Core\Model\ListModel
         $myConfig = \OxidEsales\Eshop\Core\Registry::getConfig();
         $sArticleTable = $this->getBaseObject()->getViewName();
 
-        $aSearch = explode(' ', $sSearchString);
+        $aSearch = \explode(' ', $sSearchString);
 
         $sSearch = ' and ( ';
         $blSep = false;
@@ -1032,7 +1032,7 @@ class ArticleList extends \OxidEsales\Eshop\Core\Model\ListModel
         $aSearchCols = $myConfig->getConfigParam('aSearchCols');
         $myUtilsString = \OxidEsales\Eshop\Core\Registry::getUtilsString();
         foreach ($aSearch as $sSearchString) {
-            if (!strlen($sSearchString)) {
+            if (!\strlen($sSearchString)) {
                 continue;
             }
 
@@ -1179,7 +1179,7 @@ class ArticleList extends \OxidEsales\Eshop\Core\Model\ListModel
         // fetching next update time
         $sQ = $this->getQueryToFetchNextUpdateTime();
 
-        $iTimeToUpdate = $database->getOne(sprintf($sQ, "`oxarticles`"));
+        $iTimeToUpdate = $database->getOne(\sprintf($sQ, "`oxarticles`"));
 
         return $iTimeToUpdate;
     }
@@ -1205,7 +1205,7 @@ class ArticleList extends \OxidEsales\Eshop\Core\Model\ListModel
     protected function updateOxArticles($sCurrUpdateTime, $oDb)
     {
         $sQ = $this->getQueryToUpdateOxArticle($sCurrUpdateTime);
-        $blUpdated = $oDb->execute(sprintf($sQ, "`oxarticles`"));
+        $blUpdated = $oDb->execute(\sprintf($sQ, "`oxarticles`"));
 
         return $blUpdated;
     }
@@ -1255,7 +1255,7 @@ class ArticleList extends \OxidEsales\Eshop\Core\Model\ListModel
         $descriptionJoin = '';
         $searchColumns = \OxidEsales\Eshop\Core\Registry::getConfig()->getConfigParam('aSearchCols');
 
-        if (is_array($searchColumns) && in_array('oxlongdesc', $searchColumns)) {
+        if (\is_array($searchColumns) && \in_array('oxlongdesc', $searchColumns)) {
             $viewName = getViewName('oxartextends');
             $descriptionJoin = " LEFT JOIN $viewName ON {$viewName}.oxid={$table}.oxid ";
         }

--- a/source/Application/Model/Attribute.php
+++ b/source/Application/Model/Attribute.php
@@ -103,9 +103,9 @@ class Attribute extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel
             $sAttrId = $this->_createAttribute($aSelTitle);
         }
         foreach ($aMDVariants as $sVarId => $oValue) {
-            if (strpos($sVarId, "mdvar_") === 0) {
+            if (\strpos($sVarId, "mdvar_") === 0) {
                 foreach ($oValue as $sId) {
-                    $sVarId = substr($sVarId, 6);
+                    $sVarId = \substr($sVarId, 6);
                     $oNewAssign = oxNew(\OxidEsales\Eshop\Core\Model\BaseModel::class);
                     $oNewAssign->init("oxobject2attribute");
                     $sNewId = \OxidEsales\Eshop\Core\Registry::getUtilsObject()->generateUID();

--- a/source/Application/Model/AttributeList.php
+++ b/source/Application/Model/AttributeList.php
@@ -33,14 +33,14 @@ class AttributeList extends \OxidEsales\Eshop\Core\Model\ListModel
      */
     public function loadAttributesByIds($aIds)
     {
-        if (!count($aIds)) {
+        if (!\count($aIds)) {
             return;
         }
 
         $sAttrViewName = getViewName('oxattribute');
         $sViewName = getViewName('oxobject2attribute');
 
-        $oxObjectIdsSql = implode(',', \OxidEsales\Eshop\Core\DatabaseProvider::getDb()->quoteArray($aIds));
+        $oxObjectIdsSql = \implode(',', \OxidEsales\Eshop\Core\DatabaseProvider::getDb()->quoteArray($aIds));
 
         $sSelect = "select $sAttrViewName.oxid, $sAttrViewName.oxtitle, {$sViewName}.oxvalue, {$sViewName}.oxobjectid ";
         $sSelect .= "from {$sViewName} left join $sAttrViewName on $sAttrViewName.oxid = {$sViewName}.oxattrid ";
@@ -164,10 +164,10 @@ class AttributeList extends \OxidEsales\Eshop\Core\Model\ListModel
         $oArtList->loadCategoryIDs($sCategoryId, $aSessionFilter);
 
         // Only if we have articles
-        if (count($oArtList) > 0) {
+        if (\count($oArtList) > 0) {
             $oDb = \OxidEsales\Eshop\Core\DatabaseProvider::getDb();
             $sArtIds = '';
-            foreach (array_keys($oArtList->getArray()) as $sId) {
+            foreach (\array_keys($oArtList->getArray()) as $sId) {
                 if ($sArtIds) {
                     $sArtIds .= ',';
                 }
@@ -222,14 +222,14 @@ class AttributeList extends \OxidEsales\Eshop\Core\Model\ListModel
      */
     protected function _mergeAttributes($aAttributes, $aParentAttributes) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
-        if (count($aParentAttributes)) {
+        if (\count($aParentAttributes)) {
             $aAttrIds = [];
             foreach ($aAttributes as $aAttribute) {
                 $aAttrIds[] = $aAttribute['OXID'];
             }
 
             foreach ($aParentAttributes as $aAttribute) {
-                if (!in_array($aAttribute['OXID'], $aAttrIds)) {
+                if (!\in_array($aAttribute['OXID'], $aAttrIds)) {
                     $aAttributes[] = $aAttribute;
                 }
             }

--- a/source/Application/Model/Basket.php
+++ b/source/Application/Model/Basket.php
@@ -307,7 +307,7 @@ class Basket extends \OxidEsales\Eshop\Core\Base
      */
     public function isSaveToDataBaseEnabled()
     {
-        if (is_null($this->_blSaveToDataBase)) {
+        if (\is_null($this->_blSaveToDataBase)) {
             $this->_blSaveToDataBase = (bool) !\OxidEsales\Eshop\Core\Registry::getConfig()->getConfigParam('blPerfNoBasketSaving');
         }
 
@@ -399,15 +399,15 @@ class Basket extends \OxidEsales\Eshop\Core\Base
      */
     protected function _changeBasketItemKey($sOldKey, $sNewKey, $value = null) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
-        reset($this->_aBasketContents);
+        \reset($this->_aBasketContents);
         $iOldKeyPlace = 0;
-        while (key($this->_aBasketContents) != $sOldKey && next($this->_aBasketContents)) {
+        while (\key($this->_aBasketContents) != $sOldKey && \next($this->_aBasketContents)) {
             ++$iOldKeyPlace;
         }
-        $aNewCopy = array_merge(
-            array_slice($this->_aBasketContents, 0, $iOldKeyPlace, true),
+        $aNewCopy = \array_merge(
+            \array_slice($this->_aBasketContents, 0, $iOldKeyPlace, true),
             [$sNewKey => $value],
-            array_slice($this->_aBasketContents, $iOldKeyPlace + 1, count($this->_aBasketContents) - $iOldKeyPlace, true)
+            \array_slice($this->_aBasketContents, $iOldKeyPlace + 1, \count($this->_aBasketContents) - $iOldKeyPlace, true)
         );
         $this->_aBasketContents = $aNewCopy;
     }
@@ -448,7 +448,7 @@ class Basket extends \OxidEsales\Eshop\Core\Base
         }
 
         $sItemId = $this->getItemKey($sProductID, $aSel, $aPersParam, $blBundle);
-        if ($sOldBasketItemId && (strcmp($sOldBasketItemId, $sItemId) != 0)) {
+        if ($sOldBasketItemId && (\strcmp($sOldBasketItemId, $sItemId) != 0)) {
             if (isset($this->_aBasketContents[$sItemId])) {
                 // we are merging, so params will just go to the new key
                 unset($this->_aBasketContents[$sOldBasketItemId]);
@@ -590,7 +590,7 @@ class Basket extends \OxidEsales\Eshop\Core\Base
     {
         $aSel = ($aSel != null) ? $aSel : [0 => '0'];
 
-        $sItemKey = md5($sProductId . '|' . serialize($aSel) . '|' . serialize($aPersParam) . '|' . (int) $blBundle . '|' . serialize($sAdditionalParam));
+        $sItemKey = \md5($sProductId . '|' . \serialize($aSel) . '|' . \serialize($aPersParam) . '|' . (int) $blBundle . '|' . \serialize($sAdditionalParam));
 
         return $sItemKey;
     }
@@ -615,7 +615,7 @@ class Basket extends \OxidEsales\Eshop\Core\Base
         unset($this->_aBasketContents[$sItemKey]);
 
         // basket exclude
-        if (!count($this->_aBasketContents) && \OxidEsales\Eshop\Core\Registry::getConfig()->getConfigParam('blBasketExcludeEnabled')) {
+        if (!\count($this->_aBasketContents) && \OxidEsales\Eshop\Core\Registry::getConfig()->getConfigParam('blBasketExcludeEnabled')) {
             $this->setBasketRootCatId(null);
         }
     }
@@ -626,7 +626,7 @@ class Basket extends \OxidEsales\Eshop\Core\Base
      */
     protected function _clearBundles() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
-        reset($this->_aBasketContents);
+        \reset($this->_aBasketContents);
         foreach ($this->_aBasketContents as $sItemKey => $oBasketItem) {
             if ($oBasketItem->isBundle()) {
                 $this->removeItem($sItemKey);
@@ -826,7 +826,7 @@ class Basket extends \OxidEsales\Eshop\Core\Base
                 if (!$oArticle->skipDiscounts() && $this->canCalcDiscounts()) {
                     // apply basket type discounts for item
                     $aDiscounts = $oDiscountList->getBasketItemDiscounts($oArticle, $this, $this->getBasketUser());
-                    reset($aDiscounts);
+                    \reset($aDiscounts);
                     /** @var \oxDiscount $oDiscount */
                     foreach ($aDiscounts as $oDiscount) {
                         $oBasketPrice->setDiscount($oDiscount->getAddSum(), $oDiscount->getAddSumType());
@@ -890,7 +890,7 @@ class Basket extends \OxidEsales\Eshop\Core\Base
     {
         foreach ($aItemDiscounts as $sKey => $oDiscount) {
             // add prices of the same discounts
-            if (array_key_exists($sKey, $aDiscounts)) {
+            if (\array_key_exists($sKey, $aDiscounts)) {
                 $aDiscounts[$sKey]->dDiscount += $oDiscount->dDiscount;
             } else {
                 $aDiscounts[$sKey] = $oDiscount;
@@ -939,7 +939,7 @@ class Basket extends \OxidEsales\Eshop\Core\Base
                 $this->getShippingId()
             );
 
-            if (count($aDeliveryList) > 0) {
+            if (\count($aDeliveryList) > 0) {
                 foreach ($aDeliveryList as $oDelivery) {
                     //debug trace
                     if ($myConfig->getConfigParam('iDebug') == 5) {
@@ -1093,7 +1093,7 @@ class Basket extends \OxidEsales\Eshop\Core\Base
             $dPrice = $this->_oDiscountProductsPriceList->getSum($this->isCalculationModeNetto()) - $this->_oTotalDiscount->getPrice();
 
             // recalculating
-            if (count($this->_aVouchers)) {
+            if (\count($this->_aVouchers)) {
                 $oLang = \OxidEsales\Eshop\Core\Registry::getLang();
                 foreach ($this->_aVouchers as $sVoucherId => $oStdVoucher) {
                     $oVoucher = oxNew(\OxidEsales\Eshop\Application\Model\Voucher::class);
@@ -1281,7 +1281,7 @@ class Basket extends \OxidEsales\Eshop\Core\Base
         if ($this->_oTotalDiscount === null || (!$this->isAdmin())) {
             $this->_oTotalDiscount = $this->_getPriceObject();
 
-            if (is_array($this->_aDiscounts)) {
+            if (\is_array($this->_aDiscounts)) {
                 foreach ($this->_aDiscounts as $oDiscount) {
                     // skipping bundle discounts
                     if ($oDiscount->sType == 'itm') {
@@ -1661,7 +1661,7 @@ class Basket extends \OxidEsales\Eshop\Core\Base
         // discount information
         // formatting discount value
         $this->aDiscounts = $this->getDiscounts();
-        if (is_array($this->aDiscounts) && count($this->aDiscounts) > 0) {
+        if (\is_array($this->aDiscounts) && \count($this->aDiscounts) > 0) {
             $oLang = \OxidEsales\Eshop\Core\Registry::getLang();
             foreach ($this->aDiscounts as $oDiscount) {
                 $oDiscount->fDiscount = $oLang->formatCurrency($oDiscount->dDiscount, $this->getBasketCurrency());
@@ -1768,8 +1768,8 @@ class Basket extends \OxidEsales\Eshop\Core\Base
         if (!$oUser) {
             // don't calculate if not logged in unless specified otherwise
             $aHomeCountry = $myConfig->getConfigParam('aHomeCountry');
-            if ($myConfig->getConfigParam('blCalculateDelCostIfNotLoggedIn') && is_array($aHomeCountry)) {
-                $sDeliveryCountry = current($aHomeCountry);
+            if ($myConfig->getConfigParam('blCalculateDelCostIfNotLoggedIn') && \is_array($aHomeCountry)) {
+                $sDeliveryCountry = \current($aHomeCountry);
             }
         } else {
             // ok, logged in
@@ -1897,8 +1897,8 @@ class Basket extends \OxidEsales\Eshop\Core\Base
                 if (\OxidEsales\Eshop\Core\Registry::getConfig()->getConfigParam('bl_perfLoadSelectLists')) {
                     // marking chosen select list
                     $aSelList = $oBasketItem->getSelList();
-                    if (is_array($aSelList) && ($aSelectlist = $oProduct->getSelectLists($sItemKey))) {
-                        reset($aSelList);
+                    if (\is_array($aSelList) && ($aSelectlist = $oProduct->getSelectLists($sItemKey))) {
+                        \reset($aSelList);
                         foreach ($aSelList as $conkey => $iSel) {
                             $aSelectlist[$conkey][$iSel]->selected = 1;
                         }
@@ -1940,7 +1940,7 @@ class Basket extends \OxidEsales\Eshop\Core\Base
      */
     public function getProductsPrice()
     {
-        if (is_null($this->_oProductsPriceList)) {
+        if (\is_null($this->_oProductsPriceList)) {
             $this->_oProductsPriceList = oxNew(\OxidEsales\Eshop\Core\PriceList::class);
         }
 
@@ -1954,7 +1954,7 @@ class Basket extends \OxidEsales\Eshop\Core\Base
      */
     public function getPrice()
     {
-        if (is_null($this->_oPrice)) {
+        if (\is_null($this->_oPrice)) {
             /** @var \OxidEsales\Eshop\Core\Price $price */
             $price = oxNew(\OxidEsales\Eshop\Core\Price::class);
             $this->setPrice($price);
@@ -2030,7 +2030,7 @@ class Basket extends \OxidEsales\Eshop\Core\Base
      */
     public function getProductsCount()
     {
-        return count($this->_aBasketContents);
+        return \count($this->_aBasketContents);
     }
 
     /**
@@ -2183,11 +2183,11 @@ class Basket extends \OxidEsales\Eshop\Core\Base
      */
     public function getDiscounts()
     {
-        if ($this->getTotalDiscount() && $this->getTotalDiscount()->getBruttoPrice() == 0 && count($this->_aItemDiscounts) == 0) {
+        if ($this->getTotalDiscount() && $this->getTotalDiscount()->getBruttoPrice() == 0 && \count($this->_aItemDiscounts) == 0) {
             return [];
         }
 
-        return array_merge($this->_aItemDiscounts, $this->_aDiscounts);
+        return \array_merge($this->_aItemDiscounts, $this->_aDiscounts);
     }
 
     /**
@@ -2793,7 +2793,7 @@ class Basket extends \OxidEsales\Eshop\Core\Base
     {
         $blIsBelowMinOrderPrice = false;
         $sConfValue = \OxidEsales\Eshop\Core\Registry::getConfig()->getConfigParam('iMinOrderPrice');
-        if (is_numeric($sConfValue) && $this->getProductsCount()) {
+        if (\is_numeric($sConfValue) && $this->getProductsCount()) {
             $dMinOrderPrice = \OxidEsales\Eshop\Core\Price::getPriceInActCurrency((double) $sConfValue);
             $dNotDiscountedProductPrice = 0;
             if ($oPrice = $this->getNotDiscountProductsPrice()) {

--- a/source/Application/Model/BasketContentMarkGenerator.php
+++ b/source/Application/Model/BasketContentMarkGenerator.php
@@ -50,7 +50,7 @@ class BasketContentMarkGenerator
      */
     public function getMark($sMarkIdentification)
     {
-        if (is_null($this->_aMarks)) {
+        if (\is_null($this->_aMarks)) {
             $sCurrentMark = self::DEFAULT_EXPLANATION_MARK;
             $aMarks = $this->_formMarks($sCurrentMark);
             $this->_aMarks = $aMarks;

--- a/source/Application/Model/BasketItem.php
+++ b/source/Application/Model/BasketItem.php
@@ -496,7 +496,7 @@ class BasketItem extends \OxidEsales\Eshop\Core\Base
                 /** @var \OxidEsales\Eshop\Core\Exception\NoArticleException $oEx */
                 $oEx = oxNew(\OxidEsales\Eshop\Core\Exception\NoArticleException::class);
                 $oLang = \OxidEsales\Eshop\Core\Registry::getLang();
-                $oEx->setMessage(sprintf($oLang->translateString('ERROR_MESSAGE_ARTICLE_ARTICLE_DOES_NOT_EXIST', $oLang->getBaseLanguage()), $sProductId));
+                $oEx->setMessage(\sprintf($oLang->translateString('ERROR_MESSAGE_ARTICLE_ARTICLE_DOES_NOT_EXIST', $oLang->getBaseLanguage()), $sProductId));
                 $oEx->setArticleNr($sProductId);
                 $oEx->setProductId($sProductId);
                 throw $oEx;
@@ -507,7 +507,7 @@ class BasketItem extends \OxidEsales\Eshop\Core\Base
                 /** @var \OxidEsales\Eshop\Core\Exception\NoArticleException $oEx */
                 $oEx = oxNew(\OxidEsales\Eshop\Core\Exception\NoArticleException::class);
                 $oLang = \OxidEsales\Eshop\Core\Registry::getLang();
-                $oEx->setMessage(sprintf($oLang->translateString('ERROR_MESSAGE_ARTICLE_ARTICLE_DOES_NOT_EXIST', $oLang->getBaseLanguage()), $this->_oArticle->oxarticles__oxartnum->value));
+                $oEx->setMessage(\sprintf($oLang->translateString('ERROR_MESSAGE_ARTICLE_ARTICLE_DOES_NOT_EXIST', $oLang->getBaseLanguage()), $this->_oArticle->oxarticles__oxartnum->value));
                 $oEx->setArticleNr($sProductId);
                 $oEx->setProductId($sProductId);
                 throw $oEx;
@@ -695,7 +695,7 @@ class BasketItem extends \OxidEsales\Eshop\Core\Base
     public function __sleep()
     {
         $aRet = [];
-        foreach (get_object_vars($this) as $sKey => $sVar) {
+        foreach (\get_object_vars($this) as $sKey => $sVar) {
             if ($sKey != '_oArticle') {
                 $aRet[] = $sKey;
             }
@@ -785,16 +785,16 @@ class BasketItem extends \OxidEsales\Eshop\Core\Base
     {
         // checking for default select list
         $aSelectLists = $this->getArticle()->getSelectLists();
-        if (!$aSelList || is_array($aSelList) && count($aSelList) == 0) {
-            if ($iSelCnt = count($aSelectLists)) {
-                $aSelList = array_fill(0, $iSelCnt, '0');
+        if (!$aSelList || \is_array($aSelList) && \count($aSelList) == 0) {
+            if ($iSelCnt = \count($aSelectLists)) {
+                $aSelList = \array_fill(0, $iSelCnt, '0');
             }
         }
 
         $this->_aSelList = $aSelList;
 
         //
-        if (is_array($this->_aSelList) && count($this->_aSelList)) {
+        if (\is_array($this->_aSelList) && \count($this->_aSelList)) {
             foreach ($this->_aSelList as $conkey => $iSel) {
                 $this->_aChosenSelectlist[$conkey] = new stdClass();
                 $this->_aChosenSelectlist[$conkey]->name = $aSelectLists[$conkey]['name'];

--- a/source/Application/Model/BasketReservation.php
+++ b/source/Application/Model/BasketReservation.php
@@ -251,7 +251,7 @@ class BasketReservation extends \OxidEsales\Eshop\Core\Base
      */
     public function discardReservations()
     {
-        foreach (array_keys($this->_getReservedItems()) as $sArticleId) {
+        foreach (\array_keys($this->_getReservedItems()) as $sArticleId) {
             $this->discardArticleReservation($sArticleId);
         }
         if ($this->_oReservations) {
@@ -297,7 +297,7 @@ class BasketReservation extends \OxidEsales\Eshop\Core\Base
 
         $database->startTransaction();
         try {
-            $finished = implode(',', $finished);
+            $finished = \implode(',', $finished);
 
             $reservation = $database->select(
                 'select oxartid, oxamount from oxuserbasketitems where oxbasketid in (' . $finished . ')',

--- a/source/Application/Model/Category.php
+++ b/source/Application/Model/Category.php
@@ -589,7 +589,7 @@ class Category extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implement
         $sQ = parent::getSqlActiveSnippet($blForceCoreTable);
 
         $sTable = $this->getViewName($blForceCoreTable);
-        $sQ .= (strlen($sQ) ? ' and ' : '') . " $sTable.oxhidden = '0' ";
+        $sQ .= (\strlen($sQ) ? ' and ' : '') . " $sTable.oxhidden = '0' ";
         $sQ .= $this->getAdditionalSqlFilter($blForceCoreTable);
 
         return "( $sQ ) ";
@@ -729,7 +729,7 @@ class Category extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implement
     {
         $sActCat = $this->getId();
 
-        $sKey = md5($sActCat . serialize(\OxidEsales\Eshop\Core\Registry::getSession()->getVariable('session_attrfilter')));
+        $sKey = \md5($sActCat . \serialize(\OxidEsales\Eshop\Core\Registry::getSession()->getVariable('session_attrfilter')));
         if (!isset(self::$_aCatAttributes[$sKey])) {
             $oAttrList = oxNew(\OxidEsales\Eshop\Application\Model\AttributeList::class);
             $oAttrList->getCategoryAttributes($sActCat, $this->getLanguage());
@@ -1031,7 +1031,7 @@ class Category extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implement
         //preliminary quick check saves 3% of execution time in category lists by avoiding redundant strtolower() call
         $fieldNameIndex2 = $fieldName[2];
         if ($fieldNameIndex2 === 'l' || $fieldNameIndex2 === 'L' || (isset($fieldName[16]) && ($fieldName[16] == 'l' || $fieldName[16] == 'L'))) {
-            $loweredFieldName = strtolower($fieldName);
+            $loweredFieldName = \strtolower($fieldName);
             if ('oxlongdesc' === $loweredFieldName || 'oxcategories__oxlongdesc' === $loweredFieldName) {
                 $dataType = \OxidEsales\Eshop\Core\Field::T_RAW;
             }

--- a/source/Application/Model/CategoryList.php
+++ b/source/Application/Model/CategoryList.php
@@ -133,12 +133,12 @@ class CategoryList extends \OxidEsales\Eshop\Core\Model\ListModel
      */
     protected function _getSqlSelectFieldsForTree($sTable, $aColumns = null) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
-        if ($aColumns && count($aColumns)) {
+        if ($aColumns && \count($aColumns)) {
             foreach ($aColumns as $key => $val) {
                 $aColumns[$key] .= ' as ' . $val;
             }
 
-            return "$sTable." . implode(", $sTable.", $aColumns);
+            return "$sTable." . \implode(", $sTable.", $aColumns);
         }
 
         $sFieldList = "$sTable.oxid as oxid, $sTable.oxactive as oxactive,"
@@ -391,8 +391,8 @@ class CategoryList extends \OxidEsales\Eshop\Core\Model\ListModel
      */
     public function getClickCat()
     {
-        if (count($this->_aPath)) {
-            return end($this->_aPath);
+        if (\count($this->_aPath)) {
+            return \end($this->_aPath);
         }
     }
 
@@ -403,8 +403,8 @@ class CategoryList extends \OxidEsales\Eshop\Core\Model\ListModel
      */
     public function getClickRoot()
     {
-        if (count($this->_aPath)) {
-            return [reset($this->_aPath)];
+        if (\count($this->_aPath)) {
+            return [\reset($this->_aPath)];
         }
     }
 
@@ -432,7 +432,7 @@ class CategoryList extends \OxidEsales\Eshop\Core\Model\ListModel
         foreach ($this->_aArray as $sId => $oCat) {
             if (
                 isset($aRemoveList[$oCat->oxcategories__oxrootid->value]) &&
-                is_array($aRemoveList[$oCat->oxcategories__oxrootid->value])
+                \is_array($aRemoveList[$oCat->oxcategories__oxrootid->value])
             ) {
                 foreach ($aRemoveList[$oCat->oxcategories__oxrootid->value] as $iLeft => $iRight) {
                     if (
@@ -456,7 +456,7 @@ class CategoryList extends \OxidEsales\Eshop\Core\Model\ListModel
      */
     protected function _ppAddPathInfo() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
-        if (is_null($this->_sActCat)) {
+        if (\is_null($this->_sActCat)) {
             return;
         }
 
@@ -470,7 +470,7 @@ class CategoryList extends \OxidEsales\Eshop\Core\Model\ListModel
             $sCurrentCat = $oCat->oxcategories__oxparentid->value;
         }
 
-        $this->_aPath = array_reverse($aPath);
+        $this->_aPath = \array_reverse($aPath);
     }
 
     /**
@@ -484,7 +484,7 @@ class CategoryList extends \OxidEsales\Eshop\Core\Model\ListModel
         $oContentList->loadCatMenues();
 
         foreach ($oContentList as $sCatId => $aContent) {
-            if (array_key_exists($sCatId, $this->_aArray)) {
+            if (\array_key_exists($sCatId, $this->_aArray)) {
                 $this[$sCatId]->setContentCats($aContent);
             }
         }
@@ -522,7 +522,7 @@ class CategoryList extends \OxidEsales\Eshop\Core\Model\ListModel
         foreach ($this->_aArray as $oCat) {
             $aTree[$oCat->getId()] = $oCat;
             $aSubCats = $oCat->getSubCats();
-            if (count($aSubCats) > 0) {
+            if (\count($aSubCats) > 0) {
                 foreach ($aSubCats as $oSubCat) {
                     $aTree = $this->_addDepthInfo($aTree, $oSubCat);
                 }
@@ -547,7 +547,7 @@ class CategoryList extends \OxidEsales\Eshop\Core\Model\ListModel
         $oCat->oxcategories__oxtitle->setValue($sDepth . ' ' . $oCat->oxcategories__oxtitle->value);
         $aTree[$oCat->getId()] = $oCat;
         $aSubCats = $oCat->getSubCats();
-        if (count($aSubCats) > 0) {
+        if (\count($aSubCats) > 0) {
             foreach ($aSubCats as $oSubCat) {
                 $aTree = $this->_addDepthInfo($aTree, $oSubCat, $sDepth);
             }
@@ -580,7 +580,7 @@ class CategoryList extends \OxidEsales\Eshop\Core\Model\ListModel
                 while (!$rs->EOF) {
                     $this->_aUpdateInfo[] = "<b>Processing : " . $rs->fields[1] . "</b>(" . $rs->fields[0] . ")<br>";
                     if ($blVerbose) {
-                        echo next($this->_aUpdateInfo);
+                        echo \next($this->_aUpdateInfo);
                     }
                     $oxRootId = $rs->fields[0];
 

--- a/source/Application/Model/Content.php
+++ b/source/Application/Model/Content.php
@@ -143,16 +143,16 @@ class Content extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
 
             // building subquery
             $sPattern = "IF ( %s != '', %s, %s ) ";
-            $iCount = count($aCols) - 1;
+            $iCount = \count($aCols) - 1;
 
             $sContQ = "SELECT {$sPattern}";
             foreach ($aCols as $iKey => $aCol) {
-                $sContQ = sprintf($sContQ, $aCol[0], $aCol[0], $iCount != $iKey ? $sPattern : "''");
+                $sContQ = \sprintf($sContQ, $aCol[0], $aCol[0], $iCount != $iKey ? $sPattern : "''");
             }
             $sContQ .= " FROM oxcontents WHERE oxloadid = '{$sLoadId}' AND oxshopid = '{$sShopId}'";
 
             $sSelect = $this->buildSelectString($aParams);
-            $sSelect = str_replace("`{$sTable}`.`oxcontent`", "( $sContQ ) as oxcontent", $sSelect);
+            $sSelect = \str_replace("`{$sTable}`.`oxcontent`", "( $sContQ ) as oxcontent", $sSelect);
         }
 
         $aData = \OxidEsales\Eshop\Core\DatabaseProvider::getDb(\OxidEsales\Eshop\Core\DatabaseProvider::FETCH_MODE_ASSOC)->getRow($sSelect);
@@ -185,7 +185,7 @@ class Content extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
     {
         $filteredContent = $this->filterInactive($fetchedContent, $onlyActive);
 
-        if (!is_null($filteredContent)) {
+        if (!\is_null($filteredContent)) {
             $this->assign($filteredContent);
             return true;
         }
@@ -237,7 +237,7 @@ class Content extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
         // workaround for firefox showing &lang= as &9001;= entity, mantis#0001272
 
         if ($this->oxcontents__oxcontent) {
-            $this->oxcontents__oxcontent->setValue(str_replace('&lang=', '&amp;lang=', $this->oxcontents__oxcontent->value), \OxidEsales\Eshop\Core\Field::T_RAW);
+            $this->oxcontents__oxcontent->setValue(\str_replace('&lang=', '&amp;lang=', $this->oxcontents__oxcontent->value), \OxidEsales\Eshop\Core\Field::T_RAW);
         }
     }
 
@@ -355,7 +355,7 @@ class Content extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
      */
     protected function _setFieldData($sFieldName, $sValue, $iDataType = \OxidEsales\Eshop\Core\Field::T_TEXT) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
-        $sLoweredFieldName = strtolower($sFieldName);
+        $sLoweredFieldName = \strtolower($sFieldName);
         if ('oxcontent' === $sLoweredFieldName || 'oxcontents__oxcontent' === $sLoweredFieldName) {
             $iDataType = \OxidEsales\Eshop\Core\Field::T_RAW;
         }

--- a/source/Application/Model/ContentList.php
+++ b/source/Application/Model/ContentList.php
@@ -178,7 +178,7 @@ class ContentList extends \OxidEsales\Eshop\Core\Model\ListModel
         }
 
         if ($iType == self::TYPE_SERVICE_LIST) {
-            $sIdents = implode(", ", \OxidEsales\Eshop\Core\DatabaseProvider::getDb()->quoteArray($this->getServiceKeys()));
+            $sIdents = \implode(", ", \OxidEsales\Eshop\Core\DatabaseProvider::getDb()->quoteArray($this->getServiceKeys()));
             $sSQLAdd = " AND OXLOADID IN (" . $sIdents . ")";
             $sSQLType = '';
         }

--- a/source/Application/Model/Country.php
+++ b/source/Application/Model/Country.php
@@ -44,7 +44,7 @@ class Country extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel
      */
     public function isForeignCountry()
     {
-        return !in_array($this->getId(), \OxidEsales\Eshop\Core\Registry::getConfig()->getConfigParam('aHomeCountry'));
+        return !\in_array($this->getId(), \OxidEsales\Eshop\Core\Registry::getConfig()->getConfigParam('aHomeCountry'));
     }
 
     /**
@@ -64,7 +64,7 @@ class Country extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel
      */
     public function getStates()
     {
-        if (!is_null($this->_aStates)) {
+        if (!\is_null($this->_aStates)) {
             return $this->_aStates;
         }
 

--- a/source/Application/Model/Delivery.php
+++ b/source/Application/Model/Delivery.php
@@ -144,7 +144,7 @@ class Delivery extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel
      */
     public function getArticles()
     {
-        if (is_null($this->_aArtIds)) {
+        if (\is_null($this->_aArtIds)) {
             $oDb = \OxidEsales\Eshop\Core\DatabaseProvider::getDb();
             $sQ = "select oxobjectid from oxobject2delivery 
                 where oxdeliveryid = :oxdeliveryid and oxtype = :oxtype";
@@ -165,7 +165,7 @@ class Delivery extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel
      */
     public function getCategories()
     {
-        if (is_null($this->_aCatIds)) {
+        if (\is_null($this->_aCatIds)) {
             $oDb = \OxidEsales\Eshop\Core\DatabaseProvider::getDb();
             $sQ = "select oxobjectid from oxobject2delivery 
                 where oxdeliveryid = :oxdeliveryid and oxtype = :oxtype";
@@ -186,7 +186,7 @@ class Delivery extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel
      */
     public function hasArticles()
     {
-        return (bool) count($this->getArticles());
+        return (bool) \count($this->getArticles());
     }
 
     /**
@@ -196,7 +196,7 @@ class Delivery extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel
      */
     public function hasCategories()
     {
-        return (bool) count($this->getCategories());
+        return (bool) \count($this->getCategories());
     }
 
     /**
@@ -348,7 +348,7 @@ class Delivery extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel
                 $sProductId = $oArticle->getProductId();
                 $sParentId = $oArticle->getParentId();
 
-                if ($blHasArticles && (in_array($sProductId, $aDeliveryArticles) || ($sParentId && in_array($sParentId, $aDeliveryArticles)))) {
+                if ($blHasArticles && (\in_array($sProductId, $aDeliveryArticles) || ($sParentId && \in_array($sParentId, $aDeliveryArticles)))) {
                     $blUse = true;
                     $artAmount = $this->getDeliveryAmount($oContent);
                     if ($this->isDeliveryRuleFitByArticle($artAmount)) {

--- a/source/Application/Model/DeliveryList.php
+++ b/source/Application/Model/DeliveryList.php
@@ -77,8 +77,8 @@ class DeliveryList extends \OxidEsales\Eshop\Core\Model\ListModel
      */
     public function setHomeCountry($sHomeCountry)
     {
-        if (is_array($sHomeCountry)) {
-            $this->_sHomeCountry = current($sHomeCountry);
+        if (\is_array($sHomeCountry)) {
+            $this->_sHomeCountry = \current($sHomeCountry);
         } else {
             $this->_sHomeCountry = $sHomeCountry;
         }
@@ -162,7 +162,7 @@ class DeliveryList extends \OxidEsales\Eshop\Core\Model\ListModel
         }
 
         $aIds = [];
-        if (count($aGroupIds)) {
+        if (\count($aGroupIds)) {
             foreach ($aGroupIds as $oGroup) {
                 $aIds[] = $oGroup->getId();
             }
@@ -174,7 +174,7 @@ class DeliveryList extends \OxidEsales\Eshop\Core\Model\ListModel
 
         $sCountrySql = $sCountryId ? "EXISTS(select oxobject2delivery.oxid from oxobject2delivery where oxobject2delivery.oxdeliveryid=$sTable.OXID and oxobject2delivery.oxtype='oxcountry' and oxobject2delivery.OXOBJECTID=" . $oDb->quote($sCountryId) . ")" : '0';
         $sUserSql = $sUserId ? "EXISTS(select oxobject2delivery.oxid from oxobject2delivery where oxobject2delivery.oxdeliveryid=$sTable.OXID and oxobject2delivery.oxtype='oxuser' and oxobject2delivery.OXOBJECTID=" . $oDb->quote($sUserId) . ")" : '0';
-        $sGroupSql = count($aIds) ? "EXISTS(select oxobject2delivery.oxid from oxobject2delivery where oxobject2delivery.oxdeliveryid=$sTable.OXID and oxobject2delivery.oxtype='oxgroups' and oxobject2delivery.OXOBJECTID in (" . implode(', ', \OxidEsales\Eshop\Core\DatabaseProvider::getDb()->quoteArray($aIds)) . ") )" : '0';
+        $sGroupSql = \count($aIds) ? "EXISTS(select oxobject2delivery.oxid from oxobject2delivery where oxobject2delivery.oxdeliveryid=$sTable.OXID and oxobject2delivery.oxtype='oxgroups' and oxobject2delivery.OXOBJECTID in (" . \implode(', ', \OxidEsales\Eshop\Core\DatabaseProvider::getDb()->quoteArray($aIds)) . ") )" : '0';
 
         $sQ .= " order by $sTable.oxsort asc ) as $sTable where (
             select
@@ -240,7 +240,7 @@ class DeliveryList extends \OxidEsales\Eshop\Core\Model\ListModel
 
             foreach ($aDeliveries as $sDeliveryId => $oDelivery) {
                 // skipping that was checked and didn't fit before
-                if (in_array($sDeliveryId, $aSkipDeliveries)) {
+                if (\in_array($sDeliveryId, $aSkipDeliveries)) {
                     continue;
                 }
 
@@ -252,7 +252,7 @@ class DeliveryList extends \OxidEsales\Eshop\Core\Model\ListModel
                     $blDelFound = true;
 
                     // removing from unfitting list
-                    array_pop($aSkipDeliveries);
+                    \array_pop($aSkipDeliveries);
 
                     // maybe checked "Stop processing after first match" ?
                     if ($oDelivery->oxdelivery__oxfinalize->value) {
@@ -276,7 +276,7 @@ class DeliveryList extends \OxidEsales\Eshop\Core\Model\ListModel
         }
 
         //return deliveries sets if found
-        if ($this->_blCollectFittingDeliveriesSets && count($aFittingDelSets)) {
+        if ($this->_blCollectFittingDeliveriesSets && \count($aFittingDelSets)) {
             //resetting getting delivery sets list instead of deliveries before return
             $this->_blCollectFittingDeliveriesSets = false;
 

--- a/source/Application/Model/DeliverySetList.php
+++ b/source/Application/Model/DeliverySetList.php
@@ -59,8 +59,8 @@ class DeliverySetList extends \OxidEsales\Eshop\Core\Model\ListModel
      */
     public function setHomeCountry($sHomeCountry)
     {
-        if (is_array($sHomeCountry)) {
-            $this->_sHomeCountry = current($sHomeCountry);
+        if (\is_array($sHomeCountry)) {
+            $this->_sHomeCountry = \current($sHomeCountry);
         } else {
             $this->_sHomeCountry = $sHomeCountry;
         }
@@ -142,7 +142,7 @@ class DeliverySetList extends \OxidEsales\Eshop\Core\Model\ListModel
         }
 
         $aIds = [];
-        if (count($aGroupIds)) {
+        if (\count($aGroupIds)) {
             foreach ($aGroupIds as $oGroup) {
                 $aIds[] = $oGroup->getId();
             }
@@ -156,7 +156,7 @@ class DeliverySetList extends \OxidEsales\Eshop\Core\Model\ListModel
 
         $sCountrySql = $sCountryId ? "EXISTS(select oxobject2delivery.oxid from oxobject2delivery where oxobject2delivery.oxdeliveryid=$sTable.OXID and oxobject2delivery.oxtype='oxdelset' and oxobject2delivery.OXOBJECTID=" . $oDb->quote($sCountryId) . ")" : '0';
         $sUserSql = $sUserId ? "EXISTS(select oxobject2delivery.oxid from oxobject2delivery where oxobject2delivery.oxdeliveryid=$sTable.OXID and oxobject2delivery.oxtype='oxdelsetu' and oxobject2delivery.OXOBJECTID=" . $oDb->quote($sUserId) . ")" : '0';
-        $sGroupSql = count($aIds) ? "EXISTS(select oxobject2delivery.oxid from oxobject2delivery where oxobject2delivery.oxdeliveryid=$sTable.OXID and oxobject2delivery.oxtype='oxdelsetg' and oxobject2delivery.OXOBJECTID in (" . implode(', ', \OxidEsales\Eshop\Core\DatabaseProvider::getDb()->quoteArray($aIds)) . ") )" : '0';
+        $sGroupSql = \count($aIds) ? "EXISTS(select oxobject2delivery.oxid from oxobject2delivery where oxobject2delivery.oxdeliveryid=$sTable.OXID and oxobject2delivery.oxtype='oxdelsetg' and oxobject2delivery.OXOBJECTID in (" . \implode(', ', \OxidEsales\Eshop\Core\DatabaseProvider::getDb()->quoteArray($aIds)) . ") )" : '0';
 
         $sQ .= "and (
             select
@@ -197,7 +197,7 @@ class DeliverySetList extends \OxidEsales\Eshop\Core\Model\ListModel
             $oDelSet = $aList[$sDelSet];
             unset($aList[$sDelSet]);
 
-            $aList = array_merge([$sDelSet => $oDelSet], $aList);
+            $aList = \array_merge([$sDelSet => $oDelSet], $aList);
         }
 
         return $aList;
@@ -245,7 +245,7 @@ class DeliverySetList extends \OxidEsales\Eshop\Core\Model\ListModel
             // checking if these ship sets available (number of possible payment methods > 0)
             foreach ($this as $sShipSetId => $oShipSet) {
                 $aPaymentList = $oPayList->getPaymentList($sShipSetId, $dBasketPrice, $oUser);
-                if (count($aPaymentList)) {
+                if (\count($aPaymentList)) {
                     // now checking for deliveries
                     if ($oDelList->hasDeliveries($oBasket, $oUser, $oUser->getActiveCountry(), $sShipSetId)) {
                         $aActSets[$sShipSetId] = $oShipSet;

--- a/source/Application/Model/Diagnostics.php
+++ b/source/Application/Model/Diagnostics.php
@@ -108,7 +108,7 @@ class Diagnostics
     public function getShopDetails()
     {
         $aShopDetails = [
-            'Date'                => date(\OxidEsales\Eshop\Core\Registry::getLang()->translateString('fullDateFormat'), time()),
+            'Date'                => \date(\OxidEsales\Eshop\Core\Registry::getLang()->translateString('fullDateFormat'), \time()),
             'URL'                 => $this->getShopLink(),
             'Edition'             => $this->getEdition(),
             'Version'             => $this->getVersion(),
@@ -169,7 +169,7 @@ class Diagnostics
         $aPhpIniConf = [];
 
         foreach ($aPhpIniParams as $sParam) {
-            $sValue = ini_get($sParam);
+            $sValue = \ini_get($sParam);
             $aPhpIniConf[$sParam] = $sValue;
         }
 
@@ -186,11 +186,11 @@ class Diagnostics
     {
         $sReturn = 'Zend ';
 
-        if (function_exists('zend_optimizer_version')) {
+        if (\function_exists('zend_optimizer_version')) {
             $sReturn .= 'Optimizer';
         }
 
-        if (function_exists('zend_loader_enabled')) {
+        if (\function_exists('zend_loader_enabled')) {
             $sReturn .= 'Guard Loader';
         }
 
@@ -227,7 +227,7 @@ class Diagnostics
         }
 
         $aServerInfo = [
-            'Server OS'     => @php_uname('s'),
+            'Server OS'     => @\php_uname('s'),
             'VM'            => $this->_getVirtualizationSystem(),
             'PHP'           => $this->_getPhpVersion(),
             'MySQL'         => $this->_getMySqlServerInfo(),
@@ -238,7 +238,7 @@ class Diagnostics
             'Memory free'   => $iMemFree,
             'CPU Model'     => $sCpuModel,
             'CPU frequency' => $sCpuFreq,
-            'CPU cores'     => round($iCpuCores, 0),
+            'CPU cores'     => \round($iCpuCores, 0),
         ];
 
         return $aServerInfo;
@@ -252,7 +252,7 @@ class Diagnostics
      */
     protected function _getApacheVersion() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
-        if (function_exists('apache_get_version')) {
+        if (\function_exists('apache_get_version')) {
             $sReturn = apache_get_version();
         } else {
             $sReturn = $_SERVER['SERVER_SOFTWARE'];
@@ -297,7 +297,7 @@ class Diagnostics
      */
     public function isExecAllowed()
     {
-        return function_exists('exec');
+        return \function_exists('exec');
     }
 
     /**
@@ -310,7 +310,7 @@ class Diagnostics
      */
     protected function _getDeviceList($sSystemType) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
-        return exec('lspci | grep -i ' . $sSystemType);
+        return \exec('lspci | grep -i ' . $sSystemType);
     }
 
     /**
@@ -322,7 +322,7 @@ class Diagnostics
     protected function _getCpuAmount() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         // cat /proc/cpuinfo | grep "processor" | sort -u | cut -d: -f2');
-        return exec('cat /proc/cpuinfo | grep "physical id" | sort | uniq | wc -l');
+        return \exec('cat /proc/cpuinfo | grep "physical id" | sort | uniq | wc -l');
     }
 
     /**
@@ -333,7 +333,7 @@ class Diagnostics
      */
     protected function _getCpuMhz() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
-        return round(exec('cat /proc/cpuinfo | grep "MHz" | sort -u | cut -d: -f2'), 0);
+        return \round(\exec('cat /proc/cpuinfo | grep "MHz" | sort -u | cut -d: -f2'), 0);
     }
 
     /**
@@ -344,7 +344,7 @@ class Diagnostics
      */
     protected function _getBogoMips() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
-        return exec('cat /proc/cpuinfo | grep "bogomips" | sort -u | cut -d: -f2');
+        return \exec('cat /proc/cpuinfo | grep "bogomips" | sort -u | cut -d: -f2');
     }
 
     /**
@@ -355,7 +355,7 @@ class Diagnostics
      */
     protected function _getMemoryTotal() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
-        return exec('cat /proc/meminfo | grep "MemTotal" | sort -u | cut -d: -f2');
+        return \exec('cat /proc/meminfo | grep "MemTotal" | sort -u | cut -d: -f2');
     }
 
     /**
@@ -366,7 +366,7 @@ class Diagnostics
      */
     protected function _getMemoryFree() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
-        return exec('cat /proc/meminfo | grep "MemFree" | sort -u | cut -d: -f2');
+        return \exec('cat /proc/meminfo | grep "MemFree" | sort -u | cut -d: -f2');
     }
 
     /**
@@ -377,7 +377,7 @@ class Diagnostics
      */
     protected function _getCpuModel() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
-        return exec('cat /proc/cpuinfo | grep "model name" | sort -u | cut -d: -f2');
+        return \exec('cat /proc/cpuinfo | grep "model name" | sort -u | cut -d: -f2');
     }
 
     /**
@@ -388,7 +388,7 @@ class Diagnostics
      */
     protected function _getDiskTotalSpace() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
-        return round(disk_total_space('/') / 1024 / 1024, 0) . ' GiB';
+        return \round(\disk_total_space('/') / 1024 / 1024, 0) . ' GiB';
     }
 
     /**
@@ -399,7 +399,7 @@ class Diagnostics
      */
     protected function _getDiskFreeSpace() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
-        return round(disk_free_space('/') / 1024 / 1024, 0) . ' GiB';
+        return \round(\disk_free_space('/') / 1024 / 1024, 0) . ' GiB';
     }
 
     /**
@@ -410,7 +410,7 @@ class Diagnostics
      */
     protected function _getPhpVersion() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
-        return phpversion();
+        return \phpversion();
     }
 
     /**

--- a/source/Application/Model/DiagnosticsOutput.php
+++ b/source/Application/Model/DiagnosticsOutput.php
@@ -121,7 +121,7 @@ class DiagnosticsOutput
         $sCurrentKey = (empty($sOutputKey)) ? $this->_sOutputKey : $sOutputKey;
 
         $this->_oUtils = \OxidEsales\Eshop\Core\Registry::getUtils();
-        $iFileSize = filesize($this->_oUtils->getCacheFilePath($sCurrentKey));
+        $iFileSize = \filesize($this->_oUtils->getCacheFilePath($sCurrentKey));
 
         $this->_oUtils->setHeader("Pragma: public");
         $this->_oUtils->setHeader("Expires: 0");

--- a/source/Application/Model/Discount.php
+++ b/source/Application/Model/Discount.php
@@ -102,14 +102,14 @@ class Discount extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel
     {
         // Auto assign oxsort, if it is null
         $oxsort = $this->oxdiscount__oxsort->value;
-        if (is_null($oxsort)) {
+        if (\is_null($oxsort)) {
             $shopId = $this->oxdiscount__oxshopid->value;
             $newSort = $this->getNextOxsort($shopId);
             $this->oxdiscount__oxsort = new \oxField($newSort, \OxidEsales\Eshop\Core\Field::T_RAW);
         }
 
         // Validate oxsort before saving
-        if (!is_numeric($this->oxdiscount__oxsort->value)) {
+        if (!\is_numeric($this->oxdiscount__oxsort->value)) {
             /** @var InputException $exception */
             $exception = oxNew(\OxidEsales\Eshop\Core\Exception\InputException::class);
             $exception->setMessage('DISCOUNT_ERROR_OXSORT_NOT_A_NUMBER');
@@ -120,7 +120,7 @@ class Discount extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel
         try {
             $saveStatus = parent::save();
         } catch (\OxidEsales\Eshop\Core\Exception\StandardException $exception) {
-            if ($exception->getCode() == \OxidEsales\Eshop\Core\Database\Adapter\Doctrine\Database::DUPLICATE_KEY_ERROR_CODE && false !== strpos($exception->getMessage(), 'UNIQ_OXSORT')) {
+            if ($exception->getCode() == \OxidEsales\Eshop\Core\Database\Adapter\Doctrine\Database::DUPLICATE_KEY_ERROR_CODE && false !== \strpos($exception->getMessage(), 'UNIQ_OXSORT')) {
                 $exception = oxNew(\OxidEsales\Eshop\Core\Exception\InputException::class);
                 $exception->setMessage('DISCOUNT_ERROR_OXSORT_NOT_UNIQUE');
             }
@@ -137,7 +137,7 @@ class Discount extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel
      */
     public function isGlobalDiscount()
     {
-        if (is_null($this->_blIsForArticleOrForCategory)) {
+        if (\is_null($this->_blIsForArticleOrForCategory)) {
             $oDb = \OxidEsales\Eshop\Core\DatabaseProvider::getDb();
 
             $sQuery = "select 1
@@ -446,7 +446,7 @@ class Discount extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel
 
         // Multiplying bundled articles count, if allowed
         if ($this->oxdiscount__oxitmmultiple->value && $this->oxdiscount__oxamount->value > 0) {
-            $dItemAmount = floor($dAmount / $this->oxdiscount__oxamount->value) * $this->oxdiscount__oxitmamount->value;
+            $dItemAmount = \floor($dAmount / $this->oxdiscount__oxamount->value) * $this->oxdiscount__oxitmamount->value;
         }
 
         return $dItemAmount;
@@ -530,12 +530,12 @@ class Discount extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel
     {
         // check if article is in some assigned category
         $aCatIds = $oArticle->getCategoryIds();
-        if (!$aCatIds || !count($aCatIds)) {
+        if (!$aCatIds || !\count($aCatIds)) {
             // no categories are set for article, so no discounts from categories..
             return false;
         }
 
-        $sCatIds = "(" . implode(",", \OxidEsales\Eshop\Core\DatabaseProvider::getDb()->quoteArray($aCatIds)) . ")";
+        $sCatIds = "(" . \implode(",", \OxidEsales\Eshop\Core\DatabaseProvider::getDb()->quoteArray($aCatIds)) . ")";
 
         $oDb = \OxidEsales\Eshop\Core\DatabaseProvider::getDb();
         // getOne appends limit 1, so this one should be fast enough
@@ -613,7 +613,7 @@ class Discount extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel
 
         $oDb = \OxidEsales\Eshop\Core\DatabaseProvider::getDb();
 
-        $sCategoryIds = "(" . implode(",", \OxidEsales\Eshop\Core\DatabaseProvider::getDb()->quoteArray($aCategoryIds)) . ")";
+        $sCategoryIds = "(" . \implode(",", \OxidEsales\Eshop\Core\DatabaseProvider::getDb()->quoteArray($aCategoryIds)) . ")";
         $sQ = "select 1
                 from oxobject2discount
                 where oxdiscountid = :oxdiscountid and oxobjectid in {$sCategoryIds} and oxtype = :oxtype";

--- a/source/Application/Model/File.php
+++ b/source/Application/Model/File.php
@@ -176,15 +176,15 @@ class File extends \OxidEsales\Eshop\Core\Model\BaseModel
      */
     public function isUnderDownloadFolder()
     {
-        $storageLocation = realpath($this->getStoreLocation());
+        $storageLocation = \realpath($this->getStoreLocation());
 
         if ($storageLocation === false) {
             return false;
         }
 
-        $downloadFolder = realpath($this->_getBaseDownloadDirPath());
+        $downloadFolder = \realpath($this->_getBaseDownloadDirPath());
 
-        return strpos($storageLocation, $downloadFolder) !== false;
+        return \strpos($storageLocation, $downloadFolder) !== false;
     }
 
     /**
@@ -201,7 +201,7 @@ class File extends \OxidEsales\Eshop\Core\Model\BaseModel
 
         //security check for demo shops
         if (\OxidEsales\Eshop\Core\Registry::getConfig()->isDemoShop()) {
-            $sFileName = basename($sFileName);
+            $sFileName = \basename($sFileName);
         }
 
         if ($this->isUploaded()) {
@@ -226,11 +226,11 @@ class File extends \OxidEsales\Eshop\Core\Model\BaseModel
      */
     protected function _getHashedFileDir($sFileHash) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
-        $sDir = substr($sFileHash, 0, 2);
+        $sDir = \substr($sFileHash, 0, 2);
         $sAbsDir = $this->_getBaseDownloadDirPath() . DIRECTORY_SEPARATOR . $sDir;
 
-        if (!is_dir($sAbsDir)) {
-            mkdir($sAbsDir, 0755);
+        if (!\is_dir($sAbsDir)) {
+            \mkdir($sAbsDir, 0755);
         }
 
         return $sDir;
@@ -247,7 +247,7 @@ class File extends \OxidEsales\Eshop\Core\Model\BaseModel
      */
     protected function _getFileHash($sFileName) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
-        return md5_file($sFileName);
+        return \md5_file($sFileName);
     }
 
     /**
@@ -262,10 +262,10 @@ class File extends \OxidEsales\Eshop\Core\Model\BaseModel
      */
     protected function _uploadFile($sSource, $sTarget) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
-        $blDone = move_uploaded_file($sSource, $sTarget);
+        $blDone = \move_uploaded_file($sSource, $sTarget);
 
         if ($blDone) {
-            $blDone = @chmod($sTarget, 0644);
+            $blDone = @\chmod($sTarget, 0644);
         }
 
         return $blDone;
@@ -330,7 +330,7 @@ class File extends \OxidEsales\Eshop\Core\Model\BaseModel
         );
         if (!$iCount) {
             $sPath = $this->getStoreLocation();
-            unlink($sPath);
+            \unlink($sPath);
         }
     }
 
@@ -343,7 +343,7 @@ class File extends \OxidEsales\Eshop\Core\Model\BaseModel
      */
     protected function _getFilenameForUrl() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
-        return rawurlencode($this->oxfiles__oxfilename->value);
+        return \rawurlencode($this->oxfiles__oxfilename->value);
     }
 
     /**
@@ -367,7 +367,7 @@ class File extends \OxidEsales\Eshop\Core\Model\BaseModel
         if ($iFileSize = $this->getSize()) {
             $oUtils->setHeader("Content-Length: " . $iFileSize);
         }
-        readfile($sFileLocations);
+        \readfile($sFileLocations);
         $oUtils->showMessageAndExit(null);
     }
 
@@ -378,7 +378,7 @@ class File extends \OxidEsales\Eshop\Core\Model\BaseModel
      */
     public function exist()
     {
-        return file_exists($this->getStoreLocation());
+        return \file_exists($this->getStoreLocation());
     }
 
     /**
@@ -405,7 +405,7 @@ class File extends \OxidEsales\Eshop\Core\Model\BaseModel
                         AND `oxorderarticles`.`oxstorno` = 0";
             $params = [
                 ':oxfileid' => $this->getId(),
-                ':oxvaliduntil' => date('Y-m-d H:i:s', \OxidEsales\Eshop\Core\Registry::getUtilsDate()->getTime())
+                ':oxvaliduntil' => \date('Y-m-d H:i:s', \OxidEsales\Eshop\Core\Registry::getUtilsDate()->getTime())
             ];
 
             if ($oDb->getOne($sSql, $params)) {
@@ -489,7 +489,7 @@ class File extends \OxidEsales\Eshop\Core\Model\BaseModel
     {
         $iSize = 0;
         if ($this->exist()) {
-            $iSize = filesize($this->getStoreLocation());
+            $iSize = \filesize($this->getStoreLocation());
         }
 
         return $iSize;

--- a/source/Application/Model/FileCollector.php
+++ b/source/Application/Model/FileCollector.php
@@ -69,7 +69,7 @@ class FileCollector
             throw new Exception('Base directory is not set, please use setter setBaseDirectory!');
         }
 
-        if (is_file($this->_sBaseDirectory . $sFile)) {
+        if (\is_file($this->_sBaseDirectory . $sFile)) {
             $this->_aFiles[] = $sFile;
 
             return true;
@@ -101,27 +101,27 @@ class FileCollector
 
         $aCurrentList = [];
 
-        if (!is_dir($this->_sBaseDirectory . $sFolder)) {
+        if (!\is_dir($this->_sBaseDirectory . $sFolder)) {
             return;
         }
 
-        $handle = opendir($this->_sBaseDirectory . $sFolder);
+        $handle = \opendir($this->_sBaseDirectory . $sFolder);
 
-        while ($sFile = readdir($handle)) {
+        while ($sFile = \readdir($handle)) {
             if ($sFile != "." && $sFile != "..") {
-                if (is_dir($this->_sBaseDirectory . $sFolder . $sFile)) {
+                if (\is_dir($this->_sBaseDirectory . $sFolder . $sFile)) {
                     if ($blRecursive) {
                         $aResultList = $this->addDirectoryFiles($sFolder . $sFile . '/', $aExtensions, $blRecursive);
 
-                        if (is_array($aResultList)) {
-                            $aCurrentList = array_merge($aCurrentList, $aResultList);
+                        if (\is_array($aResultList)) {
+                            $aCurrentList = \array_merge($aCurrentList, $aResultList);
                         }
                     }
                 } else {
-                    $sExt = substr(strrchr($sFile, '.'), 1);
+                    $sExt = \substr(\strrchr($sFile, '.'), 1);
 
                     if (
-                        (!empty($aExtensions) && is_array($aExtensions) && in_array($sExt, $aExtensions)) ||
+                        (!empty($aExtensions) && \is_array($aExtensions) && \in_array($sExt, $aExtensions)) ||
                         (empty($aExtensions))
                     ) {
                         $this->addFile($sFolder . $sFile);
@@ -129,6 +129,6 @@ class FileCollector
                 }
             }
         }
-        closedir($handle);
+        \closedir($handle);
     }
 }

--- a/source/Application/Model/Links.php
+++ b/source/Application/Model/Links.php
@@ -43,7 +43,7 @@ class Links extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel
      */
     protected function _setFieldData($sFieldName, $sValue, $iDataType = \OxidEsales\Eshop\Core\Field::T_TEXT) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
-        if ('oxurldesc' === strtolower($sFieldName) || 'oxlinks__oxurldesc' === strtolower($sFieldName)) {
+        if ('oxurldesc' === \strtolower($sFieldName) || 'oxlinks__oxurldesc' === \strtolower($sFieldName)) {
             $iDataType = \OxidEsales\Eshop\Core\Field::T_RAW;
         }
 

--- a/source/Application/Model/ListObject.php
+++ b/source/Application/Model/ListObject.php
@@ -38,11 +38,11 @@ class ListObject
      */
     public function assign($aData)
     {
-        if (!is_array($aData)) {
+        if (!\is_array($aData)) {
             return;
         }
         foreach ($aData as $sKey => $sValue) {
-            $sFieldName = strtolower($this->_sTableName . '__' . $sKey);
+            $sFieldName = \strtolower($this->_sTableName . '__' . $sKey);
             $this->$sFieldName = new \OxidEsales\Eshop\Core\Field($sValue);
         }
     }
@@ -54,7 +54,7 @@ class ListObject
      */
     public function getId()
     {
-        $sFieldName = strtolower($this->_sTableName . '__oxid');
+        $sFieldName = \strtolower($this->_sTableName . '__oxid');
         return $this->$sFieldName->value;
     }
 }

--- a/source/Application/Model/MdVariant.php
+++ b/source/Application/Model/MdVariant.php
@@ -138,8 +138,8 @@ class MdVariant extends \OxidEsales\Eshop\Core\Base
     public function getFirstMdSubvariant()
     {
         $aMdSubvariants = $this->getMdSubvariants();
-        if (count($aMdSubvariants)) {
-            return reset($aMdSubvariants);
+        if (\count($aMdSubvariants)) {
+            return \reset($aMdSubvariants);
         }
 
         return null;
@@ -156,14 +156,14 @@ class MdVariant extends \OxidEsales\Eshop\Core\Base
     {
         $aSubvariants = $this->getMdSubvariants();
         foreach ($aSubvariants as $oMdSubvariant) {
-            if (strcasecmp($oMdSubvariant->getName(), $sName) == 0) {
+            if (\strcasecmp($oMdSubvariant->getName(), $sName) == 0) {
                 return $oMdSubvariant;
             }
         }
 
         $oNewSubvariant = oxNew(\OxidEsales\Eshop\Application\Model\MdVariant::class);
         $oNewSubvariant->setName($sName);
-        $oNewSubvariant->setId(md5($sName . $this->getId()));
+        $oNewSubvariant->setId(\md5($sName . $this->getId()));
         $oNewSubvariant->setParentId($this->getId());
         $this->_addMdSubvariant($oNewSubvariant);
 
@@ -226,10 +226,10 @@ class MdVariant extends \OxidEsales\Eshop\Core\Base
         $aVariants = $this->getMdSubvariants();
         foreach ($aVariants as $oVariant) {
             $dMinVariantPrice = $oVariant->getMinDPrice();
-            if (is_null($dMinPrice)) {
+            if (\is_null($dMinPrice)) {
                 $dMinPrice = $dMinVariantPrice;
             }
-            if (!is_null($dMinVariantPrice) && $dMinVariantPrice < $dMinPrice) {
+            if (!\is_null($dMinVariantPrice) && $dMinVariantPrice < $dMinPrice) {
                 $dMinPrice = $dMinVariantPrice;
             }
         }
@@ -246,7 +246,7 @@ class MdVariant extends \OxidEsales\Eshop\Core\Base
     {
         $aSubvariants = $this->getMdSubvariants();
 
-        if (!count($aSubvariants)) {
+        if (!\count($aSubvariants)) {
             return 0;
         }
 
@@ -301,8 +301,8 @@ class MdVariant extends \OxidEsales\Eshop\Core\Base
      */
     public function addNames($sArtId, $aNames, $dPrice, $sUrl)
     {
-        $iCount = count($aNames);
-        $sName = array_shift($aNames);
+        $iCount = \count($aNames);
+        $sName = \array_shift($aNames);
 
         if ($iCount) {
             //get required subvariant
@@ -379,10 +379,10 @@ class MdVariant extends \OxidEsales\Eshop\Core\Base
         $aVariants = $this->getMdSubvariants();
         foreach ($aVariants as $oVariant) {
             $dVariantPrice = $oVariant->getDPrice();
-            if (is_null($dPrice)) {
+            if (\is_null($dPrice)) {
                 $dPrice = $dVariantPrice;
             }
-            if (!is_null($dVariantPrice) && $dVariantPrice != $dPrice) {
+            if (!\is_null($dVariantPrice) && $dVariantPrice != $dPrice) {
                 return false;
             }
             if (!$oVariant->_isFixedPrice()) {

--- a/source/Application/Model/MediaUrl.php
+++ b/source/Application/Model/MediaUrl.php
@@ -37,7 +37,7 @@ class MediaUrl extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel
     {
         $sUrl = $this->oxmediaurls__oxurl->value;
         //youtube link
-        if (strpos($sUrl, 'youtube.com') || strpos($sUrl, 'youtu.be')) {
+        if (\strpos($sUrl, 'youtube.com') || \strpos($sUrl, 'youtu.be')) {
             return $this->_getYoutubeHtml();
         }
 
@@ -73,7 +73,7 @@ class MediaUrl extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel
         if ($this->oxmediaurls__oxisuploaded->value) {
             $sUrl = \OxidEsales\Eshop\Core\Registry::getConfig()->isSsl() ? \OxidEsales\Eshop\Core\Registry::getConfig()->getSslShopUrl() : \OxidEsales\Eshop\Core\Registry::getConfig()->getShopUrl();
             $sUrl .= 'out/media/';
-            $sUrl .= basename($this->oxmediaurls__oxurl->value);
+            $sUrl .= \basename($this->oxmediaurls__oxurl->value);
         } else {
             $sUrl = $this->oxmediaurls__oxurl->value;
         }
@@ -101,11 +101,11 @@ class MediaUrl extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel
     public function delete($sOXID = null)
     {
         $sFilePath = \OxidEsales\Eshop\Core\Registry::getConfig()->getConfigParam('sShopDir') . "/out/media/" .
-                     basename($this->oxmediaurls__oxurl->value);
+                     \basename($this->oxmediaurls__oxurl->value);
 
         if ($this->oxmediaurls__oxisuploaded->value) {
-            if (file_exists($sFilePath)) {
-                unlink($sFilePath);
+            if (\file_exists($sFilePath)) {
+                \unlink($sFilePath);
             }
         }
 
@@ -123,16 +123,16 @@ class MediaUrl extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel
         $sUrl = $this->oxmediaurls__oxurl->value;
         $sDesc = $this->oxmediaurls__oxdesc->value;
 
-        if (strpos($sUrl, 'youtube.com')) {
-            $sYoutubeUrl = str_replace("www.youtube.com/watch?v=", "www.youtube.com/embed/", $sUrl);
-            $sYoutubeUrl = preg_replace('/&amp;/', '?', $sYoutubeUrl, 1);
+        if (\strpos($sUrl, 'youtube.com')) {
+            $sYoutubeUrl = \str_replace("www.youtube.com/watch?v=", "www.youtube.com/embed/", $sUrl);
+            $sYoutubeUrl = \preg_replace('/&amp;/', '?', $sYoutubeUrl, 1);
         }
-        if (strpos($sUrl, 'youtu.be')) {
-            $sYoutubeUrl = str_replace("youtu.be/", "www.youtube.com/embed/", $sUrl);
+        if (\strpos($sUrl, 'youtu.be')) {
+            $sYoutubeUrl = \str_replace("youtu.be/", "www.youtube.com/embed/", $sUrl);
         }
 
         $sYoutubeTemplate = '%s<br><iframe width="425" height="344" src="%s" frameborder="0" allowfullscreen></iframe>';
-        $sYoutubeHtml = sprintf($sYoutubeTemplate, $sDesc, $sYoutubeUrl, $sYoutubeUrl);
+        $sYoutubeHtml = \sprintf($sYoutubeTemplate, $sDesc, $sYoutubeUrl, $sYoutubeUrl);
 
         return $sYoutubeHtml;
     }

--- a/source/Application/Model/NewsSubscribed.php
+++ b/source/Application/Model/NewsSubscribed.php
@@ -131,7 +131,7 @@ class NewsSubscribed extends \OxidEsales\Eshop\Core\Model\BaseModel
     protected function _insert() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         // set subscription date
-        $this->oxnewssubscribed__oxsubscribed = new \OxidEsales\Eshop\Core\Field(date('Y-m-d H:i:s'), \OxidEsales\Eshop\Core\Field::T_RAW);
+        $this->oxnewssubscribed__oxsubscribed = new \OxidEsales\Eshop\Core\Field(\date('Y-m-d H:i:s'), \OxidEsales\Eshop\Core\Field::T_RAW);
 
         return parent::_insert();
     }
@@ -146,11 +146,11 @@ class NewsSubscribed extends \OxidEsales\Eshop\Core\Model\BaseModel
     {
         if (($this->_blWasSubscribed || $this->_blWasPreSubscribed) && !$this->oxnewssubscribed__oxdboptin->value) {
             // set unsubscription date
-            $this->oxnewssubscribed__oxunsubscribed->setValue(date('Y-m-d H:i:s'));
+            $this->oxnewssubscribed__oxunsubscribed->setValue(\date('Y-m-d H:i:s'));
             // 0001974 Same object can be called many times without requiring to renew date.
             // If so happens, it would have _aSkipSaveFields set to skip date field. So need to check and
             // release if _aSkipSaveFields are set for field oxunsubscribed.
-            $aSkipSaveFieldsKeys = array_keys($this->_aSkipSaveFields, 'oxunsubscribed');
+            $aSkipSaveFieldsKeys = \array_keys($this->_aSkipSaveFields, 'oxunsubscribed');
             foreach ($aSkipSaveFieldsKeys as $iSkipSaveFieldKey) {
                 unset($this->_aSkipSaveFields[$iSkipSaveFieldKey]);
             }

--- a/source/Application/Model/Newsletter.php
+++ b/source/Application/Model/Newsletter.php
@@ -219,7 +219,7 @@ class Newsletter extends \OxidEsales\Eshop\Core\Model\BaseModel
      */
     protected function _setUser($sUserid) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
-        if (is_string($sUserid)) {
+        if (\is_string($sUserid)) {
             $oUser = oxNew(User::class);
             if ($oUser->load($sUserid)) {
                 $this->_oUser = $oUser;

--- a/source/Application/Model/Order.php
+++ b/source/Application/Model/Order.php
@@ -600,10 +600,10 @@ class Order extends \OxidEsales\Eshop\Core\Model\BaseModel
      */
     protected function _convertVat($sVat) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
-        if (strpos($sVat, '.') < strpos($sVat, ',')) {
-            $sVat = str_replace(['.', ','], ['', '.'], $sVat);
+        if (\strpos($sVat, '.') < \strpos($sVat, ',')) {
+            $sVat = \str_replace(['.', ','], ['', '.'], $sVat);
         } else {
-            $sVat = str_replace(',', '', $sVat);
+            $sVat = \str_replace(',', '', $sVat);
         }
 
         return (float) $sVat;
@@ -689,7 +689,7 @@ class Order extends \OxidEsales\Eshop\Core\Model\BaseModel
         if ($this->_blReloadDiscount) {
             $dDiscount = 0;
             $aDiscounts = $oBasket->getDiscounts();
-            if (is_array($aDiscounts) && count($aDiscounts) > 0) {
+            if (\is_array($aDiscounts) && \count($aDiscounts) > 0) {
                 foreach ($aDiscounts as $oDiscount) {
                     $dDiscount += $oDiscount->dDiscount;
                 }
@@ -834,7 +834,7 @@ class Order extends \OxidEsales\Eshop\Core\Model\BaseModel
 
                 // set chosen select list
                 $sSelList = '';
-                if (count($aChosenSelList = $oContent->getChosenSelList())) {
+                if (\count($aChosenSelList = $oContent->getChosenSelList())) {
                     foreach ($aChosenSelList as $oItem) {
                         if ($sSelList) {
                             $sSelList .= ", ";
@@ -852,17 +852,17 @@ class Order extends \OxidEsales\Eshop\Core\Model\BaseModel
                 $oOrderArticle->setId();
 
                 $oOrderArticle->oxorderarticles__oxartnum = clone $oProduct->oxarticles__oxartnum;
-                $oOrderArticle->oxorderarticles__oxselvariant = new \OxidEsales\Eshop\Core\Field(trim($sSelList . ' ' . $oContent->getVarSelect()), \OxidEsales\Eshop\Core\Field::T_RAW);
+                $oOrderArticle->oxorderarticles__oxselvariant = new \OxidEsales\Eshop\Core\Field(\trim($sSelList . ' ' . $oContent->getVarSelect()), \OxidEsales\Eshop\Core\Field::T_RAW);
                 $oOrderArticle->oxorderarticles__oxshortdesc = new \OxidEsales\Eshop\Core\Field($oProduct->oxarticles__oxshortdesc->getRawValue(), \OxidEsales\Eshop\Core\Field::T_RAW);
                 // #M974: duplicated entries for the name of variants in orders
-                $oOrderArticle->oxorderarticles__oxtitle = new \OxidEsales\Eshop\Core\Field(trim($oProduct->oxarticles__oxtitle->getRawValue()), \OxidEsales\Eshop\Core\Field::T_RAW);
+                $oOrderArticle->oxorderarticles__oxtitle = new \OxidEsales\Eshop\Core\Field(\trim($oProduct->oxarticles__oxtitle->getRawValue()), \OxidEsales\Eshop\Core\Field::T_RAW);
 
                 // copying persistent parameters ...
-                if (!is_array($aPersParams = $oProduct->getPersParams())) {
+                if (!\is_array($aPersParams = $oProduct->getPersParams())) {
                     $aPersParams = $oContent->getPersParams();
                 }
-                if (is_array($aPersParams) && count($aPersParams)) {
-                    $oOrderArticle->oxorderarticles__oxpersparam = new \OxidEsales\Eshop\Core\Field(serialize($aPersParams), \OxidEsales\Eshop\Core\Field::T_RAW);
+                if (\is_array($aPersParams) && \count($aPersParams)) {
+                    $oOrderArticle->oxorderarticles__oxpersparam = new \OxidEsales\Eshop\Core\Field(\serialize($aPersParams), \OxidEsales\Eshop\Core\Field::T_RAW);
                 }
             }
 
@@ -924,14 +924,14 @@ class Order extends \OxidEsales\Eshop\Core\Model\BaseModel
             $this->delete();
 
             // checking for error messages
-            if (method_exists($oPayTransaction, 'getLastError')) {
+            if (\method_exists($oPayTransaction, 'getLastError')) {
                 if (($sLastError = $oPayTransaction->getLastError())) {
                     return $sLastError;
                 }
             }
 
             // checking for error codes
-            if (method_exists($oPayTransaction, 'getLastErrorNo')) {
+            if (\method_exists($oPayTransaction, 'getLastErrorNo')) {
                 if (($iLastErrorNo = $oPayTransaction->getLastErrorNo())) {
                     return $iLastErrorNo;
                 }
@@ -978,7 +978,7 @@ class Order extends \OxidEsales\Eshop\Core\Model\BaseModel
         // collecting dynamic values
         $aDynVal = [];
 
-        if (is_array($aPaymentDynValues = $oPayment->getDynValues())) {
+        if (\is_array($aPaymentDynValues = $oPayment->getDynValues())) {
             foreach ($aPaymentDynValues as $key => $oVal) {
                 if (isset($aDynvalue[$oVal->name])) {
                     $oVal->value = $aDynvalue[$oVal->name];
@@ -1017,7 +1017,7 @@ class Order extends \OxidEsales\Eshop\Core\Model\BaseModel
     protected function _setFolder() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $myConfig = \OxidEsales\Eshop\Core\Registry::getConfig();
-        $this->oxorder__oxfolder = new \OxidEsales\Eshop\Core\Field(key($myConfig->getShopConfVar('aOrderfolder', $myConfig->getShopId())), \OxidEsales\Eshop\Core\Field::T_RAW);
+        $this->oxorder__oxfolder = new \OxidEsales\Eshop\Core\Field(\key($myConfig->getShopConfVar('aOrderfolder', $myConfig->getShopId())), \OxidEsales\Eshop\Core\Field::T_RAW);
     }
 
     /**
@@ -1105,7 +1105,7 @@ class Order extends \OxidEsales\Eshop\Core\Model\BaseModel
     protected function _updateOrderDate() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $oDb = \OxidEsales\Eshop\Core\DatabaseProvider::getDb();
-        $sDate = date('Y-m-d H:i:s', \OxidEsales\Eshop\Core\Registry::getUtilsDate()->getTime());
+        $sDate = \date('Y-m-d H:i:s', \OxidEsales\Eshop\Core\Registry::getUtilsDate()->getTime());
         $sQ = 'update oxorder set oxorderdate = :oxorderdate where oxid = :oxid';
         $this->oxorder__oxorderdate = new \OxidEsales\Eshop\Core\Field($sDate, \OxidEsales\Eshop\Core\Field::T_RAW);
         $oDb->execute($sQ, [
@@ -1126,7 +1126,7 @@ class Order extends \OxidEsales\Eshop\Core\Model\BaseModel
     {
         $this->_aVoucherList = $oBasket->getVouchers();
 
-        if (is_array($this->_aVoucherList)) {
+        if (\is_array($this->_aVoucherList)) {
             foreach ($this->_aVoucherList as $sVoucherId => $oSimpleVoucher) {
                 $oVoucher = oxNew(\OxidEsales\Eshop\Application\Model\Voucher::class);
                 $oVoucher->load($sVoucherId);
@@ -1147,7 +1147,7 @@ class Order extends \OxidEsales\Eshop\Core\Model\BaseModel
         if (($blSave = parent::save())) {
             // saving order articles
             $oOrderArticles = $this->getOrderArticles();
-            if ($oOrderArticles && count($oOrderArticles) > 0) {
+            if ($oOrderArticles && \count($oOrderArticles) > 0) {
                 foreach ($oOrderArticles as $oOrderArticle) {
                     $oOrderArticle->save();
                 }
@@ -1218,7 +1218,7 @@ class Order extends \OxidEsales\Eshop\Core\Model\BaseModel
                 $oEx->setProductId($oProd->getId());
                 $oEx->setBasketIndex($key);
 
-                if (!is_numeric($iOnStock)) {
+                if (!\is_numeric($iOnStock)) {
                     $iOnStock = 0;
                 }
                 $oEx->setRemainingAmount($iOnStock);
@@ -1240,7 +1240,7 @@ class Order extends \OxidEsales\Eshop\Core\Model\BaseModel
 
         //V #M525 orderdate must be the same as it was
         if (!$this->oxorder__oxorderdate || !$this->oxorder__oxorderdate->value) {
-            $this->oxorder__oxorderdate = new \OxidEsales\Eshop\Core\Field(date('Y-m-d H:i:s', $oUtilsDate->getTime()), \OxidEsales\Eshop\Core\Field::T_RAW);
+            $this->oxorder__oxorderdate = new \OxidEsales\Eshop\Core\Field(\date('Y-m-d H:i:s', $oUtilsDate->getTime()), \OxidEsales\Eshop\Core\Field::T_RAW);
         } else {
             $this->oxorder__oxorderdate = new \OxidEsales\Eshop\Core\Field(
                 $oUtilsDate->formatDBDate(
@@ -1657,7 +1657,7 @@ class Order extends \OxidEsales\Eshop\Core\Model\BaseModel
         $sSelect .= 'oxshopid = :oxshopid and oxorder.oxstorno != "1" ';
 
         if ($blToday) {
-            $sSelect .= 'and oxorderdate like "' . date('Y-m-d') . '%" ';
+            $sSelect .= 'and oxorderdate like "' . \date('Y-m-d') . '%" ';
         }
 
         $params = [
@@ -1681,7 +1681,7 @@ class Order extends \OxidEsales\Eshop\Core\Model\BaseModel
         $sSelect .= 'oxshopid = :oxshopid  and oxorder.oxstorno != "1" ';
 
         if ($blToday) {
-            $sSelect .= 'and oxorderdate like "' . date('Y-m-d') . '%" ';
+            $sSelect .= 'and oxorderdate like "' . \date('Y-m-d') . '%" ';
         }
 
         $params = [
@@ -1875,7 +1875,7 @@ class Order extends \OxidEsales\Eshop\Core\Model\BaseModel
     protected function _addOrderArticlesToBasket($oBasket, $aOrderArticles) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         // if no order articles, return empty basket
-        if (count($aOrderArticles) > 0) {
+        if (\count($aOrderArticles) > 0) {
             //adding order articles to basket
             foreach ($aOrderArticles as $oOrderArticle) {
                 $oBasket->addOrderArticleToBasket($oOrderArticle);
@@ -1893,7 +1893,7 @@ class Order extends \OxidEsales\Eshop\Core\Model\BaseModel
     protected function _addArticlesToBasket($oBasket, $aArticles) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         // if no order articles
-        if (count($aArticles) > 0) {
+        if (\count($aArticles) > 0) {
             //adding order articles to basket
             foreach ($aArticles as $oArticle) {
                 $aSel = isset($oArticle->oxorderarticles__oxselvariant) ? $oArticle->oxorderarticles__oxselvariant->value : null;
@@ -1917,7 +1917,7 @@ class Order extends \OxidEsales\Eshop\Core\Model\BaseModel
     {
         $oCur = \OxidEsales\Eshop\Core\Registry::getConfig()->getActShopCurrencyObject();
 
-        return number_format((double) $this->oxorder__oxtotalordersum->value, $oCur->decimal, '.', '');
+        return \number_format((double) $this->oxorder__oxtotalordersum->value, $oCur->decimal, '.', '');
     }
 
     /**
@@ -2021,7 +2021,7 @@ class Order extends \OxidEsales\Eshop\Core\Model\BaseModel
         if ($this->_oOrderCurrency === null) {
             // setting default in case unrecognized currency was set during order
             $aCurrencies = \OxidEsales\Eshop\Core\Registry::getConfig()->getCurrencyArray();
-            $this->_oOrderCurrency = current($aCurrencies);
+            $this->_oOrderCurrency = \current($aCurrencies);
 
             foreach ($aCurrencies as $oCurr) {
                 if ($oCurr->name == $this->oxorder__oxcurrency->value) {
@@ -2298,7 +2298,7 @@ class Order extends \OxidEsales\Eshop\Core\Model\BaseModel
             $sParcelService = $oConfig->getConfigParam('sParcelService');
             $sTrackingCode = $this->getTrackCode();
             if ($sParcelService && $sTrackingCode) {
-                $this->_sShipTrackUrl = str_replace("##ID##", $sTrackingCode, $sParcelService);
+                $this->_sShipTrackUrl = \str_replace("##ID##", $sTrackingCode, $sParcelService);
             }
         }
 
@@ -2392,7 +2392,7 @@ class Order extends \OxidEsales\Eshop\Core\Model\BaseModel
         $dynamicValues = null;
         $dynamicValuesList = $this->getPaymentType()->getDynValues();
 
-        if (is_array($dynamicValuesList)) {
+        if (\is_array($dynamicValuesList)) {
             foreach ($dynamicValuesList as $value) {
                 $dynamicValues[$value->name] = $value->value;
             }

--- a/source/Application/Model/OrderArticle.php
+++ b/source/Application/Model/OrderArticle.php
@@ -92,11 +92,11 @@ class OrderArticle extends \OxidEsales\Eshop\Core\Model\BaseModel implements Art
      */
     public function copyThis($oProduct)
     {
-        $aObjectVars = get_object_vars($oProduct);
+        $aObjectVars = \get_object_vars($oProduct);
 
         foreach ($aObjectVars as $sName => $sValue) {
             if (isset($oProduct->$sName->value)) {
-                $sFieldName = preg_replace('/oxarticles__/', 'oxorderarticles__', $sName);
+                $sFieldName = \preg_replace('/oxarticles__/', 'oxorderarticles__', $sName);
                 if ($sFieldName != "oxorderarticles__oxtimestamp") {
                     $this->$sFieldName = $oProduct->$sName;
                 }
@@ -197,7 +197,7 @@ class OrderArticle extends \OxidEsales\Eshop\Core\Model\BaseModel implements Art
         }
 
         if ($this->oxorderarticles__oxpersparam->value) {
-            $this->_aPersParam = unserialize($this->oxorderarticles__oxpersparam->value);
+            $this->_aPersParam = \unserialize($this->oxorderarticles__oxpersparam->value);
         }
 
         return $this->_aPersParam;
@@ -213,7 +213,7 @@ class OrderArticle extends \OxidEsales\Eshop\Core\Model\BaseModel implements Art
         $this->_aPersParam = $aParams;
 
         // serializing persisten info stored while ordering
-        $this->oxorderarticles__oxpersparam = new \OxidEsales\Eshop\Core\Field(serialize($aParams), \OxidEsales\Eshop\Core\Field::T_RAW);
+        $this->oxorderarticles__oxpersparam = new \OxidEsales\Eshop\Core\Field(\serialize($aParams), \OxidEsales\Eshop\Core\Field::T_RAW);
     }
 
     /**
@@ -228,7 +228,7 @@ class OrderArticle extends \OxidEsales\Eshop\Core\Model\BaseModel implements Art
      */
     protected function _setFieldData($sFieldName, $sValue, $iDataType = \OxidEsales\Eshop\Core\Field::T_TEXT) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
-        $sFieldName = strtolower($sFieldName);
+        $sFieldName = \strtolower($sFieldName);
         switch ($sFieldName) {
             case 'oxpersparam':
             case 'oxorderarticles__oxpersparam':
@@ -398,24 +398,24 @@ class OrderArticle extends \OxidEsales\Eshop\Core\Model\BaseModel implements Art
         if ($this->_aOrderArticleSelList === null) {
             $sOrderArtSelList = $sOrderArtSelList ? $sOrderArtSelList : $this->oxorderarticles__oxselvariant->value;
 
-            $sOrderArtSelList = explode(' || ', $sOrderArtSelList)[0];
+            $sOrderArtSelList = \explode(' || ', $sOrderArtSelList)[0];
 
             $aRet = [];
 
             if ($oArticle = $this->_getOrderArticle($sArtId)) {
-                $aList = explode(", ", $sOrderArtSelList);
+                $aList = \explode(", ", $sOrderArtSelList);
                 $oStr = Str::getStr();
 
                 $aArticleSelList = $oArticle->getSelectLists();
 
                 //formatting temporary list array from string
-                if (count($aArticleSelList) > 0) {
+                if (\count($aArticleSelList) > 0) {
                     foreach ($aList as $sList) {
                         if ($sList) {
-                            $aVal = explode(":", $sList);
+                            $aVal = \explode(":", $sList);
                             if (isset($aVal[0]) && isset($aVal[1])) {
-                                $sOrderArtListTitle = $oStr->strtolower(trim($aVal[0]));
-                                $sOrderArtSelValue = $oStr->strtolower(trim($aVal[1]));
+                                $sOrderArtListTitle = $oStr->strtolower(\trim($aVal[0]));
+                                $sOrderArtSelValue = $oStr->strtolower(\trim($aVal[1]));
 
                                 //checking article list for matches with article list stored in oxOrderItem
                                 $iSelListNum = 0;
@@ -768,8 +768,8 @@ class OrderArticle extends \OxidEsales\Eshop\Core\Model\BaseModel implements Art
      */
     protected function _insert() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
-        $iInsertTime = time();
-        $now = date('Y-m-d H:i:s', $iInsertTime);
+        $iInsertTime = \time();
+        $now = \date('Y-m-d H:i:s', $iInsertTime);
         $this->oxorderarticles__oxtimestamp = new \OxidEsales\Eshop\Core\Field($now);
 
         return parent::_insert();

--- a/source/Application/Model/OrderFile.php
+++ b/source/Application/Model/OrderFile.php
@@ -46,13 +46,13 @@ class OrderFile extends \OxidEsales\Eshop\Core\Model\BaseModel
     {
         $oArticleFile = oxNew(\OxidEsales\Eshop\Application\Model\File::class);
         $oArticleFile->load($this->oxorderfiles__oxfileid->value);
-        if (file_exists($oArticleFile->getStoreLocation())) {
+        if (\file_exists($oArticleFile->getStoreLocation())) {
             $this->oxorderfiles__oxdownloadcount = new \OxidEsales\Eshop\Core\Field(0);
             $this->oxorderfiles__oxfirstdownload = new \OxidEsales\Eshop\Core\Field('0000-00-00 00:00:00');
             $this->oxorderfiles__oxlastdownload = new \OxidEsales\Eshop\Core\Field('0000-00-00 00:00:00');
             $iExpirationTime = $this->oxorderfiles__oxlinkexpirationtime->value * 3600;
             $sNow = \OxidEsales\Eshop\Core\Registry::getUtilsDate()->getTime();
-            $sDate = date('Y-m-d H:i:s', $sNow + $iExpirationTime);
+            $sDate = \date('Y-m-d H:i:s', $sNow + $iExpirationTime);
             $this->oxorderfiles__oxvaliduntil = new \OxidEsales\Eshop\Core\Field($sDate);
             $this->oxorderfiles__oxresetcount = new \OxidEsales\Eshop\Core\Field($this->oxorderfiles__oxresetcount->value + 1);
         }
@@ -100,7 +100,7 @@ class OrderFile extends \OxidEsales\Eshop\Core\Model\BaseModel
     public function setFile($sFileName, $sFileId, $iMaxDownloadCounts, $iExpirationTime, $iExpirationDownloadTime)
     {
         $sNow = \OxidEsales\Eshop\Core\Registry::getUtilsDate()->getTime();
-        $sDate = date('Y-m-d G:i', $sNow + $iExpirationTime * 3600);
+        $sDate = \date('Y-m-d G:i', $sNow + $iExpirationTime * 3600);
 
         $this->oxorderfiles__oxfileid = new \OxidEsales\Eshop\Core\Field($sFileId);
         $this->oxorderfiles__oxfilename = new \OxidEsales\Eshop\Core\Field($sFileName);
@@ -142,7 +142,7 @@ class OrderFile extends \OxidEsales\Eshop\Core\Model\BaseModel
             'oxorderfiles__oxpurchasedonly'
         ];
 
-        if (in_array($sFieldName, $aFieldNames)) {
+        if (\in_array($sFieldName, $aFieldNames)) {
             return $sFieldName;
         }
 
@@ -161,7 +161,7 @@ class OrderFile extends \OxidEsales\Eshop\Core\Model\BaseModel
                 return true;
             } else {
                 $sNow = \OxidEsales\Eshop\Core\Registry::getUtilsDate()->getTime();
-                $iTimestamp = strtotime($this->oxorderfiles__oxvaliduntil->value);
+                $iTimestamp = \strtotime($this->oxorderfiles__oxvaliduntil->value);
                 if (!$iTimestamp || ($iTimestamp > $sNow)) {
                     return true;
                 }
@@ -188,7 +188,7 @@ class OrderFile extends \OxidEsales\Eshop\Core\Model\BaseModel
      */
     public function getValidUntil()
     {
-        return substr($this->oxorderfiles__oxvaliduntil->value, 0, 16);
+        return \substr($this->oxorderfiles__oxvaliduntil->value, 0, 16);
     }
 
     /**
@@ -220,15 +220,15 @@ class OrderFile extends \OxidEsales\Eshop\Core\Model\BaseModel
 
                 $iExpirationTime = $this->oxorderfiles__oxdownloadexpirationtime->value * 3600;
                 $iTime = \OxidEsales\Eshop\Core\Registry::getUtilsDate()->getTime();
-                $this->oxorderfiles__oxvaliduntil = new \OxidEsales\Eshop\Core\Field(date('Y-m-d H:i:s', $iTime + $iExpirationTime));
+                $this->oxorderfiles__oxvaliduntil = new \OxidEsales\Eshop\Core\Field(\date('Y-m-d H:i:s', $iTime + $iExpirationTime));
 
-                $this->oxorderfiles__oxfirstdownload = new \OxidEsales\Eshop\Core\Field(date('Y-m-d H:i:s', $iTime));
-                $this->oxorderfiles__oxlastdownload = new \OxidEsales\Eshop\Core\Field(date('Y-m-d H:i:s', $iTime));
+                $this->oxorderfiles__oxfirstdownload = new \OxidEsales\Eshop\Core\Field(\date('Y-m-d H:i:s', $iTime));
+                $this->oxorderfiles__oxlastdownload = new \OxidEsales\Eshop\Core\Field(\date('Y-m-d H:i:s', $iTime));
             } else {
                 $this->oxorderfiles__oxdownloadcount = new \OxidEsales\Eshop\Core\Field($this->oxorderfiles__oxdownloadcount->value + 1);
 
                 $iTime = \OxidEsales\Eshop\Core\Registry::getUtilsDate()->getTime();
-                $this->oxorderfiles__oxlastdownload = new \OxidEsales\Eshop\Core\Field(date('Y-m-d H:i:s', $iTime));
+                $this->oxorderfiles__oxlastdownload = new \OxidEsales\Eshop\Core\Field(\date('Y-m-d H:i:s', $iTime));
             }
             $this->save();
 

--- a/source/Application/Model/Payment.php
+++ b/source/Application/Model/Payment.php
@@ -176,7 +176,7 @@ class Payment extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel
     {
         if (!$this->_aDynValues) {
             $sRawDynValue = null;
-            if (is_object($this->oxpayments__oxvaldesc)) {
+            if (\is_object($this->oxpayments__oxvaldesc)) {
                 $sRawDynValue = $this->oxpayments__oxvaldesc->getRawValue();
             }
 
@@ -424,7 +424,7 @@ class Payment extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel
                 return false;
             }
             if (
-                count(
+                \count(
                     \OxidEsales\Eshop\Core\Registry::get(\OxidEsales\Eshop\Application\Model\DeliverySetList::class)
                     ->getDeliverySetList(
                         $oUser,
@@ -442,7 +442,7 @@ class Payment extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel
 
         $mxValidationResult = \OxidEsales\Eshop\Core\Registry::getInputValidator()->validatePaymentInputData($this->oxpayments__oxid->value, $aDynValue);
 
-        if (is_integer($mxValidationResult)) {
+        if (\is_integer($mxValidationResult)) {
             $this->_iPaymentError = $mxValidationResult;
 
             return false;
@@ -458,7 +458,7 @@ class Payment extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel
         if ($sShipSetId) {
             $aPaymentList = \OxidEsales\Eshop\Core\Registry::get(\OxidEsales\Eshop\Application\Model\PaymentList::class)->getPaymentList($sShipSetId, $dBasketPrice, $oUser);
 
-            if (!array_key_exists($this->getId(), $aPaymentList)) {
+            if (!\array_key_exists($this->getId(), $aPaymentList)) {
                 $this->_iPaymentError = -3;
 
                 return false;

--- a/source/Application/Model/PaymentList.php
+++ b/source/Application/Model/PaymentList.php
@@ -37,8 +37,8 @@ class PaymentList extends \OxidEsales\Eshop\Core\Model\ListModel
      */
     public function setHomeCountry($sHomeCountry)
     {
-        if (is_array($sHomeCountry)) {
-            $this->_sHomeCountry = current($sHomeCountry);
+        if (\is_array($sHomeCountry)) {
+            $this->_sHomeCountry = \current($sHomeCountry);
         } else {
             $this->_sHomeCountry = $sHomeCountry;
         }

--- a/source/Application/Model/PriceAlarm.php
+++ b/source/Application/Model/PriceAlarm.php
@@ -91,7 +91,7 @@ class PriceAlarm extends \OxidEsales\Eshop\Core\Model\BaseModel
     protected function _insert() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         // set oxinsert value
-        $this->oxpricealarm__oxinsert = new \OxidEsales\Eshop\Core\Field(date('Y-m-d', \OxidEsales\Eshop\Core\Registry::getUtilsDate()->getTime()));
+        $this->oxpricealarm__oxinsert = new \OxidEsales\Eshop\Core\Field(\date('Y-m-d', \OxidEsales\Eshop\Core\Registry::getUtilsDate()->getTime()));
 
         return parent::_insert();
     }

--- a/source/Application/Model/Rating.php
+++ b/source/Application/Model/Rating.php
@@ -53,7 +53,7 @@ class Rating extends \OxidEsales\Eshop\Core\Model\BaseModel
         $myConfig = \OxidEsales\Eshop\Core\Registry::getConfig();
 
         if ($iRatingLogsTimeout = $myConfig->getConfigParam('iRatingLogsTimeout')) {
-            $sExpDate = date('Y-m-d H:i:s', \OxidEsales\Eshop\Core\Registry::getUtilsDate()->getTime() - $iRatingLogsTimeout * 24 * 60 * 60);
+            $sExpDate = \date('Y-m-d H:i:s', \OxidEsales\Eshop\Core\Registry::getUtilsDate()->getTime() - $iRatingLogsTimeout * 24 * 60 * 60);
             $oDb->execute("delete from oxratings where oxtimestamp < :expDate", [
                 ':expDate' => $sExpDate
             ]);
@@ -88,8 +88,8 @@ class Rating extends \OxidEsales\Eshop\Core\Model\BaseModel
     public function getRatingAverage($sObjectId, $sType, $aIncludedObjectsIds = null)
     {
         $sQuerySnipet = " AND `oxobjectid` = :oxobjectid";
-        if (is_array($aIncludedObjectsIds) && count($aIncludedObjectsIds) > 0) {
-            $sQuerySnipet = " AND ( `oxobjectid` = :oxobjectid OR `oxobjectid` in ('" . implode("', '", $aIncludedObjectsIds) . "') )";
+        if (\is_array($aIncludedObjectsIds) && \count($aIncludedObjectsIds) > 0) {
+            $sQuerySnipet = " AND ( `oxobjectid` = :oxobjectid OR `oxobjectid` in ('" . \implode("', '", $aIncludedObjectsIds) . "') )";
         }
 
         $sSelect = "
@@ -108,7 +108,7 @@ class Rating extends \OxidEsales\Eshop\Core\Model\BaseModel
 
         $database = \OxidEsales\Eshop\Core\DatabaseProvider::getMaster();
         if ($fRating = $database->getOne($sSelect, $params)) {
-            $fRating = round($fRating, 1);
+            $fRating = \round($fRating, 1);
         }
 
         return $fRating;
@@ -126,8 +126,8 @@ class Rating extends \OxidEsales\Eshop\Core\Model\BaseModel
     public function getRatingCount($sObjectId, $sType, $aIncludedObjectsIds = null)
     {
         $sQuerySnipet = " AND `oxobjectid` = :oxobjectid";
-        if (is_array($aIncludedObjectsIds) && count($aIncludedObjectsIds) > 0) {
-            $sQuerySnipet = " AND ( `oxobjectid` = :oxobjectid OR `oxobjectid` in ('" . implode("', '", $aIncludedObjectsIds) . "') )";
+        if (\is_array($aIncludedObjectsIds) && \count($aIncludedObjectsIds) > 0) {
+            $sQuerySnipet = " AND ( `oxobjectid` = :oxobjectid OR `oxobjectid` in ('" . \implode("', '", $aIncludedObjectsIds) . "') )";
         }
 
         $sSelect = "

--- a/source/Application/Model/RecommendationList.php
+++ b/source/Application/Model/RecommendationList.php
@@ -255,10 +255,10 @@ class RecommendationList extends \OxidEsales\Eshop\Core\Model\BaseModel implemen
      */
     public function getRecommListsByIds($aArticleIds)
     {
-        if (is_array($aArticleIds) && count($aArticleIds)) {
+        if (\is_array($aArticleIds) && \count($aArticleIds)) {
             startProfile(__FUNCTION__);
 
-            $sIds = implode(",", \OxidEsales\Eshop\Core\DatabaseProvider::getDb()->quoteArray($aArticleIds));
+            $sIds = \implode(",", \OxidEsales\Eshop\Core\DatabaseProvider::getDb()->quoteArray($aArticleIds));
 
             $oRecommList = oxNew(\OxidEsales\Eshop\Core\Model\ListModel::class);
             $oRecommList->init('oxrecommlist');
@@ -307,13 +307,13 @@ class RecommendationList extends \OxidEsales\Eshop\Core\Model\BaseModel implemen
     protected function _loadFirstArticles(\OxidEsales\Eshop\Core\Model\ListModel $oRecommList, $aIds) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $aIds = \OxidEsales\Eshop\Core\DatabaseProvider::getDb()->quoteArray($aIds);
-        $sIds = implode(", ", $aIds);
+        $sIds = \implode(", ", $aIds);
 
         $aPrevIds = [];
         $sArtView = getViewName('oxarticles');
         foreach ($oRecommList as $key => $oRecomm) {
-            if (count($aPrevIds)) {
-                $sNegateSql = " AND $sArtView.oxid not in ( '" . implode("','", $aPrevIds) . "' ) ";
+            if (\count($aPrevIds)) {
+                $sNegateSql = " AND $sArtView.oxid not in ( '" . \implode("','", $aPrevIds) . "' ) ";
             } else {
                 $sNegateSql = '';
             }
@@ -323,13 +323,13 @@ class RecommendationList extends \OxidEsales\Eshop\Core\Model\BaseModel implemen
             $oArtList->setSqlLimit(0, 1);
             $oArtList->loadRecommArticles($oRecomm->getId(), $sArticlesFilter);
 
-            if (count($oArtList) == 1) {
+            if (\count($oArtList) == 1) {
                 $oArtList->rewind();
                 $oArticle = $oArtList->current();
                 $sId = $oArticle->getId();
                 $aPrevIds[$sId] = $sId;
                 unset($aIds[$sId]);
-                $sIds = implode(", ", $aIds);
+                $sIds = \implode(", ", $aIds);
             } else {
                 unset($oRecommList[$key]);
             }
@@ -376,7 +376,7 @@ class RecommendationList extends \OxidEsales\Eshop\Core\Model\BaseModel implemen
         $iCnt = 0;
         $sSelect = $this->_getSearchSelect($sSearchStr);
         if ($sSelect) {
-            $sPartial = substr($sSelect, strpos($sSelect, ' from '));
+            $sPartial = \substr($sSelect, \strpos($sSelect, ' from '));
             $sSelect = "select count( distinct rl.oxid ) $sPartial ";
             $iCnt = \OxidEsales\Eshop\Core\DatabaseProvider::getDb()->getOne($sSelect);
         }

--- a/source/Application/Model/Remark.php
+++ b/source/Application/Model/Remark.php
@@ -64,7 +64,7 @@ class Remark extends \OxidEsales\Eshop\Core\Model\BaseModel
     protected function _insert() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         // set oxcreate
-        $sNow = date('Y-m-d H:i:s', \OxidEsales\Eshop\Core\Registry::getUtilsDate()->getTime());
+        $sNow = \date('Y-m-d H:i:s', \OxidEsales\Eshop\Core\Registry::getUtilsDate()->getTime());
         $this->oxremark__oxcreate = new \OxidEsales\Eshop\Core\Field($sNow, \OxidEsales\Eshop\Core\Field::T_RAW);
         $this->oxremark__oxheader = new \OxidEsales\Eshop\Core\Field($sNow, \OxidEsales\Eshop\Core\Field::T_RAW);
 

--- a/source/Application/Model/RequiredAddressFields.php
+++ b/source/Application/Model/RequiredAddressFields.php
@@ -43,7 +43,7 @@ class RequiredAddressFields
         $this->setRequiredFields($this->_aDefaultRequiredFields);
 
         $aRequiredFields = \OxidEsales\Eshop\Core\Registry::getConfig()->getConfigParam('aMustFillFields');
-        if (is_array($aRequiredFields)) {
+        if (\is_array($aRequiredFields)) {
             $this->setRequiredFields($aRequiredFields);
         }
     }
@@ -105,7 +105,7 @@ class RequiredAddressFields
     {
         $aAllowed = [];
         foreach ($aFields as $sKey => $sValue) {
-            if (strpos($sValue, $sPrefix) === 0) {
+            if (\strpos($sValue, $sPrefix) === 0) {
                 $aAllowed[] = $aFields[$sKey];
             }
         }

--- a/source/Application/Model/RequiredFieldValidator.php
+++ b/source/Application/Model/RequiredFieldValidator.php
@@ -22,10 +22,10 @@ class RequiredFieldValidator
     public function validateFieldValue($sFieldValue)
     {
         $blValid = true;
-        if (is_array($sFieldValue)) {
+        if (\is_array($sFieldValue)) {
             $blValid = $this->_validateFieldValueArray($sFieldValue);
         } else {
-            if (!trim($sFieldValue)) {
+            if (!\trim($sFieldValue)) {
                 $blValid = false;
             }
         }
@@ -45,7 +45,7 @@ class RequiredFieldValidator
     {
         $blValid = true;
         foreach ($aFieldValues as $sValue) {
-            if (!trim($sValue)) {
+            if (!\trim($sValue)) {
                 $blValid = false;
                 break;
             }

--- a/source/Application/Model/RequiredFieldsValidator.php
+++ b/source/Application/Model/RequiredFieldsValidator.php
@@ -40,7 +40,7 @@ class RequiredFieldsValidator
      */
     public function __construct($oFieldValidator = null)
     {
-        if (is_null($oFieldValidator)) {
+        if (\is_null($oFieldValidator)) {
             $oFieldValidator = oxNew(\OxidEsales\Eshop\Application\Model\RequiredFieldValidator::class);
         }
         $this->setFieldValidator($oFieldValidator);

--- a/source/Application/Model/Review.php
+++ b/source/Application/Model/Review.php
@@ -91,7 +91,7 @@ class Review extends \OxidEsales\Eshop\Core\Model\BaseModel
     protected function _insert() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         // set oxcreate
-        $this->oxreviews__oxcreate = new \OxidEsales\Eshop\Core\Field(date('Y-m-d H:i:s', \OxidEsales\Eshop\Core\Registry::getUtilsDate()->getTime()));
+        $this->oxreviews__oxcreate = new \OxidEsales\Eshop\Core\Field(\date('Y-m-d H:i:s', \OxidEsales\Eshop\Core\Registry::getUtilsDate()->getTime()));
 
         return parent::_insert();
     }
@@ -113,12 +113,12 @@ class Review extends \OxidEsales\Eshop\Core\Model\BaseModel
 
         $params = [
             ':oxtype' => $sType,
-            ':oxlang' => is_null($iLoadInLang) ? (int) \OxidEsales\Eshop\Core\Registry::getLang()->getBaseLanguage() : (int) $iLoadInLang
+            ':oxlang' => \is_null($iLoadInLang) ? (int) \OxidEsales\Eshop\Core\Registry::getLang()->getBaseLanguage() : (int) $iLoadInLang
         ];
 
-        if (is_array($aIds) && count($aIds)) {
-            $sObjectIdWhere = "oxreviews.oxobjectid in ( " . implode(", ", \OxidEsales\Eshop\Core\DatabaseProvider::getDb()->quoteArray($aIds)) . " )";
-        } elseif (is_string($aIds) && $aIds) {
+        if (\is_array($aIds) && \count($aIds)) {
+            $sObjectIdWhere = "oxreviews.oxobjectid in ( " . \implode(", ", \OxidEsales\Eshop\Core\DatabaseProvider::getDb()->quoteArray($aIds)) . " )";
+        } elseif (\is_string($aIds) && $aIds) {
             $sObjectIdWhere = "oxreviews.oxobjectid = :oxobjectid";
             $params[':oxobjectid'] = $aIds;
         } else {
@@ -162,7 +162,7 @@ class Review extends \OxidEsales\Eshop\Core\Model\BaseModel
      */
     public function getObjectType()
     {
-        return is_object($this->oxreviews__oxtype) ? $this->oxreviews__oxtype->value : $this->oxreviews__oxtype;
+        return \is_object($this->oxreviews__oxtype) ? $this->oxreviews__oxtype->value : $this->oxreviews__oxtype;
     }
 
     /**
@@ -172,7 +172,7 @@ class Review extends \OxidEsales\Eshop\Core\Model\BaseModel
      */
     public function getObjectId()
     {
-        return is_object($this->oxreviews__oxobjectid) ? $this->oxreviews__oxobjectid->value : $this->oxreviews__oxobjectid;
+        return \is_object($this->oxreviews__oxobjectid) ? $this->oxreviews__oxobjectid->value : $this->oxreviews__oxobjectid;
     }
 
     /**

--- a/source/Application/Model/RssFeed.php
+++ b/source/Application/Model/RssFeed.php
@@ -61,7 +61,7 @@ class RssFeed extends \OxidEsales\Eshop\Core\Base
 
         $sFileCacheName = $aOxActionToCacheIds[$sOxActionId];
 
-        if (is_null($sFileCacheName)) {
+        if (\is_null($sFileCacheName)) {
             $sFileCacheName = '';
         }
 
@@ -122,7 +122,7 @@ class RssFeed extends \OxidEsales\Eshop\Core\Base
 
         $editionSelector = new EditionSelector();
         $this->_aChannel['image']['url'] = \OxidEsales\Eshop\Core\Registry::getConfig()->getImageUrl()
-            . 'logo_' . strtolower($editionSelector->getEdition()) . '.png';
+            . 'logo_' . \strtolower($editionSelector->getEdition()) . '.png';
 
         $this->_aChannel['image']['title'] = $this->_aChannel['title'];
         $this->_aChannel['image']['link'] = $this->_aChannel['link'];
@@ -156,7 +156,7 @@ class RssFeed extends \OxidEsales\Eshop\Core\Base
     protected function _loadFromCache($name) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         if ($aRes = Registry::getUtils()->fromFileCache($this->_getCacheId($name))) {
-            if ($aRes['timestamp'] > time() - self::CACHE_TTL) {
+            if ($aRes['timestamp'] > \time() - self::CACHE_TTL) {
                 return $aRes['content'];
             }
         }
@@ -182,12 +182,12 @@ class RssFeed extends \OxidEsales\Eshop\Core\Base
             $sLastBuildDate = $aData2['content']['lastBuildDate'];
             $aData2['content']['lastBuildDate'] = '';
             $aData['lastBuildDate'] = '';
-            if (!strcmp(serialize($aData), serialize($aData2['content']))) {
+            if (!\strcmp(\serialize($aData), \serialize($aData2['content']))) {
                 return $sLastBuildDate;
             }
         }
 
-        return date('D, d M Y H:i:s O');
+        return \date('D, d M Y H:i:s O');
     }
 
     /**
@@ -205,7 +205,7 @@ class RssFeed extends \OxidEsales\Eshop\Core\Base
      */
     protected function _saveToCache($name, $aContent) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
-        $aData = ['timestamp' => time(), 'content' => $aContent];
+        $aData = ['timestamp' => \time(), 'content' => $aContent];
 
         return Registry::getUtils()->toFileCache($this->_getCacheId($name), $aData);
     }
@@ -244,7 +244,7 @@ class RssFeed extends \OxidEsales\Eshop\Core\Base
                 $sPrice .= ' ' . $sFrom . $oLang->formatCurrency($oPrice->getBruttoPrice(), $oActCur) . ' ' . $oActCur->sign;
             }
 
-            $oItem->title = strip_tags($oArticle->oxarticles__oxtitle->value . $sPrice);
+            $oItem->title = \strip_tags($oArticle->oxarticles__oxtitle->value . $sPrice);
             $oItem->guid = $oItem->link = $myUtilsUrl->prepareUrlForNoSession($oArticle->getLink());
             $oItem->isGuidPermalink = true;
             // $oItem->description             = $oArticle->getLongDescription()->value; //oxarticles__oxshortdesc->value;
@@ -255,23 +255,23 @@ class RssFeed extends \OxidEsales\Eshop\Core\Base
                 $oItem->description = $oArticle->getLongDescription()->value;
             }
 
-            if (trim(str_replace('&nbsp;', '', (strip_tags($oItem->description)))) == '') {
+            if (\trim(\str_replace('&nbsp;', '', (\strip_tags($oItem->description)))) == '') {
                 $oItem->description = $oArticle->oxarticles__oxshortdesc->value;
             }
 
-            $oItem->description = trim($oItem->description);
+            $oItem->description = \trim($oItem->description);
             if ($sThumb = $oArticle->getThumbnailUrl()) {
                 $oItem->description = "<img src='$sThumb' border=0 align='left' hspace=5>" . $oItem->description;
             }
             $oItem->description = $oStr->htmlspecialchars($oItem->description);
 
             if ($oArticle->oxarticles__oxtimestamp->value) {
-                list($date, $time) = explode(' ', $oArticle->oxarticles__oxtimestamp->value);
-                $date = explode('-', $date);
-                $time = explode(':', $time);
-                $oItem->date = date('D, d M Y H:i:s O', mktime($time[0], $time[1], $time[2], $date[1], $date[2], $date[0]));
+                list($date, $time) = \explode(' ', $oArticle->oxarticles__oxtimestamp->value);
+                $date = \explode('-', $date);
+                $time = \explode(':', $time);
+                $oItem->date = \date('D, d M Y H:i:s O', \mktime($time[0], $time[1], $time[2], $date[1], $date[2], $date[0]));
             } else {
-                $oItem->date = date('D, d M Y H:i:s O', time());
+                $oItem->date = \date('D, d M Y H:i:s O', \time());
             }
 
             $aItems[] = $oItem;
@@ -376,7 +376,7 @@ class RssFeed extends \OxidEsales\Eshop\Core\Base
             $this->_aChannel['lastBuildDate'] = $this->_getLastBuildDate($sTag, $this->_aChannel);
             $this->_saveToCache($sTag, $this->_aChannel);
         } else {
-            $this->_aChannel['lastBuildDate'] = date('D, d M Y H:i:s O', Registry::getUtilsDate()->getTime());
+            $this->_aChannel['lastBuildDate'] = \date('D, d M Y H:i:s O', Registry::getUtilsDate()->getTime());
         }
     }
 
@@ -542,8 +542,8 @@ class RssFeed extends \OxidEsales\Eshop\Core\Base
         $oLang = Registry::getLang();
 
         return $this->_prepareUrl(
-            "cl=rss&amp;fnc=catarts&amp;cat=" . urlencode($oCat->getId()),
-            sprintf($oLang->translateString('CATEGORY_PRODUCTS_S', $oLang->getBaseLanguage()), $oCat->oxcategories__oxtitle->value)
+            "cl=rss&amp;fnc=catarts&amp;cat=" . \urlencode($oCat->getId()),
+            \sprintf($oLang->translateString('CATEGORY_PRODUCTS_S', $oLang->getBaseLanguage()), $oCat->oxcategories__oxtitle->value)
         );
     }
 
@@ -571,7 +571,7 @@ class RssFeed extends \OxidEsales\Eshop\Core\Base
         $this->_loadData(
             self::RSS_CATARTS . $sId,
             $this->getCategoryArticlesTitle($oCat),
-            sprintf($oLang->translateString('S_CATEGORY_PRODUCTS', $oLang->getBaseLanguage()), $oCat->oxcategories__oxtitle->value),
+            \sprintf($oLang->translateString('S_CATEGORY_PRODUCTS', $oLang->getBaseLanguage()), $oCat->oxcategories__oxtitle->value),
             $this->_getArticleItems($oArtList),
             $this->getCategoryArticlesUrl($oCat),
             $oCat->getLink()
@@ -611,17 +611,17 @@ class RssFeed extends \OxidEsales\Eshop\Core\Base
      */
     protected function _getSearchParamsUrl($sSearch, $sCatId, $sVendorId, $sManufacturerId) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
-        $sParams = "searchparam=" . urlencode($sSearch);
+        $sParams = "searchparam=" . \urlencode($sSearch);
         if ($sCatId) {
-            $sParams .= "&amp;searchcnid=" . urlencode($sCatId);
+            $sParams .= "&amp;searchcnid=" . \urlencode($sCatId);
         }
 
         if ($sVendorId) {
-            $sParams .= "&amp;searchvendor=" . urlencode($sVendorId);
+            $sParams .= "&amp;searchvendor=" . \urlencode($sVendorId);
         }
 
         if ($sManufacturerId) {
-            $sParams .= "&amp;searchmanufacturer=" . urlencode($sManufacturerId);
+            $sParams .= "&amp;searchmanufacturer=" . \urlencode($sManufacturerId);
         }
 
         return $sParams;
@@ -670,22 +670,22 @@ class RssFeed extends \OxidEsales\Eshop\Core\Base
         $oLang = Registry::getLang();
         $sCatTitle = '';
         if ($sTitle = $this->_getObjectField($sCatId, 'oxcategory', 'oxcategories__oxtitle')) {
-            $sCatTitle = sprintf($oLang->translateString('CATEGORY_S', $oLang->getBaseLanguage()), $sTitle);
+            $sCatTitle = \sprintf($oLang->translateString('CATEGORY_S', $oLang->getBaseLanguage()), $sTitle);
         }
         $sVendorTitle = '';
         if ($sTitle = $this->_getObjectField($sVendorId, 'oxvendor', 'oxvendor__oxtitle')) {
-            $sVendorTitle = sprintf($oLang->translateString('VENDOR_S', $oLang->getBaseLanguage()), $sTitle);
+            $sVendorTitle = \sprintf($oLang->translateString('VENDOR_S', $oLang->getBaseLanguage()), $sTitle);
         }
         $sManufacturerTitle = '';
         if ($sTitle = $this->_getObjectField($sManufacturerId, 'oxmanufacturer', 'oxmanufacturers__oxtitle')) {
-            $sManufacturerTitle = sprintf($oLang->translateString('MANUFACTURER_S', $oLang->getBaseLanguage()), $sTitle);
+            $sManufacturerTitle = \sprintf($oLang->translateString('MANUFACTURER_S', $oLang->getBaseLanguage()), $sTitle);
         }
 
-        $sRet = sprintf($oLang->translateString($sSearch, $oLang->getBaseLanguage()), $sId);
+        $sRet = \sprintf($oLang->translateString($sSearch, $oLang->getBaseLanguage()), $sId);
 
-        $sRet = str_replace('<TAG_CATEGORY>', $sCatTitle, $sRet);
-        $sRet = str_replace('<TAG_VENDOR>', $sVendorTitle, $sRet);
-        $sRet = str_replace('<TAG_MANUFACTURER>', $sManufacturerTitle, $sRet);
+        $sRet = \str_replace('<TAG_CATEGORY>', $sCatTitle, $sRet);
+        $sRet = \str_replace('<TAG_VENDOR>', $sVendorTitle, $sRet);
+        $sRet = \str_replace('<TAG_MANUFACTURER>', $sManufacturerTitle, $sRet);
 
         return $sRet;
     }
@@ -708,7 +708,7 @@ class RssFeed extends \OxidEsales\Eshop\Core\Base
         $sUrl = $this->_prepareUrl("cl=rss&amp;fnc=searcharts", $oLang->translateString('SEARCH', $oLang->getBaseLanguage()));
 
         $sJoin = '?';
-        if (strpos($sUrl, '?') !== false) {
+        if (\strpos($sUrl, '?') !== false) {
             $sJoin = '&amp;';
         }
 
@@ -763,7 +763,7 @@ class RssFeed extends \OxidEsales\Eshop\Core\Base
         $oLang = Registry::getLang();
         $iLang = $oLang->getBaseLanguage();
 
-        return $this->_prepareFeedName(sprintf($oLang->translateString('LISTMANIA_LIST_FOR', $iLang), $oArticle->oxarticles__oxtitle->value));
+        return $this->_prepareFeedName(\sprintf($oLang->translateString('LISTMANIA_LIST_FOR', $iLang), $oArticle->oxarticles__oxtitle->value));
     }
 
     /**
@@ -839,7 +839,7 @@ class RssFeed extends \OxidEsales\Eshop\Core\Base
         $this->_loadData(
             self::RSS_ARTRECOMMLISTS . $oArticle->getId(),
             $this->getRecommListsTitle($oArticle),
-            sprintf($oLang->translateString('LISTMANIA_LIST_FOR', $oLang->getBaseLanguage()), $oArticle->oxarticles__oxtitle->value),
+            \sprintf($oLang->translateString('LISTMANIA_LIST_FOR', $oLang->getBaseLanguage()), $oArticle->oxarticles__oxtitle->value),
             $this->_getRecommListItems($oList),
             $this->getRecommListsUrl($oArticle),
             $oArticle->getLink()
@@ -860,7 +860,7 @@ class RssFeed extends \OxidEsales\Eshop\Core\Base
         $oLang = Registry::getLang();
         $iLang = $oLang->getBaseLanguage();
 
-        return $this->_prepareFeedName(sprintf($oLang->translateString('LISTMANIA_LIST_PRODUCTS', $iLang), $oRecommList->oxrecommlists__oxtitle->value));
+        return $this->_prepareFeedName(\sprintf($oLang->translateString('LISTMANIA_LIST_PRODUCTS', $iLang), $oRecommList->oxrecommlists__oxtitle->value));
     }
 
     /**
@@ -905,7 +905,7 @@ class RssFeed extends \OxidEsales\Eshop\Core\Base
         $this->_loadData(
             self::RSS_RECOMMLISTARTS . $oRecommList->getId(),
             $this->getRecommListArticlesTitle($oRecommList),
-            sprintf($oLang->translateString('LISTMANIA_LIST_PRODUCTS', $oLang->getBaseLanguage()), $oRecommList->oxrecommlists__oxtitle->value),
+            \sprintf($oLang->translateString('LISTMANIA_LIST_PRODUCTS', $oLang->getBaseLanguage()), $oRecommList->oxrecommlists__oxtitle->value),
             $this->_getArticleItems($oList),
             $this->getRecommListArticlesUrl($oRecommList),
             $oRecommList->getLink()
@@ -985,6 +985,6 @@ class RssFeed extends \OxidEsales\Eshop\Core\Base
      */
     protected function _deleteFile($sFilePath) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
-        return @unlink($sFilePath);
+        return @\unlink($sFilePath);
     }
 }

--- a/source/Application/Model/Search.php
+++ b/source/Application/Model/Search.php
@@ -92,7 +92,7 @@ class Search extends \OxidEsales\Eshop\Core\Base
         $iCnt = 0;
         $sSelect = $this->_getSearchSelect($sSearchParamForQuery, $sInitialSearchCat, $sInitialSearchVendor, $sInitialSearchManufacturer, false);
         if ($sSelect) {
-            $sPartial = substr($sSelect, strpos($sSelect, ' from '));
+            $sPartial = \substr($sSelect, \strpos($sSelect, ' from '));
             $sSelect = "select count( " . getViewName('oxarticles', $this->_iLanguage) . ".oxid ) $sPartial ";
 
             $iCnt = \OxidEsales\Eshop\Core\DatabaseProvider::getDb()->getOne($sSelect);
@@ -249,17 +249,17 @@ class Search extends \OxidEsales\Eshop\Core\Base
         $sArticleTable = getViewName('oxarticles', $this->_iLanguage);
 
         $aSearchCols = $myConfig->getConfigParam('aSearchCols');
-        if (!(is_array($aSearchCols) && count($aSearchCols))) {
+        if (!(\is_array($aSearchCols) && \count($aSearchCols))) {
             return '';
         }
 
         $sSearchSep = $myConfig->getConfigParam('blSearchUseAND') ? 'and ' : 'or ';
-        $aSearch = explode(' ', $sSearchString);
+        $aSearch = \explode(' ', $sSearchString);
         $sSearch = ' and ( ';
         $myUtilsString = \OxidEsales\Eshop\Core\Registry::getUtilsString();
 
         foreach ($aSearch as $sSearchString) {
-            if (!strlen($sSearchString)) {
+            if (!\strlen($sSearchString)) {
                 continue;
             }
 
@@ -309,7 +309,7 @@ class Search extends \OxidEsales\Eshop\Core\Base
         $descriptionJoin = '';
         $searchColumns = \OxidEsales\Eshop\Core\Registry::getConfig()->getConfigParam('aSearchCols');
 
-        if (is_array($searchColumns) && in_array('oxlongdesc', $searchColumns)) {
+        if (\is_array($searchColumns) && \in_array('oxlongdesc', $searchColumns)) {
             $viewName = getViewName('oxartextends', $this->_iLanguage);
             $descriptionJoin = " LEFT JOIN {$viewName } ON {$table}.oxid={$viewName }.oxid ";
         }

--- a/source/Application/Model/SelectList.php
+++ b/source/Application/Model/SelectList.php
@@ -166,7 +166,7 @@ class SelectList extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel impleme
         if ($this->_oActiveSelection === null) {
             if (($aSelections = $this->getSelections())) {
                 // first is allways active
-                $this->_oActiveSelection = reset($aSelections);
+                $this->_oActiveSelection = \reset($aSelections);
             }
         }
 

--- a/source/Application/Model/SeoEncoderArticle.php
+++ b/source/Application/Model/SeoEncoderArticle.php
@@ -265,7 +265,7 @@ class SeoEncoderArticle extends \OxidEsales\Eshop\Core\SeoEncoder
 
         // add main category caching;
         $sQ = "select oxcatnid from " . $categoryViewName . " where oxobjectid = :oxobjectid order by oxtime";
-        $sIdent = md5($categoryViewName . $sArtId);
+        $sIdent = \md5($categoryViewName . $sArtId);
 
         if (($sMainCatId = $this->_loadFromCache($sIdent, "oxarticle")) === false) {
             $sMainCatId = $oDb->getOne($sQ, [

--- a/source/Application/Model/SeoEncoderCategory.php
+++ b/source/Application/Model/SeoEncoderCategory.php
@@ -105,7 +105,7 @@ class SeoEncoderCategory extends \OxidEsales\Eshop\Core\SeoEncoder
                 // prepare oCat title part
                 $sTitle = $this->_prepareTitle($oCat->oxcategories__oxtitle->value, false, $oCat->getLanguage());
 
-                foreach (array_keys($aCacheMap) as $id) {
+                foreach (\array_keys($aCacheMap) as $id) {
                     $aCacheMap[$id] = $sTitle . '/' . $aCacheMap[$id];
                 }
 

--- a/source/Application/Model/Shop.php
+++ b/source/Application/Model/Shop.php
@@ -47,7 +47,7 @@ class Shop extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel
      */
     public function getTables()
     {
-        if (is_null($this->_aTables)) {
+        if (\is_null($this->_aTables)) {
             $aTables = $this->formDatabaseTablesArray();
             $this->setTables($aTables);
         }
@@ -122,7 +122,7 @@ class Shop extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel
      */
     public function getMultiShopTables()
     {
-        if (is_null($this->_aMultiShopTables)) {
+        if (\is_null($this->_aMultiShopTables)) {
             $this->_aMultiShopTables = [];
         }
 
@@ -177,7 +177,7 @@ class Shop extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel
     {
         $sStart = 'CREATE OR REPLACE SQL SECURITY INVOKER VIEW';
 
-        if (!is_array($aLanguages)) {
+        if (!\is_array($aLanguages)) {
             $aLanguages = [null => null];
         }
 
@@ -205,7 +205,7 @@ class Shop extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel
             }
         }
 
-        return implode(',', $aFields);
+        return \implode(',', $aFields);
     }
 
     /**
@@ -221,7 +221,7 @@ class Shop extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel
         $aFields = [];
 
         $oMetaData = oxNew(\OxidEsales\Eshop\Core\DbMetaDataHandler::class);
-        $aTables = array_merge([$sTable], $oMetaData->getAllMultiTables($sTable));
+        $aTables = \array_merge([$sTable], $oMetaData->getAllMultiTables($sTable));
         foreach ($aTables as $sTableKey => $sTableName) {
             $aTableFields = $oMetaData->getFields($sTableName);
             foreach ($aTableFields as $sCoreField => $sField) {
@@ -231,7 +231,7 @@ class Shop extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel
             }
         }
 
-        return implode(',', $aFields);
+        return \implode(',', $aFields);
     }
 
     /**
@@ -247,7 +247,7 @@ class Shop extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel
         $sJoin = ' ';
         $oMetaData = oxNew(\OxidEsales\Eshop\Core\DbMetaDataHandler::class);
         $aTables = $oMetaData->getAllMultiTables($sTable);
-        if (count($aTables)) {
+        if (\count($aTables)) {
             foreach ($aTables as $sTableKey => $sTableName) {
                 $sJoin .= "LEFT JOIN {$sTableName} USING (OXID) ";
             }
@@ -320,7 +320,7 @@ class Shop extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel
         $aTables = $this->getTables();
         foreach ($aTables as $sTable) {
             $this->createViewQuery($sTable);
-            if (in_array($sTable, $aMultilangTables)) {
+            if (\in_array($sTable, $aMultilangTables)) {
                 $this->createViewQuery($sTable, $aLanguages);
             }
         }
@@ -390,7 +390,7 @@ class Shop extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel
     {
         $multilanguageTables = Registry::getLang()->getMultiLangTables();
 
-        return array_unique($multilanguageTables);
+        return \array_unique($multilanguageTables);
     }
 
     /**

--- a/source/Application/Model/ShopViewValidator.php
+++ b/source/Application/Model/ShopViewValidator.php
@@ -160,8 +160,8 @@ class ShopViewValidator
     {
         $blResult = false;
 
-        $blEndsWithShopId = preg_match("/[_]([0-9]+)$/", $sViewName, $aMatchEndsWithShopId);
-        $blContainsShopId = preg_match("/[_]([0-9]+)[_]/", $sViewName, $aMatchContainsShopId);
+        $blEndsWithShopId = \preg_match("/[_]([0-9]+)$/", $sViewName, $aMatchEndsWithShopId);
+        $blContainsShopId = \preg_match("/[_]([0-9]+)[_]/", $sViewName, $aMatchContainsShopId);
 
         if (
             (!$blEndsWithShopId && !$blContainsShopId) ||
@@ -238,7 +238,7 @@ class ShopViewValidator
     {
         $this->_aValidShopViews[] = 'oxv_' . $tableName;
 
-        if (in_array($tableName, $this->getMultiLangTables())) {
+        if (\in_array($tableName, $this->getMultiLangTables())) {
             foreach ($this->getAllShopLanguages() as $sLang) {
                 $this->_aValidShopViews[] = 'oxv_' . $tableName . '_' . $sLang;
             }
@@ -255,7 +255,7 @@ class ShopViewValidator
      */
     protected function _isViewValid($sViewName) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
-        return in_array($sViewName, $this->_getValidShopViews());
+        return \in_array($sViewName, $this->_getValidShopViews());
     }
 
     /**

--- a/source/Application/Model/User.php
+++ b/source/Application/Model/User.php
@@ -186,7 +186,7 @@ class User extends \OxidEsales\Eshop\Core\Model\BaseModel
      */
     protected function _getStateObject() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
-        if (is_null($this->_oStateObject)) {
+        if (\is_null($this->_oStateObject)) {
             $this->_oStateObject = oxNew(\OxidEsales\Eshop\Application\Model\State::class);
         }
 
@@ -476,7 +476,7 @@ class User extends \OxidEsales\Eshop\Core\Model\BaseModel
                     $oAddress = $oAddresses->current();
                 } else {
                     $aAddresses = $oAddresses->getArray();
-                    $oAddress = array_pop($aAddresses);
+                    $oAddress = \array_pop($aAddresses);
                 }
                 $oAddress->selected = 1;
                 $oAddress->setSelected();
@@ -529,7 +529,7 @@ class User extends \OxidEsales\Eshop\Core\Model\BaseModel
         ) {
             $blAddRemark = true;
             //save oxregister value
-            $this->oxuser__oxregister = new \OxidEsales\Eshop\Core\Field(date('Y-m-d H:i:s'), \OxidEsales\Eshop\Core\Field::T_RAW);
+            $this->oxuser__oxregister = new \OxidEsales\Eshop\Core\Field(\date('Y-m-d H:i:s'), \OxidEsales\Eshop\Core\Field::T_RAW);
         }
 
         // setting user rights
@@ -539,7 +539,7 @@ class User extends \OxidEsales\Eshop\Core\Model\BaseModel
         );
 
         // processing birth date which came from output as array
-        if ($this->oxuser__oxbirthdate && is_array($this->oxuser__oxbirthdate->value)) {
+        if ($this->oxuser__oxbirthdate && \is_array($this->oxuser__oxbirthdate->value)) {
             $this->oxuser__oxbirthdate = new \OxidEsales\Eshop\Core\Field(
                 $this->convertBirthday($this->oxuser__oxbirthdate->value),
                 \OxidEsales\Eshop\Core\Field::T_RAW
@@ -818,7 +818,7 @@ class User extends \OxidEsales\Eshop\Core\Model\BaseModel
      */
     public function getEncodedDeliveryAddress()
     {
-        return md5($this->_getMergedAddressFields());
+        return \md5($this->_getMergedAddressFields());
     }
 
     /**
@@ -891,7 +891,7 @@ class User extends \OxidEsales\Eshop\Core\Model\BaseModel
                 /** @var UserException $oEx */
                 $oEx = oxNew(UserException::class);
                 $oLang = Registry::getLang();
-                $oEx->setMessage(sprintf($oLang->translateString('ERROR_MESSAGE_USER_USEREXISTS', $oLang->getTplLanguage()), $this->oxuser__oxusername->value));
+                $oEx->setMessage(\sprintf($oLang->translateString('ERROR_MESSAGE_USER_USEREXISTS', $oLang->getTplLanguage()), $this->oxuser__oxusername->value));
                 throw $oEx;
             }
         }
@@ -980,7 +980,7 @@ class User extends \OxidEsales\Eshop\Core\Model\BaseModel
      */
     public function onOrderExecute($oBasket, $iSuccess)
     {
-        if (is_numeric($iSuccess) && $iSuccess != 2 && $iSuccess <= 3) {
+        if (\is_numeric($iSuccess) && $iSuccess != 2 && $iSuccess <= 3) {
             //adding user to particular customer groups
             $myConfig = \OxidEsales\Eshop\Core\Registry::getConfig();
             $dMidlleCustPrice = (float) $myConfig->getConfigParam('sMidlleCustPrice');
@@ -1056,7 +1056,7 @@ class User extends \OxidEsales\Eshop\Core\Model\BaseModel
 
         // year
         if (!$iYear || $iYear < 1000 || $iYear > 9999) {
-            $iYear = date('Y');
+            $iYear = \date('Y');
         }
 
         // month
@@ -1076,7 +1076,7 @@ class User extends \OxidEsales\Eshop\Core\Model\BaseModel
             case 6:
             case 9:
             case 11:
-                $iMaxDays = min(30, $iMaxDays);
+                $iMaxDays = \min(30, $iMaxDays);
                 break;
         }
 
@@ -1086,7 +1086,7 @@ class User extends \OxidEsales\Eshop\Core\Model\BaseModel
         }
 
         // whole date
-        return sprintf("%04d-%02d-%02d", $iYear, $iMonth, $iDay);
+        return \sprintf("%04d-%02d-%02d", $iYear, $iMonth, $iDay);
     }
 
     /**
@@ -1270,7 +1270,7 @@ class User extends \OxidEsales\Eshop\Core\Model\BaseModel
      */
     protected function _assignAddress($aDelAddress) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
-        if (is_array($aDelAddress) && count($aDelAddress)) {
+        if (\is_array($aDelAddress) && \count($aDelAddress)) {
             $sAddressId = \OxidEsales\Eshop\Core\Registry::getConfig()->getRequestParameter('oxaddressid');
             $sAddressId = ($sAddressId === null || $sAddressId == -1 || $sAddressId == -2) ? null : $sAddressId;
 
@@ -1614,7 +1614,7 @@ class User extends \OxidEsales\Eshop\Core\Model\BaseModel
         $sShopID = $oConfig->getShopId();
         if (($sSet = Registry::getUtilsServer()->getUserCookie($sShopID))) {
             $oDb = \OxidEsales\Eshop\Core\DatabaseProvider::getDb();
-            $aData = explode('@@@', $sSet);
+            $aData = \explode('@@@', $sSet);
             $sUser = $aData[0];
             $sPWD = @$aData[1];
 
@@ -1622,7 +1622,7 @@ class User extends \OxidEsales\Eshop\Core\Model\BaseModel
             $rs = $oDb->select($sSelect);
             if ($rs != false && $rs->count() > 0) {
                 while (!$rs->EOF) {
-                    $sTest = crypt($rs->fields[1], static::USER_COOKIE_SALT);
+                    $sTest = \crypt($rs->fields[1], static::USER_COOKIE_SALT);
                     if ($sTest == $sPWD) {
                         // found
                         $sUserID = $rs->fields[0];
@@ -1690,7 +1690,7 @@ class User extends \OxidEsales\Eshop\Core\Model\BaseModel
 
                 // map all user data fields
                 foreach ($aData as $fldname => $value) {
-                    $sField = "oxuser__" . strtolower($fldname);
+                    $sField = "oxuser__" . \strtolower($fldname);
                     $this->$sField = new Field($aData[$fldname]);
                 }
 
@@ -1755,11 +1755,11 @@ class User extends \OxidEsales\Eshop\Core\Model\BaseModel
         $aRights[] = 'user';
 
         if (!$sAuthRights || !($sAuthRights == 'malladmin' || $sAuthRights == $myConfig->getShopId())) {
-            return current($aRights);
+            return \current($aRights);
         } elseif ($sAuthRights == $myConfig->getShopId()) {
             $aRights[] = $sAuthRights;
-            if (!in_array($this->oxuser__oxrights->value, $aRights)) {
-                return current($aRights);
+            if (!\in_array($this->oxuser__oxrights->value, $aRights)) {
+                return \current($aRights);
             }
         }
 
@@ -1777,7 +1777,7 @@ class User extends \OxidEsales\Eshop\Core\Model\BaseModel
     {
 
         // set oxcreate date
-        $this->oxuser__oxcreate = new \OxidEsales\Eshop\Core\Field(date('Y-m-d H:i:s'), \OxidEsales\Eshop\Core\Field::T_RAW);
+        $this->oxuser__oxcreate = new \OxidEsales\Eshop\Core\Field(\date('Y-m-d H:i:s'), \OxidEsales\Eshop\Core\Field::T_RAW);
 
         if (!isset($this->oxuser__oxboni->value)) {
             $this->oxuser__oxboni = new \OxidEsales\Eshop\Core\Field($this->getBoni(), \OxidEsales\Eshop\Core\Field::T_RAW);
@@ -1951,8 +1951,8 @@ class User extends \OxidEsales\Eshop\Core\Model\BaseModel
 
         $aHomeCountry = \OxidEsales\Eshop\Core\Registry::getConfig()->getConfigParam('aHomeCountry');
         // foreigner ?
-        if (is_array($aHomeCountry)) {
-            if (in_array($sCountryId, $aHomeCountry)) {
+        if (\is_array($aHomeCountry)) {
+            if (\in_array($sCountryId, $aHomeCountry)) {
                 $blForeigner = false;
             }
         } elseif ($sCountryId == $aHomeCountry) {
@@ -1995,7 +1995,7 @@ class User extends \OxidEsales\Eshop\Core\Model\BaseModel
         $sQ = "select oxid from " . $this->getViewName() . "
             where oxupdateexp >= :time
                 and MD5( CONCAT( oxid, oxshopid, oxupdatekey ) ) = :hash";
-        if ($sUserId = $oDb->getOne($sQ, [':time' => time(), ':hash' => $sUid])) {
+        if ($sUserId = $oDb->getOne($sQ, [':time' => \time(), ':hash' => $sUid])) {
             return $this->load($sUserId);
         }
     }
@@ -2045,7 +2045,7 @@ class User extends \OxidEsales\Eshop\Core\Model\BaseModel
             where oxupdateexp >= :time
             and MD5( CONCAT( oxid, oxshopid, oxupdatekey ) ) = :hash";
 
-        return !((bool) $oDb->getOne($sQ, [':time' => time(), ':hash' => $sKey]));
+        return !((bool) $oDb->getOne($sQ, [':time' => \time(), ':hash' => $sKey]));
     }
 
     /**
@@ -2057,7 +2057,7 @@ class User extends \OxidEsales\Eshop\Core\Model\BaseModel
     {
         if ($this->_sUpdateKey === null) {
             $this->setUpdateKey();
-            $this->_sUpdateKey = md5($this->getId() . $this->oxuser__oxshopid->value . $this->oxuser__oxupdatekey->value);
+            $this->_sUpdateKey = \md5($this->getId() . $this->oxuser__oxshopid->value . $this->oxuser__oxupdatekey->value);
         }
 
         return $this->_sUpdateKey;
@@ -2121,7 +2121,7 @@ class User extends \OxidEsales\Eshop\Core\Model\BaseModel
      */
     public function isSamePassword($password)
     {
-        return  password_verify($password, $this->oxuser__oxpassword->value);
+        return  \password_verify($password, $this->oxuser__oxpassword->value);
     }
 
     /**
@@ -2192,7 +2192,7 @@ class User extends \OxidEsales\Eshop\Core\Model\BaseModel
     {
         $oState = $this->_getStateObject();
 
-        if (is_null($sId)) {
+        if (\is_null($sId)) {
             $sId = $this->getStateId();
         }
 
@@ -2307,9 +2307,9 @@ class User extends \OxidEsales\Eshop\Core\Model\BaseModel
         $oDb = \OxidEsales\Eshop\Core\DatabaseProvider::getDb();
         $sUserId = $this->getId();
 
-        if ($sUserId && is_array($aRecEmail) && count($aRecEmail) > 0) {
+        if ($sUserId && \is_array($aRecEmail) && \count($aRecEmail) > 0) {
             //iserting statistics about invitation
-            $sDate = Registry::getUtilsDate()->formatDBDate(date("Y-m-d"), true);
+            $sDate = Registry::getUtilsDate()->formatDBDate(\date("Y-m-d"), true);
             foreach ($aRecEmail as $sRecEmail) {
                 $sSql = "INSERT INTO oxinvitations SET oxuserid = :oxuserid, oxemail = :oxemail, oxdate = :oxdate, oxpending = '1', oxaccepted = '0', oxtype = '1'";
                 $oDb->execute($sSql, [
@@ -2588,7 +2588,7 @@ class User extends \OxidEsales\Eshop\Core\Model\BaseModel
         $ids = $database->getCol('SELECT oxid FROM oxaddress WHERE oxuserid = :oxuserid', [
             ':oxuserid' => $this->getId()
         ]);
-        array_walk($ids, [$this, 'deleteItemById'], \OxidEsales\Eshop\Application\Model\Address::class);
+        \array_walk($ids, [$this, 'deleteItemById'], \OxidEsales\Eshop\Application\Model\Address::class);
     }
 
     /**
@@ -2601,7 +2601,7 @@ class User extends \OxidEsales\Eshop\Core\Model\BaseModel
         $ids = $database->getCol('SELECT oxid FROM oxuserbaskets WHERE oxuserid = :oxuserid', [
             ':oxuserid' => $this->getId()
         ]);
-        array_walk($ids, [$this, 'deleteItemById'], \OxidEsales\Eshop\Application\Model\UserBasket::class);
+        \array_walk($ids, [$this, 'deleteItemById'], \OxidEsales\Eshop\Application\Model\UserBasket::class);
     }
 
     /**
@@ -2616,7 +2616,7 @@ class User extends \OxidEsales\Eshop\Core\Model\BaseModel
             ':oxparentid' => $this->getId(),
             ':notoxtype' => 'o'
         ]);
-        array_walk($ids, [$this, 'deleteItemById'], \OxidEsales\Eshop\Application\Model\Remark::class);
+        \array_walk($ids, [$this, 'deleteItemById'], \OxidEsales\Eshop\Application\Model\Remark::class);
     }
 
     /**
@@ -2629,7 +2629,7 @@ class User extends \OxidEsales\Eshop\Core\Model\BaseModel
         $ids = $database->getCol('SELECT oxid FROM oxrecommlists WHERE oxuserid = :oxuserid ', [
             ':oxuserid' => $this->getId()
         ]);
-        array_walk($ids, [$this, 'deleteItemById'], \OxidEsales\Eshop\Application\Model\RecommendationList::class);
+        \array_walk($ids, [$this, 'deleteItemById'], \OxidEsales\Eshop\Application\Model\RecommendationList::class);
     }
 
     /**
@@ -2642,7 +2642,7 @@ class User extends \OxidEsales\Eshop\Core\Model\BaseModel
         $ids = $database->getCol('SELECT oxid FROM oxnewssubscribed WHERE oxuserid = :oxuserid ', [
             ':oxuserid' => $this->getId()
         ]);
-        array_walk($ids, [$this, 'deleteItemById'], \OxidEsales\Eshop\Application\Model\NewsSubscribed::class);
+        \array_walk($ids, [$this, 'deleteItemById'], \OxidEsales\Eshop\Application\Model\NewsSubscribed::class);
     }
 
 
@@ -2656,7 +2656,7 @@ class User extends \OxidEsales\Eshop\Core\Model\BaseModel
         $ids = $database->getCol('select oxid from oxreviews where oxuserid = :oxuserid', [
             ':oxuserid' => $this->getId()
         ]);
-        array_walk($ids, [$this, 'deleteItemById'], \OxidEsales\Eshop\Application\Model\Review::class);
+        \array_walk($ids, [$this, 'deleteItemById'], \OxidEsales\Eshop\Application\Model\Review::class);
     }
 
     /**
@@ -2669,7 +2669,7 @@ class User extends \OxidEsales\Eshop\Core\Model\BaseModel
         $ids = $database->getCol('SELECT oxid FROM oxratings WHERE oxuserid = :oxuserid', [
             ':oxuserid' => $this->getId()
         ]);
-        array_walk($ids, [$this, 'deleteItemById'], \OxidEsales\Eshop\Application\Model\Rating::class);
+        \array_walk($ids, [$this, 'deleteItemById'], \OxidEsales\Eshop\Application\Model\Rating::class);
     }
 
     /**
@@ -2682,7 +2682,7 @@ class User extends \OxidEsales\Eshop\Core\Model\BaseModel
         $ids = $database->getCol('SELECT oxid FROM oxpricealarm WHERE oxuserid = :oxuserid', [
             ':oxuserid' => $this->getId()
         ]);
-        array_walk($ids, [$this, 'deleteItemById'], \OxidEsales\Eshop\Application\Model\PriceAlarm::class);
+        \array_walk($ids, [$this, 'deleteItemById'], \OxidEsales\Eshop\Application\Model\PriceAlarm::class);
     }
 
     /**

--- a/source/Application/Model/UserBasket.php
+++ b/source/Application/Model/UserBasket.php
@@ -122,7 +122,7 @@ class UserBasket extends \OxidEsales\Eshop\Core\Model\BaseModel
     {
         $aRes = [];
         $aItems = $this->getItems();
-        if (is_array($aItems)) {
+        if (\is_array($aItems)) {
             foreach ($aItems as $sId => $oItem) {
                 $oArticle = $oItem->getArticle($sId);
                 $aRes[$this->_getItemKey($oArticle->getId(), $oItem->getSelList(), $oItem->getPersParams())] = $oArticle;
@@ -192,7 +192,7 @@ class UserBasket extends \OxidEsales\Eshop\Core\Model\BaseModel
         $oNewItem = oxNew(\OxidEsales\Eshop\Application\Model\UserBasketItem::class);
         $oNewItem->oxuserbasketitems__oxartid = new \OxidEsales\Eshop\Core\Field($sProductId, \OxidEsales\Eshop\Core\Field::T_RAW);
         $oNewItem->oxuserbasketitems__oxbasketid = new \OxidEsales\Eshop\Core\Field($this->getId(), \OxidEsales\Eshop\Core\Field::T_RAW);
-        if ($aPersParams && count($aPersParams)) {
+        if ($aPersParams && \count($aPersParams)) {
             $oNewItem->setPersParams($aPersParams);
         }
 
@@ -200,8 +200,8 @@ class UserBasket extends \OxidEsales\Eshop\Core\Model\BaseModel
             $oArticle = oxNew(\OxidEsales\Eshop\Application\Model\Article::class);
             $oArticle->load($sProductId);
             $aSelectLists = $oArticle->getSelectLists();
-            if (($iSelCnt = count($aSelectLists))) {
-                $aSelList = array_fill(0, $iSelCnt, '0');
+            if (($iSelCnt = \count($aSelectLists))) {
+                $aSelList = \array_fill(0, $iSelCnt, '0');
             }
         }
 
@@ -253,7 +253,7 @@ class UserBasket extends \OxidEsales\Eshop\Core\Model\BaseModel
     {
         $aSel = ($aSel != null) ? $aSel : [0 => '0'];
 
-        return md5($sProductId . '|' . serialize($aSel) . '|' . serialize($aPersParam));
+        return \md5($sProductId . '|' . \serialize($aSel) . '|' . \serialize($aPersParam));
     }
 
     /**
@@ -265,7 +265,7 @@ class UserBasket extends \OxidEsales\Eshop\Core\Model\BaseModel
      */
     public function getItemCount($blReload = false)
     {
-        return count($this->getItems($blReload));
+        return \count($this->getItems($blReload));
     }
 
     /**

--- a/source/Application/Model/UserBasketItem.php
+++ b/source/Application/Model/UserBasketItem.php
@@ -103,7 +103,7 @@ class UserBasketItem extends \OxidEsales\Eshop\Core\Model\BaseModel
             }
 
             $aSelList = $this->getSelList();
-            if (($aSelectlist = $this->_oArticle->getSelectLists()) && is_array($aSelList)) {
+            if (($aSelectlist = $this->_oArticle->getSelectLists()) && \is_array($aSelList)) {
                 foreach ($aSelList as $iKey => $iSel) {
                     if (isset($aSelectlist[$iKey][$iSel])) {
                         // cloning select list information
@@ -129,7 +129,7 @@ class UserBasketItem extends \OxidEsales\Eshop\Core\Model\BaseModel
     public function __sleep()
     {
         $aRet = [];
-        foreach (get_object_vars($this) as $sKey => $sVar) {
+        foreach (\get_object_vars($this) as $sKey => $sVar) {
             if ($sKey != '_oArticle') {
                 $aRet[] = $sKey;
             }
@@ -146,7 +146,7 @@ class UserBasketItem extends \OxidEsales\Eshop\Core\Model\BaseModel
     public function getSelList()
     {
         if ($this->_aSelList == null && $this->oxuserbasketitems__oxsellist->value) {
-            $this->_aSelList = unserialize($this->oxuserbasketitems__oxsellist->value);
+            $this->_aSelList = \unserialize($this->oxuserbasketitems__oxsellist->value);
         }
 
         return $this->_aSelList;
@@ -159,7 +159,7 @@ class UserBasketItem extends \OxidEsales\Eshop\Core\Model\BaseModel
      */
     public function setSelList($aSelList)
     {
-        $this->oxuserbasketitems__oxsellist = new \OxidEsales\Eshop\Core\Field(serialize($aSelList), \OxidEsales\Eshop\Core\Field::T_RAW);
+        $this->oxuserbasketitems__oxsellist = new \OxidEsales\Eshop\Core\Field(\serialize($aSelList), \OxidEsales\Eshop\Core\Field::T_RAW);
     }
 
     /**
@@ -170,7 +170,7 @@ class UserBasketItem extends \OxidEsales\Eshop\Core\Model\BaseModel
     public function getPersParams()
     {
         if ($this->_aPersParam == null && $this->oxuserbasketitems__oxpersparam->value) {
-            $this->_aPersParam = unserialize($this->oxuserbasketitems__oxpersparam->value);
+            $this->_aPersParam = \unserialize($this->oxuserbasketitems__oxpersparam->value);
         }
 
         return $this->_aPersParam;
@@ -183,7 +183,7 @@ class UserBasketItem extends \OxidEsales\Eshop\Core\Model\BaseModel
      */
     public function setPersParams($sPersParams)
     {
-        $this->oxuserbasketitems__oxpersparam = new \OxidEsales\Eshop\Core\Field(serialize($sPersParams), \OxidEsales\Eshop\Core\Field::T_RAW);
+        $this->oxuserbasketitems__oxpersparam = new \OxidEsales\Eshop\Core\Field(\serialize($sPersParams), \OxidEsales\Eshop\Core\Field::T_RAW);
     }
 
     /**
@@ -199,8 +199,8 @@ class UserBasketItem extends \OxidEsales\Eshop\Core\Model\BaseModel
     protected function _setFieldData($sFieldName, $sValue, $iDataType = \OxidEsales\Eshop\Core\Field::T_TEXT) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         if (
-            'oxsellist' === strtolower($sFieldName) || 'oxuserbasketitems__oxsellist' === strtolower($sFieldName)
-            || 'oxpersparam' === strtolower($sFieldName) || 'oxuserbasketitems__oxpersparam' === strtolower($sFieldName)
+            'oxsellist' === \strtolower($sFieldName) || 'oxuserbasketitems__oxsellist' === \strtolower($sFieldName)
+            || 'oxpersparam' === \strtolower($sFieldName) || 'oxuserbasketitems__oxpersparam' === \strtolower($sFieldName)
         ) {
             $iDataType = \OxidEsales\Eshop\Core\Field::T_RAW;
         }

--- a/source/Application/Model/UserList.php
+++ b/source/Application/Model/UserList.php
@@ -32,7 +32,7 @@ class UserList extends \OxidEsales\Eshop\Core\Model\ListModel
      */
     public function loadWishlistUsers($sSearchStr)
     {
-        $sSearchStr = trim($sSearchStr);
+        $sSearchStr = \trim($sSearchStr);
 
         if (!$sSearchStr) {
             return;

--- a/source/Application/Model/UserPayment.php
+++ b/source/Application/Model/UserPayment.php
@@ -144,7 +144,7 @@ class UserPayment extends \OxidEsales\Eshop\Core\Model\BaseModel
     {
         if (!$this->_aDynValues) {
             $sRawDynValue = null;
-            if (is_object($this->oxuserpayments__oxvalue)) {
+            if (\is_object($this->oxuserpayments__oxvalue)) {
                 $sRawDynValue = $this->oxuserpayments__oxvalue->getRawValue();
             }
 

--- a/source/Application/Model/VariantHandler.php
+++ b/source/Application/Model/VariantHandler.php
@@ -60,9 +60,9 @@ class VariantHandler extends \OxidEsales\Eshop\Core\Base
         $oMdVariants->setParentId($sParentId);
         $oMdVariants->setName("_parent_product_");
         foreach ($oVariants as $sKey => $oVariant) {
-            $aNames = explode(trim($this->_sMdSeparator), $oVariant->oxarticles__oxvarselect->value);
+            $aNames = \explode(\trim($this->_sMdSeparator), $oVariant->oxarticles__oxvarselect->value);
             foreach ($aNames as $sNameKey => $sName) {
-                $aNames[$sNameKey] = trim($sName);
+                $aNames[$sNameKey] = \trim($sName);
             }
             $oMdVariants->addNames(
                 $sKey,
@@ -136,7 +136,7 @@ class VariantHandler extends \OxidEsales\Eshop\Core\Base
         $iCounter = 0;
         $aVarselect = []; //multilanguage names of existing variants
         //iterating through all select list values (eg. $oValue->name = S, M, X, XL)
-        for ($i = 0; $i < count($aValues); $i++) {
+        for ($i = 0; $i < \count($aValues); $i++) {
             $oValue = $aValues[$i][0];
             $dPriceMod = $this->_getValuePrice($oValue, $oArticle->oxarticles__oxprice->value);
             if ($oVariants->count() > 0) {
@@ -224,7 +224,7 @@ class VariantHandler extends \OxidEsales\Eshop\Core\Base
             if ($oValue->priceUnit == 'abs') {
                 $dPriceMod = $oValue->price;
             } elseif ($oValue->priceUnit == '%') {
-                $dPriceModPerc = abs($oValue->price) * $dParentPrice / 100.0;
+                $dPriceModPerc = \abs($oValue->price) * $dParentPrice / 100.0;
                 if (($oValue->price) >= 0.0) {
                     $dPriceMod = $dPriceModPerc;
                 } else {
@@ -289,7 +289,7 @@ class VariantHandler extends \OxidEsales\Eshop\Core\Base
     public function isMdVariant($oArticle)
     {
         if (\OxidEsales\Eshop\Core\Registry::getConfig()->getConfigParam('blUseMultidimensionVariants')) {
-            if (strpos($oArticle->oxarticles__oxvarselect->value, trim($this->_sMdSeparator)) !== false) {
+            if (\strpos($oArticle->oxarticles__oxvarselect->value, \trim($this->_sMdSeparator)) !== false) {
                 return true;
             }
         }
@@ -317,9 +317,9 @@ class VariantHandler extends \OxidEsales\Eshop\Core\Base
             $aNames = $this->_getSelections($oVariant->oxarticles__oxvarselect->getRawValue());
             $blActive = ($sActVariantId === $oVariant->getId()) ? true : false;
             for ($i = 0; $i < $iVarSelCnt; $i++) {
-                $sName = isset($aNames[$i]) ? trim($aNames[$i]) : false;
+                $sName = isset($aNames[$i]) ? \trim($aNames[$i]) : false;
                 if ($sName !== '' && $sName !== false) {
-                    $sHash = md5($sName);
+                    $sHash = \md5($sName);
 
                     // filling up filter
                     if ($blActive) {
@@ -345,7 +345,7 @@ class VariantHandler extends \OxidEsales\Eshop\Core\Base
     protected function _cleanFilter($aFilter) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $aCleanFilter = false;
-        if (is_array($aFilter) && count($aFilter)) {
+        if (\is_array($aFilter) && \count($aFilter)) {
             foreach ($aFilter as $iKey => $sFilter) {
                 if ($sFilter) {
                     $aCleanFilter[$iKey] = $sFilter;
@@ -372,12 +372,12 @@ class VariantHandler extends \OxidEsales\Eshop\Core\Base
         $blPerfectFit = false;
         // applying filters, disabling/activating items
         if (($aFilter = $this->_cleanFilter($aFilter))) {
-            $aFilterKeys = array_keys($aFilter);
-            $iFilterKeysCount = count($aFilter);
+            $aFilterKeys = \array_keys($aFilter);
+            $iFilterKeysCount = \count($aFilter);
             foreach ($aSelections as $sVariantId => &$aLineSelections) {
                 $iActive = 0;
                 foreach ($aFilter as $iKey => $sVal) {
-                    if (strcmp($aLineSelections[$iKey]['hash'], $sVal) === 0) {
+                    if (\strcmp($aLineSelections[$iKey]['hash'], $sVal) === 0) {
                         $aLineSelections[$iKey]['active'] = true;
                         $iActive++;
                     } else {
@@ -389,12 +389,12 @@ class VariantHandler extends \OxidEsales\Eshop\Core\Base
                     }
                 }
                 foreach ($aLineSelections as $iOtherKey => &$aLineOtherVariant) {
-                    if (!in_array($iOtherKey, $aFilterKeys)) {
+                    if (!\in_array($iOtherKey, $aFilterKeys)) {
                         $aLineOtherVariant['disabled'] = !($iFilterKeysCount == $iActive);
                     }
                 }
 
-                $blFitsAll = $iActive && (count($aLineSelections) == $iActive) && ($iFilterKeysCount == $iActive);
+                $blFitsAll = $iActive && (\count($aLineSelections) == $iActive) && ($iFilterKeysCount == $iActive);
                 if (($iActive > $iMaxActiveCount) || (!$blPerfectFit && $blFitsAll)) {
                     $blPerfectFit = $blFitsAll;
                     $sMostSuitableVariantId = $sVariantId;
@@ -446,7 +446,7 @@ class VariantHandler extends \OxidEsales\Eshop\Core\Base
     protected function _getSelections($sTitle) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         if (\OxidEsales\Eshop\Core\Registry::getConfig()->getConfigParam('blUseMultidimensionVariants')) {
-            $aSelections = explode($this->_sMdSeparator, $sTitle);
+            $aSelections = \explode($this->_sMdSeparator, $sTitle);
         } else {
             $aSelections = [$sTitle];
         }
@@ -471,9 +471,9 @@ class VariantHandler extends \OxidEsales\Eshop\Core\Base
         $aVarSelects = $this->_getSelections($sVarName);
 
         if ($iLimit) {
-            $aVarSelects = array_slice($aVarSelects, 0, $iLimit);
+            $aVarSelects = \array_slice($aVarSelects, 0, $iLimit);
         }
-        if (($iVarSelCnt = count($aVarSelects))) {
+        if (($iVarSelCnt = \count($aVarSelects))) {
             // filling selections
             $aRawVariantSelections = $this->_fillVariantSelections($oVariantList, $iVarSelCnt, $aFilter, $sActVariantId);
 

--- a/source/Application/Model/VariantSelectList.php
+++ b/source/Application/Model/VariantSelectList.php
@@ -50,7 +50,7 @@ class VariantSelectList implements \OxidEsales\Eshop\Core\Contract\ISelectList
      */
     public function __construct($sLabel, $iIndex)
     {
-        $this->_sLabel = trim($sLabel);
+        $this->_sLabel = \trim($sLabel);
         $this->_iIndex = $iIndex;
     }
 
@@ -74,7 +74,7 @@ class VariantSelectList implements \OxidEsales\Eshop\Core\Contract\ISelectList
      */
     public function addVariant($sName, $sValue, $blDisabled, $blActive)
     {
-        $sName = trim($sName);
+        $sName = \trim($sName);
         //#6053 Allow "0" as a valid value.
         if (!empty($sName) || $sName === '0') {
             $sKey = $sValue;

--- a/source/Application/Model/VatSelector.php
+++ b/source/Application/Model/VatSelector.php
@@ -44,7 +44,7 @@ class VatSelector extends \OxidEsales\Eshop\Core\Base
 
         if (!$blCacheReset) {
             if (
-                array_key_exists($cacheId, self::$_aUserVatCache) &&
+                \array_key_exists($cacheId, self::$_aUserVatCache) &&
                 self::$_aUserVatCache[$cacheId] !== null
             ) {
                 return self::$_aUserVatCache[$cacheId];

--- a/source/Application/Model/VendorList.php
+++ b/source/Application/Model/VendorList.php
@@ -93,7 +93,7 @@ class VendorList extends \OxidEsales\Eshop\Core\Model\ListModel
      */
     public function buildVendorTree($sLinkTarget, $sActCat, $sShopHomeUrl)
     {
-        $sActCat = str_replace('v_', '', $sActCat);
+        $sActCat = \str_replace('v_', '', $sActCat);
 
         //Load vendor list
         $this->loadVendorList();

--- a/source/Application/Model/Voucher.php
+++ b/source/Application/Model/Voucher.php
@@ -63,7 +63,7 @@ class Voucher extends \OxidEsales\Eshop\Core\Model\BaseModel
                         {$sSeriesViewName}.oxid = {$sViewName}.oxvoucherserieid and
                         {$sViewName}.oxvouchernr = " . $oDb->quote($sVoucherNr) . " and ";
 
-            if (is_array($aVouchers)) {
+            if (\is_array($aVouchers)) {
                 foreach ($aVouchers as $sVoucherId => $sSkipVoucherNr) {
                     $sQ .= "{$sViewName}.oxid != " . $oDb->quote($sVoucherId) . " and ";
                 }
@@ -73,7 +73,7 @@ class Voucher extends \OxidEsales\Eshop\Core\Model\BaseModel
 
             //voucher timeout for 3 hours
             if ($blCheckavalability) {
-                $iTime = time() - $this->_getVoucherTimeout();
+                $iTime = \time() - $this->_getVoucherTimeout();
                 $sQ .= " and {$sViewName}.oxreserved < '{$iTime}' ";
             }
 
@@ -104,7 +104,7 @@ class Voucher extends \OxidEsales\Eshop\Core\Model\BaseModel
             $this->oxvouchers__oxorderid->setValue($sOrderId);
             $this->oxvouchers__oxuserid->setValue($sUserId);
             $this->oxvouchers__oxdiscount->setValue($dDiscount);
-            $this->oxvouchers__oxdateused->setValue(date("Y-m-d", \OxidEsales\Eshop\Core\Registry::getUtilsDate()->getTime()));
+            $this->oxvouchers__oxdateused->setValue(\date("Y-m-d", \OxidEsales\Eshop\Core\Registry::getUtilsDate()->getTime()));
             $this->save();
         }
     }
@@ -121,7 +121,7 @@ class Voucher extends \OxidEsales\Eshop\Core\Model\BaseModel
             $oDb = \OxidEsales\Eshop\Core\DatabaseProvider::getMaster();
             $sQ = "update oxvouchers set oxreserved = :oxreserved where oxid = :oxid";
             $oDb->execute($sQ, [
-                ':oxreserved' => time(),
+                ':oxreserved' => \time(),
                 ':oxid' => $sVoucherID
             ]);
         }
@@ -245,7 +245,7 @@ class Voucher extends \OxidEsales\Eshop\Core\Model\BaseModel
      */
     protected function _isAvailableWithSameSeries($aVouchers) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
-        if (is_array($aVouchers)) {
+        if (\is_array($aVouchers)) {
             $sId = $this->getId();
             if (isset($aVouchers[$sId])) {
                 unset($aVouchers[$sId]);
@@ -281,9 +281,9 @@ class Voucher extends \OxidEsales\Eshop\Core\Model\BaseModel
      */
     protected function _isAvailableWithOtherSeries($aVouchers) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
-        if (is_array($aVouchers) && count($aVouchers)) {
+        if (\is_array($aVouchers) && \count($aVouchers)) {
             $oSeries = $this->getSerie();
-            $sIds = implode(',', \OxidEsales\Eshop\Core\DatabaseProvider::getDb()->quoteArray(array_keys($aVouchers)));
+            $sIds = \implode(',', \OxidEsales\Eshop\Core\DatabaseProvider::getDb()->quoteArray(\array_keys($aVouchers)));
             $blAvailable = true;
             $oDb = \OxidEsales\Eshop\Core\DatabaseProvider::getDb();
             if (!$oSeries->oxvoucherseries__oxallowotherseries->value) {
@@ -324,19 +324,19 @@ class Voucher extends \OxidEsales\Eshop\Core\Model\BaseModel
     protected function _isValidDate() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $oSeries = $this->getSerie();
-        $iTime = time();
+        $iTime = \time();
 
         // If date is not set will add day before and day after to check if voucher valid today.
-        $iTomorrow = mktime(0, 0, 0, date("m"), date("d") + 1, date("Y"));
-        $iYesterday = mktime(0, 0, 0, date("m"), date("d") - 1, date("Y"));
+        $iTomorrow = \mktime(0, 0, 0, \date("m"), \date("d") + 1, \date("Y"));
+        $iYesterday = \mktime(0, 0, 0, \date("m"), \date("d") - 1, \date("Y"));
 
         // Checks if beginning date is set, if not set $iFrom to yesterday so it will be valid.
         $iFrom = ((int) $oSeries->oxvoucherseries__oxbegindate->value) ?
-            strtotime($oSeries->oxvoucherseries__oxbegindate->value) : $iYesterday;
+            \strtotime($oSeries->oxvoucherseries__oxbegindate->value) : $iYesterday;
 
         // Checks if end date is set, if no set $iTo to tomorrow so it will be valid.
         $iTo = ((int) $oSeries->oxvoucherseries__oxenddate->value) ?
-            strtotime($oSeries->oxvoucherseries__oxenddate->value) : $iTomorrow;
+            \strtotime($oSeries->oxvoucherseries__oxenddate->value) : $iTomorrow;
 
         if ($iFrom < $iTime && $iTo > $iTime) {
             return true;
@@ -361,7 +361,7 @@ class Voucher extends \OxidEsales\Eshop\Core\Model\BaseModel
      */
     protected function _isNotReserved() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
-        if ($this->oxvouchers__oxreserved->value < time() - $this->_getVoucherTimeout()) {
+        if ($this->oxvouchers__oxreserved->value < \time() - $this->_getVoucherTimeout()) {
             return true;
         }
 
@@ -599,7 +599,7 @@ class Voucher extends \OxidEsales\Eshop\Core\Model\BaseModel
      */
     protected function _getOrderBasketItems($oDiscount = null) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
-        if (is_null($oDiscount)) {
+        if (\is_null($oDiscount)) {
             $oDiscount = $this->_getSerieDiscount();
         }
 
@@ -634,7 +634,7 @@ class Voucher extends \OxidEsales\Eshop\Core\Model\BaseModel
      */
     protected function _getSessionBasketItems($oDiscount = null) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
-        if (is_null($oDiscount)) {
+        if (\is_null($oDiscount)) {
             $oDiscount = $this->_getSerieDiscount();
         }
 
@@ -759,7 +759,7 @@ class Voucher extends \OxidEsales\Eshop\Core\Model\BaseModel
         $aBasketItems = $this->_getBasketItems($oDiscount);
 
         // Basket Item Count and isAdmin check (unble to access property $oOrder->_getOrderBasket()->_blSkipVouchersAvailabilityChecking)
-        if (!count($aBasketItems) && !$this->isAdmin()) {
+        if (!\count($aBasketItems) && !$this->isAdmin()) {
             $oEx = oxNew(\OxidEsales\Eshop\Core\Exception\VoucherException::class);
             $oEx->setMessage('ERROR_MESSAGE_VOUCHER_NOVOUCHER');
             $oEx->setVoucherNr($this->oxvouchers__oxvouchernr->value);
@@ -841,7 +841,7 @@ class Voucher extends \OxidEsales\Eshop\Core\Model\BaseModel
         $aBasketItems = $this->_getBasketItems($oDiscount);
 
         // Basket Item Count and isAdmin check (unable to access property $oOrder->_getOrderBasket()->_blSkipVouchersAvailabilityChecking)
-        if (!count($aBasketItems) && !$this->isAdmin()) {
+        if (!\count($aBasketItems) && !$this->isAdmin()) {
             $oEx = oxNew(\OxidEsales\Eshop\Core\Exception\VoucherException::class);
             $oEx->setMessage('ERROR_MESSAGE_VOUCHER_NOVOUCHER');
             $oEx->setVoucherNr($this->oxvouchers__oxvouchernr->value);

--- a/source/Application/Model/VoucherSerie.php
+++ b/source/Application/Model/VoucherSerie.php
@@ -179,7 +179,7 @@ class VoucherSerie extends \OxidEsales\Eshop\Core\Model\BaseModel
 
         //If nothing pass, use current server time
         if ($sNow == null) {
-            $sNow = date('Y-m-d H:i:s', $oUtilsDate->getTime());
+            $sNow = \date('Y-m-d H:i:s', $oUtilsDate->getTime());
         }
 
         //Check for active status.

--- a/source/Core/Autoload/BackwardsCompatibilityAutoload.php
+++ b/source/Core/Autoload/BackwardsCompatibilityAutoload.php
@@ -29,7 +29,7 @@ class BackwardsCompatibilityAutoload
          * Classes from unified namespace canot be loaded by this auto loader.
          * Do not try to load them in order to avoid strange errors in edge cases.
          */
-        if (false !== strpos($class, 'OxidEsales\Eshop\\')) {
+        if (false !== \strpos($class, 'OxidEsales\Eshop\\')) {
             return false;
         }
 
@@ -49,7 +49,7 @@ class BackwardsCompatibilityAutoload
     private static function getUnifiedNamespaceClassForBcAlias($bcAlias)
     {
         $classMap = static::getBackwardsCompatibilityClassMap();
-        $bcAlias = strtolower($bcAlias);
+        $bcAlias = \strtolower($bcAlias);
         $result = isset($classMap[$bcAlias]) ? $classMap[$bcAlias] : "";
 
         return $result;
@@ -63,7 +63,7 @@ class BackwardsCompatibilityAutoload
      */
     private static function forceBackwardsCompatiblityClassLoading($class)
     {
-        class_exists($class);
+        \class_exists($class);
     }
 
     /**

--- a/source/Core/Autoload/ModuleAutoload.php
+++ b/source/Core/Autoload/ModuleAutoload.php
@@ -66,19 +66,19 @@ class ModuleAutoload
          * Classes from unified namespace canot be loaded by this auto loader.
          * Do not try to load them in order to avoid strange errors in edge cases.
          */
-        if (false !== strpos($class, 'OxidEsales\Eshop\\')) {
+        if (false !== \strpos($class, 'OxidEsales\Eshop\\')) {
             return false;
         }
         $instance = static::getInstance();
 
-        $class = strtolower(basename($class));
+        $class = \strtolower(\basename($class));
 
         if ($classPath = $instance->getFilePath($class)) {
             include $classPath;
         } else {
-            $class = preg_replace('/_parent$/i', '', $class);
+            $class = \preg_replace('/_parent$/i', '', $class);
 
-            if (!in_array($class, $instance->triedClasses)) {
+            if (!\in_array($class, $instance->triedClasses)) {
                 $instance->triedClasses[] = $class;
                 $instance->createExtensionClassChain($class);
             }
@@ -111,12 +111,12 @@ class ModuleAutoload
         $filePath = '';
 
         $moduleFiles = Registry::getUtilsObject()->getModuleVar('aModuleFiles');
-        if (is_array($moduleFiles)) {
+        if (\is_array($moduleFiles)) {
             $basePath = getShopBasePath();
             foreach ($moduleFiles as $moduleId => $classPaths) {
-                if (array_key_exists($class, $classPaths)) {
+                if (\array_key_exists($class, $classPaths)) {
                     $moduleFilePath = $basePath . 'modules/' . $classPaths[$class];
-                    if (file_exists($moduleFilePath)) {
+                    if (\file_exists($moduleFilePath)) {
                         $filePath = $moduleFilePath;
                     }
                 }
@@ -137,11 +137,11 @@ class ModuleAutoload
         $utilsObject = Registry::getUtilsObject();
 
         $extensions = $utilsObject->getModuleVar('aModules');
-        if (is_array($extensions)) {
-            $class = preg_quote($class, '/');
+        if (\is_array($extensions)) {
+            $class = \preg_quote($class, '/');
 
             foreach ($extensions as $parentClass => $extensionPath) {
-                if (preg_match('/\b' . $class . '($|\&)/i', $extensionPath)) {
+                if (\preg_match('/\b' . $class . '($|\&)/i', $extensionPath)) {
                     $utilsObject->getClassName($parentClass);
                     break;
                 }

--- a/source/Core/BackwardsCompatibleClassNameProvider.php
+++ b/source/Core/BackwardsCompatibleClassNameProvider.php
@@ -37,7 +37,7 @@ class BackwardsCompatibleClassNameProvider
     public function getClassName($classAlias)
     {
         $className = $classAlias;
-        if (array_key_exists($classAlias, $this->classMap)) {
+        if (\array_key_exists($classAlias, $this->classMap)) {
             $className = $this->classMap[$classAlias];
         }
 
@@ -56,8 +56,8 @@ class BackwardsCompatibleClassNameProvider
         /*
          * Sanitize input: class names in namespaces should not, but may include a leading backslash
          */
-        $className = ltrim($className, '\\');
-        $classAlias = array_search($className, $this->classMap);
+        $className = \ltrim($className, '\\');
+        $classAlias = \array_search($className, $this->classMap);
 
         if ($classAlias === false) {
             $classAlias = null;

--- a/source/Core/Base.php
+++ b/source/Core/Base.php
@@ -45,16 +45,16 @@ class Base
      */
     public function __call($method, $arguments)
     {
-        if (defined('OXID_PHP_UNIT')) {
-            if (substr($method, 0, 4) === 'UNIT') {
-                $method = str_replace('UNIT', '_', $method);
+        if (\defined('OXID_PHP_UNIT')) {
+            if (\substr($method, 0, 4) === 'UNIT') {
+                $method = \str_replace('UNIT', '_', $method);
             }
-            if (method_exists($this, $method)) {
-                return call_user_func_array([& $this, $method], $arguments);
+            if (\method_exists($this, $method)) {
+                return \call_user_func_array([& $this, $method], $arguments);
             }
         }
 
-        throw new \OxidEsales\Eshop\Core\Exception\SystemComponentException("Function '$method' does not exist or is not accessible! (" . get_class($this) . ")" . PHP_EOL);
+        throw new \OxidEsales\Eshop\Core\Exception\SystemComponentException("Function '$method' does not exist or is not accessible! (" . \get_class($this) . ")" . PHP_EOL);
     }
 
     /**

--- a/source/Core/CompanyVatInCountryChecker.php
+++ b/source/Core/CompanyVatInCountryChecker.php
@@ -55,7 +55,7 @@ class CompanyVatInCountryChecker extends \OxidEsales\Eshop\Core\CompanyVatInChec
     {
         $result = false;
         $country = $this->getCountry();
-        if (!is_null($country)) {
+        if (!\is_null($country)) {
             $result = ($country->getVATIdentificationNumberPrefix() === $vatIn->getCountryCode());
             if (!$result) {
                 $this->setError(self::ERROR_ID_NOT_VALID);

--- a/source/Core/Config.php
+++ b/source/Core/Config.php
@@ -19,7 +19,7 @@ use OxidEsales\EshopCommunity\Internal\Framework\Module\Setting\Event\SettingCha
 use OxidEsales\EshopCommunity\Internal\Framework\Theme\Event\ThemeSettingChangedEvent;
 
 //max integer
-define('MAX_64BIT_INTEGER', '18446744073709551615');
+\define('MAX_64BIT_INTEGER', '18446744073709551615');
 
 /**
  * Main shop configuration class.
@@ -403,7 +403,7 @@ class Config extends \OxidEsales\Eshop\Core\Base
         // Admin handling
         $this->setConfigParam('blAdmin', isAdmin());
 
-        if (defined('OX_ADMIN_DIR')) {
+        if (\defined('OX_ADMIN_DIR')) {
             $this->setConfigParam('sAdminDir', OX_ADMIN_DIR);
         }
 
@@ -492,36 +492,36 @@ class Config extends \OxidEsales\Eshop\Core\Base
     {
         $this->setConfigParam('sTheme', 'azure');
 
-        if (is_null($this->getConfigParam('sDefaultLang'))) {
+        if (\is_null($this->getConfigParam('sDefaultLang'))) {
             $this->setConfigParam('sDefaultLang', 0);
         }
 
-        if (is_null($this->getConfigParam('blLogChangesInAdmin'))) {
+        if (\is_null($this->getConfigParam('blLogChangesInAdmin'))) {
             $this->setConfigParam('blLogChangesInAdmin', false);
         }
 
-        if (is_null($this->getConfigParam('blCheckTemplates'))) {
+        if (\is_null($this->getConfigParam('blCheckTemplates'))) {
             $this->setConfigParam('blCheckTemplates', false);
         }
 
-        if (is_null($this->getConfigParam('blAllowArticlesubclass'))) {
+        if (\is_null($this->getConfigParam('blAllowArticlesubclass'))) {
             $this->setConfigParam('blAllowArticlesubclass', false);
         }
 
-        if (is_null($this->getConfigParam('iAdminListSize'))) {
+        if (\is_null($this->getConfigParam('iAdminListSize'))) {
             $this->setConfigParam('iAdminListSize', 9);
         }
 
         // #1173M  for EE - not all pic are deleted
-        if (is_null($this->getConfigParam('iPicCount'))) {
+        if (\is_null($this->getConfigParam('iPicCount'))) {
             $this->setConfigParam('iPicCount', 12);
         }
 
-        if (is_null($this->getConfigParam('iZoomPicCount'))) {
+        if (\is_null($this->getConfigParam('iZoomPicCount'))) {
             $this->setConfigParam('iZoomPicCount', 4);
         }
 
-        if (is_null($this->getConfigParam('iDebug'))) {
+        if (\is_null($this->getConfigParam('iDebug'))) {
             $this->setConfigParam('iDebug', $this->isProductiveMode() ? 0 : -1);
         }
 
@@ -535,7 +535,7 @@ class Config extends \OxidEsales\Eshop\Core\Base
     protected function _loadCustomConfig() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $custConfig = getShopBasePath() . '/cust_config.inc.php';
-        if (is_readable($custConfig)) {
+        if (\is_readable($custConfig)) {
             include $custConfig;
         }
     }
@@ -581,7 +581,7 @@ class Config extends \OxidEsales\Eshop\Core\Base
             }
         }
 
-        return (bool) count($result);
+        return (bool) \count($result);
     }
 
     /**
@@ -595,11 +595,11 @@ class Config extends \OxidEsales\Eshop\Core\Base
     protected function _getConfigParamsSelectSnippet($vars) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $select = '';
-        if (is_array($vars) && !empty($vars)) {
+        if (\is_array($vars) && !empty($vars)) {
             foreach ($vars as &$field) {
                 $field = '"' . $field . '"';
             }
-            $select = ' and oxvarname in ( ' . implode(', ', $vars) . ' ) ';
+            $select = ' and oxvarname in ( ' . \implode(', ', $vars) . ' ) ';
         }
 
         return $select;
@@ -628,7 +628,7 @@ class Config extends \OxidEsales\Eshop\Core\Base
         switch ($varType) {
             case 'arr':
             case 'aarr':
-                $this->setConfigParam($varName, unserialize($varVal));
+                $this->setConfigParam($varName, \unserialize($varVal));
                 break;
             case 'bool':
                 $this->setConfigParam($varName, ($varVal == 'true' || $varVal == '1'));
@@ -798,7 +798,7 @@ class Config extends \OxidEsales\Eshop\Core\Base
      */
     public function getShopId()
     {
-        if (is_null($this->_iShopId)) {
+        if (\is_null($this->_iShopId)) {
             $shopId = $this->calculateActiveShopId();
             $this->setShopId($shopId);
 
@@ -837,15 +837,15 @@ class Config extends \OxidEsales\Eshop\Core\Base
             $this->setIsSsl($this->getConfigParam('sSSLShopURL') || $this->getConfigParam('sMallSSLShopURL'));
             if ($this->isAdmin() && !$this->_blIsSsl) {
                 //#4026
-                $this->setIsSsl(!is_null($this->getConfigParam('sAdminSSLURL')));
+                $this->setIsSsl(!\is_null($this->getConfigParam('sAdminSSLURL')));
             }
         }
 
         //additional special handling for profihost customers
         if (
             isset($serverVars['HTTP_X_FORWARDED_SERVER']) &&
-            (strpos($serverVars['HTTP_X_FORWARDED_SERVER'], 'ssl') !== false ||
-             strpos($serverVars['HTTP_X_FORWARDED_SERVER'], 'secure-online-shopping.de') !== false)
+            (\strpos($serverVars['HTTP_X_FORWARDED_SERVER'], 'ssl') !== false ||
+             \strpos($serverVars['HTTP_X_FORWARDED_SERVER'], 'secure-online-shopping.de') !== false)
         ) {
             $this->setIsSsl(true);
         }
@@ -859,7 +859,7 @@ class Config extends \OxidEsales\Eshop\Core\Base
      */
     public function isSsl()
     {
-        if (is_null($this->_blIsSsl)) {
+        if (\is_null($this->_blIsSsl)) {
             $this->_checkSsl();
         }
 
@@ -901,11 +901,11 @@ class Config extends \OxidEsales\Eshop\Core\Base
     public function isCurrentProtocol($url)
     {
         // Missing protocol, cannot proceed, assuming true.
-        if (!$url || (strpos($url, "http") !== 0)) {
+        if (!$url || (\strpos($url, "http") !== 0)) {
             return true;
         }
 
-        return (strpos($url, "https:") === 0) == $this->isSsl();
+        return (\strpos($url, "https:") === 0) == $this->isSsl();
     }
 
     /**
@@ -1101,7 +1101,7 @@ class Config extends \OxidEsales\Eshop\Core\Base
             $cur = $this->getShopCurrency();
             $currencies = $this->getCurrencyArray();
             if (!isset($currencies[$cur])) {
-                $this->_oActCurrencyObject = reset($currencies); // reset() returns the first element
+                $this->_oActCurrencyObject = \reset($currencies); // reset() returns the first element
             } else {
                 $this->_oActCurrencyObject = $currencies[$cur];
             }
@@ -1170,7 +1170,7 @@ class Config extends \OxidEsales\Eshop\Core\Base
     {
         $path = $absolute ? $this->getConfigParam('sShopDir') : '';
         $path .= 'Application/translations/';
-        if (is_readable($path . $dir . '/' . $file)) {
+        if (\is_readable($path . $dir . '/' . $file)) {
             return $path . $dir . '/' . $file;
         }
 
@@ -1204,8 +1204,8 @@ class Config extends \OxidEsales\Eshop\Core\Base
      */
     public function getOutUrl($ssl = null, $admin = null, $nativeImg = false)
     {
-        $ssl = is_null($ssl) ? $this->isSsl() : $ssl;
-        $admin = is_null($admin) ? $this->isAdmin() : $admin;
+        $ssl = \is_null($ssl) ? $this->isSsl() : $ssl;
+        $admin = \is_null($admin) ? $this->isAdmin() : $admin;
 
         if ($ssl) {
             if ($nativeImg && !$admin) {
@@ -1239,7 +1239,7 @@ class Config extends \OxidEsales\Eshop\Core\Base
      */
     public function getDir($file, $dir, $admin, $lang = null, $shop = null, $theme = null, $absolute = true, $ignoreCust = false)
     {
-        if (is_null($theme)) {
+        if (\is_null($theme)) {
             $theme = $this->getConfigParam('sTheme');
         }
 
@@ -1260,14 +1260,14 @@ class Config extends \OxidEsales\Eshop\Core\Base
         if ($lang !== false) {
             $language = Registry::getLang();
 
-            if (is_null($lang)) {
+            if (\is_null($lang)) {
                 $lang = $language->getEditLanguage();
             }
 
             $langAbbr = $language->getLanguageAbbr($lang);
         }
 
-        if (is_null($shop)) {
+        if (\is_null($shop)) {
             $shop = $this->getShopId();
         }
 
@@ -1288,7 +1288,7 @@ class Config extends \OxidEsales\Eshop\Core\Base
         }
 
         //test lang level ..
-        if (!$return && !$admin && is_readable($absBase . $path)) {
+        if (!$return && !$admin && \is_readable($absBase . $path)) {
             $return = $base . $path;
         }
 
@@ -1299,25 +1299,25 @@ class Config extends \OxidEsales\Eshop\Core\Base
 
         //test theme language level ..
         $path = "$theme/$langAbbr/$dir/$file";
-        if (!$return && $lang !== false && is_readable($absBase . $path)) {
+        if (!$return && $lang !== false && \is_readable($absBase . $path)) {
             $return = $base . $path;
         }
 
         //test theme level ..
         $path = "$theme/$dir/$file";
-        if (!$return && is_readable($absBase . $path)) {
+        if (!$return && \is_readable($absBase . $path)) {
             $return = $base . $path;
         }
 
         //test out language level ..
         $path = "$langAbbr/$dir/$file";
-        if (!$return && $lang !== false && is_readable($absBase . $path)) {
+        if (!$return && $lang !== false && \is_readable($absBase . $path)) {
             $return = $base . $path;
         }
 
         //test out level ..
         $path = "$dir/$file";
-        if (!$return && is_readable($absBase . $path)) {
+        if (!$return && \is_readable($absBase . $path)) {
             $return = $base . $path;
         }
 
@@ -1348,7 +1348,7 @@ class Config extends \OxidEsales\Eshop\Core\Base
         $return = false;
 
         $path = "$theme/$shop/$dir/$file";
-        if (is_readable($absBase . $path)) {
+        if (\is_readable($absBase . $path)) {
             $return = $base . $path;
         }
 
@@ -1371,7 +1371,7 @@ class Config extends \OxidEsales\Eshop\Core\Base
      */
     public function getUrl($file, $dir, $admin = null, $ssl = null, $nativeImg = false, $lang = null, $shop = null, $theme = null)
     {
-        return str_replace(
+        return \str_replace(
             $this->getOutDir(),
             $this->getOutUrl($ssl, $admin, $nativeImg),
             $this->getDir($file, $dir, $admin, $lang, $shop, $theme)
@@ -1403,7 +1403,7 @@ class Config extends \OxidEsales\Eshop\Core\Base
      */
     public function getImageUrl($admin = false, $ssl = null, $nativeImg = null, $file = null)
     {
-        $nativeImg = is_null($nativeImg) ? $this->getConfigParam('blNativeImages') : $nativeImg;
+        $nativeImg = \is_null($nativeImg) ? $this->getConfigParam('blNativeImages') : $nativeImg;
 
         return $this->getUrl($file, $this->_sImageDir, $admin, $ssl, $nativeImg);
     }
@@ -1574,7 +1574,7 @@ class Config extends \OxidEsales\Eshop\Core\Base
     public function getTemplateBase($admin = false)
     {
         // Base template dir is the parent dir of template dir
-        return str_replace($this->_sTemplateDir . '/', '', $this->getDir(null, $this->_sTemplateDir, $admin, null, null, null, false));
+        return \str_replace($this->_sTemplateDir . '/', '', $this->getDir(null, $this->_sTemplateDir, $admin, null, null, null, false));
     }
 
     /**
@@ -1645,28 +1645,28 @@ class Config extends \OxidEsales\Eshop\Core\Base
     public function getCurrencyArray($currency = null)
     {
         $confCurrencies = $this->getConfigParam('aCurrencies');
-        if (!is_array($confCurrencies)) {
+        if (!\is_array($confCurrencies)) {
             return [];
         }
 
         // processing currency configuration data
         $currencies = [];
-        reset($confCurrencies);
+        \reset($confCurrencies);
         foreach ($confCurrencies as $key => $val) {
             if ($val) {
                 $cur = new stdClass();
                 $cur->id = $key;
-                $curValues = explode('@', $val);
-                $cur->name = trim($curValues[0]);
-                $cur->rate = trim($curValues[1]);
-                $cur->dec = trim($curValues[2]);
-                $cur->thousand = trim($curValues[3]);
-                $cur->sign = trim($curValues[4]);
-                $cur->decimal = trim($curValues[5]);
+                $curValues = \explode('@', $val);
+                $cur->name = \trim($curValues[0]);
+                $cur->rate = \trim($curValues[1]);
+                $cur->dec = \trim($curValues[2]);
+                $cur->thousand = \trim($curValues[3]);
+                $cur->sign = \trim($curValues[4]);
+                $cur->decimal = \trim($curValues[5]);
 
                 // change for US version
                 if (isset($curValues[6])) {
-                    $cur->side = trim($curValues[6]);
+                    $cur->side = \trim($curValues[6]);
                 }
 
                 if (isset($currency) && $key == $currency) {
@@ -1760,8 +1760,8 @@ class Config extends \OxidEsales\Eshop\Core\Base
     public function getPackageInfo()
     {
         $fileName = $this->getConfigParam('sShopDir') . "/pkg.info";
-        $rev = @file_get_contents($fileName);
-        $rev = str_replace("\n", "<br>", $rev);
+        $rev = @\file_get_contents($fileName);
+        $rev = \str_replace("\n", "<br>", $rev);
 
         if (!$rev) {
             return false;
@@ -1816,11 +1816,11 @@ class Config extends \OxidEsales\Eshop\Core\Base
         switch ($varType) {
             case 'arr':
             case 'aarr':
-                $value = serialize($varVal);
+                $value = \serialize($varVal);
                 break;
             case 'bool':
                 //config param
-                $varVal = (($varVal == 'true' || $varVal) && $varVal && strcasecmp($varVal, "false"));
+                $varVal = (($varVal == 'true' || $varVal) && $varVal && \strcasecmp($varVal, "false"));
                 //db value
                 $value = $varVal ? "1" : "";
                 break;
@@ -1917,7 +1917,7 @@ class Config extends \OxidEsales\Eshop\Core\Base
         switch ($type) {
             case 'arr':
             case 'aarr':
-                $value = unserialize($mOrigValue);
+                $value = \unserialize($mOrigValue);
                 break;
             case 'bool':
                 $value = ($mOrigValue == 'true' || $mOrigValue == '1');
@@ -1983,8 +1983,8 @@ class Config extends \OxidEsales\Eshop\Core\Base
      */
     public function getActiveView()
     {
-        if (count($this->_aActiveViews)) {
-            $actView = end($this->_aActiveViews);
+        if (\count($this->_aActiveViews)) {
+            $actView = \end($this->_aActiveViews);
         }
         if (!isset($actView) || $actView == null) {
             $actView = oxNew(\OxidEsales\Eshop\Application\Controller\FrontendController::class);
@@ -2001,8 +2001,8 @@ class Config extends \OxidEsales\Eshop\Core\Base
      */
     public function getTopActiveView()
     {
-        if (count($this->_aActiveViews)) {
-            return reset($this->_aActiveViews);
+        if (\count($this->_aActiveViews)) {
+            return \reset($this->_aActiveViews);
         } else {
             return $this->getActiveView();
         }
@@ -2033,7 +2033,7 @@ class Config extends \OxidEsales\Eshop\Core\Base
      */
     public function dropLastActiveView()
     {
-        array_pop($this->_aActiveViews);
+        \array_pop($this->_aActiveViews);
     }
 
     /**
@@ -2043,7 +2043,7 @@ class Config extends \OxidEsales\Eshop\Core\Base
      */
     public function hasActiveViewsChain()
     {
-        return (count($this->_aActiveViews) > 1);
+        return (\count($this->_aActiveViews) > 1);
     }
 
     /**
@@ -2059,7 +2059,7 @@ class Config extends \OxidEsales\Eshop\Core\Base
     {
         $names = [];
 
-        if (is_array($this->getActiveViewsList())) {
+        if (\is_array($this->getActiveViewsList())) {
             foreach ($this->getActiveViewsList() as $view) {
                 $names[] = $view->getClassName();
             }
@@ -2077,7 +2077,7 @@ class Config extends \OxidEsales\Eshop\Core\Base
     {
         $ids = [];
 
-        if (is_array($this->getActiveViewsList())) {
+        if (\is_array($this->getActiveViewsList())) {
             foreach ($this->getActiveViewsList() as $view) {
                 $ids[] = $view->getClassKey();
             }
@@ -2320,10 +2320,10 @@ class Config extends \OxidEsales\Eshop\Core\Base
     {
         if (empty($extension)) {
             $this->dispatchEvent(new ShopConfigurationChangedEvent($varName, (int) $shopId));
-        } elseif (false !== strpos($extension, self::OXMODULE_MODULE_PREFIX)) {
-            $moduleId = str_replace(self::OXMODULE_MODULE_PREFIX, '', $extension);
+        } elseif (false !== \strpos($extension, self::OXMODULE_MODULE_PREFIX)) {
+            $moduleId = \str_replace(self::OXMODULE_MODULE_PREFIX, '', $extension);
             $this->dispatchEvent(new SettingChangedEvent($varName, (int) $shopId, $moduleId));
-        } elseif (false !== strpos($extension, self::OXMODULE_THEME_PREFIX)) {
+        } elseif (false !== \strpos($extension, self::OXMODULE_THEME_PREFIX)) {
             $this->dispatchEvent(new ThemeSettingChangedEvent($varName, (int) $shopId, $extension));
         }
     }

--- a/source/Core/ConfigFile.php
+++ b/source/Core/ConfigFile.php
@@ -64,7 +64,7 @@ class ConfigFile
      */
     public function getVars()
     {
-        return get_object_vars($this);
+        return \get_object_vars($this);
     }
 
     /**
@@ -74,7 +74,7 @@ class ConfigFile
      */
     public function setFile($fileName)
     {
-        if (is_readable($fileName)) {
+        if (\is_readable($fileName)) {
             $this->_loadVars($fileName);
         }
     }

--- a/source/Core/Controller/BaseController.php
+++ b/source/Core/Controller/BaseController.php
@@ -177,7 +177,7 @@ class BaseController extends \OxidEsales\Eshop\Core\Base
     public function init()
     {
         // setting current view class name
-        $this->_sThisAction = strtolower(get_class($this));
+        $this->_sThisAction = \strtolower(\get_class($this));
 
         if (!$this->_blIsComponent) {
             // assume that cached components does not affect this method ...
@@ -532,7 +532,7 @@ class BaseController extends \OxidEsales\Eshop\Core\Base
     {
         // execute
         if ($sFunction && !self::$_blExecuted) {
-            if (method_exists($this, $sFunction)) {
+            if (\method_exists($this, $sFunction)) {
                 $sNewAction = $this->$sFunction();
                 self::$_blExecuted = true;
                 $this->dispatchEvent(new AfterRequestProcessedEvent());
@@ -569,18 +569,18 @@ class BaseController extends \OxidEsales\Eshop\Core\Base
             $myConfig = \OxidEsales\Eshop\Core\Registry::getConfig();
 
             // page parameters is the part which goes after '?'
-            $params = explode('?', $sNewAction);
+            $params = \explode('?', $sNewAction);
 
             // action parameters is the part before '?'
             $pageParams = isset($params[1]) ? $params[1] : null;
 
             // looking for function name
-            $params = explode('/', $params[0]);
+            $params = \explode('/', $params[0]);
             $className = $params[0];
             $resolvedClassName = \OxidEsales\Eshop\Core\Registry::getControllerClassNameResolver()->getClassNameById($className);
             $realClassName = $resolvedClassName ? \OxidEsales\Eshop\Core\Registry::getUtilsObject()->getClassName($resolvedClassName) : \OxidEsales\Eshop\Core\Registry::getUtilsObject()->getClassName($className);
 
-            if (false === class_exists($realClassName)) {
+            if (false === \class_exists($realClassName)) {
                 //If redirect tries to use a not existing class throw an exception.
                 //we'll be redirected to start page directly.
                 $exception =  new \OxidEsales\Eshop\Core\Exception\SystemComponentException();
@@ -719,7 +719,7 @@ class BaseController extends \OxidEsales\Eshop\Core\Base
      */
     public function isBetaVersion()
     {
-        return (stripos(\OxidEsales\Eshop\Core\Registry::getConfig()->getVersion(), 'beta') !== false);
+        return (\stripos(\OxidEsales\Eshop\Core\Registry::getConfig()->getVersion(), 'beta') !== false);
     }
 
     /**
@@ -729,7 +729,7 @@ class BaseController extends \OxidEsales\Eshop\Core\Base
      */
     public function isRCVersion()
     {
-        return (stripos(\OxidEsales\Eshop\Core\Registry::getConfig()->getVersion(), 'rc') !== false);
+        return (\stripos(\OxidEsales\Eshop\Core\Registry::getConfig()->getVersion(), 'rc') !== false);
     }
 
     /**

--- a/source/Core/Curl.php
+++ b/source/Core/Curl.php
@@ -130,11 +130,11 @@ class Curl
      */
     public function getQuery()
     {
-        if (is_null($this->_sQuery)) {
+        if (\is_null($this->_sQuery)) {
             $query = "";
             if ($params = $this->getParameters()) {
                 $params = $this->_prepareQueryParameters($params);
-                $query = http_build_query($params, "", "&");
+                $query = \http_build_query($params, "", "&");
             }
             $this->setQuery($query);
         }
@@ -190,7 +190,7 @@ class Curl
      */
     public function setHeader($header = null)
     {
-        if (is_null($header) && $this->getMethod() == "POST") {
+        if (\is_null($header) && $this->getMethod() == "POST") {
             $host = $this->getHost();
 
             $header = [];
@@ -211,7 +211,7 @@ class Curl
      */
     public function getHeader()
     {
-        if (is_null($this->_aHeader)) {
+        if (\is_null($this->_aHeader)) {
             $this->setHeader();
         }
 
@@ -225,7 +225,7 @@ class Curl
      */
     public function setMethod($method)
     {
-        $this->_sMethod = strtoupper($method);
+        $this->_sMethod = \strtoupper($method);
     }
 
     /**
@@ -248,10 +248,10 @@ class Curl
      */
     public function setOption($name, $value)
     {
-        if (strpos($name, 'CURLOPT_') !== 0 || !defined($constant  = strtoupper($name))) {
+        if (\strpos($name, 'CURLOPT_') !== 0 || !\defined($constant  = \strtoupper($name))) {
             $exception = oxNew(\OxidEsales\Eshop\Core\Exception\StandardException::class);
             $lang = \OxidEsales\Eshop\Core\Registry::getLang();
-            $exception->setMessage(sprintf($lang->translateString('EXCEPTION_NOT_VALID_CURL_CONSTANT', $lang->getTplLanguage()), $name));
+            $exception->setMessage(\sprintf($lang->translateString('EXCEPTION_NOT_VALID_CURL_CONSTANT', $lang->getTplLanguage()), $name));
             throw $exception;
         }
 
@@ -289,7 +289,7 @@ class Curl
         if ($curlErrorNumber) {
             $exception = oxNew(\OxidEsales\Eshop\Core\Exception\StandardException::class);
             $lang = \OxidEsales\Eshop\Core\Registry::getLang();
-            $exception->setMessage(sprintf($lang->translateString('EXCEPTION_CURL_ERROR', $lang->getTplLanguage()), $curlErrorNumber));
+            $exception->setMessage(\sprintf($lang->translateString('EXCEPTION_CURL_ERROR', $lang->getTplLanguage()), $curlErrorNumber));
             throw $exception;
         }
 
@@ -345,8 +345,8 @@ class Curl
      */
     protected function _getResource() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
-        if (is_null($this->_rCurl)) {
-            $this->_setResource(curl_init());
+        if (\is_null($this->_rCurl)) {
+            $this->_setResource(\curl_init());
         }
 
         return $this->_rCurl;
@@ -358,7 +358,7 @@ class Curl
      */
     protected function _setOptions() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
-        if (!is_null($this->getHeader())) {
+        if (!\is_null($this->getHeader())) {
             $this->_setOpt(CURLOPT_HTTPHEADER, $this->getHeader());
         }
         $this->_setOpt(CURLOPT_URL, $this->getUrl());
@@ -369,9 +369,9 @@ class Curl
         }
 
         $options = $this->getOptions();
-        if (count($options)) {
+        if (\count($options)) {
             foreach ($options as $name => $mValue) {
-                $this->_setOpt(constant($name), $mValue);
+                $this->_setOpt(\constant($name), $mValue);
             }
         }
     }
@@ -384,7 +384,7 @@ class Curl
      */
     protected function _execute() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
-        return curl_exec($this->_getResource());
+        return \curl_exec($this->_getResource());
     }
 
     /**
@@ -393,7 +393,7 @@ class Curl
      */
     protected function _close() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
-        curl_close($this->_getResource());
+        \curl_close($this->_getResource());
         $this->_setResource(null);
     }
 
@@ -406,7 +406,7 @@ class Curl
      */
     protected function _setOpt($name, $value) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
-        curl_setopt($this->_getResource(), $name, $value);
+        \curl_setopt($this->_getResource(), $name, $value);
     }
 
     /**
@@ -417,7 +417,7 @@ class Curl
      */
     protected function _getErrorNumber() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
-        return curl_errno($this->_getResource());
+        return \curl_errno($this->_getResource());
     }
 
     /**
@@ -426,7 +426,7 @@ class Curl
      */
     protected function _saveStatusCode() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
-        $this->_sStatusCode = curl_getinfo($this->_getResource(), CURLINFO_HTTP_CODE);
+        $this->_sStatusCode = \curl_getinfo($this->_getResource(), CURLINFO_HTTP_CODE);
     }
 
     /**
@@ -439,7 +439,7 @@ class Curl
      */
     protected function _prepareQueryParameters($params) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
-        return array_map([$this, '_htmlDecode'], array_filter($params));
+        return \array_map([$this, '_htmlDecode'], \array_filter($params));
     }
 
     /**
@@ -452,10 +452,10 @@ class Curl
      */
     protected function _htmlDecode($mParam) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
-        if (is_array($mParam)) {
+        if (\is_array($mParam)) {
             $mParam = $this->_prepareQueryParameters($mParam);
         } else {
-            $mParam = html_entity_decode(stripslashes($mParam), ENT_QUOTES, $this->getConnectionCharset());
+            $mParam = \html_entity_decode(\stripslashes($mParam), ENT_QUOTES, $this->getConnectionCharset());
         }
 
         return $mParam;

--- a/source/Core/Dao/ApplicationServerDao.php
+++ b/source/Core/Dao/ApplicationServerDao.php
@@ -101,7 +101,7 @@ class ApplicationServerDao implements \OxidEsales\Eshop\Core\Dao\ApplicationServ
             $serverData = $this->selectDataById($id);
 
             if ($serverData != false) {
-                $appServerProperties = (array)unserialize($serverData);
+                $appServerProperties = (array)\unserialize($serverData);
             } else {
                 return null;
             }
@@ -242,8 +242,8 @@ class ApplicationServerDao implements \OxidEsales\Eshop\Core\Dao\ApplicationServ
      */
     private function getServerIdFromConfig($varName)
     {
-        $constNameLength = strlen(self::CONFIG_NAME_FOR_SERVER_INFO);
-        $id = substr($varName, $constNameLength);
+        $constNameLength = \strlen(self::CONFIG_NAME_FOR_SERVER_INFO);
+        $id = \substr($varName, $constNameLength);
         return $id;
     }
 
@@ -256,7 +256,7 @@ class ApplicationServerDao implements \OxidEsales\Eshop\Core\Dao\ApplicationServ
      */
     private function getValueFromConfig($varValue)
     {
-        return (array) unserialize($varValue);
+        return (array) \unserialize($varValue);
     }
 
     /**
@@ -290,7 +290,7 @@ class ApplicationServerDao implements \OxidEsales\Eshop\Core\Dao\ApplicationServ
      */
     private function getServerParameter($data, $name)
     {
-        return array_key_exists($name, $data) ? $data[$name] : null;
+        return \array_key_exists($name, $data) ? $data[$name] : null;
     }
 
     /**
@@ -310,6 +310,6 @@ class ApplicationServerDao implements \OxidEsales\Eshop\Core\Dao\ApplicationServ
             'lastAdminUsage'    => $appServer->getLastAdminUsage()
         ];
 
-        return serialize($serverData);
+        return \serialize($serverData);
     }
 }

--- a/source/Core/Database/Adapter/Doctrine/Database.php
+++ b/source/Core/Database/Adapter/Doctrine/Database.php
@@ -87,7 +87,7 @@ class Database implements DatabaseInterface
      */
     public function setConnectionParameters(array $connectionParameters)
     {
-        if (array_key_exists('default', $connectionParameters)) {
+        if (\array_key_exists('default', $connectionParameters)) {
             $this->connectionParameters = $this->getPdoMysqlConnectionParameters($connectionParameters['default']);
         }
     }
@@ -122,7 +122,7 @@ class Database implements DatabaseInterface
      */
     public function forceMasterConnection()
     {
-        if (is_null($this->connection)) {
+        if (\is_null($this->connection)) {
             $this->connect();
         }
     }
@@ -132,7 +132,7 @@ class Database implements DatabaseInterface
      */
     public function forceSlaveConnection()
     {
-        if (is_null($this->connection)) {
+        if (\is_null($this->connection)) {
             $this->connect();
         }
     }
@@ -143,7 +143,7 @@ class Database implements DatabaseInterface
     public function closeConnection()
     {
         $this->connection->close();
-        gc_collect_cycles();
+        \gc_collect_cycles();
     }
 
     /**
@@ -242,7 +242,7 @@ class Database implements DatabaseInterface
      */
     protected function addConnectionCharset(array &$existingParameters, $connectionCharset)
     {
-        $sanitizedCharset = trim(strtolower((string) $connectionCharset));
+        $sanitizedCharset = \trim(\strtolower((string) $connectionCharset));
 
         if (!empty($sanitizedCharset)) {
             $existingParameters['charset'] = $sanitizedCharset;
@@ -315,7 +315,7 @@ class Database implements DatabaseInterface
                 $this->handleException($exception);
             }
         } else {
-            \OxidEsales\Eshop\Core\Registry::getLogger()->warning('Given statement does not produce output and was not executed', [debug_backtrace()]);
+            \OxidEsales\Eshop\Core\Registry::getLogger()->warning('Given statement does not produce output and was not executed', [\debug_backtrace()]);
         }
 
         return false;
@@ -391,7 +391,7 @@ class Database implements DatabaseInterface
             $identifierQuoteCharacter = '`';
         }
 
-        $string = trim(str_replace($identifierQuoteCharacter, '', $string));
+        $string = \trim(\str_replace($identifierQuoteCharacter, '', $string));
         try {
             $result = $this->getConnection()->quoteIdentifier($string);
         } catch (DBALException $exception) {
@@ -524,9 +524,9 @@ class Database implements DatabaseInterface
      */
     public function setTransactionIsolationLevel($level)
     {
-        $level = strtoupper($level);
+        $level = \strtoupper($level);
 
-        if (!array_key_exists($level, $this->transactionIsolationLevelMap)) {
+        if (!\array_key_exists($level, $this->transactionIsolationLevelMap)) {
             throw new \InvalidArgumentException('Transaction isolation level is invalid');
         }
 
@@ -655,8 +655,8 @@ class Database implements DatabaseInterface
          * At the moment there will be no InvalidArgumentException thrown on non numeric values as this may break
          * too many things.
          */
-        if (!is_numeric($rowCount) || !is_numeric($offset)) {
-            trigger_error(
+        if (!\is_numeric($rowCount) || !\is_numeric($offset)) {
+            \trigger_error(
                 'Parameters rowCount and offset have to be numeric in DatabaseInterface::selectLimit(). ' .
                 'Please fix your code as this error may trigger an exception in future versions of OXID eShop.',
                 E_USER_DEPRECATED
@@ -713,7 +713,7 @@ class Database implements DatabaseInterface
             $rows = $this->getConnection()->fetchAll($query, $parameters);
             foreach ($rows as $row) {
                 // cause there is no doctrine equivalent, we take this little detour and restructure the result
-                $columnNames = array_keys($row);
+                $columnNames = \array_keys($row);
                 $columnName = $columnNames[0];
 
                 $result[] = $row[$columnName];
@@ -803,12 +803,12 @@ class Database implements DatabaseInterface
     private function assureParameterIsAnArray($parameter)
     {
         /** If $parameter evaluates to true and it is not an array throw an InvalidArgumentException */
-        if ($parameter && !is_array($parameter)) {
+        if ($parameter && !\is_array($parameter)) {
             throw new \InvalidArgumentException();
         }
 
         /** If $parameter evaluates to false and it is not an array convert it into an array */
-        if (!is_array($parameter)) {
+        if (!\is_array($parameter)) {
             $parameter = [];
         }
 
@@ -855,7 +855,7 @@ class Database implements DatabaseInterface
         ];
         $command = $this->getFirstCommandInStatement($query);
 
-        return in_array($command, $allowedCommands);
+        return \in_array($command, $allowedCommands);
     }
 
     /**
@@ -884,7 +884,7 @@ class Database implements DatabaseInterface
                  */
                 // ConnectionException will be mapped to DatabaseConnectionException::class
                 // no break
-            case is_a($exception->getPrevious(), '\Exception') && in_array($exception->getPrevious()->getCode(), ['2003']):
+            case \is_a($exception->getPrevious(), '\Exception') && \in_array($exception->getPrevious()->getCode(), ['2003']):
                 $exceptionClass = DatabaseConnectionException::class;
                 break;
             case $exception instanceof DBALException:
@@ -913,7 +913,7 @@ class Database implements DatabaseInterface
                 $message = $exception->errorInfo[2];
 
                 /** In case the original code (int) cannot be recovered, code is set to 0 */
-                if (!is_integer($code)) {
+                if (!\is_integer($code)) {
                     $code = 0;
                 }
 
@@ -1004,7 +1004,7 @@ class Database implements DatabaseInterface
         if ($this->doesStatementProduceOutput($query)) {
             $result = $statement->fetchAll();
         } else {
-            \OxidEsales\Eshop\Core\Registry::getLogger()->warning('Given statement does not produce output and was not executed', [debug_backtrace()]);
+            \OxidEsales\Eshop\Core\Registry::getLogger()->warning('Given statement does not produce output and was not executed', [\debug_backtrace()]);
         }
 
         return $result;
@@ -1087,21 +1087,21 @@ class Database implements DatabaseInterface
 
             if ($default !== null) {
                 // MariaDB puts quotes around default values:
-                $default = trim($default, "'");
+                $default = \trim($default, "'");
             }
 
-            $typeInformation = explode('(', $type);
-            $typeName = trim($typeInformation[0]);
+            $typeInformation = \explode('(', $type);
+            $typeName = \trim($typeInformation[0]);
 
             $item = new \stdClass();
             $item->name = $field;
             $item->type = $typeName;
-            $item->not_null = ('no' === strtolower($null));
-            $item->primary_key = (strtolower($key) == 'pri');
-            $item->auto_increment = strtolower($extra) == 'auto_increment';
-            $item->binary = (false !== strpos(strtolower($type), 'blob'));
-            $item->unsigned = (false !== strpos(strtolower($type), 'unsigned'));
-            $item->has_default = ((is_null($default)) || ($default === '')) ? false : true;
+            $item->not_null = ('no' === \strtolower($null));
+            $item->primary_key = (\strtolower($key) == 'pri');
+            $item->auto_increment = \strtolower($extra) == 'auto_increment';
+            $item->binary = (false !== \strpos(\strtolower($type), 'blob'));
+            $item->unsigned = (false !== \strpos(\strtolower($type), 'unsigned'));
+            $item->has_default = ((\is_null($default)) || ($default === '')) ? false : true;
             if ($item->has_default) {
                 $item->default_value = $default;
             }
@@ -1139,7 +1139,7 @@ class Database implements DatabaseInterface
              */
             // $item->enums
 
-            if (array_key_exists('Field', $column)) {
+            if (\array_key_exists('Field', $column)) {
                 $result[$item->name] = $item;
             } else {
                 $result[] = $item;
@@ -1203,7 +1203,7 @@ class Database implements DatabaseInterface
      */
     protected function getMetaColumnValueByKey(array $column, $key)
     {
-        if (array_key_exists('Field', $column)) {
+        if (\array_key_exists('Field', $column)) {
             $keyMap = [
                 'Field'        => 'Field',
                 'Type'         => 'Type',
@@ -1256,27 +1256,27 @@ class Database implements DatabaseInterface
         /** Get the maximum display width for the type */
 
         /** Match Precision an scale E.g DECIMAL(5,2) */
-        if (preg_match("/^(.+)\((\d+),(\d+)/", $mySqlType, $matches)) {
-            if (is_numeric($matches[2])) {
+        if (\preg_match("/^(.+)\((\d+),(\d+)/", $mySqlType, $matches)) {
+            if (\is_numeric($matches[2])) {
                 $maxLength = $matches[2];
             }
-            if (is_numeric($matches[3])) {
+            if (\is_numeric($matches[3])) {
                 $scale = $matches[3];
             }
             /** Match max length E.g CHAR(4) */
-        } elseif (preg_match("/^(.+)\((\d+)/", $mySqlType, $matches)) {
-            if (is_numeric($matches[2])) {
+        } elseif (\preg_match("/^(.+)\((\d+)/", $mySqlType, $matches)) {
+            if (\is_numeric($matches[2])) {
                 $maxLength = $matches[2];
             }
             /**
              * Match List type E.g. SET('A', 'B', 'CDE)
              * In this case the length will be the string length of the longest element
              */
-        } elseif (preg_match("/^(enum|set)\((.*)\)$/i", strtolower($mySqlType), $matches)) {
+        } elseif (\preg_match("/^(enum|set)\((.*)\)$/i", \strtolower($mySqlType), $matches)) {
             if ($matches[2]) {
-                $pieces = explode(",", $matches[2]);
+                $pieces = \explode(",", $matches[2]);
                 /** The array values contain 2 quotes, so we have to subtract 2 from the strlen */
-                $maxLength = max(array_map("strlen", $pieces)) - 2;
+                $maxLength = \max(\array_map("strlen", $pieces)) - 2;
                 if ($maxLength <= 0) {
                     $maxLength = 1;
                 }
@@ -1294,14 +1294,14 @@ class Database implements DatabaseInterface
         /** Date types, which may have a maximum length */
         $dateTypes = ['YEAR'];
 
-        $assignedType = strtoupper($assignedType);
+        $assignedType = \strtoupper($assignedType);
         if (
             (
-            in_array($assignedType, $integerTypes) ||
-                in_array($assignedType, $fixedPointTypes) ||
-                in_array($assignedType, $floatingPointTypes) ||
-                in_array($assignedType, $textTypes) ||
-                in_array($assignedType, $dateTypes)
+            \in_array($assignedType, $integerTypes) ||
+                \in_array($assignedType, $fixedPointTypes) ||
+                \in_array($assignedType, $floatingPointTypes) ||
+                \in_array($assignedType, $textTypes) ||
+                \in_array($assignedType, $dateTypes)
             ) && -1 == $maxLength
         ) {
             /**
@@ -1321,13 +1321,13 @@ class Database implements DatabaseInterface
      */
     protected function getFirstCommandInStatement($query)
     {
-        $singleLineQuery = str_replace(["\r", "\n"], ' ', $query);
+        $singleLineQuery = \str_replace(["\r", "\n"], ' ', $query);
         $sqlComments = '@(([\'"]).*?[^\\\]\2)|((?:\#|--).*?$|/\*(?:[^/*]|/(?!\*)|\*(?!/)|(?R))*\*\/)\s*|(?<=;)\s+@ms';
-        $uncommentedQuery = preg_replace($sqlComments, '$1', $singleLineQuery);
+        $uncommentedQuery = \preg_replace($sqlComments, '$1', $singleLineQuery);
 
-        $command = strtoupper(
-            trim(
-                explode(' ', trim($uncommentedQuery))[0]
+        $command = \strtoupper(
+            \trim(
+                \explode(' ', \trim($uncommentedQuery))[0]
             )
         );
 

--- a/source/Core/DatabaseProvider.php
+++ b/source/Core/DatabaseProvider.php
@@ -293,7 +293,7 @@ class DatabaseProvider
          * @var string $databaseDriverOptions The options to pass to the database driver.
          */
         $databaseDriverOptions = $this->getConfigParam('dbDriverOptions');
-        if (!is_array($databaseDriverOptions)) {
+        if (!\is_array($databaseDriverOptions)) {
             $databaseDriverOptions = array();
         }
         /**
@@ -323,7 +323,7 @@ class DatabaseProvider
             $charset = 'utf8';
         }
         
-        $connectionParameters['default'] = array_merge($connectionParameters['default'], ['connectionCharset' => $charset]);
+        $connectionParameters['default'] = \array_merge($connectionParameters['default'], ['connectionCharset' => $charset]);
 
         return $connectionParameters;
     }
@@ -352,7 +352,7 @@ class DatabaseProvider
         $isValid = true;
 
         // If the shop has not been configured yet the hostname has the format '<dbHost>'
-        if (false  !== strpos($config->getVar('dbHost'), '<')) {
+        if (false  !== \strpos($config->getVar('dbHost'), '<')) {
             $isValid = false;
         }
 

--- a/source/Core/DbMetaDataHandler.php
+++ b/source/Core/DbMetaDataHandler.php
@@ -55,7 +55,7 @@ class DbMetaDataHandler extends \OxidEsales\Eshop\Core\Base
     {
         $fields = [];
         $rawFields = \OxidEsales\Eshop\Core\DatabaseProvider::getDb()->MetaColumns($tableName);
-        if (is_array($rawFields)) {
+        if (\is_array($rawFields)) {
             foreach ($rawFields as $field) {
                 $fields[$field->name] = "{$tableName}.{$field->name}";
             }
@@ -76,7 +76,7 @@ class DbMetaDataHandler extends \OxidEsales\Eshop\Core\Base
         $db = \OxidEsales\Eshop\Core\DatabaseProvider::getDb();
         $tables = $db->getAll("show tables like " . $db->quote($tableName));
 
-        return count($tables) > 0;
+        return \count($tables) > 0;
     }
 
     /**
@@ -90,11 +90,11 @@ class DbMetaDataHandler extends \OxidEsales\Eshop\Core\Base
     public function fieldExists($fieldName, $tableName)
     {
         $tableFields = $this->getFields($tableName);
-        $tableName = strtoupper($tableName);
-        if (is_array($tableFields)) {
-            $fieldName = strtoupper($fieldName);
-            $tableFields = array_map('strtoupper', $tableFields);
-            if (in_array("{$tableName}.{$fieldName}", $tableFields)) {
+        $tableName = \strtoupper($tableName);
+        if (\is_array($tableFields)) {
+            $fieldName = \strtoupper($fieldName);
+            $tableFields = \array_map('strtoupper', $tableFields);
+            if (\in_array("{$tableName}.{$fieldName}", $tableFields)) {
                 return true;
             }
         }
@@ -195,9 +195,9 @@ class DbMetaDataHandler extends \OxidEsales\Eshop\Core\Base
     public function getAllMultiTables($table)
     {
         $mLTables = [];
-        foreach (array_keys(\OxidEsales\Eshop\Core\Registry::getLang()->getLanguageIds()) as $langId) {
+        foreach (\array_keys(\OxidEsales\Eshop\Core\Registry::getLang()->getLanguageIds()) as $langId) {
             $langTableName = getLangTableName($table, $langId);
-            if ($table != $langTableName && !in_array($langTableName, $mLTables)) {
+            if ($table != $langTableName && !\in_array($langTableName, $mLTables)) {
                 $mLTables[] = $langTableName;
             }
         }
@@ -224,7 +224,7 @@ class DbMetaDataHandler extends \OxidEsales\Eshop\Core\Base
         return "CREATE TABLE `{$tableSet}` (" .
                 "`OXID` char(32) NOT NULL, " .
                 "PRIMARY KEY (`OXID`)" .
-                ") " . strstr($res[0][1], 'ENGINE=');
+                ") " . \strstr($res[0][1], 'ENGINE=');
     }
 
     /**
@@ -247,13 +247,13 @@ class DbMetaDataHandler extends \OxidEsales\Eshop\Core\Base
         $tableSql = $res[0][1];
 
         // removing comments;
-        $tableSql = preg_replace('/COMMENT \\\'.*?\\\'/', '', $tableSql);
-        preg_match("/.*,\s+(['`]?" . preg_quote($field, '/') . "['`]?\s+[^,]+),.*/", $tableSql, $match);
+        $tableSql = \preg_replace('/COMMENT \\\'.*?\\\'/', '', $tableSql);
+        \preg_match("/.*,\s+(['`]?" . \preg_quote($field, '/') . "['`]?\s+[^,]+),.*/", $tableSql, $match);
         $fieldSql = $match[1];
 
         $sql = "";
         if (!empty($fieldSql)) {
-            $fieldSql = preg_replace("/" . preg_quote($field, '/') . "/", $newField, $fieldSql);
+            $fieldSql = \preg_replace("/" . \preg_quote($field, '/') . "/", $newField, $fieldSql);
             $sql = "ALTER TABLE `$tableSet` ADD " . $fieldSql;
             if ($this->tableExists($tableSet) && $this->fieldExists($prevField, $tableSet)) {
                 $sql .= " AFTER `$prevField`";
@@ -280,7 +280,7 @@ class DbMetaDataHandler extends \OxidEsales\Eshop\Core\Base
 
         $tableSql = $res[0][1];
 
-        preg_match_all("/([\w]+\s+)?\bKEY\s+(`[^`]+`)?\s*\([^)]+(\(\d++\))*\)/iU", $tableSql, $match);
+        \preg_match_all("/([\w]+\s+)?\bKEY\s+(`[^`]+`)?\s*\([^)]+(\(\d++\))*\)/iU", $tableSql, $match);
         $index = $match[0];
 
         $usingTableSet = $tableSet ? true : false;
@@ -291,24 +291,24 @@ class DbMetaDataHandler extends \OxidEsales\Eshop\Core\Base
 
         $indexQueries = [];
         $sql = [];
-        if (count($index)) {
+        if (\count($index)) {
             foreach ($index as $key => $indexQuery) {
-                if (preg_match("/\([^)]*\b" . $field . "\b[^)]*\)/i", $indexQuery)) {
+                if (\preg_match("/\([^)]*\b" . $field . "\b[^)]*\)/i", $indexQuery)) {
                     //removing index name - new will be added automaticly
-                    $indexQuery = preg_replace("/(.*\bKEY\s+)`[^`]+`/", "$1", $indexQuery);
+                    $indexQuery = \preg_replace("/(.*\bKEY\s+)`[^`]+`/", "$1", $indexQuery);
 
                     if ($usingTableSet) {
                         // replacing multiple fields to one (#3269)
-                        $indexQuery = preg_replace("/\([^\)]+\)+/", "(`$newField`{$match[3][$key]})", $indexQuery);
+                        $indexQuery = \preg_replace("/\([^\)]+\)+/", "(`$newField`{$match[3][$key]})", $indexQuery);
                     } else {
                         //replacing previous field name with new one
-                        $indexQuery = preg_replace("/\b" . $field . "\b/", $newField, $indexQuery);
+                        $indexQuery = \preg_replace("/\b" . $field . "\b/", $newField, $indexQuery);
                     }
                     $indexQueries[] = "ADD " . $indexQuery;
                 }
             }
-            if (count($indexQueries)) {
-                $sql = ["ALTER TABLE `$tableSet` " . implode(", ", $indexQueries)];
+            if (\count($indexQueries)) {
+                $sql = ["ALTER TABLE `$tableSet` " . \implode(", ", $indexQueries)];
             }
         }
 
@@ -362,7 +362,7 @@ class DbMetaDataHandler extends \OxidEsales\Eshop\Core\Base
         $multiLangFields = [];
 
         foreach ($fields as $field) {
-            if (preg_match("/({$table}\.)?(?<field>.+)_1$/", $field, $matches)) {
+            if (\preg_match("/({$table}\.)?(?<field>.+)_1$/", $field, $matches)) {
                 $multiLangFields[] = $matches['field'];
             }
         }
@@ -388,11 +388,11 @@ class DbMetaDataHandler extends \OxidEsales\Eshop\Core\Base
         //Some fields (for example OXID) must be taken from core table.
         $langFields = $this->filterCoreFields($langFields);
 
-        $fields = array_merge($baseFields, $langFields);
+        $fields = \array_merge($baseFields, $langFields);
         $singleLangFields = [];
 
         foreach ($fields as $fieldName => $field) {
-            if (preg_match("/(({$table}|{$langTable})\.)?(?<field>.+)_(?<lang>[0-9]+)$/", $field, $matches)) {
+            if (\preg_match("/(({$table}|{$langTable})\.)?(?<field>.+)_(?<lang>[0-9]+)$/", $field, $matches)) {
                 if ($matches['lang'] == $lang) {
                     $singleLangFields[$matches['field']] = $field;
                 }
@@ -451,7 +451,7 @@ class DbMetaDataHandler extends \OxidEsales\Eshop\Core\Base
         $sql = [];
 
         $fields = $this->getMultilangFields($tableName);
-        if (is_array($fields) && count($fields) > 0) {
+        if (\is_array($fields) && \count($fields) > 0) {
             foreach ($fields as $fieldName) {
                 $fieldName = $fieldName . "_" . $langId;
 
@@ -504,7 +504,7 @@ class DbMetaDataHandler extends \OxidEsales\Eshop\Core\Base
 
         // removing tables which does not requires reset
         foreach ($this->_aSkipTablesOnReset as $skipTable) {
-            if (($skipId = array_search($skipTable, $tables)) !== false) {
+            if (($skipId = \array_search($skipTable, $tables)) !== false) {
                 unset($tables[$skipId]);
             }
         }
@@ -523,9 +523,9 @@ class DbMetaDataHandler extends \OxidEsales\Eshop\Core\Base
     {
         $db = \OxidEsales\Eshop\Core\DatabaseProvider::getDb();
 
-        if (is_array($queries) && !empty($queries)) {
+        if (\is_array($queries) && !empty($queries)) {
             foreach ($queries as $query) {
-                $query = trim($query);
+                $query = \trim($query);
                 if (!empty($query)) {
                     $db->execute($query);
                 }
@@ -542,7 +542,7 @@ class DbMetaDataHandler extends \OxidEsales\Eshop\Core\Base
      */
     public function updateViews($tables = null)
     {
-        set_time_limit(0);
+        \set_time_limit(0);
 
         $db = \OxidEsales\Eshop\Core\DatabaseProvider::getDb();
         $config = \OxidEsales\Eshop\Core\Registry::getConfig();
@@ -590,7 +590,7 @@ class DbMetaDataHandler extends \OxidEsales\Eshop\Core\Base
     protected function filterCoreFields($fields)
     {
         foreach ($this->forceOriginalFields as $fieldname) {
-            if (array_key_exists($fieldname, $fields)) {
+            if (\array_key_exists($fieldname, $fields)) {
                 unset($fields[$fieldname]);
             }
         }
@@ -608,7 +608,7 @@ class DbMetaDataHandler extends \OxidEsales\Eshop\Core\Base
         $maxLang = $this->getCurrentMaxLangId();
         $multiLanguageTables = \OxidEsales\Eshop\Core\Registry::getConfig()->getConfigParam('aMultiLangTables');
 
-        if (!is_array($multiLanguageTables) || empty($multiLanguageTables)) {
+        if (!\is_array($multiLanguageTables) || empty($multiLanguageTables)) {
             return; //nothing to do
         }
 
@@ -640,7 +640,7 @@ class DbMetaDataHandler extends \OxidEsales\Eshop\Core\Base
             $sql[] = $this->_getCreateTableSetSql($table, $languageId);
         }
 
-        if (is_array($fields) && count($fields) > 0) {
+        if (\is_array($fields) && \count($fields) > 0) {
             foreach ($fields as $field) {
                 $newFieldName = $field . "_" . $languageId;
                 if ($languageId > 1) {
@@ -655,7 +655,7 @@ class DbMetaDataHandler extends \OxidEsales\Eshop\Core\Base
                     $sql[] = $this->getAddFieldSql($table, $field, $newFieldName, $previousField, $tableSet);
 
                     //getting add index sql on added field
-                    $sql = array_merge($sql, (array) $this->getAddFieldIndexSql($table, $field, $newFieldName, $tableSet));
+                    $sql = \array_merge($sql, (array) $this->getAddFieldIndexSql($table, $field, $newFieldName, $tableSet));
                 }
             }
         }

--- a/source/Core/DebugInfo.php
+++ b/source/Core/DebugInfo.php
@@ -22,11 +22,11 @@ class DebugInfo
     public function formatTemplateData($viewData = [])
     {
         $log = '';
-        reset($viewData);
+        \reset($viewData);
         foreach ($viewData as $viewName => $viewDataObject) {
             // show debbuging information
             $log .= "TemplateData[$viewName] : <br />\n";
-            $log .= print_r($viewDataObject, 1);
+            $log .= \print_r($viewDataObject, 1);
         }
 
         return $log;
@@ -40,26 +40,26 @@ class DebugInfo
     public function formatMemoryUsage()
     {
         $log = '';
-        if (function_exists('memory_get_usage')) {
-            $kb = (int) (memory_get_usage() / 1024);
-            $mb = round($kb / 1024, 3);
+        if (\function_exists('memory_get_usage')) {
+            $kb = (int) (\memory_get_usage() / 1024);
+            $mb = \round($kb / 1024, 3);
             $log .= 'Memory usage: ' . $mb . ' MB';
 
-            if (function_exists('memory_get_peak_usage')) {
-                $peakKb = (int) (memory_get_peak_usage() / 1024);
-                $peakMb = round($peakKb / 1024, 3);
+            if (\function_exists('memory_get_peak_usage')) {
+                $peakKb = (int) (\memory_get_peak_usage() / 1024);
+                $peakMb = \round($peakKb / 1024, 3);
                 $log .= ' (peak: ' . $peakMb . ' MB)';
             }
             $log .= '<br />';
 
-            if (version_compare(PHP_VERSION, '5.2.0', '>=')) {
-                $kb = (int) (memory_get_usage(true) / 1024);
-                $mb = round($kb / 1024, 3);
+            if (\version_compare(PHP_VERSION, '5.2.0', '>=')) {
+                $kb = (int) (\memory_get_usage(true) / 1024);
+                $mb = \round($kb / 1024, 3);
                 $log .= 'System memory usage: ' . $mb . ' MB';
 
-                if (function_exists('memory_get_peak_usage')) {
-                    $peakKb = (int) (memory_get_peak_usage(true) / 1024);
-                    $peakMb = round($peakKb / 1024, 3);
+                if (\function_exists('memory_get_peak_usage')) {
+                    $peakKb = (int) (\memory_get_peak_usage(true) / 1024);
+                    $peakMb = \round($peakKb / 1024, 3);
                     $log .= ' (peak: ' . $peakMb . ' MB)';
                 }
                 $log .= '<br />';
@@ -78,22 +78,22 @@ class DebugInfo
      */
     public function formatExecutionTime($dTotalTime)
     {
-        $log = 'Execution time:' . round($dTotalTime, 4) . '<br />';
+        $log = 'Execution time:' . \round($dTotalTime, 4) . '<br />';
         global $aProfileTimes;
         global $executionCounts;
-        if (is_array($aProfileTimes)) {
+        if (\is_array($aProfileTimes)) {
             $log .= "----------------------------------------------------------<br>" . PHP_EOL;
-            arsort($aProfileTimes);
+            \arsort($aProfileTimes);
             $log .= "<table cellspacing='10px' style='border: 1px solid #000'>";
             foreach ($aProfileTimes as $key => $val) {
-                $log .= "<tr><td style='border-bottom: 1px dotted #000;min-width:300px;'>Profile $key: </td><td style='border-bottom: 1px dotted #000;min-width:100px;'>" . round($val, 5) . "s</td>";
+                $log .= "<tr><td style='border-bottom: 1px dotted #000;min-width:300px;'>Profile $key: </td><td style='border-bottom: 1px dotted #000;min-width:100px;'>" . \round($val, 5) . "s</td>";
                 if ($dTotalTime) {
-                    $log .= "<td style='border-bottom: 1px dotted #000;min-width:100px;'>" . round($val * 100 / $dTotalTime, 2) . "%</td>";
+                    $log .= "<td style='border-bottom: 1px dotted #000;min-width:100px;'>" . \round($val * 100 / $dTotalTime, 2) . "%</td>";
                 }
                 if ($executionCounts[$key]) {
                     $log .= " <td style='border-bottom: 1px dotted #000;min-width:50px;padding-right:30px;' align='right'>" . $executionCounts[$key] . "</td>"
                              . "<td style='border-bottom: 1px dotted #000;min-width:15px; '>*</td>"
-                             . "<td style='border-bottom: 1px dotted #000;min-width:100px;'>" . round($val / $executionCounts[$key], 5) . "s</td>" . PHP_EOL;
+                             . "<td style='border-bottom: 1px dotted #000;min-width:100px;'>" . \round($val / $executionCounts[$key], 5) . "s</td>" . PHP_EOL;
                 } else {
                     $log .= " <td colspan=3 style='border-bottom: 1px dotted #000;min-width:100px;'> not stopped correctly! </td>" . PHP_EOL;
                 }
@@ -129,8 +129,8 @@ class DebugInfo
     {
         $log = '';
         $className = \OxidEsales\Eshop\Core\Registry::getConfig()->getActiveView()->getClassName();
-        $log .= "<div id='" . $className . "_executed'>Executed: " . date('Y-m-d H:i:s') . "</div>";
-        $log .= "<div id='" . $className . "_timestamp'>Timestamp: " . microtime(true) . "</div>";
+        $log .= "<div id='" . $className . "_executed'>Executed: " . \date('Y-m-d H:i:s') . "</div>";
+        $log .= "<div id='" . $className . "_timestamp'>Timestamp: " . \microtime(true) . "</div>";
 
         return $log;
     }

--- a/source/Core/Decryptor.php
+++ b/source/Core/Decryptor.php
@@ -24,12 +24,12 @@ class Decryptor
     {
         $key = $this->_formKey($key, $string);
 
-        $string = substr($string, 3);
-        $string = str_replace('!', '=', $string);
-        $string = base64_decode($string);
+        $string = \substr($string, 3);
+        $string = \str_replace('!', '=', $string);
+        $string = \base64_decode($string);
         $string = $string ^ $key;
 
-        return substr($string, 2, -2);
+        return \substr($string, 2, -2);
     }
 
     /**
@@ -44,8 +44,8 @@ class Decryptor
     protected function _formKey($key, $string) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $key = '_' . $key;
-        $keyLength = (strlen($string) / strlen($key)) + 5;
+        $keyLength = (\strlen($string) / \strlen($key)) + 5;
 
-        return str_repeat($key, $keyLength);
+        return \str_repeat($key, $keyLength);
     }
 }

--- a/source/Core/DisplayError.php
+++ b/source/Core/DisplayError.php
@@ -31,7 +31,7 @@ class DisplayError implements \OxidEsales\Eshop\Core\Contract\IDisplayError
     {
         $translatedMessage = \OxidEsales\Eshop\Core\Registry::getLang()->translateString($this->_sMessage);
         if (!empty($this->_aFormatParameters)) {
-            $translatedMessage = vsprintf($translatedMessage, $this->_aFormatParameters);
+            $translatedMessage = \vsprintf($translatedMessage, $this->_aFormatParameters);
         }
 
         return $translatedMessage;

--- a/source/Core/DynamicImageGenerator.php
+++ b/source/Core/DynamicImageGenerator.php
@@ -8,7 +8,7 @@
 namespace {
 
     /** Checks if instance name getter does not exist */
-    if (!function_exists("getGeneratorInstanceName")) {
+    if (!\function_exists("getGeneratorInstanceName")) {
         /**
          * Returns image generator instance name
          *
@@ -21,7 +21,7 @@ namespace {
     }
 
     /** Checks if GD library version getter does not exist */
-    if (!function_exists("getGdVersion")) {
+    if (!\function_exists("getGdVersion")) {
         /**
          * Returns GD library version
          *
@@ -33,11 +33,11 @@ namespace {
 
             if ($version === null) {
                 $version = false;
-                if (function_exists("gd_info")) {
+                if (\function_exists("gd_info")) {
                     // extracting GD version from php
-                    $info = gd_info();
+                    $info = \gd_info();
                     if (isset($info["GD Version"])) {
-                        $version = version_compare(preg_replace("/[^0-9\.]/", "", $info["GD Version"]), 1, '>') ? 2 : 1;
+                        $version = \version_compare(\preg_replace("/[^0-9\.]/", "", $info["GD Version"]), 1, '>') ? 2 : 1;
                     }
                 }
             }
@@ -47,7 +47,7 @@ namespace {
     }
 
     /** Checks if image utils file loader does not exist */
-    if (!function_exists("includeImageUtils")) {
+    if (!\function_exists("includeImageUtils")) {
         /**
          * Includes image utils
          */
@@ -155,16 +155,16 @@ namespace OxidEsales\EshopCommunity\Core {
          */
         public function __call($method, $args)
         {
-            if (defined('OXID_PHP_UNIT')) {
-                if (substr($method, 0, 4) == "UNIT") {
-                    $method = str_replace("UNIT", "_", $method);
+            if (\defined('OXID_PHP_UNIT')) {
+                if (\substr($method, 0, 4) == "UNIT") {
+                    $method = \str_replace("UNIT", "_", $method);
                 }
-                if (method_exists($this, $method)) {
-                    return call_user_func_array([& $this, $method], $args);
+                if (\method_exists($this, $method)) {
+                    return \call_user_func_array([& $this, $method], $args);
                 }
             }
 
-            throw new \OxidEsales\Eshop\Core\Exception\SystemComponentException("Function '$method' does not exist or is not accessible! (" . get_class($this) . ")" . PHP_EOL);
+            throw new \OxidEsales\Eshop\Core\Exception\SystemComponentException("Function '$method' does not exist or is not accessible! (" . \get_class($this) . ")" . PHP_EOL);
         }
 
         /**
@@ -190,13 +190,13 @@ namespace OxidEsales\EshopCommunity\Core {
                 $this->_sImageUri = "";
                 $reqPath = 'out/pictures/generated';
 
-                $reqImg = isset($_SERVER["REQUEST_URI"]) ? urldecode($_SERVER["REQUEST_URI"]) : "";
-                $reqImg = str_replace('//', '/', $reqImg);
-                if (($pos = strpos($reqImg, $reqPath)) !== false) {
-                    $this->_sImageUri = substr($reqImg, $pos);
+                $reqImg = isset($_SERVER["REQUEST_URI"]) ? \urldecode($_SERVER["REQUEST_URI"]) : "";
+                $reqImg = \str_replace('//', '/', $reqImg);
+                if (($pos = \strpos($reqImg, $reqPath)) !== false) {
+                    $this->_sImageUri = \substr($reqImg, $pos);
                 }
 
-                $this->_sImageUri = trim($this->_sImageUri, "/");
+                $this->_sImageUri = \trim($this->_sImageUri, "/");
             }
 
             return $this->_sImageUri;
@@ -210,7 +210,7 @@ namespace OxidEsales\EshopCommunity\Core {
          */
         protected function _getImageName() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
         {
-            return basename($this->_getImageUri());
+            return \basename($this->_getImageUri());
         }
 
         /**
@@ -224,8 +224,8 @@ namespace OxidEsales\EshopCommunity\Core {
             $uri = $this->_getImageUri();
             $path = false;
 
-            if ($uri && ($path = dirname(dirname($uri)))) {
-                $path = preg_replace("/\/([^\/]*)\/([^\/]*)\/([^\/]*)$/", "/master/\\2/\\3/", $path);
+            if ($uri && ($path = \dirname(\dirname($uri)))) {
+                $path = \preg_replace("/\/([^\/]*)\/([^\/]*)\/([^\/]*)$/", "/master/\\2/\\3/", $path);
             }
 
             return $path;
@@ -241,7 +241,7 @@ namespace OxidEsales\EshopCommunity\Core {
         {
             $info = [];
             if (($uri = $this->_getImageUri())) {
-                $info = explode($this->_sImageInfoSep, basename(dirname($uri)));
+                $info = \explode($this->_sImageInfoSep, \basename(\dirname($uri)));
             }
 
             return $info;
@@ -268,7 +268,7 @@ namespace OxidEsales\EshopCommunity\Core {
         {
             $path = $this->_getShopBasePath() . $this->_getImageUri();
 
-            return str_replace($this->_getImageName(), "nopic.jpg", $path);
+            return \str_replace($this->_getImageName(), "nopic.jpg", $path);
         }
 
         /**
@@ -279,7 +279,7 @@ namespace OxidEsales\EshopCommunity\Core {
          */
         protected function _getImageType() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
         {
-            $fileExtension = strtolower(pathinfo($this->_getImageName(), PATHINFO_EXTENSION));
+            $fileExtension = \strtolower(\pathinfo($this->_getImageName(), PATHINFO_EXTENSION));
             if (!$this->validateImageFileExtension($fileExtension)) {
                 return false;
             }
@@ -306,7 +306,7 @@ namespace OxidEsales\EshopCommunity\Core {
          */
         protected function _generatePng($source, $target, $width, $height) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
         {
-            return resizePng($source, $target, $width, $height, @getimagesize($source), getGdVersion(), null);
+            return resizePng($source, $target, $width, $height, @\getimagesize($source), getGdVersion(), null);
         }
 
         /**
@@ -323,7 +323,7 @@ namespace OxidEsales\EshopCommunity\Core {
          */
         protected function _generateJpg($source, $target, $width, $height, $quality) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
         {
-            return resizeJpeg($source, $target, $width, $height, @getimagesize($source), getGdVersion(), null, $quality);
+            return resizeJpeg($source, $target, $width, $height, @\getimagesize($source), getGdVersion(), null, $quality);
         }
 
         /**
@@ -339,7 +339,7 @@ namespace OxidEsales\EshopCommunity\Core {
          */
         protected function _generateGif($source, $target, $width, $height) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
         {
-            $imageInfo = @getimagesize($source);
+            $imageInfo = @\getimagesize($source);
 
             return resizeGif($source, $target, $width, $height, $imageInfo[0], $imageInfo[1], $this->validateGdVersion());
         }
@@ -356,10 +356,10 @@ namespace OxidEsales\EshopCommunity\Core {
         protected function _isTargetPathValid($path) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
         {
             $valid = true;
-            $dir = dirname(trim($path));
+            $dir = \dirname(\trim($path));
 
             // first time folder access?
-            if (!is_dir($dir) && ($valid = $this->_isValidPath($dir))) {
+            if (!\is_dir($dir) && ($valid = $this->_isValidPath($dir))) {
                 // creating missing folders
                 $valid = $this->_createFolders($dir);
             }
@@ -378,18 +378,18 @@ namespace OxidEsales\EshopCommunity\Core {
         protected function _createFolders($dir) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
         {
             $config = Registry::getConfig();
-            $picFolderPath = dirname($config->getMasterPictureDir());
+            $picFolderPath = \dirname($config->getMasterPictureDir());
 
             $done = false;
-            if ($picFolderPath && is_dir($picFolderPath)) {
+            if ($picFolderPath && \is_dir($picFolderPath)) {
                 // if its in main path..
-                if (strcmp($picFolderPath, substr($dir, 0, strlen($picFolderPath))) == 0) {
+                if (\strcmp($picFolderPath, \substr($dir, 0, \strlen($picFolderPath))) == 0) {
                     // folder does not exist yet?
-                    if (!($done = file_exists($dir))) {
-                        clearstatcache();
+                    if (!($done = \file_exists($dir))) {
+                        \clearstatcache();
                         // in case creation did not succeed, maybe another process allready created folder?
                         $mode = 0755;
-                        $done = mkdir($dir, $mode, true) || file_exists($dir);
+                        $done = \mkdir($dir, $mode, true) || \file_exists($dir);
                     }
                 }
             }
@@ -417,14 +417,14 @@ namespace OxidEsales\EshopCommunity\Core {
                 // parameter names
                 $names = [];
                 foreach ($this->_aConfParamToPath as $paramName => $pathReg) {
-                    if (preg_match($pathReg, $path)) {
+                    if (\preg_match($pathReg, $path)) {
                         $names[] = $db->quote($paramName);
                         if ($paramName == "sManufacturerIconsize" || $paramName == "sCatIconsize") {
                             $names[] = $db->quote("sIconsize");
                         }
                     }
                 }
-                $names = implode(', ', $names);
+                $names = \implode(', ', $names);
 
                 // any name matching path?
                 if ($names) {
@@ -440,7 +440,7 @@ namespace OxidEsales\EshopCommunity\Core {
 
                     // building query:
                     // shop id
-                    $shopIds = implode(', ', array_map(function ($shopId) use ($db) {
+                    $shopIds = \implode(', ', \array_map(function ($shopId) use ($db) {
                         // probably here we can resolve and check shop id to shorten check?
                         return $db->quote($shopId['oxshopid']);
                     }, $shopIdsArray));
@@ -458,7 +458,7 @@ namespace OxidEsales\EshopCommunity\Core {
                         foreach ($values as $value) {
                             $confValues = (array) $config->decodeValue($value["oxvartype"], $value["oxvarvalue"]);
                             foreach ($confValues as $confValue) {
-                                if (strcmp($checkSize, $confValue) == 0) {
+                                if (\strcmp($checkSize, $confValue) == 0) {
                                     $valid = true;
                                     break;
                                 }
@@ -487,8 +487,8 @@ namespace OxidEsales\EshopCommunity\Core {
             $generatedImagePath = false;
             list($targetWidth, $targetHeight, $targetQuality) = $this->_getImageInfo();
 
-            $fileExtensionSource = strtolower(pathinfo($imageSource, PATHINFO_EXTENSION));
-            $fileExtensionTarget = strtolower(pathinfo($imageTarget, PATHINFO_EXTENSION));
+            $fileExtensionSource = \strtolower(\pathinfo($imageSource, PATHINFO_EXTENSION));
+            $fileExtensionTarget = \strtolower(\pathinfo($imageTarget, PATHINFO_EXTENSION));
 
             // Do some validation and return false on failure
             if (
@@ -567,11 +567,11 @@ namespace OxidEsales\EshopCommunity\Core {
             $lockName = $this->_getLockName($source);
 
             // creating lock file
-            $this->_hLockHandle = @fopen($lockName, "w");
-            if (is_resource($this->_hLockHandle)) {
-                if (!($locked = flock($this->_hLockHandle, LOCK_EX))) {
+            $this->_hLockHandle = @\fopen($lockName, "w");
+            if (\is_resource($this->_hLockHandle)) {
+                if (!($locked = \flock($this->_hLockHandle, LOCK_EX))) {
                     // on failure - closing
-                    fclose($this->_hLockHandle);
+                    \fclose($this->_hLockHandle);
                     $this->_hLockHandle = null;
                 }
             }
@@ -579,8 +579,8 @@ namespace OxidEsales\EshopCommunity\Core {
             // in case system does not support file lockings
             if (!$locked) {
                 // start a blank file to inform other processes we are dealing with it.
-                if (!(file_exists($lockName) && abs(time() - filectime($lockName) < 40))) {
-                    if ($this->_hLockHandle = @fopen($lockName, "w")) {
+                if (!(\file_exists($lockName) && \abs(\time() - \filectime($lockName) < 40))) {
+                    if ($this->_hLockHandle = @\fopen($lockName, "w")) {
                         $locked = true;
                     }
                 }
@@ -597,11 +597,11 @@ namespace OxidEsales\EshopCommunity\Core {
          */
         protected function _unlock($source) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
         {
-            if (is_resource($this->_hLockHandle)) {
-                flock($this->_hLockHandle, LOCK_UN);
-                fclose($this->_hLockHandle);
+            if (\is_resource($this->_hLockHandle)) {
+                \flock($this->_hLockHandle, LOCK_UN);
+                \fclose($this->_hLockHandle);
                 $this->_hLockHandle = null;
-                unlink($this->_getLockName($source));
+                \unlink($this->_getLockName($source));
             }
         }
 
@@ -620,7 +620,7 @@ namespace OxidEsales\EshopCommunity\Core {
         public function getImagePath($absPath = false)
         {
             if ($absPath) {
-                $this->_sImageUri = str_replace($this->_getShopBasePath(), "", $absPath);
+                $this->_sImageUri = \str_replace($this->_getShopBasePath(), "", $absPath);
             }
 
             $imagePath = false;
@@ -629,11 +629,11 @@ namespace OxidEsales\EshopCommunity\Core {
             // building base path + extracting image name + extracting master image path
             $masterImagePath = $this->_getShopBasePath() . $masterPath . $this->_getImageName();
 
-            if (file_exists($masterImagePath)) {
+            if (\file_exists($masterImagePath)) {
                 $genImagePath = $this->_getImageTarget();
             } else {
                 // nopic master path
-                $masterImagePath = $this->_getShopBasePath() . dirname(dirname($masterPath)) . "/nopic.jpg";
+                $masterImagePath = $this->_getShopBasePath() . \dirname(\dirname($masterPath)) . "/nopic.jpg";
                 $genImagePath = $this->_getNopicImageTarget();
 
                 // 404 header for nopic
@@ -641,16 +641,16 @@ namespace OxidEsales\EshopCommunity\Core {
             }
 
             // checking if master image is accessible
-            if (file_exists($genImagePath)) {
+            if (\file_exists($genImagePath)) {
                 $imagePath = $genImagePath;
-            } elseif (file_exists($masterImagePath)) {
+            } elseif (\file_exists($masterImagePath)) {
                 // generating image
                 $imagePath = $this->_generateImage($masterImagePath, $genImagePath);
             }
 
             if ($this->validateFileExist($imagePath)) {
                 // image Content-Type
-                $contentType = mime_content_type($imagePath);
+                $contentType = \mime_content_type($imagePath);
                 $this->_setHeader("Content-Type: $contentType;");
             } else {
                 // unable to output any file
@@ -671,7 +671,7 @@ namespace OxidEsales\EshopCommunity\Core {
 
             // starting output buffering
             if ($buffer) {
-                ob_start();
+                \ob_start();
             }
 
             //
@@ -679,24 +679,24 @@ namespace OxidEsales\EshopCommunity\Core {
 
             // cleaning extra output
             if ($buffer) {
-                ob_clean();
+                \ob_clean();
             }
 
             // outputting headers
             $headers = $this->_getHeaders();
             foreach ($headers as $header) {
-                header($header);
+                \header($header);
             }
 
             // sending headers
             if ($buffer) {
-                ob_end_flush();
+                \ob_end_flush();
             }
 
             // file is generated?
             if ($imgPath) {
                 // outputting file
-                @readfile($imgPath);
+                @\readfile($imgPath);
             }
         }
 
@@ -707,7 +707,7 @@ namespace OxidEsales\EshopCommunity\Core {
          */
         protected function validateImageFileExtension($fileExtension)
         {
-            return in_array(strtolower($fileExtension), $this->_aAllowedImgTypes);
+            return \in_array(\strtolower($fileExtension), $this->_aAllowedImgTypes);
         }
 
         /**
@@ -751,7 +751,7 @@ namespace OxidEsales\EshopCommunity\Core {
          */
         protected function validateFileExist($filePath)
         {
-            return file_exists($filePath);
+            return \file_exists($filePath);
         }
 
         /**
@@ -765,7 +765,7 @@ namespace OxidEsales\EshopCommunity\Core {
         protected function getImageDimensions($imageFilePath)
         {
             try {
-                list($width, $height) = getimagesize($imageFilePath);
+                list($width, $height) = \getimagesize($imageFilePath);
                 $imageDimensions = [$width, $height];
             } catch (\Exception $exception) {
                 $imageDimensions = [0,0];

--- a/source/Core/Edition/EditionRootPathProvider.php
+++ b/source/Core/Edition/EditionRootPathProvider.php
@@ -52,7 +52,7 @@ class EditionRootPathProvider
             $path = $editionsPath . '/' .  static::PROFESSIONAL_DIRECTORY;
         }
 
-        return realpath($path) . DIRECTORY_SEPARATOR;
+        return \realpath($path) . DIRECTORY_SEPARATOR;
     }
 
     /**

--- a/source/Core/Edition/EditionSelector.php
+++ b/source/Core/Edition/EditionSelector.php
@@ -81,14 +81,14 @@ class EditionSelector
      */
     protected function findEdition()
     {
-        if (!class_exists('OxidEsales\EshopCommunity\Core\Registry') || !Registry::instanceExists('oxConfigFile')) {
+        if (!\class_exists('OxidEsales\EshopCommunity\Core\Registry') || !Registry::instanceExists('oxConfigFile')) {
             $configFile = new ConfigFile(OX_BASE_PATH . DIRECTORY_SEPARATOR . "config.inc.php");
         }
         $configFile = isset($configFile) ? $configFile : Registry::get(\OxidEsales\Eshop\Core\ConfigFile::class);
         $edition = $configFile->getVar('edition') ?: $this->getEditionByExistingClasses();
         $configFile->setVar('edition', $edition);
 
-        return strtoupper($edition);
+        return \strtoupper($edition);
     }
 
     /**

--- a/source/Core/Email.php
+++ b/source/Core/Email.php
@@ -314,16 +314,16 @@ class Email extends PHPMailer
      */
     public function __call($method, $args)
     {
-        if (defined('OXID_PHP_UNIT')) {
-            if (substr($method, 0, 4) == "UNIT") {
-                $method = str_replace("UNIT", "_", $method);
+        if (\defined('OXID_PHP_UNIT')) {
+            if (\substr($method, 0, 4) == "UNIT") {
+                $method = \str_replace("UNIT", "_", $method);
             }
-            if (method_exists($this, $method)) {
-                return call_user_func_array([&$this, $method], $args);
+            if (\method_exists($this, $method)) {
+                return \call_user_func_array([&$this, $method], $args);
             }
         }
 
-        throw new SystemComponentException("Function '$method' does not exist or is not accessible! (" . get_class($this) . ")" . PHP_EOL);
+        throw new SystemComponentException("Function '$method' does not exist or is not accessible! (" . \get_class($this) . ")" . PHP_EOL);
     }
 
     /**
@@ -375,7 +375,7 @@ class Email extends PHPMailer
     public function send()
     {
         // if no recipients found, skipping sending
-        if (count($this->getRecipient()) < 1) {
+        if (\count($this->getRecipient()) < 1) {
             return false;
         }
 
@@ -438,7 +438,7 @@ class Email extends PHPMailer
         if (Str::getStr()->preg_match('@^([0-9a-z]+://)?(.*)$@i', $url, $match)) {
             if ($match[1]) {
                 if (($match[1] == 'ssl://') || ($match[1] == 'tls://')) {
-                    $this->set("SMTPSecure", substr($match[1], 0, 3));
+                    $this->set("SMTPSecure", \substr($match[1], 0, 3));
                 } else {
                     $protocol = $match[1];
                 }
@@ -503,9 +503,9 @@ class Email extends PHPMailer
                     $smtpPort = (int) $match[3];
                 }
             }
-            if ($isSmtp = (bool) ($rHandle = @fsockopen($smtpHost, $smtpPort, $errNo, $errStr, 30))) {
+            if ($isSmtp = (bool) ($rHandle = @\fsockopen($smtpHost, $smtpPort, $errNo, $errStr, 30))) {
                 // closing connection ..
-                fclose($rHandle);
+                \fclose($rHandle);
             }
         }
 
@@ -812,7 +812,7 @@ class Email extends PHPMailer
 
         // create messages
         $renderer = $this->getRenderer();
-        $confirmCode = md5($user->oxuser__oxusername->value . $user->oxuser__oxpasssalt->value);
+        $confirmCode = \md5($user->oxuser__oxusername->value . $user->oxuser__oxpasssalt->value);
         $this->setViewData("subscribeLink", $this->_getNewsSubsLink($user->oxuser__oxid->value, $confirmCode));
         $this->setUser($user);
 
@@ -925,12 +925,12 @@ class Email extends PHPMailer
             $homeUrl .= "su=" . $activeUser->getId();
         }
 
-        if (is_array($user->rec_email) && count($user->rec_email) > 0) {
+        if (\is_array($user->rec_email) && \count($user->rec_email) > 0) {
             foreach ($user->rec_email as $email) {
                 if (!empty($email)) {
                     $registerUrl = \OxidEsales\Eshop\Core\Registry::getUtilsUrl()->appendParamSeparator($homeUrl);
                     //setting recipient user email
-                    $registerUrl .= "re=" . md5($email);
+                    $registerUrl .= "re=" . \md5($email);
                     $this->setViewData("sHomeUrl", $registerUrl);
 
                     // Process view data array through oxoutput processor
@@ -1111,7 +1111,7 @@ class Email extends PHPMailer
         $attPath = \OxidEsales\Eshop\Core\Registry::getUtilsFile()->normalizeDir($attPath);
         foreach ($attFiles as $num => $attFile) {
             $fullPath = $attPath . $attFile;
-            if (@is_readable($fullPath) && @is_file($fullPath)) {
+            if (@\is_readable($fullPath) && @\is_file($fullPath)) {
                 $attashSucc = $this->addAttachment($fullPath, $attFile);
             } else {
                 $attashSucc = false;
@@ -1148,7 +1148,7 @@ class Email extends PHPMailer
         //set mail params (from, fromName, smtp)
         $this->_setMailParams();
 
-        if (is_array($to)) {
+        if (\is_array($to)) {
             foreach ($to as $address) {
                 $this->setRecipient($address, "");
                 $this->setReplyTo($address, "");
@@ -1353,7 +1353,7 @@ class Email extends PHPMailer
     protected function _includeImages($imageDir = null, $imageDirNoSSL = null, $dynImageDir = null, $absImageDir = null, $absDynImageDir = null) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $body = $this->getBody();
-        if (preg_match_all('/<\s*img\s+[^>]*?src[\s]*=[\s]*[\'"]?([^[\'">]]+|.*?)?[\'">]/i', $body, $matches, PREG_SET_ORDER)) {
+        if (\preg_match_all('/<\s*img\s+[^>]*?src[\s]*=[\s]*[\'"]?([^[\'">]]+|.*?)?[\'">]/i', $body, $matches, PREG_SET_ORDER)) {
             $fileUtils = \OxidEsales\Eshop\Core\Registry::getUtilsFile();
             $reSetBody = false;
 
@@ -1362,7 +1362,7 @@ class Email extends PHPMailer
             $imageDir = $fileUtils->normalizeDir($imageDir);
             $imageDirNoSSL = $fileUtils->normalizeDir($imageDirNoSSL);
 
-            if (is_array($matches) && count($matches)) {
+            if (\is_array($matches) && \count($matches)) {
                 $imageCache = [];
                 $myUtils = \OxidEsales\Eshop\Core\Registry::getUtils();
                 $myUtilsObject = $this->getUtilsObjectInstance();
@@ -1371,15 +1371,15 @@ class Email extends PHPMailer
                 foreach ($matches as $image) {
                     $imageName = $image[1];
                     $fileName = '';
-                    if (strpos($imageName, $dynImageDir) === 0) {
-                        $fileName = $fileUtils->normalizeDir($absDynImageDir) . str_replace($dynImageDir, '', $imageName);
-                    } elseif (strpos($imageName, $imageDir) === 0) {
-                        $fileName = $fileUtils->normalizeDir($absImageDir) . str_replace($imageDir, '', $imageName);
-                    } elseif (strpos($imageName, $imageDirNoSSL) === 0) {
-                        $fileName = $fileUtils->normalizeDir($absImageDir) . str_replace($imageDirNoSSL, '', $imageName);
+                    if (\strpos($imageName, $dynImageDir) === 0) {
+                        $fileName = $fileUtils->normalizeDir($absDynImageDir) . \str_replace($dynImageDir, '', $imageName);
+                    } elseif (\strpos($imageName, $imageDir) === 0) {
+                        $fileName = $fileUtils->normalizeDir($absImageDir) . \str_replace($imageDir, '', $imageName);
+                    } elseif (\strpos($imageName, $imageDirNoSSL) === 0) {
+                        $fileName = $fileUtils->normalizeDir($absImageDir) . \str_replace($imageDirNoSSL, '', $imageName);
                     }
 
-                    if ($fileName && !@is_readable($fileName)) {
+                    if ($fileName && !@\is_readable($fileName)) {
                         $fileName = $imgGenerator->getImagePath($fileName);
                     }
 
@@ -1398,8 +1398,8 @@ class Email extends PHPMailer
                             }
                         }
                         if ($cId && $cId == $imageCache[$fileName]) {
-                            if ($replTag = str_replace($imageName, 'cid:' . $cId, $image[0])) {
-                                $body = str_replace($image[0], $replTag, $body);
+                            if ($replTag = \str_replace($imageName, 'cid:' . $cId, $image[0])) {
+                                $body = \str_replace($image[0], $replTag, $body);
                                 $reSetBody = true;
                             }
                         }
@@ -1421,7 +1421,7 @@ class Email extends PHPMailer
     public function setSubject($subject = null)
     {
         // A. HTML entities in subjects must be replaced
-        $subject = str_replace(['&amp;', '&quot;', '&#039;', '&lt;', '&gt;'], ['&', '"', "'", '<', '>'], $subject);
+        $subject = \str_replace(['&amp;', '&quot;', '&#039;', '&lt;', '&gt;'], ['&', '"', "'", '<', '>'], $subject);
 
         $this->set("Subject", $subject);
     }
@@ -1476,7 +1476,7 @@ class Email extends PHPMailer
         }
 
         // A. alt body is used for plain text emails so we should eliminate HTML entities
-        $altBody = str_replace(['&amp;', '&quot;', '&#039;', '&lt;', '&gt;'], ['&', '"', "'", '<', '>'], $altBody);
+        $altBody = \str_replace(['&amp;', '&quot;', '&#039;', '&lt;', '&gt;'], ['&', '"', "'", '<', '>'], $altBody);
 
         $this->set("AltBody", $altBody);
     }
@@ -1585,8 +1585,8 @@ class Email extends PHPMailer
      */
     public function setFrom($address, $name = null, $auto = true)
     {
-        $address = substr($address, 0, 150);
-        $name = substr($name, 0, 150);
+        $address = \substr($address, 0, 150);
+        $name = \substr($name, 0, 150);
 
         $success = false;
         try {
@@ -1741,7 +1741,7 @@ class Email extends PHPMailer
     ) {
         $this->_aAttachments[] = [
             $path,
-            basename($path),
+            \basename($path),
             $name,
             $encoding,
             $type,
@@ -1783,7 +1783,7 @@ class Email extends PHPMailer
      */
     public function headerLine($name, $value)
     {
-        if (stripos($name, 'X-') !== false) {
+        if (\stripos($name, 'X-') !== false) {
             return null;
         }
 
@@ -1824,7 +1824,7 @@ class Email extends PHPMailer
         // shop info
         $shop = $this->_getShop();
 
-        return @mail($shop->oxshops__oxorderemail->value, "eMail problem in shop!", $ownerMessage);
+        return @\mail($shop->oxshops__oxorderemail->value, "eMail problem in shop!", $ownerMessage);
     }
 
     /**
@@ -2025,7 +2025,7 @@ class Email extends PHPMailer
         // processing assigned smarty variables
         $newArray = $outputProcessor->processViewArray($this->_aViewData, "oxemail");
 
-        $this->_aViewData = array_merge($this->_aViewData, $newArray);
+        $this->_aViewData = \array_merge($this->_aViewData, $newArray);
     }
 
     /**
@@ -2161,7 +2161,7 @@ class Email extends PHPMailer
         $orderFileList = oxNew(OrderFileList::class);
         $orderFileList->loadOrderFiles($orderId);
 
-        if (count($orderFileList) > 0) {
+        if (\count($orderFileList) > 0) {
             return $orderFileList;
         }
 
@@ -2248,14 +2248,14 @@ class Email extends PHPMailer
      */
     private function idnToAscii($idn)
     {
-        if (function_exists('idn_to_ascii')) {
+        if (\function_exists('idn_to_ascii')) {
             // for old PHP versions support
             // remove it after the PHP 7.1 support is dropped
-            if (defined('INTL_IDNA_VARIANT_UTS46')) {
-                return idn_to_ascii($idn, 0, INTL_IDNA_VARIANT_UTS46);
+            if (\defined('INTL_IDNA_VARIANT_UTS46')) {
+                return \idn_to_ascii($idn, 0, INTL_IDNA_VARIANT_UTS46);
             }
 
-            return idn_to_ascii($idn);
+            return \idn_to_ascii($idn);
         }
 
         return $idn;

--- a/source/Core/EmailBuilder.php
+++ b/source/Core/EmailBuilder.php
@@ -117,7 +117,7 @@ abstract class EmailBuilder
         $lang = \OxidEsales\Eshop\Core\Registry::getLang();
         $shopUrl = \OxidEsales\Eshop\Core\Registry::getConfig()->getConfigParam('sShopURL');
 
-        return "<br>" . sprintf(
+        return "<br>" . \sprintf(
             $lang->translateString(
                 'SHOP_EMAIL_ORIGIN_MESSAGE',
                 null,

--- a/source/Core/Encryptor.php
+++ b/source/Core/Encryptor.php
@@ -27,8 +27,8 @@ class Encryptor
         $key = $this->_formKey($key, $string);
 
         $string = $string ^ $key;
-        $string = base64_encode($string);
-        $string = str_replace("=", "!", $string);
+        $string = \base64_encode($string);
+        $string = \str_replace("=", "!", $string);
 
         return "ox_$string";
     }
@@ -45,8 +45,8 @@ class Encryptor
     protected function _formKey($key, $string) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $key = '_' . $key;
-        $keyLength = (strlen($string) / strlen($key)) + 5;
+        $keyLength = (\strlen($string) / \strlen($key)) + 5;
 
-        return str_repeat($key, $keyLength);
+        return \str_repeat($key, $keyLength);
     }
 }

--- a/source/Core/Exception/ExceptionHandler.php
+++ b/source/Core/Exception/ExceptionHandler.php
@@ -48,12 +48,12 @@ class ExceptionHandler
      */
     public function __call($sMethod, $aArgs)
     {
-        if (defined('OXID_PHP_UNIT')) {
-            if (substr($sMethod, 0, 4) == "UNIT") {
-                $sMethod = str_replace("UNIT", "_", $sMethod);
+        if (\defined('OXID_PHP_UNIT')) {
+            if (\substr($sMethod, 0, 4) == "UNIT") {
+                $sMethod = \str_replace("UNIT", "_", $sMethod);
             }
-            if (method_exists($this, $sMethod)) {
-                return call_user_func_array([& $this, $sMethod], $aArgs);
+            if (\method_exists($this, $sMethod)) {
+                return \call_user_func_array([& $this, $sMethod], $aArgs);
             }
         }
 
@@ -86,7 +86,7 @@ class ExceptionHandler
             $logger->error($exception);
         }
 
-        if ($this->_iDebug || defined('OXID_PHP_UNIT') || php_sapi_name() === 'cli') {
+        if ($this->_iDebug || \defined('OXID_PHP_UNIT') || \php_sapi_name() === 'cli') {
             throw $exception;
         } else {
             \oxTriggerOfflinePageDisplay();

--- a/source/Core/Exception/ExceptionToDisplay.php
+++ b/source/Core/Exception/ExceptionToDisplay.php
@@ -157,7 +157,7 @@ class ExceptionToDisplay implements \OxidEsales\Eshop\Core\Contract\IDisplayErro
      */
     public function setMessageArgs()
     {
-        $this->_aMessageArgs = func_get_args();
+        $this->_aMessageArgs = \func_get_args();
     }
 
     /**
@@ -173,7 +173,7 @@ class ExceptionToDisplay implements \OxidEsales\Eshop\Core\Contract\IDisplayErro
             $sString = \OxidEsales\Eshop\Core\Registry::getLang()->translateString($this->_sMessage);
 
             if (!empty($this->_aMessageArgs)) {
-                $sString = vsprintf($sString, $this->_aMessageArgs);
+                $sString = \vsprintf($sString, $this->_aMessageArgs);
             }
 
             return $sString;
@@ -187,7 +187,7 @@ class ExceptionToDisplay implements \OxidEsales\Eshop\Core\Contract\IDisplayErro
      */
     public function __toString()
     {
-        $sRes = $this->getErrorClassType() . " (time: " . date('Y-m-d H:i:s', \OxidEsales\Eshop\Core\Registry::getUtilsDate()->getTime()) . "): " . $this->getOxMessage() . " \n Stack Trace: " . $this->getStackTrace() . "\n";
+        $sRes = $this->getErrorClassType() . " (time: " . \date('Y-m-d H:i:s', \OxidEsales\Eshop\Core\Registry::getUtilsDate()->getTime()) . "): " . $this->getOxMessage() . " \n Stack Trace: " . $this->getStackTrace() . "\n";
         foreach ($this->_aValues as $key => $value) {
             $sRes .= $key . " => " . $value . "\n";
         }

--- a/source/Core/Exception/ObjectException.php
+++ b/source/Core/Exception/ObjectException.php
@@ -57,6 +57,6 @@ class ObjectException extends \OxidEsales\Eshop\Core\Exception\StandardException
      */
     public function getString()
     {
-        return __CLASS__ . '-' . parent::getString() . " Faulty Object --> " . get_class($this->_oObject) . "\n";
+        return __CLASS__ . '-' . parent::getString() . " Faulty Object --> " . \get_class($this->_oObject) . "\n";
     }
 }

--- a/source/Core/Exception/RoutingException.php
+++ b/source/Core/Exception/RoutingException.php
@@ -29,7 +29,7 @@ class RoutingException extends \OxidEsales\Eshop\Core\Exception\StandardExceptio
      */
     public function __construct($controllerId)
     {
-        $message = sprintf('No controller defined for id %s', $controllerId);
+        $message = \sprintf('No controller defined for id %s', $controllerId);
         parent::__construct($message);
     }
 }

--- a/source/Core/Exception/StandardException.php
+++ b/source/Core/Exception/StandardException.php
@@ -111,7 +111,7 @@ class StandardException extends \Exception
             $sWarning .= "--!--RENDERER--!--";
         }
 
-        $currentTime = date('Y-m-d H:i:s', \OxidEsales\Eshop\Core\Registry::getUtilsDate()->getTime());
+        $currentTime = \date('Y-m-d H:i:s', \OxidEsales\Eshop\Core\Registry::getUtilsDate()->getTime());
 
         return $sWarning . __CLASS__ . " (time: " . $currentTime . "): [{$this->code}]: {$this->message} \n Stack Trace: {$this->getTraceAsString()}\n\n";
     }

--- a/source/Core/Field.php
+++ b/source/Core/Field.php
@@ -94,7 +94,7 @@ class Field // extends \OxidEsales\Eshop\Core\Base
                 return $this->value;
                 break;
             case 'value':
-                if (is_string($this->rawValue)) {
+                if (\is_string($this->rawValue)) {
                     $this->value = Str::getStr()->htmlspecialchars($this->rawValue);
                 } else {
                     // TODO: call htmlentities for each value (recursively?)
@@ -134,7 +134,7 @@ class Field // extends \OxidEsales\Eshop\Core\Base
      */
     public function convertToPseudoHtml()
     {
-        $this->setValue(str_replace("\r", '', nl2br(Str::getStr()->htmlspecialchars($this->rawValue))), self::T_RAW);
+        $this->setValue(\str_replace("\r", '', \nl2br(Str::getStr()->htmlspecialchars($this->rawValue))), self::T_RAW);
     }
 
     /**

--- a/source/Core/FileCache.php
+++ b/source/Core/FileCache.php
@@ -30,13 +30,13 @@ class FileCache
     {
         $fileName = $this->getCacheFilePath($key);
         $value = null;
-        if (is_readable($fileName)) {
-            $value = file_get_contents($fileName);
-            if ($value == serialize(false)) {
+        if (\is_readable($fileName)) {
+            $value = \file_get_contents($fileName);
+            if ($value == \serialize(false)) {
                 return false;
             }
 
-            $value = unserialize($value);
+            $value = \unserialize($value);
             if ($value === false) {
                 $value = null;
             }
@@ -56,10 +56,10 @@ class FileCache
         $fileName = $this->getCacheFilePath($key);
         $cacheDirectory = $this->getCacheDir();
 
-        $tmpFile = $cacheDirectory . "/" . basename($fileName) . uniqid('.temp', true) . '.txt';
-        file_put_contents($tmpFile, serialize($value), LOCK_EX);
+        $tmpFile = $cacheDirectory . "/" . \basename($fileName) . \uniqid('.temp', true) . '.txt';
+        \file_put_contents($tmpFile, \serialize($value), LOCK_EX);
 
-        rename($tmpFile, $fileName);
+        \rename($tmpFile, $fileName);
     }
 
     /**
@@ -69,11 +69,11 @@ class FileCache
     {
         $tempDirectory = \OxidEsales\Eshop\Core\Registry::get(\OxidEsales\Eshop\Core\ConfigFile::class)->getVar("sCompileDir");
         $mask = $tempDirectory . "/" . self::CACHE_FILE_PREFIX . ".*.txt";
-        $files = glob($mask);
-        if (is_array($files)) {
+        $files = \glob($mask);
+        if (\is_array($files)) {
             foreach ($files as $file) {
-                if (is_file($file)) {
-                    @unlink($file);
+                if (\is_file($file)) {
+                    @\unlink($file);
                 }
             }
         }
@@ -110,7 +110,7 @@ class FileCache
      */
     protected function getCacheFileName($key)
     {
-        $name = strtolower(basename($key));
+        $name = \strtolower(\basename($key));
 
         return self::CACHE_FILE_PREFIX . ".all.$name.txt";
     }

--- a/source/Core/FileSystem/FileSystem.php
+++ b/source/Core/FileSystem/FileSystem.php
@@ -23,12 +23,12 @@ class FileSystem
      */
     public function combinePaths()
     {
-        $pathElements = func_get_args();
+        $pathElements = \func_get_args();
         foreach ($pathElements as $key => $pathElement) {
-            $pathElements[$key] = rtrim($pathElement, DIRECTORY_SEPARATOR);
+            $pathElements[$key] = \rtrim($pathElement, DIRECTORY_SEPARATOR);
         }
 
-        return implode(DIRECTORY_SEPARATOR, $pathElements);
+        return \implode(DIRECTORY_SEPARATOR, $pathElements);
     }
 
     /**
@@ -40,6 +40,6 @@ class FileSystem
      */
     public function isReadable($filePath)
     {
-        return (is_file($filePath) && is_readable($filePath));
+        return (\is_file($filePath) && \is_readable($filePath));
     }
 }

--- a/source/Core/Form/FormFieldsCleaner.php
+++ b/source/Core/Form/FormFieldsCleaner.php
@@ -53,9 +53,9 @@ class FormFieldsCleaner
      */
     private function filterFieldsByWhiteList(\ArrayIterator $allowedFields, array $listToClean)
     {
-        $allowedFieldsLowerCase = array_map('strtolower', (array)$allowedFields);
-        $cleanedList = array_filter($listToClean, function ($field) use ($allowedFieldsLowerCase) {
-            return in_array(strtolower($field), $allowedFieldsLowerCase);
+        $allowedFieldsLowerCase = \array_map('strtolower', (array)$allowedFields);
+        $cleanedList = \array_filter($listToClean, function ($field) use ($allowedFieldsLowerCase) {
+            return \in_array(\strtolower($field), $allowedFieldsLowerCase);
         }, ARRAY_FILTER_USE_KEY);
 
         return $cleanedList;

--- a/source/Core/Form/FormFieldsTrimmer.php
+++ b/source/Core/Form/FormFieldsTrimmer.php
@@ -26,7 +26,7 @@ class FormFieldsTrimmer implements EshopFormFieldsTrimmerInterface
     {
         $updatableFields = $fields->getUpdatableFields()->getArrayCopy();
 
-        array_walk_recursive($updatableFields, function (&$value) {
+        \array_walk_recursive($updatableFields, function (&$value) {
             $value = $this->isTrimmableField($value) ? $this->trimField($value) : $value;
         });
 
@@ -40,7 +40,7 @@ class FormFieldsTrimmer implements EshopFormFieldsTrimmerInterface
      */
     private function isTrimmableField($value)
     {
-        return is_string($value);
+        return \is_string($value);
     }
 
     /**
@@ -52,6 +52,6 @@ class FormFieldsTrimmer implements EshopFormFieldsTrimmerInterface
      */
     private function trimField($field)
     {
-        return trim($field);
+        return \trim($field);
     }
 }

--- a/source/Core/GenericImport/GenericImport.php
+++ b/source/Core/GenericImport/GenericImport.php
@@ -167,16 +167,16 @@ class GenericImport
             return $this->returnMessage = 'ERPGENIMPORT_ERROR_USER_NO_RIGHTS';
         }
 
-        $file = @fopen($this->importFilePath, 'r');
+        $file = @\fopen($this->importFilePath, 'r');
 
         if (isset($file) && $file) {
             $data = [];
-            while (($row = fgetcsv($file, $this->maxLineLength, $this->getCsvFieldsTerminator(), $this->getCsvFieldsEncolser())) !== false) {
+            while (($row = \fgetcsv($file, $this->maxLineLength, $this->getCsvFieldsTerminator(), $this->getCsvFieldsEncolser())) !== false) {
                 $data[] = $this->csvTextConvert($row, false);
             }
 
             if ($this->csvContainsHeader) {
-                array_shift($data);
+                \array_shift($data);
             }
 
             try {
@@ -189,7 +189,7 @@ class GenericImport
             $this->returnMessage = 'ERPGENIMPORT_ERROR_WRONG_FILE';
         }
 
-        @fclose($file);
+        @\fclose($file);
 
         return $this->returnMessage;
     }
@@ -235,7 +235,7 @@ class GenericImport
      */
     public function getImportedRowCount()
     {
-        return count($this->importedIds);
+        return \count($this->importedIds);
     }
 
     /**
@@ -301,7 +301,7 @@ class GenericImport
             }
         }
 
-        if (!empty($dataForRetry) && (!$this->retried || count($dataForRetry) != count($data))) {
+        if (!empty($dataForRetry) && (!$this->retried || \count($dataForRetry) != \count($data))) {
             $this->retried = true;
             $this->returnMessage = '';
             $this->importData($dataForRetry);
@@ -319,7 +319,7 @@ class GenericImport
     {
         $type = $this->importType;
 
-        if (strlen($type) != 1 || !array_key_exists($type, $this->objects)) {
+        if (\strlen($type) != 1 || !\array_key_exists($type, $this->objects)) {
             throw new Exception('Error unknown command: ' . $type);
         } else {
             return $this->objects[$type];
@@ -332,7 +332,7 @@ class GenericImport
      */
     protected function addImportedId($id)
     {
-        if (!array_key_exists($id, $this->importedIds)) {
+        if (!\array_key_exists($id, $this->importedIds)) {
             $this->importedIds[$id] = true;
         }
     }
@@ -351,7 +351,7 @@ class GenericImport
 
         foreach ($this->csvFileFieldsOrder as $value) {
             if (!empty($value)) {
-                if (strtolower($data[$index]) == 'null') {
+                if (\strtolower($data[$index]) == 'null') {
                     $result[$value] = null;
                 } else {
                     $result[$value] = $data[$index];
@@ -373,13 +373,13 @@ class GenericImport
      */
     protected function csvTextConvert($text, $mode)
     {
-        $search = [chr(13), chr(10), '\'', '"'];
+        $search = [\chr(13), \chr(10), '\'', '"'];
         $replace = ['&#13;', '&#10;', '&#39;', '&#34;'];
 
         if ($mode) {
-            $text = str_replace($search, $replace, $text);
+            $text = \str_replace($search, $replace, $text);
         } else {
-            $text = str_replace($replace, $search, $text);
+            $text = \str_replace($replace, $search, $text);
         }
 
         return $text;

--- a/source/Core/GenericImport/ImportObject/ImportObject.php
+++ b/source/Core/GenericImport/ImportObject/ImportObject.php
@@ -99,7 +99,7 @@ abstract class ImportObject
         }
 
         foreach ($this->fieldList as $field) {
-            $accessRightFields[] = strtolower($this->tableName . '__' . $field);
+            $accessRightFields[] = \strtolower($this->tableName . '__' . $field);
         }
 
         return $accessRightFields;
@@ -127,9 +127,9 @@ abstract class ImportObject
         }
 
         $viewName = $shopObject->getViewName();
-        $fields = str_ireplace('`' . $viewName . "`.", "", strtoupper($shopObject->getSelectFields()));
-        $fields = str_ireplace([" ", "`"], ["", ""], $fields);
-        $this->fieldList = explode(",", $fields);
+        $fields = \str_ireplace('`' . $viewName . "`.", "", \strtoupper($shopObject->getSelectFields()));
+        $fields = \str_ireplace([" ", "`"], ["", ""], $fields);
+        $this->fieldList = \explode(",", $fields);
 
         return $this->fieldList;
     }
@@ -187,7 +187,7 @@ abstract class ImportObject
 
         // null values support
         foreach ($data as $key => $val) {
-            if (!strlen((string) $val)) {
+            if (!\strlen((string) $val)) {
                 // oxBase will quote it as string if db does not support null for this field
                 $data[$key] = null;
             }
@@ -224,14 +224,14 @@ abstract class ImportObject
 
         foreach ($data as $key => $value) {
             // change case to UPPER
-            $uppercaseKey = strtoupper($key);
+            $uppercaseKey = \strtoupper($key);
             if (!isset($data[$uppercaseKey])) {
                 unset($data[$key]);
                 $data[$uppercaseKey] = $value;
             }
         }
 
-        if (method_exists($shopObject, 'setForceCoreTableUsage')) {
+        if (\method_exists($shopObject, 'setForceCoreTableUsage')) {
             $shopObject->setForceCoreTableUsage(true);
         }
 
@@ -287,7 +287,7 @@ abstract class ImportObject
      */
     protected function getOxidFromKeyFields($data)
     {
-        if (!is_array($this->getKeyFields())) {
+        if (!\is_array($this->getKeyFields())) {
             return null;
         }
 
@@ -296,7 +296,7 @@ abstract class ImportObject
         $queryWherePart = [];
         $allKeysExists = true;
         foreach ($this->getKeyFields() as $key) {
-            if (array_key_exists($key, $data)) {
+            if (\array_key_exists($key, $data)) {
                 $queryWherePart[] = $key . '=' . $database->quote($data[$key]);
             } else {
                 $allKeysExists = false;
@@ -304,7 +304,7 @@ abstract class ImportObject
         }
 
         if ($allKeysExists) {
-            $query = 'SELECT OXID FROM ' . $this->getTableName() . ' WHERE ' . implode(' AND ', $queryWherePart);
+            $query = 'SELECT OXID FROM ' . $this->getTableName() . ' WHERE ' . \implode(' AND ', $queryWherePart);
 
             return $database->getOne($query);
         }
@@ -342,7 +342,7 @@ abstract class ImportObject
     {
         if (!isset($id) || !$id) {
             throw new Exception("ERROR: Articlenumber/ID missing!");
-        } elseif (strlen($id) > 32) {
+        } elseif (\strlen($id) > 32) {
             throw new Exception("ERROR: Articlenumber/ID longer then allowed (32 chars max.)!");
         }
     }

--- a/source/Core/GenericImport/ImportObject/OrderArticle.php
+++ b/source/Core/GenericImport/ImportObject/OrderArticle.php
@@ -32,13 +32,13 @@ class OrderArticle extends \OxidEsales\Eshop\Core\GenericImport\ImportObject\Imp
         $data = parent::preAssignObject($shopObject, $data, $allowCustomShopId);
 
         // check if data is not serialized
-        $persParamValues = @unserialize($data['OXPERSPARAM']);
-        if (!is_array($persParamValues)) {
+        $persParamValues = @\unserialize($data['OXPERSPARAM']);
+        if (!\is_array($persParamValues)) {
             // data is a string with | separation, prepare for oxid
-            $persParamValues = explode("|", $data['OXPERSPARAM']);
-            $data['OXPERSPARAM'] = serialize($persParamValues);
+            $persParamValues = \explode("|", $data['OXPERSPARAM']);
+            $data['OXPERSPARAM'] = \serialize($persParamValues);
         }
-        if (array_key_exists('OXORDERSHOPID', $data)) {
+        if (\array_key_exists('OXORDERSHOPID', $data)) {
             $data['OXORDERSHOPID'] = $this->getOrderShopId($data['OXORDERSHOPID']);
         }
 

--- a/source/Core/Header.php
+++ b/source/Core/Header.php
@@ -22,7 +22,7 @@ class Header
      */
     public function setHeader($header)
     {
-        $header = str_replace(["\n", "\r"], '', $header);
+        $header = \str_replace(["\n", "\r"], '', $header);
         $this->_aHeader[] = (string) $header . "\r\n";
     }
 
@@ -43,7 +43,7 @@ class Header
     {
         foreach ($this->_aHeader as $header) {
             if (isset($header)) {
-                header($header);
+                \header($header);
             }
         }
     }

--- a/source/Core/InputValidator.php
+++ b/source/Core/InputValidator.php
@@ -69,9 +69,9 @@ class InputValidator extends \OxidEsales\Eshop\Core\Base
      */
     public function validateBasketAmount($amount)
     {
-        $amount = str_replace(',', '.', $amount);
+        $amount = \str_replace(',', '.', $amount);
 
-        if (!is_numeric($amount) || $amount < 0) {
+        if (!\is_numeric($amount) || $amount < 0) {
             /**
              * @var \OxidEsales\Eshop\Core\Exception\ArticleInputException $exception
              */
@@ -81,7 +81,7 @@ class InputValidator extends \OxidEsales\Eshop\Core\Base
         }
 
         if (!\OxidEsales\Eshop\Core\Registry::getConfig()->getConfigParam('blAllowUnevenAmounts')) {
-            $amount = round((string) $amount);
+            $amount = \round((string) $amount);
         }
 
         //negative amounts are not allowed
@@ -133,7 +133,7 @@ class InputValidator extends \OxidEsales\Eshop\Core\Base
         if ($user->checkIfEmailExists($login)) {
             //if exists then we do not allow to do that
             $exception = oxNew(\OxidEsales\Eshop\Core\Exception\UserException::class);
-            $exception->setMessage(sprintf(\OxidEsales\Eshop\Core\Registry::getLang()->translateString('ERROR_MESSAGE_USER_USEREXISTS'), $login));
+            $exception->setMessage(\sprintf(\OxidEsales\Eshop\Core\Registry::getLang()->translateString('ERROR_MESSAGE_USER_USEREXISTS'), $login));
 
             return $this->addValidationError("oxuser__oxusername", $exception);
         }
@@ -245,7 +245,7 @@ class InputValidator extends \OxidEsales\Eshop\Core\Base
             $deliveryAddress = $this->_setFields(oxNew(\OxidEsales\Eshop\Application\Model\Address::class), $deliveryAddress);
             $fieldsValidator->setRequiredFields($requiredAddressFields->getDeliveryFields());
             $fieldsValidator->validateFields($deliveryAddress);
-            $invalidFields = array_merge($invalidFields, $fieldsValidator->getInvalidFields());
+            $invalidFields = \array_merge($invalidFields, $fieldsValidator->getInvalidFields());
         }
 
         foreach ($invalidFields as $sField) {
@@ -267,7 +267,7 @@ class InputValidator extends \OxidEsales\Eshop\Core\Base
      */
     private function _setFields($object, $fields) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
-        $fields = is_array($fields) ? $fields : [];
+        $fields = \is_array($fields) ? $fields : [];
         foreach ($fields as $sKey => $sValue) {
             $object->$sKey = oxNew('oxField', $sValue);
         }
@@ -385,9 +385,9 @@ class InputValidator extends \OxidEsales\Eshop\Core\Base
      */
     public function getFirstValidationError()
     {
-        $aErr = reset($this->_aInputValidationErrors);
-        if (is_array($aErr)) {
-            return reset($aErr);
+        $aErr = \reset($this->_aInputValidationErrors);
+        if (\is_array($aErr)) {
+            return \reset($aErr);
         }
     }
 
@@ -498,7 +498,7 @@ class InputValidator extends \OxidEsales\Eshop\Core\Base
         $oStr = Str::getStr();
 
         if ($oStr->strlen($debitInfo['lsktonr']) < 10) {
-            $sNewNum = str_repeat(
+            $sNewNum = \str_repeat(
                 '0',
                 10 - $oStr->strlen($debitInfo['lsktonr'])
             ) . $debitInfo['lsktonr'];
@@ -521,7 +521,7 @@ class InputValidator extends \OxidEsales\Eshop\Core\Base
     {
         $isSet = true;
         foreach ($requiredFields as $fieldName) {
-            if (!isset($bankInformation[$fieldName]) || !trim($bankInformation[$fieldName])) {
+            if (!isset($bankInformation[$fieldName]) || !\trim($bankInformation[$fieldName])) {
                 $isSet = false;
                 break;
             }
@@ -540,8 +540,8 @@ class InputValidator extends \OxidEsales\Eshop\Core\Base
      */
     protected function _cleanDebitInformation($debitInformation) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
-        $debitInformation['lsblz'] = str_replace(' ', '', $debitInformation['lsblz']);
-        $debitInformation['lsktonr'] = str_replace(' ', '', $debitInformation['lsktonr']);
+        $debitInformation['lsblz'] = \str_replace(' ', '', $debitInformation['lsblz']);
+        $debitInformation['lsktonr'] = \str_replace(' ', '', $debitInformation['lsktonr']);
 
         return $debitInformation;
     }
@@ -578,7 +578,7 @@ class InputValidator extends \OxidEsales\Eshop\Core\Base
      */
     public function getCompanyVatInValidator($country)
     {
-        if (is_null($this->_oCompanyVatInValidator)) {
+        if (\is_null($this->_oCompanyVatInValidator)) {
             /** @var \OxidEsales\Eshop\Core\CompanyVatInValidator $vatInValidator */
             $vatInValidator = oxNew('oxCompanyVatInValidator', $country);
 

--- a/source/Core/Language.php
+++ b/source/Core/Language.php
@@ -161,14 +161,14 @@ class Language extends \OxidEsales\Eshop\Core\Base
                 $this->_iBaseLanguageId = $iSeLang;
             }
 
-            if (is_null($this->_iBaseLanguageId)) {
+            if (\is_null($this->_iBaseLanguageId)) {
                 $this->_iBaseLanguageId = Registry::getConfig()->getRequestParameter('lang');
             }
 
             //or determining by domain
             $aLanguageUrls = $myConfig->getConfigParam('aLanguageURLs');
 
-            if (!$blAdmin && is_array($aLanguageUrls)) {
+            if (!$blAdmin && \is_array($aLanguageUrls)) {
                 foreach ($aLanguageUrls as $iId => $sUrl) {
                     if ($sUrl && $myConfig->isCurrentUrl($sUrl)) {
                         $this->_iBaseLanguageId = $iId;
@@ -177,7 +177,7 @@ class Language extends \OxidEsales\Eshop\Core\Base
                 }
             }
 
-            if (is_null($this->_iBaseLanguageId)) {
+            if (\is_null($this->_iBaseLanguageId)) {
                 $this->_iBaseLanguageId = Registry::getConfig()->getRequestParameter('language');
                 if (!isset($this->_iBaseLanguageId)) {
                     $this->_iBaseLanguageId = Registry::getSession()->getVariable('language');
@@ -186,17 +186,17 @@ class Language extends \OxidEsales\Eshop\Core\Base
 
             // if language still not set and not search engine browsing,
             // getting language from browser
-            if (is_null($this->_iBaseLanguageId) && !$blAdmin && !Registry::getUtils()->isSearchEngine()) {
+            if (\is_null($this->_iBaseLanguageId) && !$blAdmin && !Registry::getUtils()->isSearchEngine()) {
                 // getting from cookie
                 $this->_iBaseLanguageId = Registry::getUtilsServer()->getOxCookie('language');
 
                 // getting from browser
-                if (is_null($this->_iBaseLanguageId)) {
+                if (\is_null($this->_iBaseLanguageId)) {
                     $this->_iBaseLanguageId = $this->detectLanguageByBrowser();
                 }
             }
 
-            if (is_null($this->_iBaseLanguageId)) {
+            if (\is_null($this->_iBaseLanguageId)) {
                 $this->_iBaseLanguageId = $myConfig->getConfigParam('sDefaultLang');
             }
 
@@ -227,7 +227,7 @@ class Language extends \OxidEsales\Eshop\Core\Base
                     !isset($aLanguages[$this->_iObjectTplLanguageId]) ||
                     $aLanguages[$this->_iObjectTplLanguageId]->active == 0
                 ) {
-                    $this->_iObjectTplLanguageId = key($aLanguages);
+                    $this->_iObjectTplLanguageId = \key($aLanguages);
                 }
             }
         }
@@ -297,7 +297,7 @@ class Language extends \OxidEsales\Eshop\Core\Base
     {
         $myConfig = Registry::getConfig();
 
-        if (is_null($iLanguage)) {
+        if (\is_null($iLanguage)) {
             $iLanguage = $this->_iBaseLanguageId;
         }
 
@@ -305,11 +305,11 @@ class Language extends \OxidEsales\Eshop\Core\Base
         $aConfLanguages = $myConfig->getConfigParam('aLanguages');
         $aLangParams = $myConfig->getConfigParam('aLanguageParams');
 
-        if (is_array($aConfLanguages)) {
+        if (\is_array($aConfLanguages)) {
             $i = 0;
-            reset($aConfLanguages);
+            \reset($aConfLanguages);
             foreach ($aConfLanguages as $key => $val) {
-                if ($blOnlyActive && is_array($aLangParams)) {
+                if ($blOnlyActive && \is_array($aLangParams)) {
                     //skipping non active languages
                     if (!$aLangParams[$key]['active']) {
                         $i++;
@@ -324,7 +324,7 @@ class Language extends \OxidEsales\Eshop\Core\Base
                     $oLang->abbr = $key;
                     $oLang->name = $val;
 
-                    if (is_array($aLangParams)) {
+                    if (\is_array($aLangParams)) {
                         $oLang->active = $aLangParams[$key]['active'];
                         $oLang->sort = $aLangParams[$key]['sort'];
                     }
@@ -336,8 +336,8 @@ class Language extends \OxidEsales\Eshop\Core\Base
             }
         }
 
-        if ($blSort && is_array($aLangParams)) {
-            uasort($aLanguages, [$this, '_sortLanguagesCallback']);
+        if ($blSort && \is_array($aLangParams)) {
+            \uasort($aLanguages, [$this, '_sortLanguagesCallback']);
         }
 
         return $aLanguages;
@@ -366,14 +366,14 @@ class Language extends \OxidEsales\Eshop\Core\Base
 
             foreach ($langArray as $langKey => $language) {
                 $filePath = $sourceDirectory . $language->abbr . DIRECTORY_SEPARATOR . 'lang.php';
-                if (file_exists($filePath) && is_readable($filePath)) {
+                if (\file_exists($filePath) && \is_readable($filePath)) {
                     $this->_aAdminTplLanguageArray[$langKey] = $language;
                 }
             }
         }
 
         // moving pointer to beginning
-        reset($this->_aAdminTplLanguageArray);
+        \reset($this->_aAdminTplLanguageArray);
 
         return $this->_aAdminTplLanguageArray;
     }
@@ -443,7 +443,7 @@ class Language extends \OxidEsales\Eshop\Core\Base
         }
 
         // checking if in theme options exist
-        if (count($this->_aAdditionalLangFiles)) {
+        if (\count($this->_aAdditionalLangFiles)) {
             $aLang = $this->_getLangTranslationArray($iLang, $blAdminMode, $this->_aAdditionalLangFiles);
             if (isset($aLang[$sStringToTranslate])) {
                 return $aLang[$sStringToTranslate];
@@ -455,7 +455,7 @@ class Language extends \OxidEsales\Eshop\Core\Base
         if (!$this->isTranslated()) {
             Registry::getLogger()->warning(
                 "translation for $sStringToTranslate not found",
-                compact('iLang', 'blAdminMode')
+                \compact('iLang', 'blAdminMode')
             );
         }
 
@@ -476,7 +476,7 @@ class Language extends \OxidEsales\Eshop\Core\Base
     protected function _collectSimilar($aData, $sKey, $aCollection = []) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         foreach ($aData as $sValKey => $sValue) {
-            if (strpos($sValKey, $sKey) === 0) {
+            if (\strpos($sValKey, $sKey) === 0) {
                 $aCollection[$sValKey] = $sValue;
             }
         }
@@ -510,7 +510,7 @@ class Language extends \OxidEsales\Eshop\Core\Base
         $aSimilarConst = $this->_collectSimilar($aMap, $sKey, $aSimilarConst);
 
         // checking if in theme options exist
-        if (count($this->_aAdditionalLangFiles)) {
+        if (\count($this->_aAdditionalLangFiles)) {
             $aLang = $this->_getLangTranslationArray($iLang, $blAdmin, $this->_aAdditionalLangFiles);
             $aSimilarConst = $this->_collectSimilar($aLang, $sKey, $aSimilarConst);
         }
@@ -535,7 +535,7 @@ class Language extends \OxidEsales\Eshop\Core\Base
         }
         $sValue = Registry::getUtils()->fRound($dValue, $oActCur);
 
-        return number_format((double) $sValue, $oActCur->decimal, $oActCur->dec, $oActCur->thousand);
+        return \number_format((double) $sValue, $oActCur->decimal, $oActCur->dec, $oActCur->thousand);
     }
 
     /**
@@ -558,7 +558,7 @@ class Language extends \OxidEsales\Eshop\Core\Base
         $oActCur = $oActCur ? $oActCur : Registry::getConfig()->getActShopCurrencyObject();
         $iDecPos = ($iDecPos < $oActCur->decimal) ? $iDecPos : $oActCur->decimal;
 
-        return number_format((double) $dValue, $iDecPos, $oActCur->dec, $oActCur->thousand);
+        return \number_format((double) $dValue, $iDecPos, $oActCur->dec, $oActCur->thousand);
     }
 
     /**
@@ -590,8 +590,8 @@ class Language extends \OxidEsales\Eshop\Core\Base
     {
         // checking if this language is valid
         $aLanguages = $this->getLanguageArray(null, !$this->isAdmin());
-        if (!isset($aLanguages[$iLang]) && is_array($aLanguages)) {
-            $oLang = current($aLanguages);
+        if (!isset($aLanguages[$iLang]) && \is_array($aLanguages)) {
+            $oLang = \current($aLanguages);
             if (isset($oLang->id)) {
                 $iLang = $oLang->id;
             }
@@ -607,7 +607,7 @@ class Language extends \OxidEsales\Eshop\Core\Base
      */
     public function setBaseLanguage($iLang = null)
     {
-        if (is_null($iLang)) {
+        if (\is_null($iLang)) {
             $iLang = $this->getBaseLanguage();
         } else {
             $this->_iBaseLanguageId = (int) $iLang;
@@ -629,7 +629,7 @@ class Language extends \OxidEsales\Eshop\Core\Base
         if ($this->isAdmin()) {
             $aLanguages = $this->getAdminTplLanguageArray();
             if (!isset($aLanguages[$this->_iTplLanguageId])) {
-                $this->_iTplLanguageId = key($aLanguages);
+                $this->_iTplLanguageId = \key($aLanguages);
             }
         }
 
@@ -677,7 +677,7 @@ class Language extends \OxidEsales\Eshop\Core\Base
     protected function _recodeLangArrayValues(&$aLangArray, $sCharset, $newEncoding) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         foreach ($aLangArray as $sItemKey => &$sValue) {
-            $sValue = iconv($sCharset, $newEncoding, $sValue);
+            $sValue = \iconv($sCharset, $newEncoding, $sValue);
         }
     }
 
@@ -696,8 +696,8 @@ class Language extends \OxidEsales\Eshop\Core\Base
     {
         $aLangs = [];
         foreach ($aLangArray as $sItemKey => $sValue) {
-            $sItemKey = iconv($sCharset, $newEncoding, $sItemKey);
-            $aLangs[$sItemKey] = iconv($sCharset, $newEncoding, $sValue);
+            $sItemKey = \iconv($sCharset, $newEncoding, $sItemKey);
+            $aLangs[$sItemKey] = \iconv($sCharset, $newEncoding, $sValue);
         }
 
         return $aLangs;
@@ -735,16 +735,16 @@ class Language extends \OxidEsales\Eshop\Core\Base
         //get generic lang files
         $sGenericPath = $sAppDir . 'translations/' . $sLang;
         if ($sGenericPath) {
-            $aLangFiles = array_merge($aLangFiles, $this->getAbbreviationDirectoryLanguageFiles($sGenericPath));
+            $aLangFiles = \array_merge($aLangFiles, $this->getAbbreviationDirectoryLanguageFiles($sGenericPath));
         }
 
         //get theme lang files
         if ($sTheme) {
             $sThemePath = $sAppDir . 'views/' . $sTheme . '/';
-            $aLangFiles = array_merge($aLangFiles, $this->getThemeLanguageFiles($sThemePath, $sLang));
+            $aLangFiles = \array_merge($aLangFiles, $this->getThemeLanguageFiles($sThemePath, $sLang));
         }
 
-        $aLangFiles = array_merge($aLangFiles, $this->getCustomThemeLanguageFiles($iLang));
+        $aLangFiles = \array_merge($aLangFiles, $this->getCustomThemeLanguageFiles($iLang));
 
         // modules language files
         $aLangFiles = $this->_appendModuleLangFiles($aLangFiles, $aModulePaths, $sLang);
@@ -752,7 +752,7 @@ class Language extends \OxidEsales\Eshop\Core\Base
         // custom language files
         $aLangFiles = $this->_appendCustomLangFiles($aLangFiles, $sLang);
 
-        return count($aLangFiles) ? $aLangFiles : false;
+        return \count($aLangFiles) ? $aLangFiles : false;
     }
 
     /**
@@ -766,7 +766,7 @@ class Language extends \OxidEsales\Eshop\Core\Base
             $themePath . 'translations/' . $languageAbbreviation
         );
 
-        $files = array_merge($files, $this->getAbbreviationDirectoryLanguageFiles(
+        $files = \array_merge($files, $this->getAbbreviationDirectoryLanguageFiles(
             $themePath . $languageAbbreviation
         ));
 
@@ -805,7 +805,7 @@ class Language extends \OxidEsales\Eshop\Core\Base
 
         if ($sCustomTheme) {
             $customThemePath = $sAppDir . 'views/' . $sCustomTheme;
-            $aLangFiles = array_merge($aLangFiles, $this->getThemeLanguageFiles($customThemePath, $sLang));
+            $aLangFiles = \array_merge($aLangFiles, $this->getThemeLanguageFiles($customThemePath, $sLang));
         }
 
         return $aLangFiles;
@@ -828,8 +828,8 @@ class Language extends \OxidEsales\Eshop\Core\Base
         $language = Registry::getLang()->getLanguageAbbr($activeLanguage);
 
         $modulePaths = [];
-        $modulePaths = array_merge($modulePaths, $this->_getActiveModuleInfo());
-        $modulePaths = array_merge($modulePaths, $this->_getDisabledModuleInfo());
+        $modulePaths = \array_merge($modulePaths, $this->_getActiveModuleInfo());
+        $modulePaths = \array_merge($modulePaths, $this->_getDisabledModuleInfo());
 
         // admin lang files
         $adminThemeName = $this->getContainer()->get(AdminThemeBridgeInterface::class)->getActiveTheme();
@@ -858,7 +858,7 @@ class Language extends \OxidEsales\Eshop\Core\Base
         // custom language files
         $langFiles = $this->_appendCustomLangFiles($langFiles, $language, true);
 
-        return count($langFiles) ? $langFiles : false;
+        return \count($langFiles) ? $langFiles : false;
     }
 
     /**
@@ -873,10 +873,10 @@ class Language extends \OxidEsales\Eshop\Core\Base
      */
     protected function _appendLangFile($aLangFiles, $sFullPath, $sFilePattern = "lang") // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
-        $aFiles = glob($sFullPath . "/*_{$sFilePattern}.php");
-        if (is_array($aFiles) && count($aFiles)) {
+        $aFiles = \glob($sFullPath . "/*_{$sFilePattern}.php");
+        if (\is_array($aFiles) && \count($aFiles)) {
             foreach ($aFiles as $sFile) {
-                if (!strpos($sFile, 'cust_lang.php')) {
+                if (!\strpos($sFile, 'cust_lang.php')) {
                     $aLangFiles[] = $sFile;
                 }
             }
@@ -942,7 +942,7 @@ class Language extends \OxidEsales\Eshop\Core\Base
      */
     protected function _appendModuleLangFiles($aLangFiles, $aModulePaths, $sLang, $blForAdmin = false) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
-        if (is_array($aModulePaths)) {
+        if (\is_array($aModulePaths)) {
             foreach ($aModulePaths as $sPath) {
                 $moduleTranslationPathFinder = $this->getModuleTranslationPathFinder();
                 $sFullPath = $moduleTranslationPathFinder->findTranslationPath($sLang, $blForAdmin, $sPath);
@@ -972,8 +972,8 @@ class Language extends \OxidEsales\Eshop\Core\Base
     {
         $myConfig = Registry::getConfig();
         $sLangFilesIdent = '_default';
-        if (is_array($aLangFiles) && $aLangFiles) {
-            $sLangFilesIdent = '_' . md5(implode('+', $aLangFiles));
+        if (\is_array($aLangFiles) && $aLangFiles) {
+            $sLangFilesIdent = '_' . \md5(\implode('+', $aLangFiles));
         }
 
         return "langcache_" . ((int) $blAdmin) . "_{$iLang}_" . $myConfig->getShopId() . "_" . $myConfig->getConfigParam('sTheme') . $sLangFilesIdent;
@@ -1008,18 +1008,18 @@ class Language extends \OxidEsales\Eshop\Core\Base
             $aLang = [];
             $aLangSeoReplaceChars = [];
             foreach ($aLangFiles as $sLangFile) {
-                if (file_exists($sLangFile) && is_readable($sLangFile)) {
+                if (\file_exists($sLangFile) && \is_readable($sLangFile)) {
                     //$aSeoReplaceChars null indicates that there is no setting made
                     $aSeoReplaceChars = null;
                     include $sLangFile;
 
-                    $aLang = array_merge(['charset' => 'UTF-8'], $aLang);
+                    $aLang = \array_merge(['charset' => 'UTF-8'], $aLang);
 
-                    if (isset($aSeoReplaceChars) && is_array($aSeoReplaceChars)) {
-                        $aLangSeoReplaceChars = array_merge($aLangSeoReplaceChars, $aSeoReplaceChars);
+                    if (isset($aSeoReplaceChars) && \is_array($aSeoReplaceChars)) {
+                        $aLangSeoReplaceChars = \array_merge($aLangSeoReplaceChars, $aSeoReplaceChars);
                     }
 
-                    $aLangCache = array_merge($aLangCache, $aLang);
+                    $aLangCache = \array_merge($aLangCache, $aLang);
                 }
             }
 
@@ -1059,9 +1059,9 @@ class Language extends \OxidEsales\Eshop\Core\Base
             $parentMapFile = $this->getLanguageMappingFilePath($language, $parentThemeDirectory);
             $customThemeMapFile = $this->getLanguageMappingFilePath($language, $customThemeDirectory);
 
-            if (file_exists($customThemeMapFile) && is_readable($customThemeMapFile)) {
+            if (\file_exists($customThemeMapFile) && \is_readable($customThemeMapFile)) {
                 $mapFile = $customThemeMapFile;
-            } elseif (file_exists($parentMapFile) && is_readable($parentMapFile)) {
+            } elseif (\file_exists($parentMapFile) && \is_readable($parentMapFile)) {
                 $mapFile = $parentMapFile;
             }
 
@@ -1258,7 +1258,7 @@ class Language extends \OxidEsales\Eshop\Core\Base
     {
         $sBrowserLanguage = $this->_getBrowserLanguage();
 
-        if (!is_null($sBrowserLanguage)) {
+        if (!\is_null($sBrowserLanguage)) {
             $aLanguages = $this->getLanguageArray(null, true);
             foreach ($aLanguages as $oLang) {
                 if ($oLang->abbr == $sBrowserLanguage) {
@@ -1312,7 +1312,7 @@ class Language extends \OxidEsales\Eshop\Core\Base
     {
         // get language replace chars
         $aSeoReplaceChars = $this->translateString('_aSeoReplaceChars', $iLang);
-        if (!is_array($aSeoReplaceChars)) {
+        if (!\is_array($aSeoReplaceChars)) {
             $aSeoReplaceChars = [];
         }
 
@@ -1360,7 +1360,7 @@ class Language extends \OxidEsales\Eshop\Core\Base
     protected function _getBrowserLanguage() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         if (isset($_SERVER['HTTP_ACCEPT_LANGUAGE']) && $_SERVER['HTTP_ACCEPT_LANGUAGE']) {
-            return strtolower(substr($_SERVER['HTTP_ACCEPT_LANGUAGE'], 0, 2));
+            return \strtolower(\substr($_SERVER['HTTP_ACCEPT_LANGUAGE'], 0, 2));
         }
     }
 
@@ -1403,7 +1403,7 @@ class Language extends \OxidEsales\Eshop\Core\Base
 
         //if exists language parameters array, extract lang id's from there
         $aLangParams = $oConfig->getConfigParam('aLanguageParams');
-        if (is_array($aLangParams)) {
+        if (\is_array($aLangParams)) {
             $aIds = $this->_getLanguageIdsFromLanguageParamsArray($aLangParams);
         } else {
             $aIds = $this->_getLanguageIdsFromLanguagesArray($oConfig->getConfigParam('aLanguages'));
@@ -1440,7 +1440,7 @@ class Language extends \OxidEsales\Eshop\Core\Base
         $aConfigValues = $this->_selectLanguageParamValues($sLanguageParameterName, $iShopId);
 
         foreach ($aConfigValues as $sConfigValue) {
-            $aConfigLanguages = unserialize($sConfigValue['oxvarvalue']);
+            $aConfigLanguages = \unserialize($sConfigValue['oxvarvalue']);
 
             $aLanguages = [];
             if ($sLanguageParameterName == 'aLanguageParams') {
@@ -1449,7 +1449,7 @@ class Language extends \OxidEsales\Eshop\Core\Base
                 $aLanguages = $this->_getLanguageIdsFromLanguagesArray($aConfigLanguages);
             }
 
-            $aConfigDecodedValues = array_unique(array_merge($aConfigDecodedValues, $aLanguages));
+            $aConfigDecodedValues = \array_unique(\array_merge($aConfigDecodedValues, $aLanguages));
         }
 
         return $aConfigDecodedValues;
@@ -1513,7 +1513,7 @@ class Language extends \OxidEsales\Eshop\Core\Base
      */
     protected function _getLanguageIdsFromLanguagesArray($aLanguages) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
-        return array_keys($aLanguages);
+        return \array_keys($aLanguages);
     }
 
     /**
@@ -1523,7 +1523,7 @@ class Language extends \OxidEsales\Eshop\Core\Base
      */
     protected function getModuleTranslationPathFinder()
     {
-        if (is_null($this->moduleTranslationPathFinder)) {
+        if (\is_null($this->moduleTranslationPathFinder)) {
             $this->moduleTranslationPathFinder = oxNew(\OxidEsales\Eshop\Core\Module\ModuleTranslationPathFinder::class);
         }
 

--- a/source/Core/Model/BaseModel.php
+++ b/source/Core/Model/BaseModel.php
@@ -10,11 +10,11 @@ namespace OxidEsales\EshopCommunity\Core\Model;
 /**
  * Defining triggered action type.
  */
-DEFINE('ACTION_NA', 0);
-DEFINE('ACTION_DELETE', 1);
-DEFINE('ACTION_INSERT', 2);
-DEFINE('ACTION_UPDATE', 3);
-DEFINE('ACTION_UPDATE_STOCK', 4);
+\DEFINE('ACTION_NA', 0);
+\DEFINE('ACTION_DELETE', 1);
+\DEFINE('ACTION_INSERT', 2);
+\DEFINE('ACTION_UPDATE', 3);
+\DEFINE('ACTION_UPDATE_STOCK', 4);
 
 use Exception;
 use OxidEsales\EshopCommunity\Core\Exception\DatabaseException;
@@ -239,14 +239,14 @@ class BaseModel extends \OxidEsales\Eshop\Core\Base
     public function __set($fieldName, $fieldValue)
     {
         $this->$fieldName = $fieldValue;
-        if ($this->_blUseLazyLoading && strpos($fieldName, $this->_sCoreTable . '__') === 0) {
-            $preparedFieldName = str_replace($this->_sCoreTable . '__', '', $fieldName);
+        if ($this->_blUseLazyLoading && \strpos($fieldName, $this->_sCoreTable . '__') === 0) {
+            $preparedFieldName = \str_replace($this->_sCoreTable . '__', '', $fieldName);
             if (
                 $preparedFieldName !== 'oxnid'
                 && (!isset($this->_aFieldNames[$preparedFieldName]) || !$this->_aFieldNames[$preparedFieldName])
             ) {
                 $allFieldsList = $this->_getAllFields(true);
-                if (isset($allFieldsList[strtolower($preparedFieldName)])) {
+                if (isset($allFieldsList[\strtolower($preparedFieldName)])) {
                     $fieldStatus = $this->_getFieldStatus($preparedFieldName);
                     $this->_addField($preparedFieldName, $fieldStatus);
                 }
@@ -278,11 +278,11 @@ class BaseModel extends \OxidEsales\Eshop\Core\Base
         // implementing lazy loading fields
         // This part of the code is slow and normally is called before field cache is built.
         // Make sure it is not called after first page is loaded and cache data is fully built.
-        if ($this->_blUseLazyLoading && stripos($variableName, $this->_sCoreTable . "__") === 0) {
+        if ($this->_blUseLazyLoading && \stripos($variableName, $this->_sCoreTable . "__") === 0) {
             if ($this->getId()) {
                 //lazy load it
-                $fieldName = str_replace($this->_sCoreTable . '__', '', $variableName);
-                $cacheFieldName = strtoupper($fieldName);
+                $fieldName = \str_replace($this->_sCoreTable . '__', '', $variableName);
+                $cacheFieldName = \strtoupper($fieldName);
 
                 $fieldStatus = $this->_getFieldStatus($fieldName);
 
@@ -297,8 +297,8 @@ class BaseModel extends \OxidEsales\Eshop\Core\Base
                             ':oxid' => $id
                         ]);
                         if ($queryResult && $queryResult->count()) {
-                            $this->_aInnerLazyCache = array_change_key_case($queryResult->fields, CASE_UPPER);
-                            if (array_key_exists($cacheFieldName, $this->_aInnerLazyCache)) {
+                            $this->_aInnerLazyCache = \array_change_key_case($queryResult->fields, CASE_UPPER);
+                            if (\array_key_exists($cacheFieldName, $this->_aInnerLazyCache)) {
                                 $fieldValue = $this->_aInnerLazyCache[$cacheFieldName];
                             } else {
                                 return null;
@@ -306,7 +306,7 @@ class BaseModel extends \OxidEsales\Eshop\Core\Base
                         } else {
                             return null;
                         }
-                    } elseif (array_key_exists($cacheFieldName, $this->_aInnerLazyCache)) {
+                    } elseif (\array_key_exists($cacheFieldName, $this->_aInnerLazyCache)) {
                         $fieldValue = $this->_aInnerLazyCache[$cacheFieldName];
                     } else {
                         return null;
@@ -329,10 +329,10 @@ class BaseModel extends \OxidEsales\Eshop\Core\Base
 
                 //do not use field cache for this page
                 //as if we use it for lists then objects are loaded empty instead of lazy loading.
-                self::$_blDisableFieldCaching[get_class($this)] = true;
+                self::$_blDisableFieldCaching[\get_class($this)] = true;
             }
 
-            \OxidEsales\Eshop\Core\Registry::getUtilsObject()->resetInstanceCache(get_class($this));
+            \OxidEsales\Eshop\Core\Registry::getUtilsObject()->resetInstanceCache(\get_class($this));
         }
 
         //returns stdClass implementing __toString() method due to uknown scenario where this var should be used.
@@ -373,7 +373,7 @@ class BaseModel extends \OxidEsales\Eshop\Core\Base
         if (!$this->_blIsSimplyClonable) {
             foreach ($this->_aFieldNames as $fieldName => $fieldValue) {
                 $fieldLongName = $this->_getFieldLongName($fieldName);
-                if (is_object($this->$fieldLongName)) {
+                if (\is_object($this->$fieldLongName)) {
                     $this->$fieldLongName = clone $this->$fieldLongName;
                 }
             }
@@ -387,9 +387,9 @@ class BaseModel extends \OxidEsales\Eshop\Core\Base
      */
     public function oxClone($object)
     {
-        $classVariables = get_object_vars($object);
+        $classVariables = \get_object_vars($object);
         foreach ($classVariables as $name => $value) {
-            if (is_object($object->$name)) {
+            if (\is_object($object->$name)) {
                 $this->$name = clone $object->$name;
             } else {
                 $this->$name = $object->$name;
@@ -427,7 +427,7 @@ class BaseModel extends \OxidEsales\Eshop\Core\Base
      */
     protected function _setUpdateSeoOnFieldChange($fieldName) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
-        if ($this->getId() && in_array($fieldName, $this->getFieldNames())) {
+        if ($this->getId() && \in_array($fieldName, $this->getFieldNames())) {
             $database = \OxidEsales\Eshop\Core\DatabaseProvider::getDb();
             $tableName = $this->getCoreTableName();
             $title = $database->getOne("select `{$fieldName}` from `{$tableName}` where `oxid` = :oxid", [
@@ -457,7 +457,7 @@ class BaseModel extends \OxidEsales\Eshop\Core\Base
         // reset view table
         $this->_sViewTable = false;
 
-        if (count($this->_aFieldNames) <= 1) {
+        if (\count($this->_aFieldNames) <= 1) {
             $this->_initDataStructure($forceAllFields);
         }
     }
@@ -471,7 +471,7 @@ class BaseModel extends \OxidEsales\Eshop\Core\Base
      */
     public function assign($dbRecord)
     {
-        if (!is_array($dbRecord)) {
+        if (!\is_array($dbRecord)) {
             return;
         }
 
@@ -531,7 +531,7 @@ class BaseModel extends \OxidEsales\Eshop\Core\Base
                 $objectId = $this->oxobject2category__oxobjectid;
                 $categoryId = $this->oxobject2category__oxcatnid;
                 $shopId = $this->oxobject2category__oxshopid;
-                $this->_sOXID = md5($objectId . $categoryId . $shopId);
+                $this->_sOXID = \md5($objectId . $categoryId . $shopId);
             } else {
                 $this->_sOXID = \OxidEsales\Eshop\Core\Registry::getUtilsObject()->generateUID();
             }
@@ -705,7 +705,7 @@ class BaseModel extends \OxidEsales\Eshop\Core\Base
         $query = "select $get from " . $this->getViewName() . ' where 1 ';
 
         if ($whereCondition) {
-            reset($whereCondition);
+            \reset($whereCondition);
             foreach ($whereCondition as $name => $value) {
                 $query .= ' and ' . $name . ' = ' . $database->quote($value);
             }
@@ -780,7 +780,7 @@ class BaseModel extends \OxidEsales\Eshop\Core\Base
             }
         }
 
-        return implode(', ', $selectFields);
+        return \implode(', ', $selectFields);
     }
 
     /**
@@ -833,7 +833,7 @@ class BaseModel extends \OxidEsales\Eshop\Core\Base
      */
     public function save()
     {
-        if (!is_array($this->_aFieldNames)) {
+        if (!\is_array($this->_aFieldNames)) {
             return false;
         }
 
@@ -1041,9 +1041,9 @@ class BaseModel extends \OxidEsales\Eshop\Core\Base
 
         //returning simple array
         $result = [];
-        if (is_array($metaFields)) {
+        if (\is_array($metaFields)) {
             foreach ($metaFields as $valueObject) {
-                $result[strtolower($valueObject->name)] = 0;
+                $result[\strtolower($valueObject->name)] = 0;
             }
         }
 
@@ -1188,7 +1188,7 @@ class BaseModel extends \OxidEsales\Eshop\Core\Base
     protected function _addField($fieldName, $fieldStatus, $type = null, $length = null) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         //preparation
-        $fieldName = strtolower($fieldName);
+        $fieldName = \strtolower($fieldName);
 
         //adding field names element
         $this->_aFieldNames[$fieldName] = $fieldStatus;
@@ -1233,11 +1233,11 @@ class BaseModel extends \OxidEsales\Eshop\Core\Base
     {
         //trying to avoid strpos call as often as possible
         $coreTableName = $this->getCoreTableName();
-        if ($fieldName[2] == $coreTableName[2] && strpos($fieldName, $coreTableName . '__') === 0) {
+        if ($fieldName[2] == $coreTableName[2] && \strpos($fieldName, $coreTableName . '__') === 0) {
             return $fieldName;
         }
 
-        return $coreTableName . '__' . strtolower($fieldName);
+        return $coreTableName . '__' . \strtolower($fieldName);
     }
 
     /**
@@ -1265,7 +1265,7 @@ class BaseModel extends \OxidEsales\Eshop\Core\Base
             && !$this->isPropertyLoaded($longFieldName)
         ) {
             $fieldsList = $this->_getAllFields(true);
-            if (isset($fieldsList[strtolower($fieldName)])) {
+            if (isset($fieldsList[\strtolower($fieldName)])) {
                 $this->_addField($fieldName, $this->_getFieldStatus($fieldName));
             }
         }
@@ -1276,13 +1276,13 @@ class BaseModel extends \OxidEsales\Eshop\Core\Base
             && isset($this->$longFieldName->fldtype)
             && $this->$longFieldName->fldtype == 'double'
         ) {
-            $fieldValue = str_replace(',', '.', $fieldValue);
+            $fieldValue = \str_replace(',', '.', $fieldValue);
         }
 
         // isset is REQUIRED here not to use getter
         if (
             $isPropertyLoaded
-            && is_object($this->$longFieldName)
+            && \is_object($this->$longFieldName)
         ) {
             $this->$longFieldName->setValue($fieldValue, $dataType);
         } else {
@@ -1302,7 +1302,7 @@ class BaseModel extends \OxidEsales\Eshop\Core\Base
     {
         $metaData = $this->_getAllFields();
         foreach ($metaData as $metaInfo) {
-            if (strcasecmp($metaInfo->name, $fieldName) == 0) {
+            if (\strcasecmp($metaInfo->name, $fieldName) == 0) {
                 return !$metaInfo->not_null;
             }
         }
@@ -1322,8 +1322,8 @@ class BaseModel extends \OxidEsales\Eshop\Core\Base
     {
         $metaData = $this->_getAllFields();
         foreach ($metaData as $metaInfo) {
-            if (strcasecmp($metaInfo->name, $fieldName) == 0) {
-                return property_exists($metaInfo, 'default_value') ? $metaInfo->default_value : null;
+            if (\strcasecmp($metaInfo->name, $fieldName) == 0) {
+                return \property_exists($metaInfo, 'default_value') ? $metaInfo->default_value : null;
             }
         }
 
@@ -1375,7 +1375,7 @@ class BaseModel extends \OxidEsales\Eshop\Core\Base
         $query = '';
         $separator = '';
 
-        foreach (array_keys($this->_aFieldNames) as $oneFieldName) {
+        foreach (\array_keys($this->_aFieldNames) as $oneFieldName) {
             $longName = $this->_getFieldLongName($oneFieldName);
             $field = $this->$longName;
 
@@ -1383,7 +1383,7 @@ class BaseModel extends \OxidEsales\Eshop\Core\Base
                 continue;
             }
 
-            if (!$useSkipSaveFields || ($useSkipSaveFields && !in_array(strtolower($oneFieldName), $this->_aSkipSaveFields))) {
+            if (!$useSkipSaveFields || ($useSkipSaveFields && !\in_array(\strtolower($oneFieldName), $this->_aSkipSaveFields))) {
                 $query .= $separator . $oneFieldName . ' = ' . $this->_getUpdateFieldValue($oneFieldName, $field);
                 $separator = ',';
             }
@@ -1506,7 +1506,7 @@ class BaseModel extends \OxidEsales\Eshop\Core\Base
      */
     protected function _isDisabledFieldCache() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
-        $class = get_class($this);
+        $class = \get_class($this);
         if (isset(self::$_blDisableFieldCaching[$class]) && self::$_blDisableFieldCaching[$class]) {
             return true;
         }
@@ -1578,7 +1578,7 @@ class BaseModel extends \OxidEsales\Eshop\Core\Base
             $fieldNames = $this->_getNonCachedFieldNames(true);
         }
 
-        return array_keys($fieldNames);
+        return \array_keys($fieldNames);
     }
 
     /**
@@ -1589,7 +1589,7 @@ class BaseModel extends \OxidEsales\Eshop\Core\Base
     public function addFieldName($name)
     {
         //preparation
-        $name = strtolower($name);
+        $name = \strtolower($name);
         $this->_aFieldNames[$name] = 0;
     }
 
@@ -1612,7 +1612,7 @@ class BaseModel extends \OxidEsales\Eshop\Core\Base
      */
     public function isPropertyLoaded($name)
     {
-        return property_exists($this, $name) && $this->$name !== null;
+        return \property_exists($this, $name) && $this->$name !== null;
     }
 
     /**

--- a/source/Core/Model/FieldNameHelper.php
+++ b/source/Core/Model/FieldNameHelper.php
@@ -26,14 +26,14 @@ class FieldNameHelper
     public function getFullFieldNames($tableName, $fieldNames)
     {
         $combinedFields = [];
-        $tablePrefix = strtolower($tableName) . '__';
+        $tablePrefix = \strtolower($tableName) . '__';
         foreach ($fieldNames as $fieldName) {
-            $fieldName = strtolower($fieldName);
+            $fieldName = \strtolower($fieldName);
 
-            $fieldNameWithoutTableName = str_replace($tablePrefix, '', $fieldName);
+            $fieldNameWithoutTableName = \str_replace($tablePrefix, '', $fieldName);
             $combinedFields[] = $fieldNameWithoutTableName;
 
-            if (strpos($fieldName, $tablePrefix) !== 0) {
+            if (\strpos($fieldName, $tablePrefix) !== 0) {
                 $fieldName = $tablePrefix . $fieldName;
             }
 

--- a/source/Core/Model/ListModel.php
+++ b/source/Core/Model/ListModel.php
@@ -109,7 +109,7 @@ class ListModel extends \OxidEsales\Eshop\Core\Base implements \ArrayAccess, \It
      */
     public function offsetUnset($offset)
     {
-        if (strcmp($offset, $this->key()) === 0) {
+        if (\strcmp($offset, $this->key()) === 0) {
             // #0002184: active element removed, next element will be prev / first
             $this->_blRemovedActive = true;
         }
@@ -124,7 +124,7 @@ class ListModel extends \OxidEsales\Eshop\Core\Base implements \ArrayAccess, \It
      */
     public function arrayKeys()
     {
-        return array_keys($this->_aArray);
+        return \array_keys($this->_aArray);
     }
 
     /**
@@ -133,7 +133,7 @@ class ListModel extends \OxidEsales\Eshop\Core\Base implements \ArrayAccess, \It
     public function rewind()
     {
         $this->_blRemovedActive = false;
-        $this->_blValid = (false !== reset($this->_aArray));
+        $this->_blValid = (false !== \reset($this->_aArray));
     }
 
     /**
@@ -143,7 +143,7 @@ class ListModel extends \OxidEsales\Eshop\Core\Base implements \ArrayAccess, \It
      */
     public function current()
     {
-        return current($this->_aArray);
+        return \current($this->_aArray);
     }
 
     /**
@@ -153,7 +153,7 @@ class ListModel extends \OxidEsales\Eshop\Core\Base implements \ArrayAccess, \It
      */
     public function key()
     {
-        return key($this->_aArray);
+        return \key($this->_aArray);
     }
 
     /**
@@ -163,10 +163,10 @@ class ListModel extends \OxidEsales\Eshop\Core\Base implements \ArrayAccess, \It
      */
     public function prev()
     {
-        $oVar = prev($this->_aArray);
+        $oVar = \prev($this->_aArray);
         if ($oVar === false) {
             // the first element, reset pointer
-            $oVar = reset($this->_aArray);
+            $oVar = \reset($this->_aArray);
         }
         $this->_blRemovedActive = false;
 
@@ -178,10 +178,10 @@ class ListModel extends \OxidEsales\Eshop\Core\Base implements \ArrayAccess, \It
      */
     public function next()
     {
-        if ($this->_blRemovedActive === true && current($this->_aArray)) {
+        if ($this->_blRemovedActive === true && \current($this->_aArray)) {
             $oVar = $this->prev();
         } else {
-            $oVar = next($this->_aArray);
+            $oVar = \next($this->_aArray);
         }
 
         $this->_blValid = (false !== $oVar);
@@ -204,7 +204,7 @@ class ListModel extends \OxidEsales\Eshop\Core\Base implements \ArrayAccess, \It
      */
     public function count()
     {
-        return count($this->_aArray);
+        return \count($this->_aArray);
     }
 
     /**
@@ -237,7 +237,7 @@ class ListModel extends \OxidEsales\Eshop\Core\Base implements \ArrayAccess, \It
      */
     public function reverse()
     {
-        return array_reverse($this->_aArray);
+        return \array_reverse($this->_aArray);
     }
 
     /**
@@ -368,7 +368,7 @@ class ListModel extends \OxidEsales\Eshop\Core\Base implements \ArrayAccess, \It
 
         $oDb = \OxidEsales\Eshop\Core\DatabaseProvider::getDb(\OxidEsales\Eshop\Core\DatabaseProvider::FETCH_MODE_ASSOC);
         if ($this->_aSqlLimit[0] || $this->_aSqlLimit[1]) {
-            $rs = $oDb->selectLimit($sql, $this->_aSqlLimit[1], max(0, $this->_aSqlLimit[0]), $parameters);
+            $rs = $oDb->selectLimit($sql, $this->_aSqlLimit[1], \max(0, $this->_aSqlLimit[0]), $parameters);
         } else {
             $rs = $oDb->select($sql, $parameters);
         }
@@ -410,7 +410,7 @@ class ListModel extends \OxidEsales\Eshop\Core\Base implements \ArrayAccess, \It
     public function assignArray($aData)
     {
         $this->clear();
-        if (count($aData)) {
+        if (\count($aData)) {
             $oSaved = clone $this->getBaseObject();
 
             foreach ($aData as $aItem) {

--- a/source/Core/Model/MultiLanguageModel.php
+++ b/source/Core/Model/MultiLanguageModel.php
@@ -93,7 +93,7 @@ class MultiLanguageModel extends \OxidEsales\Eshop\Core\Model\BaseModel
             }
             // reset
             $this->_sViewTable = false;
-            if (count($this->_aFieldNames) > 1) {
+            if (\count($this->_aFieldNames) > 1) {
                 $this->_initDataStructure();
             }
         }
@@ -109,7 +109,7 @@ class MultiLanguageModel extends \OxidEsales\Eshop\Core\Model\BaseModel
      */
     public function isMultilingualField($fieldName)
     {
-        $fieldName = strtolower($fieldName);
+        $fieldName = \strtolower($fieldName);
         if (isset($this->_aFieldNames[$fieldName])) {
             return (bool) $this->_aFieldNames[$fieldName];
         }
@@ -190,7 +190,7 @@ class MultiLanguageModel extends \OxidEsales\Eshop\Core\Model\BaseModel
         //selecting all object multilang fields
         foreach ($objFields as $key => $value) {
             //skipping oxactive field
-            if (preg_match('/^oxactive(_(\d{1,2}))?$/', $key)) {
+            if (\preg_match('/^oxactive(_(\d{1,2}))?$/', $key)) {
                 continue;
             }
 
@@ -198,13 +198,13 @@ class MultiLanguageModel extends \OxidEsales\Eshop\Core\Model\BaseModel
 
             //checking, if field is multilanguage
             if ($this->isMultilingualField($key) || $fieldLang > 0) {
-                $newKey = preg_replace('/_(\d{1,2})$/', '', $key);
+                $newKey = \preg_replace('/_(\d{1,2})$/', '', $key);
                 $multiLangFields[$newKey][] = (int) $fieldLang;
             }
         }
 
         // if no multilanguage fields, return default languages array
-        if (count($multiLangFields) < 1) {
+        if (\count($multiLangFields) < 1) {
             return $languages;
         }
 
@@ -219,11 +219,11 @@ class MultiLanguageModel extends \OxidEsales\Eshop\Core\Model\BaseModel
 
         // checks if object field data is not empty in all available languages
         // and formats not available in languages array
-        if (isset($rs[0]) && is_array($rs[0]) && count($rs[0])) {
+        if (isset($rs[0]) && \is_array($rs[0]) && \count($rs[0])) {
             foreach ($multiLangFields as $fieldId => $multiLangIds) {
                 foreach ($multiLangIds as $multiLangId) {
                     $fieldName = ($multiLangId == 0) ? $fieldId : $fieldId . '_' . $multiLangId;
-                    if ($rs[0][strtoupper($fieldName)]) {
+                    if ($rs[0][\strtoupper($fieldName)]) {
                         unset($notInLang[$multiLangId]);
                         continue;
                     }
@@ -231,7 +231,7 @@ class MultiLanguageModel extends \OxidEsales\Eshop\Core\Model\BaseModel
             }
         }
 
-        return array_diff($languages, $notInLang);
+        return \array_diff($languages, $notInLang);
     }
 
     /**
@@ -246,7 +246,7 @@ class MultiLanguageModel extends \OxidEsales\Eshop\Core\Model\BaseModel
     protected function _getFieldStatus($fieldName) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $allField = $this->_getAllFields(true);
-        if (isset($allField[strtolower($fieldName) . "_1"])) {
+        if (isset($allField[\strtolower($fieldName) . "_1"])) {
             return 1;
         }
 
@@ -306,10 +306,10 @@ class MultiLanguageModel extends \OxidEsales\Eshop\Core\Model\BaseModel
      */
     protected function _getFieldLang($fieldName) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
-        if (false === strpos($fieldName, '_')) {
+        if (false === \strpos($fieldName, '_')) {
             return 0;
         }
-        if (preg_match('/_(\d{1,2})$/', $fieldName, $regs)) {
+        if (\preg_match('/_(\d{1,2})$/', $fieldName, $regs)) {
             return $regs[1];
         } else {
             return 0;
@@ -375,8 +375,8 @@ class MultiLanguageModel extends \OxidEsales\Eshop\Core\Model\BaseModel
 
         $sql = '';
         $sep = false;
-        foreach (array_keys($this->_aFieldNames) as $key) {
-            $keyLowercase = strtolower($key);
+        foreach (\array_keys($this->_aFieldNames) as $key) {
+            $keyLowercase = \strtolower($key);
             if ($keyLowercase != 'oxid') {
                 if ($this->_blEmployMultilanguage) {
                     if ($skipMultilingual && $this->isMultilingualField($key)) {
@@ -405,7 +405,7 @@ class MultiLanguageModel extends \OxidEsales\Eshop\Core\Model\BaseModel
             $longName = $this->_getFieldLongName($key);
             $field = $this->$longName;
 
-            if (!$useSkipSaveFields || ($useSkipSaveFields && !in_array($keyLowercase, $this->_aSkipSaveFields))) {
+            if (!$useSkipSaveFields || ($useSkipSaveFields && !\in_array($keyLowercase, $this->_aSkipSaveFields))) {
                 $key = $this->getUpdateSqlFieldName($key);
                 $sql .= (($sep) ? ',' : '') . $key . " = " . $this->_getUpdateFieldValue($key, $field);
                 $sep = true;
@@ -592,7 +592,7 @@ class MultiLanguageModel extends \OxidEsales\Eshop\Core\Model\BaseModel
      */
     protected function _canFieldBeNull($fieldName) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
-        $fieldName = preg_replace('/_\d{1,2}$/', '', $fieldName);
+        $fieldName = \preg_replace('/_\d{1,2}$/', '', $fieldName);
 
         return parent::_canFieldBeNull($fieldName);
     }

--- a/source/Core/Module/Module.php
+++ b/source/Core/Module/Module.php
@@ -133,8 +133,8 @@ class Module extends \OxidEsales\Eshop\Core\Base
         $sModuleId = null;
         $aModulePaths = $this->getModulePaths();
 
-        if (is_array($aModulePaths)) {
-            $sModuleId = array_search($sModuleDir, $aModulePaths);
+        if (\is_array($aModulePaths)) {
+            $sModuleId = \array_search($sModuleDir, $aModulePaths);
         }
 
         // if no module id defined, using module dir as id
@@ -209,11 +209,11 @@ class Module extends \OxidEsales\Eshop\Core\Base
      */
     public function getControllers()
     {
-        if (isset($this->_aModule['controllers']) && ! is_array($this->_aModule['controllers'])) {
+        if (isset($this->_aModule['controllers']) && ! \is_array($this->_aModule['controllers'])) {
             throw new \InvalidArgumentException('Value for metadata key "controllers" must be an array');
         }
 
-        return isset($this->_aModule['controllers']) ? array_change_key_case($this->_aModule['controllers']) : [];
+        return isset($this->_aModule['controllers']) ? \array_change_key_case($this->_aModule['controllers']) : [];
     }
 
     /**
@@ -221,7 +221,7 @@ class Module extends \OxidEsales\Eshop\Core\Base
      */
     public function getSmartyPluginDirectories()
     {
-        if (isset($this->_aModule['smartyPluginDirectories']) && !is_array($this->_aModule['smartyPluginDirectories'])) {
+        if (isset($this->_aModule['smartyPluginDirectories']) && !\is_array($this->_aModule['smartyPluginDirectories'])) {
             throw new \InvalidArgumentException('Value for metadata key "smartyPluginDirectories" must be an array');
         }
 
@@ -253,16 +253,16 @@ class Module extends \OxidEsales\Eshop\Core\Base
         if (!$moduleId) {
             $modulePaths = $this->getModulePaths();
 
-            if (is_array($modulePaths)) {
+            if (\is_array($modulePaths)) {
                 foreach ($modulePaths as $id => $path) {
-                    if (strpos($moduleFile, $path . "/") === 0) {
+                    if (\strpos($moduleFile, $path . "/") === 0) {
                         $moduleId = $id;
                     }
                 }
             }
         }
         if (!$moduleId) {
-            $moduleId = substr($moduleFile, 0, strpos($moduleFile, "/"));
+            $moduleId = \substr($moduleFile, 0, \strpos($moduleFile, "/"));
         }
         if (!$moduleId) {
             $moduleId = $moduleFile;
@@ -317,7 +317,7 @@ class Module extends \OxidEsales\Eshop\Core\Base
     public function getInfo($sName, $iLang = null)
     {
         if (isset($this->_aModule[$sName])) {
-            if ($iLang !== null && is_array($this->_aModule[$sName])) {
+            if ($iLang !== null && \is_array($this->_aModule[$sName])) {
                 $sValue = null;
 
                 $sLang = \OxidEsales\Eshop\Core\Registry::getLang()->getLanguageAbbr($iLang);
@@ -330,7 +330,7 @@ class Module extends \OxidEsales\Eshop\Core\Base
                         $sValue = $this->_aModule[$sName][$this->_aModule['lang']];
                     } else {
                         // returning first array value
-                        $sValue = reset($this->_aModule[$sName]);
+                        $sValue = \reset($this->_aModule[$sName]);
                     }
 
                     return $sValue;
@@ -400,7 +400,7 @@ class Module extends \OxidEsales\Eshop\Core\Base
     public function getMetadataPath()
     {
         $sModulePath = $this->getModuleFullPath();
-        if (substr($sModulePath, -1) != DIRECTORY_SEPARATOR) {
+        if (\substr($sModulePath, -1) != DIRECTORY_SEPARATOR) {
             $sModulePath .= DIRECTORY_SEPARATOR;
         }
 
@@ -436,7 +436,7 @@ class Module extends \OxidEsales\Eshop\Core\Base
         $sModulePath = (isset($aModulePaths[$sModuleId])) ? $aModulePaths[$sModuleId] : '';
 
         // if still no module dir, try using module ID as dir name
-        if (!$sModulePath && is_dir(\OxidEsales\Eshop\Core\Registry::getConfig()->getModulesDir() . $sModuleId)) {
+        if (!$sModulePath && \is_dir(\OxidEsales\Eshop\Core\Registry::getConfig()->getModulesDir() . $sModuleId)) {
             $sModulePath = $sModuleId;
         }
 
@@ -490,7 +490,7 @@ class Module extends \OxidEsales\Eshop\Core\Base
      */
     public function getTemplates($sModuleId = null)
     {
-        if (is_null($sModuleId)) {
+        if (\is_null($sModuleId)) {
             $sModuleId = $this->getId();
         }
 

--- a/source/Core/Module/ModuleCache.php
+++ b/source/Core/Module/ModuleCache.php
@@ -75,7 +75,7 @@ class ModuleCache extends \OxidEsales\Eshop\Core\Base
      */
     protected function _clearApcCache() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
-        if (extension_loaded('apc') && ini_get('apc.enabled')) {
+        if (\extension_loaded('apc') && \ini_get('apc.enabled')) {
             apc_clear_cache();
         }
     }

--- a/source/Core/Module/ModuleChainsGenerator.php
+++ b/source/Core/Module/ModuleChainsGenerator.php
@@ -86,14 +86,14 @@ class ModuleChainsGenerator
     public function getFullChain($className, $classAlias)
     {
         $fullChain = [];
-        $lowerCaseClassAlias = strtolower($classAlias);
-        $lowerCaseClassName = strtolower($className);
+        $lowerCaseClassAlias = \strtolower($classAlias);
+        $lowerCaseClassName = \strtolower($className);
 
         $variablesLocator = $this->getModuleVariablesLocator();
         $modules = $this->getClassExtensionChain($variablesLocator);
-        $modules = array_change_key_case($modules);
-        $allExtendedClasses = array_keys($modules);
-        $currentExtendedClasses = array_intersect($allExtendedClasses, [$lowerCaseClassName, $lowerCaseClassAlias]);
+        $modules = \array_change_key_case($modules);
+        $allExtendedClasses = \array_keys($modules);
+        $currentExtendedClasses = \array_intersect($allExtendedClasses, [$lowerCaseClassName, $lowerCaseClassAlias]);
         if (!empty($currentExtendedClasses)) {
             /*
              * there may be 2 class chains, matching the same class:
@@ -103,28 +103,28 @@ class ModuleChainsGenerator
              */
             $classChains = [];
             /* Get the position of the class name */
-            if (false !== $position = array_search($lowerCaseClassName, $allExtendedClasses)) {
-                $classChains[$position] = explode("&", $modules[$lowerCaseClassName]);
+            if (false !== $position = \array_search($lowerCaseClassName, $allExtendedClasses)) {
+                $classChains[$position] = \explode("&", $modules[$lowerCaseClassName]);
             }
             /* Get the position of the alias class name */
-            if (false !== $position = array_search($lowerCaseClassAlias, $allExtendedClasses)) {
-                $classChains[$position] = explode("&", $modules[$lowerCaseClassAlias]);
+            if (false !== $position = \array_search($lowerCaseClassAlias, $allExtendedClasses)) {
+                $classChains[$position] = \explode("&", $modules[$lowerCaseClassAlias]);
             }
 
             /* Notice that the array keys will be ordered, but do not necessarily start at 0 */
-            ksort($classChains);
+            \ksort($classChains);
             $fullChain = [];
-            if (1 === count($classChains)) {
+            if (1 === \count($classChains)) {
                 /**
                  * @var array $fullChain uses the one and only element of the array
                  */
-                $fullChain = reset($classChains);
+                $fullChain = \reset($classChains);
             }
-            if (2 === count($classChains)) {
+            if (2 === \count($classChains)) {
                 /**
                  * @var array $fullChain merges the first and then the second array from the $classChains
                  */
-                $fullChain = array_merge(reset($classChains), next($classChains));
+                $fullChain = \array_merge(\reset($classChains), \next($classChains));
             }
         }
 
@@ -170,7 +170,7 @@ class ModuleChainsGenerator
 
         $toBeRemovedFromChain = [];
         if (isset($registeredExtensions[$moduleId])) {
-            $toBeRemovedFromChain = array_combine($registeredExtensions[$moduleId], $registeredExtensions[$moduleId]);
+            $toBeRemovedFromChain = \array_combine($registeredExtensions[$moduleId], $registeredExtensions[$moduleId]);
         }
 
         foreach ($classChain as $key => $moduleClass) {
@@ -242,19 +242,19 @@ class ModuleChainsGenerator
     protected function createClassExtensions($classChain, $baseClass)
     {
         //security: just preventing string termination
-        $lastClass = str_replace(chr(0), '', $baseClass);
+        $lastClass = \str_replace(\chr(0), '', $baseClass);
         $parentClass = $lastClass;
 
         foreach ($classChain as $extensionPath) {
-            $extensionPath = str_replace(chr(0), '', $extensionPath);
+            $extensionPath = \str_replace(\chr(0), '', $extensionPath);
 
             if ($this->createClassExtension($parentClass, $extensionPath)) {
                 if (\OxidEsales\Eshop\Core\NamespaceInformationProvider::isNamespacedClass($extensionPath)) {
                     $parentClass = $extensionPath;
                     $lastClass = $extensionPath;
                 } else {
-                    $parentClass = basename($extensionPath);
-                    $lastClass = basename($extensionPath);
+                    $parentClass = \basename($extensionPath);
+                    $lastClass = \basename($extensionPath);
                 }
             }
         }
@@ -293,7 +293,7 @@ class ModuleChainsGenerator
         $composerClassLoader = include VENDOR_PATH . 'autoload.php';
         if (
             !$this->isUnitTest() && // In unit test some classes are created dynamically, so the files would not exist :-(
-            !strpos($moduleClass, '_parent') &&
+            !\strpos($moduleClass, '_parent') &&
             !$composerClassLoader->findFile($moduleClass)
         ) {
             $this->handleSpecialCases($parentClass);
@@ -303,8 +303,8 @@ class ModuleChainsGenerator
         }
 
         $moduleClassParentAlias = $moduleClass . "_parent";
-        if (!class_exists($moduleClassParentAlias, false)) {
-            class_alias($parentClass, $moduleClassParentAlias);
+        if (!\class_exists($moduleClassParentAlias, false)) {
+            \class_alias($parentClass, $moduleClassParentAlias);
         }
 
         return true;
@@ -323,7 +323,7 @@ class ModuleChainsGenerator
      */
     private function backwardsCompatibleCreateClassExtension($parentClass, $moduleClassPath)
     {
-        $moduleClass = basename($moduleClassPath);
+        $moduleClass = \basename($moduleClassPath);
         /**
          * Due to the way the shop is prepared for testing, you must not use Registry::getConfig() in this class.
          * So do not try to get "sShopDir" like this:
@@ -338,7 +338,7 @@ class ModuleChainsGenerator
          */
         if (
             !$this->isUnitTest() && // In unit test some classes are created dynamically, so the files would not exist :-(
-            !is_readable($moduleClassFile)
+            !\is_readable($moduleClassFile)
         ) {
             $this->handleSpecialCases($parentClass);
             $this->onModuleExtensionCreationError($moduleClass);
@@ -346,19 +346,19 @@ class ModuleChainsGenerator
             return false;
         }
 
-        if (!class_exists($moduleClass, false)) {
+        if (!\class_exists($moduleClass, false)) {
             /**
              * Create parent alias before trying to load the module class as the class extends this alias
              */
-            if (!class_exists($moduleClassParentAlias, false)) {
-                class_alias($parentClass, $moduleClassParentAlias);
+            if (!\class_exists($moduleClassParentAlias, false)) {
+                \class_alias($parentClass, $moduleClassParentAlias);
             }
             include_once $moduleClassFile;
 
             /**
              * Test if the class could be loaded
              */
-            if (!class_exists($moduleClass, false)) {
+            if (!\class_exists($moduleClass, false)) {
                 $this->handleSpecialCases($parentClass);
                 $this->onModuleExtensionCreationError($moduleClassPath);
 
@@ -395,7 +395,7 @@ class ModuleChainsGenerator
 
             // We can be sure that the parent class of the current class is actually defined due to the way
             // the extension chain is traversed.
-        } while ($currentClass = get_parent_class($currentClass));
+        } while ($currentClass = \get_parent_class($currentClass));
 
         if ($isConfigClass) {
             $config = new \OxidEsales\Eshop\Core\Config();
@@ -411,11 +411,11 @@ class ModuleChainsGenerator
     protected function onModuleExtensionCreationError($moduleClass)
     {
         $moduleId = "(module id not availible)";
-        if (class_exists("\OxidEsales\Eshop\Core\Module\Module", false)) {
+        if (\class_exists("\OxidEsales\Eshop\Core\Module\Module", false)) {
             $module = oxNew(\OxidEsales\Eshop\Core\Module\Module::class);
             $moduleId = $module->getIdByPath($moduleClass);
         }
-        $message = sprintf('Module class %s not found. Module ID %s', $moduleClass, $moduleId);
+        $message = \sprintf('Module class %s not found. Module ID %s', $moduleClass, $moduleId);
         $exception = new \OxidEsales\Eshop\Core\Exception\SystemComponentException($message);
         \OxidEsales\Eshop\Core\Registry::getLogger()->error($exception->getMessage(), [$exception]);
     }
@@ -484,7 +484,7 @@ class ModuleChainsGenerator
      */
     protected function isUnitTest()
     {
-        return defined('OXID_PHP_UNIT');
+        return \defined('OXID_PHP_UNIT');
     }
 
     /**

--- a/source/Core/Module/ModuleExtensionsCleaner.php
+++ b/source/Core/Module/ModuleExtensionsCleaner.php
@@ -38,10 +38,10 @@ class ModuleExtensionsCleaner
 
         $installedModuleExtensions = $this->filterExtensionsByModuleId($installedExtensions, $module->getId());
 
-        if (count($installedModuleExtensions)) {
+        if (\count($installedModuleExtensions)) {
             $garbage = $this->getModuleExtensionsGarbage($moduleExtensions, $installedModuleExtensions);
 
-            if (count($garbage)) {
+            if (\count($garbage)) {
                 $installedExtensions = $this->removeGarbage($installedExtensions, $garbage);
             }
         }
@@ -71,7 +71,7 @@ class ModuleExtensionsCleaner
 
         foreach ($installedExtensions as $class => $extend) {
             foreach ($extend as $extendPath) {
-                if (strpos($extendPath, $moduleConfiguration->getPath()) === 0) {
+                if (\strpos($extendPath, $moduleConfiguration->getPath()) === 0) {
                     $filteredExtensions[$class][] = $extendPath;
                 }
             }
@@ -96,17 +96,17 @@ class ModuleExtensionsCleaner
             if (isset($moduleMetaDataExtensions[$installedClassName])) {
                 // In case more than one extension is specified per module.
                 $metaDataExtensionPaths = $moduleMetaDataExtensions[$installedClassName];
-                if (!is_array($metaDataExtensionPaths)) {
+                if (!\is_array($metaDataExtensionPaths)) {
                     $metaDataExtensionPaths = [$metaDataExtensionPaths];
                 }
 
                 foreach ($installedClassPaths as $index => $installedClassPath) {
-                    if (in_array($installedClassPath, $metaDataExtensionPaths)) {
+                    if (\in_array($installedClassPath, $metaDataExtensionPaths)) {
                         unset($garbage[$installedClassName][$index]);
                     }
                 }
 
-                if (count($garbage[$installedClassName]) == 0) {
+                if (\count($garbage[$installedClassName]) == 0) {
                     unset($garbage[$installedClassName]);
                 }
             }
@@ -128,8 +128,8 @@ class ModuleExtensionsCleaner
         foreach ($garbage as $className => $classPaths) {
             foreach ($classPaths as $sClassPath) {
                 if (isset($installedExtensions[$className])) {
-                    unset($installedExtensions[$className][array_search($sClassPath, $installedExtensions[$className])]);
-                    if (count($installedExtensions[$className]) == 0) {
+                    unset($installedExtensions[$className][\array_search($sClassPath, $installedExtensions[$className])]);
+                    if (\count($installedExtensions[$className]) == 0) {
                         unset($installedExtensions[$className]);
                     }
                 }

--- a/source/Core/Module/ModuleInstaller.php
+++ b/source/Core/Module/ModuleInstaller.php
@@ -115,9 +115,9 @@ class ModuleInstaller extends \OxidEsales\Eshop\Core\Base
     public function buildModuleChains($aModuleArray)
     {
         $aModules = [];
-        if (is_array($aModuleArray)) {
+        if (\is_array($aModuleArray)) {
             foreach ($aModuleArray as $sClass => $aModuleChain) {
-                $aModules[$sClass] = implode('&', $aModuleChain);
+                $aModules[$sClass] = \implode('&', $aModuleChain);
             }
         }
 
@@ -135,22 +135,22 @@ class ModuleInstaller extends \OxidEsales\Eshop\Core\Base
      */
     public function diffModuleArrays($aAllModuleArray, $aRemModuleArray)
     {
-        if (is_array($aAllModuleArray) && is_array($aRemModuleArray)) {
+        if (\is_array($aAllModuleArray) && \is_array($aRemModuleArray)) {
             foreach ($aAllModuleArray as $sClass => $aModuleChain) {
-                if (!is_array($aModuleChain)) {
+                if (!\is_array($aModuleChain)) {
                     $aModuleChain = [$aModuleChain];
                 }
                 if (isset($aRemModuleArray[$sClass])) {
-                    if (!is_array($aRemModuleArray[$sClass])) {
+                    if (!\is_array($aRemModuleArray[$sClass])) {
                         $aRemModuleArray[$sClass] = [$aRemModuleArray[$sClass]];
                     }
                     $aAllModuleArray[$sClass] = [];
                     foreach ($aModuleChain as $sModule) {
-                        if (!in_array($sModule, $aRemModuleArray[$sClass])) {
+                        if (!\in_array($sModule, $aRemModuleArray[$sClass])) {
                             $aAllModuleArray[$sClass][] = $sModule;
                         }
                     }
-                    if (!count($aAllModuleArray[$sClass])) {
+                    if (!\count($aAllModuleArray[$sClass])) {
                         unset($aAllModuleArray[$sClass]);
                     }
                 } else {

--- a/source/Core/Module/ModuleList.php
+++ b/source/Core/Module/ModuleList.php
@@ -206,10 +206,10 @@ class ModuleList extends \OxidEsales\Eshop\Core\Base
         $aModules = $this->getModulesWithExtendedClass();
         $aModulePaths = [];
 
-        if (is_array($aModules) && count($aModules) > 0) {
+        if (\is_array($aModules) && \count($aModules) > 0) {
             foreach ($aModules as $aModuleClasses) {
                 foreach ($aModuleClasses as $sModule) {
-                    $sModuleId = substr($sModule, 0, strpos($sModule, "/"));
+                    $sModuleId = \substr($sModule, 0, \strpos($sModule, "/"));
                     $aModulePaths[$sModuleId] = $sModuleId;
                 }
             }
@@ -269,7 +269,7 @@ class ModuleList extends \OxidEsales\Eshop\Core\Base
     {
         $deletedModules = $this->getDeletedExtensions();
 
-        $deletedModuleIds = array_keys($deletedModules);
+        $deletedModuleIds = \array_keys($deletedModules);
 
         $moduleActivationBridge = ContainerFactory::getInstance()
             ->getContainer()
@@ -321,22 +321,22 @@ class ModuleList extends \OxidEsales\Eshop\Core\Base
      */
     public function diffModuleArrays($aAllModuleArray, $aRemModuleArray)
     {
-        if (is_array($aAllModuleArray) && is_array($aRemModuleArray)) {
+        if (\is_array($aAllModuleArray) && \is_array($aRemModuleArray)) {
             foreach ($aAllModuleArray as $sClass => $aModuleChain) {
-                if (!is_array($aModuleChain)) {
+                if (!\is_array($aModuleChain)) {
                     $aModuleChain = [$aModuleChain];
                 }
                 if (isset($aRemModuleArray[$sClass])) {
-                    if (!is_array($aRemModuleArray[$sClass])) {
+                    if (!\is_array($aRemModuleArray[$sClass])) {
                         $aRemModuleArray[$sClass] = [$aRemModuleArray[$sClass]];
                     }
                     $aAllModuleArray[$sClass] = [];
                     foreach ($aModuleChain as $sModule) {
-                        if (!in_array($sModule, $aRemModuleArray[$sClass])) {
+                        if (!\in_array($sModule, $aRemModuleArray[$sClass])) {
                             $aAllModuleArray[$sClass][] = $sModule;
                         }
                     }
-                    if (!count($aAllModuleArray[$sClass])) {
+                    if (!\count($aAllModuleArray[$sClass])) {
                         unset($aAllModuleArray[$sClass]);
                     }
                 } else {
@@ -358,9 +358,9 @@ class ModuleList extends \OxidEsales\Eshop\Core\Base
     public function buildModuleChains($aModuleArray)
     {
         $aModules = [];
-        if (is_array($aModuleArray)) {
+        if (\is_array($aModuleArray)) {
             foreach ($aModuleArray as $sClass => $aModuleChain) {
-                $aModules[$sClass] = implode('&', $aModuleChain);
+                $aModules[$sClass] = \implode('&', $aModuleChain);
             }
         }
 
@@ -388,10 +388,10 @@ class ModuleList extends \OxidEsales\Eshop\Core\Base
     {
         $moduleArray = [];
 
-        if (is_array($modules)) {
+        if (\is_array($modules)) {
             foreach ($modules as $class => $moduleChain) {
-                if (strstr($moduleChain, '&')) {
-                    $moduleChain = explode('&', $moduleChain);
+                if (\strstr($moduleChain, '&')) {
+                    $moduleChain = \explode('&', $moduleChain);
                 } else {
                     $moduleChain = [$moduleChain];
                 }
@@ -429,18 +429,18 @@ class ModuleList extends \OxidEsales\Eshop\Core\Base
     {
         $sModulesDir = \OxidEsales\Eshop\Core\Registry::getUtilsFile()->normalizeDir($sModulesDir);
 
-        foreach (glob($sModulesDir . '*') as $sModuleDirPath) {
-            $sModuleDirPath .= (is_dir($sModuleDirPath)) ? '/' : '';
-            $sModuleDirName = basename($sModuleDirPath);
+        foreach (\glob($sModulesDir . '*') as $sModuleDirPath) {
+            $sModuleDirPath .= (\is_dir($sModuleDirPath)) ? '/' : '';
+            $sModuleDirName = \basename($sModuleDirPath);
 
             // skipping some file
-            if (in_array($sModuleDirName, $this->_aSkipFiles) || (!is_dir($sModuleDirPath) && substr($sModuleDirName, -4) != ".php")) {
+            if (\in_array($sModuleDirName, $this->_aSkipFiles) || (!\is_dir($sModuleDirPath) && \substr($sModuleDirName, -4) != ".php")) {
                 continue;
             }
 
             if ($this->_isVendorDir($sModuleDirPath)) {
                 // scanning modules vendor directory
-                $this->getModulesFromDir($sModuleDirPath, basename($sModuleDirPath));
+                $this->getModulesFromDir($sModuleDirPath, \basename($sModuleDirPath));
             } else {
                 // loading module info
                 $oModule = $this->getModule();
@@ -453,7 +453,7 @@ class ModuleList extends \OxidEsales\Eshop\Core\Base
         }
         // sorting by name
         if ($this->_aModules !== null) {
-            uasort($this->_aModules, [$this, '_sortModules']);
+            \uasort($this->_aModules, [$this, '_sortModules']);
         }
 
         return $this->_aModules;
@@ -521,7 +521,7 @@ class ModuleList extends \OxidEsales\Eshop\Core\Base
      */
     protected function _sortModules($oModule1, $oModule2) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
-        return strcasecmp($oModule1->getTitle(), $oModule2->getTitle());
+        return \strcasecmp($oModule1->getTitle(), $oModule2->getTitle());
     }
 
     /**
@@ -534,14 +534,14 @@ class ModuleList extends \OxidEsales\Eshop\Core\Base
      */
     protected function _isVendorDir($sModuleDir) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
-        if (!is_dir($sModuleDir)) {
+        if (!\is_dir($sModuleDir)) {
             return false;
         }
 
-        $currentDirectoryContents = scandir($sModuleDir);
-        $currentDirectoryContents = array_diff($currentDirectoryContents, ['.', '..']);
+        $currentDirectoryContents = \scandir($sModuleDir);
+        $currentDirectoryContents = \array_diff($currentDirectoryContents, ['.', '..']);
         foreach ($currentDirectoryContents as $entry) {
-            if (is_dir("$sModuleDir/$entry") && file_exists("$sModuleDir/$entry/metadata.php")) {
+            if (\is_dir("$sModuleDir/$entry") && \file_exists("$sModuleDir/$entry/metadata.php")) {
                 return true;
             }
         }
@@ -591,7 +591,7 @@ class ModuleList extends \OxidEsales\Eshop\Core\Base
     private function backwardsCompatibleGetInvalidExtensions($moduleClass, &$invalidModuleClasses, $extendedShopClass)
     {
         $moduleClassFile = \OxidEsales\Eshop\Core\Registry::getConfig()->getModulesDir() . $moduleClass . '.php';
-        if (!is_readable($moduleClassFile)) {
+        if (!\is_readable($moduleClassFile)) {
             $invalidModuleClasses[$extendedShopClass][] = $moduleClass;
         }
     }

--- a/source/Core/Module/ModuleMetadataValidator.php
+++ b/source/Core/Module/ModuleMetadataValidator.php
@@ -31,7 +31,7 @@ class ModuleMetadataValidator implements \OxidEsales\Eshop\Core\Contract\IModule
      */
     public function validate(\OxidEsales\Eshop\Core\Module\Module $module)
     {
-        return file_exists($module->getMetadataPath());
+        return \file_exists($module->getMetadataPath());
     }
 
     /**
@@ -70,7 +70,7 @@ class ModuleMetadataValidator implements \OxidEsales\Eshop\Core\Contract\IModule
                 NamespaceInformationProvider::isNamespacedClass($classToBePatched)
                  && (
                      NamespaceInformationProvider::classBelongsToShopEditionNamespace($classToBePatched)
-                      || (NamespaceInformationProvider::classBelongsToShopUnifiedNamespace($classToBePatched) && !class_exists($classToBePatched))
+                      || (NamespaceInformationProvider::classBelongsToShopUnifiedNamespace($classToBePatched) && !\class_exists($classToBePatched))
                     )
             ) {
                 $incorrect[$classToBePatched] = $moduleClass;
@@ -91,8 +91,8 @@ class ModuleMetadataValidator implements \OxidEsales\Eshop\Core\Contract\IModule
         foreach ($incorrect as $patchee => $patch) {
             $additionalInformation .= $patchee . ' => ' . $patch . ', ';
         }
-        $additionalInformation = rtrim($additionalInformation, ', ');
-        $message = sprintf(Registry::getLang()->translateString($languageConstant, null, true), $additionalInformation);
+        $additionalInformation = \rtrim($additionalInformation, ', ');
+        $message = \sprintf(Registry::getLang()->translateString($languageConstant, null, true), $additionalInformation);
 
         return $message;
     }

--- a/source/Core/Module/ModuleSmartyPluginDirectoryValidator.php
+++ b/source/Core/Module/ModuleSmartyPluginDirectoryValidator.php
@@ -44,6 +44,6 @@ class ModuleSmartyPluginDirectoryValidator
      */
     private function doesDirectoryExist($directory)
     {
-        return is_dir($directory);
+        return \is_dir($directory);
     }
 }

--- a/source/Core/Module/ModuleTemplateBlockContentReader.php
+++ b/source/Core/Module/ModuleTemplateBlockContentReader.php
@@ -30,21 +30,21 @@ class ModuleTemplateBlockContentReader
     {
         if (!$pathFormatter instanceof \OxidEsales\Eshop\Core\Module\ModuleTemplateBlockPathFormatter) {
             $exceptionMessage = 'Provided object is not an instance of class %s or does not have method getPath().';
-            throw oxNew(\oxException::class, sprintf($exceptionMessage, \OxidEsales\Eshop\Core\Module\ModuleTemplateBlockPathFormatter::class));
+            throw oxNew(\oxException::class, \sprintf($exceptionMessage, \OxidEsales\Eshop\Core\Module\ModuleTemplateBlockPathFormatter::class));
         }
 
         $filePath = $pathFormatter->getPath();
 
-        if (!file_exists($filePath)) {
+        if (!\file_exists($filePath)) {
             $exceptionMessage = "Template block file (%s) was not found for module '%s'.";
-            throw oxNew(\oxException::class, sprintf($exceptionMessage, $filePath, $pathFormatter->getModuleId()));
+            throw oxNew(\oxException::class, \sprintf($exceptionMessage, $filePath, $pathFormatter->getModuleId()));
         }
 
-        if (!is_readable($filePath)) {
+        if (!\is_readable($filePath)) {
             $exceptionMessage = "Template block file (%s) is not readable for module '%s'.";
-            throw oxNew(\oxException::class, sprintf($exceptionMessage, $filePath, $pathFormatter->getModuleId()));
+            throw oxNew(\oxException::class, \sprintf($exceptionMessage, $filePath, $pathFormatter->getModuleId()));
         }
 
-        return file_get_contents($filePath);
+        return \file_get_contents($filePath);
     }
 }

--- a/source/Core/Module/ModuleTemplateBlockPathFormatter.php
+++ b/source/Core/Module/ModuleTemplateBlockPathFormatter.php
@@ -68,16 +68,16 @@ class ModuleTemplateBlockPathFormatter
      */
     public function getPath()
     {
-        if (is_null($this->moduleId) || is_null($this->fileName)) {
+        if (\is_null($this->moduleId) || \is_null($this->fileName)) {
             throw oxNew(\OxidEsales\Eshop\Core\Exception\StandardException::class);
         }
 
         $fileName = $this->fileName;
 
         // for < 4.6 modules, since 4.7/5.0 insert in oxtplblocks the full file name and path
-        if (basename($fileName) === $fileName) {
+        if (\basename($fileName) === $fileName) {
             // for 4.5 modules, since 4.6 insert in oxtplblocks the full file name
-            if (substr($fileName, -4) !== '.tpl') {
+            if (\substr($fileName, -4) !== '.tpl') {
                 $fileName = $fileName . ".tpl";
             }
 
@@ -86,7 +86,7 @@ class ModuleTemplateBlockPathFormatter
 
         $activeModuleInfo = (array) Registry::getConfig()->getConfigParam('aModulePaths');
 
-        if (!array_key_exists($this->moduleId, $activeModuleInfo)) {
+        if (!\array_key_exists($this->moduleId, $activeModuleInfo)) {
             throw oxNew(\oxException::class, 'Module: ' . $this->moduleId . ' is not active.');
         }
 

--- a/source/Core/Module/ModuleTemplateBlockRepository.php
+++ b/source/Core/Module/ModuleTemplateBlockRepository.php
@@ -26,7 +26,7 @@ class ModuleTemplateBlockRepository
     public function getBlocksCount($modulesId, $shopId)
     {
         $db = \OxidEsales\Eshop\Core\DatabaseProvider::getDb(\OxidEsales\Eshop\Core\DatabaseProvider::FETCH_MODE_ASSOC);
-        $modulesIdQuery = implode(", ", \OxidEsales\Eshop\Core\DatabaseProvider::getDb()->quoteArray($modulesId));
+        $modulesIdQuery = \implode(", ", \OxidEsales\Eshop\Core\DatabaseProvider::getDb()->quoteArray($modulesId));
         $sql = "select COUNT(*)
                             from oxtplblocks
                             where oxactive = :oxactive
@@ -51,7 +51,7 @@ class ModuleTemplateBlockRepository
      */
     public function getBlocks($shopTemplateName, $activeModulesId, $shopId, $themesId = [])
     {
-        $modulesId = implode(", ", \OxidEsales\Eshop\Core\DatabaseProvider::getDb()->quoteArray($activeModulesId));
+        $modulesId = \implode(", ", \OxidEsales\Eshop\Core\DatabaseProvider::getDb()->quoteArray($activeModulesId));
 
         $activeThemesIdQuery = $this->formActiveThemesIdQuery($themesId);
         $sql = "select *
@@ -80,8 +80,8 @@ class ModuleTemplateBlockRepository
     private function formActiveThemesIdQuery($activeThemeIds = [])
     {
         $defaultThemeIndicator = '';
-        array_unshift($activeThemeIds, $defaultThemeIndicator);
+        \array_unshift($activeThemeIds, $defaultThemeIndicator);
 
-        return implode(', ', \OxidEsales\Eshop\Core\DatabaseProvider::getDb()->quoteArray($activeThemeIds));
+        return \implode(', ', \OxidEsales\Eshop\Core\DatabaseProvider::getDb()->quoteArray($activeThemeIds));
     }
 }

--- a/source/Core/Module/ModuleTemplatePathCalculator.php
+++ b/source/Core/Module/ModuleTemplatePathCalculator.php
@@ -41,13 +41,13 @@ class ModuleTemplatePathCalculator
      */
     public function __construct($moduleList = null, $theme = null, $fileSystem = null)
     {
-        if (is_null($moduleList)) {
+        if (\is_null($moduleList)) {
             $moduleList = oxNew(\OxidEsales\Eshop\Core\Module\ModuleList::class);
         }
-        if (is_null($theme)) {
+        if (\is_null($theme)) {
             $theme = oxNew(Theme::class);
         }
-        if (is_null($fileSystem)) {
+        if (\is_null($fileSystem)) {
             $fileSystem = oxNew(FileSystem::class);
         }
 
@@ -89,7 +89,7 @@ class ModuleTemplatePathCalculator
 
         $finalTemplatePath = '';
 
-        if (is_array($moduleTemplates) && is_array($activeModules)) {
+        if (\is_array($moduleTemplates) && \is_array($activeModules)) {
             foreach ($moduleTemplates as $sModuleId => $aTemplates) {
                 // check if module is active
                 if (isset($activeModules[$sModuleId])) {
@@ -113,7 +113,7 @@ class ModuleTemplatePathCalculator
                             $finalTemplatePath = $foundTemplate;
                             break;
                         } else {
-                            throw oxNew(\oxException::class, sprintf('Cannot find template file "%s".', $foundTemplate));
+                            throw oxNew(\oxException::class, \sprintf('Cannot find template file "%s".', $foundTemplate));
                         }
                     }
                 }
@@ -121,7 +121,7 @@ class ModuleTemplatePathCalculator
         }
 
         if (!$finalTemplatePath) {
-            throw oxNew(\oxException::class, sprintf('Cannot find template "%s" in modules configuration.', $templateName));
+            throw oxNew(\oxException::class, \sprintf('Cannot find template "%s" in modules configuration.', $templateName));
         }
 
         return $finalTemplatePath;

--- a/source/Core/Module/ModuleTranslationPathFinder.php
+++ b/source/Core/Module/ModuleTranslationPathFinder.php
@@ -95,7 +95,7 @@ class ModuleTranslationPathFinder
      */
     protected function directoryExists($path)
     {
-        return file_exists($path);
+        return \file_exists($path);
     }
 
     /**

--- a/source/Core/Module/ModuleVariablesLocator.php
+++ b/source/Core/Module/ModuleVariablesLocator.php
@@ -57,7 +57,7 @@ class ModuleVariablesLocator
         //first try to get it from cache
         $value = $cache->getFromCache($name);
 
-        if (is_null($value)) {
+        if (\is_null($value)) {
             $value = $this->getModuleVarFromDB($name);
             $cache->setToCache($name, $value);
         }
@@ -75,7 +75,7 @@ class ModuleVariablesLocator
      */
     public function setModuleVariable($name, $value)
     {
-        if (is_null($value)) {
+        if (\is_null($value)) {
             self::$moduleVariables = null;
         } else {
             self::$moduleVariables[$name] = $value;
@@ -115,7 +115,7 @@ class ModuleVariablesLocator
             ':oxshopid'  => $shopId
         ]);
 
-        return unserialize($value);
+        return \unserialize($value);
     }
 
     /**

--- a/source/Core/NamespaceInformationProvider.php
+++ b/source/Core/NamespaceInformationProvider.php
@@ -74,7 +74,7 @@ class NamespaceInformationProvider
      */
     public static function isNamespacedClass($className)
     {
-        return strpos($className, '\\') !== false;
+        return \strpos($className, '\\') !== false;
     }
 
     /**
@@ -98,9 +98,9 @@ class NamespaceInformationProvider
      */
     public static function classBelongsToShopUnifiedNamespace($className)
     {
-        $lcClassName = strtolower(ltrim($className, '\\'));
+        $lcClassName = \strtolower(\ltrim($className, '\\'));
         $unifiedNamespace = static::getUnifiedNamespace();
-        $belongsToUnifiedNamespace = (false !== strpos($lcClassName, strtolower($unifiedNamespace)));
+        $belongsToUnifiedNamespace = (false !== \strpos($lcClassName, \strtolower($unifiedNamespace)));
 
         return $belongsToUnifiedNamespace;
     }
@@ -116,11 +116,11 @@ class NamespaceInformationProvider
     private static function classBelongsToNamespace($className, $namespaces)
     {
         $belongsToNamespace = false;
-        $check = array_values($namespaces);
-        $lcClassName = strtolower(ltrim($className, '\\'));
+        $check = \array_values($namespaces);
+        $lcClassName = \strtolower(\ltrim($className, '\\'));
 
         foreach ($check as $namespace) {
-            if (false !== strpos($lcClassName, strtolower($namespace))) {
+            if (false !== \strpos($lcClassName, \strtolower($namespace))) {
                 $belongsToNamespace = true;
                 continue;
             }

--- a/source/Core/NoJsValidator.php
+++ b/source/Core/NoJsValidator.php
@@ -21,6 +21,6 @@ class NoJsValidator
      */
     public function isValid($configValue)
     {
-        return preg_match('/<script.*>/', $configValue) === 0;
+        return \preg_match('/<script.*>/', $configValue) === 0;
     }
 }

--- a/source/Core/OnlineLicenseCheck.php
+++ b/source/Core/OnlineLicenseCheck.php
@@ -274,7 +274,7 @@ class OnlineLicenseCheck
 
         $request->productSpecificInformation = new stdClass();
 
-        if (!is_null($this->getAppServerExporter())) {
+        if (!\is_null($this->getAppServerExporter())) {
             $servers = $this->getAppServerExporter()->exportAppServerList();
             $request->productSpecificInformation->servers = ['server' => $servers];
         }
@@ -298,7 +298,7 @@ class OnlineLicenseCheck
 
         $counters = [];
 
-        if (!is_null($this->getUserCounter())) {
+        if (!\is_null($this->getUserCounter())) {
             $counters[] = [
                 'name' => 'admin users',
                 'value' => $userCounter->getAdminCount(),

--- a/source/Core/OnlineModuleVersionNotifier.php
+++ b/source/Core/OnlineModuleVersionNotifier.php
@@ -137,7 +137,7 @@ class OnlineModuleVersionNotifier
             $modules[$moduleConfiguration->getId()] = $module;
         }
 
-        ksort($modules);
+        \ksort($modules);
 
         return $modules;
     }

--- a/source/Core/OnlineVatIdCheck.php
+++ b/source/Core/OnlineVatIdCheck.php
@@ -107,16 +107,16 @@ class OnlineVatIdCheck extends \OxidEsales\Eshop\Core\CompanyVatInChecker
     protected function _isServiceAvailable() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         if ($this->_blServiceIsOn === null) {
-            $this->_blServiceIsOn = class_exists('SoapClient') ? true : false;
+            $this->_blServiceIsOn = \class_exists('SoapClient') ? true : false;
             if ($this->_blServiceIsOn) {
-                $rFp = @fopen($this->getWsdlUrl(), 'r');
+                $rFp = @\fopen($this->getWsdlUrl(), 'r');
                 $this->_blServiceIsOn = $rFp !== false;
                 if ($this->_blServiceIsOn) {
                     $sWsdl = '';
-                    while (!feof($rFp)) {
-                        $sWsdl .= fread($rFp, 8192);
+                    while (!\feof($rFp)) {
+                        $sWsdl .= \fread($rFp, 8192);
                     }
-                    fclose($rFp);
+                    \fclose($rFp);
 
                     // validating wsdl file
                     try {
@@ -149,10 +149,10 @@ class OnlineVatIdCheck extends \OxidEsales\Eshop\Core\CompanyVatInChecker
 
             //T2009-07-02
             //how long socket should wait for server RESPONSE
-            ini_set('default_socket_timeout', 5);
+            \ini_set('default_socket_timeout', 5);
 
             // setting local error handler to catch possible soap errors
-            set_error_handler([$this, 'catchWarning'], E_WARNING);
+            \set_error_handler([$this, 'catchWarning'], E_WARNING);
 
             do {
                 try {
@@ -164,7 +164,7 @@ class OnlineVatIdCheck extends \OxidEsales\Eshop\Core\CompanyVatInChecker
                 } catch (SoapFault $e) {
                     $this->setError($e->faultstring);
                     if ($this->getError() == "SERVER_BUSY") {
-                        usleep(self::BUSY_RETRY_WAITUSEC);
+                        \usleep(self::BUSY_RETRY_WAITUSEC);
                     } else {
                         $iTryMoreCnt = 0;
                     }
@@ -172,7 +172,7 @@ class OnlineVatIdCheck extends \OxidEsales\Eshop\Core\CompanyVatInChecker
             } while (0 < $iTryMoreCnt--);
 
             // restoring previous error handler
-            restore_error_handler();
+            \restore_error_handler();
 
             return (bool) $oRes->valid;
         } else {

--- a/source/Core/OpenSSLFunctionalityChecker.php
+++ b/source/Core/OpenSSLFunctionalityChecker.php
@@ -19,6 +19,6 @@ class OpenSSLFunctionalityChecker
      */
     public function isOpenSslRandomBytesGeneratorAvailable()
     {
-        return function_exists('openssl_random_pseudo_bytes');
+        return \function_exists('openssl_random_pseudo_bytes');
     }
 }

--- a/source/Core/Output.php
+++ b/source/Core/Output.php
@@ -90,15 +90,15 @@ class Output extends \OxidEsales\Eshop\Core\Base
     {
         // DISPLAY IT
         $sEdition = \OxidEsales\Eshop\Core\Registry::getConfig()->getFullEdition();
-        $sCurYear = date("Y");
+        $sCurYear = \date("Y");
 
         // Replacing only once per page
         $sSearch = "</head>";
         $sReplace = "</head>\n  <!-- OXID eShop {$sEdition}, Shopping Cart System (c) OXID eSales AG 2003 - {$sCurYear} - https://www.oxid-esales.com -->";
 
-        $sOutput = ltrim($sOutput);
-        if (($pos = stripos($sOutput, $sSearch)) !== false) {
-            $sOutput = substr_replace($sOutput, $sReplace, $pos, strlen($sSearch));
+        $sOutput = \ltrim($sOutput);
+        if (($pos = \stripos($sOutput, $sSearch)) !== false) {
+            $sOutput = \substr_replace($sOutput, $sReplace, $pos, \strlen($sSearch));
         }
 
         return $sOutput;

--- a/source/Core/PasswordSaltGenerator.php
+++ b/source/Core/PasswordSaltGenerator.php
@@ -42,7 +42,7 @@ class PasswordSaltGenerator
     public function generate()
     {
         if ($this->_getOpenSSLFunctionalityChecker()->isOpenSslRandomBytesGeneratorAvailable()) {
-            $sSalt = bin2hex(openssl_random_pseudo_bytes(16));
+            $sSalt = \bin2hex(\openssl_random_pseudo_bytes(16));
         } else {
             $sSalt = $this->_customSaltGenerator();
         }
@@ -72,8 +72,8 @@ class PasswordSaltGenerator
         $sHash = '';
         $sSalt = '';
         for ($i = 0; $i < 32; $i++) {
-            $sHash = hash('sha256', $sHash . mt_rand());
-            $iPosition = mt_rand(0, 62);
+            $sHash = \hash('sha256', $sHash . \mt_rand());
+            $iPosition = \mt_rand(0, 62);
             $sSalt .= $sHash[$iPosition];
         }
 

--- a/source/Core/PictureHandler.php
+++ b/source/Core/PictureHandler.php
@@ -31,7 +31,7 @@ class PictureHandler extends \OxidEsales\Eshop\Core\Base
         $blGeneratedImagesOnly = !$blDeleteMasterPicture;
 
         $sAbsDynImageDir = $myConfig->getPictureDir(false);
-        $sMasterImage = basename($oObject->{"oxarticles__oxpic" . $iIndex}->value);
+        $sMasterImage = \basename($oObject->{"oxarticles__oxpic" . $iIndex}->value);
         if (!$sMasterImage || $sMasterImage == "nopic.jpg") {
             return;
         }
@@ -48,7 +48,7 @@ class PictureHandler extends \OxidEsales\Eshop\Core\Base
             if ($iIndex == 1) {
                 // deleting generated main icon picture if custom main icon
                 // file name not equal with generated from master picture
-                if ($this->getMainIconName($sMasterImage) != basename($oObject->oxarticles__oxicon->value)) {
+                if ($this->getMainIconName($sMasterImage) != \basename($oObject->oxarticles__oxicon->value)) {
                     $aDelPics[] = ["sField"    => "oxpic1",
                                         "sDir"      => $oUtilsFile->getImageDirByType("ICO", $blGeneratedImagesOnly),
                                         "sFileName" => $this->getMainIconName($sMasterImage)];
@@ -56,7 +56,7 @@ class PictureHandler extends \OxidEsales\Eshop\Core\Base
 
                 // deleting generated thumbnail picture if custom thumbnail
                 // file name not equal with generated from master picture
-                if ($this->getThumbName($sMasterImage) != basename($oObject->oxarticles__oxthumb->value)) {
+                if ($this->getThumbName($sMasterImage) != \basename($oObject->oxarticles__oxthumb->value)) {
                     $aDelPics[] = ["sField"    => "oxpic1",
                                         "sDir"      => $oUtilsFile->getImageDirByType("TH", $blGeneratedImagesOnly),
                                         "sFileName" => $this->getThumbName($sMasterImage)];
@@ -70,7 +70,7 @@ class PictureHandler extends \OxidEsales\Eshop\Core\Base
 
         //deleting custom zoom pic (compatibility mode)
         if ($oObject->{"oxarticles__oxzoom" . $iIndex}->value) {
-            if (basename($oObject->{"oxarticles__oxzoom" . $iIndex}->value) !== "nopic.jpg") {
+            if (\basename($oObject->{"oxarticles__oxzoom" . $iIndex}->value) !== "nopic.jpg") {
                 // deleting old zoom picture
                 $this->deleteZoomPicture($oObject, $iIndex);
             }
@@ -125,7 +125,7 @@ class PictureHandler extends \OxidEsales\Eshop\Core\Base
                 return;
             }
         } else {
-            $sZoomPicName = basename($oObject->{"oxarticles__oxzoom" . $iIndex}->value);
+            $sZoomPicName = \basename($oObject->{"oxarticles__oxzoom" . $iIndex}->value);
             $sFieldToCheck = "oxzoom" . $iIndex;
         }
 
@@ -169,7 +169,7 @@ class PictureHandler extends \OxidEsales\Eshop\Core\Base
      */
     public function getThumbName($sMasterImageFile)
     {
-        return basename($sMasterImageFile);
+        return \basename($sMasterImageFile);
     }
 
     /**
@@ -182,7 +182,7 @@ class PictureHandler extends \OxidEsales\Eshop\Core\Base
      */
     public function getZoomName($sMasterImageFile, $iIndex)
     {
-        return basename($sMasterImageFile);
+        return \basename($sMasterImageFile);
     }
 
     /**
@@ -195,7 +195,7 @@ class PictureHandler extends \OxidEsales\Eshop\Core\Base
      */
     protected function _getBaseMasterImageFileName($sMasterImageFile) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
-        return basename($sMasterImageFile);
+        return \basename($sMasterImageFile);
     }
 
     /**
@@ -209,12 +209,12 @@ class PictureHandler extends \OxidEsales\Eshop\Core\Base
     public function getImageSize($aImgSizes, $sIndex = null)
     {
         $aSize = [];
-        if (isset($sIndex) && is_array($aImgSizes) && isset($aImgSizes[$sIndex])) {
-            $aSize = explode('*', $aImgSizes[$sIndex]);
-        } elseif (is_string($aImgSizes)) {
-            $aSize = explode('*', $aImgSizes);
+        if (isset($sIndex) && \is_array($aImgSizes) && isset($aImgSizes[$sIndex])) {
+            $aSize = \explode('*', $aImgSizes[$sIndex]);
+        } elseif (\is_string($aImgSizes)) {
+            $aSize = \explode('*', $aImgSizes);
         }
-        if (is_array($aSize) && 2 == count($aSize)) {
+        if (\is_array($aSize) && 2 == \count($aSize)) {
             $x = (int) $aSize[0];
             $y = (int) $aSize[1];
             if ($x && $y) {
@@ -254,7 +254,7 @@ class PictureHandler extends \OxidEsales\Eshop\Core\Base
         $sDirPrefix = $oConfig->getOutDir();
         $sUrlPrefix = $oConfig->getOutUrl($blSSL, $blAdmin, $oConfig->getConfigParam('blNativeImages'));
 
-        return ['path' => $sPath, 'url' => str_replace($sDirPrefix, $sUrlPrefix, $sPath)];
+        return ['path' => $sPath, 'url' => \str_replace($sDirPrefix, $sUrlPrefix, $sPath)];
     }
 
     /**
@@ -276,7 +276,7 @@ class PictureHandler extends \OxidEsales\Eshop\Core\Base
         }
 
         if ($sAltUrl) {
-            if ((is_null($blSSL) && $oConfig->isSsl()) || $blSSL) {
+            if ((\is_null($blSSL) && $oConfig->isSsl()) || $blSSL) {
                 $sSslAltUrl = $oConfig->getConfigParam('sSSLAltImageUrl');
                 if (!$sSslAltUrl) {
                     $sSslAltUrl = $oConfig->getConfigParam('sSSLAltImageDir');
@@ -287,7 +287,7 @@ class PictureHandler extends \OxidEsales\Eshop\Core\Base
                 }
             }
 
-            if (!is_null($sFile)) {
+            if (!\is_null($sFile)) {
                 $sAltUrl = Registry::getUtils()->checkUrlEndingSlash($sAltUrl) . $sFilePath . $sFile;
             }
         }
@@ -314,7 +314,7 @@ class PictureHandler extends \OxidEsales\Eshop\Core\Base
             $aPicInfo = $this->_getPictureInfo("master/" . ($sAltPath ? $sAltPath : $sPath), $sFile, $this->isAdmin(), $bSsl);
             if ($aPicInfo['url'] && $aSize[0] && $aSize[1]) {
                 $sDirName = "{$aSize[0]}_{$aSize[1]}_" . \OxidEsales\Eshop\Core\Registry::getConfig()->getConfigParam('sDefaultImageQuality');
-                $sUrl = str_replace("/master/" . ($sAltPath ? $sAltPath : $sPath), "/generated/{$sPath}{$sDirName}/", $aPicInfo['url']);
+                $sUrl = \str_replace("/master/" . ($sAltPath ? $sAltPath : $sPath), "/generated/{$sPath}{$sDirName}/", $aPicInfo['url']);
             }
         }
 

--- a/source/Core/Price.php
+++ b/source/Core/Price.php
@@ -63,7 +63,7 @@ class Price
     {
         $this->setNettoMode(\OxidEsales\Eshop\Core\Registry::getConfig()->getConfigParam('blEnterNetPrice'));
 
-        if (!is_null($dPrice)) {
+        if (!\is_null($dPrice)) {
             $this->setPrice($dPrice);
         }
     }
@@ -151,7 +151,7 @@ class Price
      */
     public function setPrice($dPrice, $dVat = null)
     {
-        if (!is_null($dVat)) {
+        if (!\is_null($dVat)) {
             $this->setVat($dVat);
         }
 

--- a/source/Core/PriceList.php
+++ b/source/Core/PriceList.php
@@ -136,11 +136,11 @@ class PriceList
     public function getMostUsedVatPercent()
     {
         $aPrices = $this->getPriceInfo();
-        if (count($aPrices) == 0) {
+        if (\count($aPrices) == 0) {
             return;
         }
 
-        return max(array_keys($aPrices, max($aPrices)));
+        return \max(\array_keys($aPrices, \max($aPrices)));
     }
 
     /**
@@ -185,7 +185,7 @@ class PriceList
      */
     public function calculateToPrice()
     {
-        if (count($this->_aList) == 0) {
+        if (\count($this->_aList) == 0) {
             return;
         }
 
@@ -217,6 +217,6 @@ class PriceList
      */
     public function getCount()
     {
-        return count($this->_aList);
+        return \count($this->_aList);
     }
 }

--- a/source/Core/Registry.php
+++ b/source/Core/Registry.php
@@ -66,7 +66,7 @@ class Registry
     {
         $key = self::getStorageKey($className);
 
-        if (is_null($instance)) {
+        if (\is_null($instance)) {
             unset(self::$instances[$key]);
 
             return;
@@ -338,7 +338,7 @@ class Registry
      */
     public static function getKeys()
     {
-        return array_keys(self::$instances);
+        return \array_keys(self::$instances);
     }
 
     /**
@@ -362,7 +362,7 @@ class Registry
      */
     public static function getBackwardsCompatibilityClassMap()
     {
-        if (is_null(self::$backwardsCompatibilityClassMap)) {
+        if (\is_null(self::$backwardsCompatibilityClassMap)) {
             $classMap = (new BackwardsCompatibilityClassMapProvider())->getMap();
             self::$backwardsCompatibilityClassMap = $classMap;
         }
@@ -384,7 +384,7 @@ class Registry
 
         if (!\OxidEsales\Eshop\Core\NamespaceInformationProvider::isNamespacedClass($className)) {
             $bcMap = self::getBackwardsCompatibilityClassMap();
-            $key = isset($bcMap[strtolower($key)]) ? $bcMap[strtolower($key)] : strtolower($key);
+            $key = isset($bcMap[\strtolower($key)]) ? $bcMap[\strtolower($key)] : \strtolower($key);
         }
 
         return $key;
@@ -403,7 +403,7 @@ class Registry
      */
     protected static function createObject($className)
     {
-        if (('oxutilsobject' === strtolower($className)) || \OxidEsales\Eshop\Core\UtilsObject::class === $className) {
+        if (('oxutilsobject' === \strtolower($className)) || \OxidEsales\Eshop\Core\UtilsObject::class === $className) {
             $object = \OxidEsales\Eshop\Core\UtilsObject::getInstance();
         } else {
             $object = \oxNew($className);

--- a/source/Core/Request.php
+++ b/source/Core/Request.php
@@ -75,7 +75,7 @@ class Request
             }
 
             // trying to resolve controller file name
-            if ($rawRequestUrl && ($iPos = stripos($rawRequestUrl, '?')) !== false) {
+            if ($rawRequestUrl && ($iPos = \stripos($rawRequestUrl, '?')) !== false) {
                 $string = Str::getStr();
                 // formatting request url
                 $requestUrl = 'index.php' . $string->substr($rawRequestUrl, $iPos);
@@ -84,7 +84,7 @@ class Request
                 $requestUrl = $string->preg_replace('/(&|\?)(force_)?(admin_)?sid=[^&]*&?/', '$1', $requestUrl);
                 $requestUrl = $string->preg_replace('/(&|\?)stoken=[^&]*&?/', '$1', $requestUrl);
                 $requestUrl = $string->preg_replace('/&$/', '', $requestUrl);
-                $requestUrl = str_replace('&', '&amp;', $requestUrl);
+                $requestUrl = \str_replace('&', '&amp;', $requestUrl);
             }
         }
 
@@ -102,15 +102,15 @@ class Request
      */
     public function checkParamSpecialChars(&$sValue, $aRaw = null)
     {
-        if (is_object($sValue)) {
+        if (\is_object($sValue)) {
             return $sValue;
         }
 
-        if (is_array($sValue)) {
+        if (\is_array($sValue)) {
             $newValue = [];
             foreach ($sValue as $sKey => $sVal) {
                 $sValidKey = $sKey;
-                if (!$aRaw || !in_array($sKey, $aRaw)) {
+                if (!$aRaw || !\in_array($sKey, $aRaw)) {
                     $this->checkParamSpecialChars($sValidKey);
                     $this->checkParamSpecialChars($sVal);
                     if ($sValidKey != $sKey) {
@@ -120,9 +120,9 @@ class Request
                 $newValue[$sValidKey] = $sVal;
             }
             $sValue = $newValue;
-        } elseif (is_string($sValue)) {
-            $sValue = str_replace(
-                ['&', '<', '>', '"', "'", chr(0), '\\', "\n", "\r"],
+        } elseif (\is_string($sValue)) {
+            $sValue = \str_replace(
+                ['&', '<', '>', '"', "'", \chr(0), '\\', "\n", "\r"],
                 ['&amp;', '&lt;', '&gt;', '&quot;', '&#039;', '', '&#092;', '&#10;', '&#13;'],
                 $sValue
             );

--- a/source/Core/Routing/ControllerClassNameResolver.php
+++ b/source/Core/Routing/ControllerClassNameResolver.php
@@ -116,7 +116,7 @@ class ControllerClassNameResolver implements ClassNameResolverInterface
     {
         $shopControllerMapProvider = $this->getShopControllerMapProvider();
         $idToNameMap = $shopControllerMapProvider->getControllerMap();
-        $classId = $this->arrayLookup($className, array_flip($idToNameMap));
+        $classId = $this->arrayLookup($className, \array_flip($idToNameMap));
 
         return $classId;
     }
@@ -132,7 +132,7 @@ class ControllerClassNameResolver implements ClassNameResolverInterface
     {
         $moduleControllerMapProvider = $this->getModuleControllerMapProvider();
         $idToNameMap = $moduleControllerMapProvider->getControllerMap();
-        $classId = $this->arrayLookup($className, array_flip($idToNameMap));
+        $classId = $this->arrayLookup($className, \array_flip($idToNameMap));
 
         return $classId;
     }
@@ -145,9 +145,9 @@ class ControllerClassNameResolver implements ClassNameResolverInterface
      */
     protected function arrayLookup($key, $keys2Values)
     {
-        $keys2Values = array_change_key_case($keys2Values);
-        $key = strtolower($key);
-        $match = array_key_exists($key, $keys2Values) ? $keys2Values[$key] : null;
+        $keys2Values = \array_change_key_case($keys2Values);
+        $key = \strtolower($key);
+        $match = \array_key_exists($key, $keys2Values) ? $keys2Values[$key] : null;
 
         return $match;
     }
@@ -159,7 +159,7 @@ class ControllerClassNameResolver implements ClassNameResolverInterface
      */
     protected function getShopControllerMapProvider()
     {
-        if (is_null($this->shopControllerMapProvider)) {
+        if (\is_null($this->shopControllerMapProvider)) {
             $this->shopControllerMapProvider = oxNew(\OxidEsales\Eshop\Core\Routing\ShopControllerMapProvider::class);
         }
 
@@ -173,7 +173,7 @@ class ControllerClassNameResolver implements ClassNameResolverInterface
      */
     protected function getModuleControllerMapProvider()
     {
-        if (is_null($this->moduleControllerMapProvider)) {
+        if (\is_null($this->moduleControllerMapProvider)) {
             $this->moduleControllerMapProvider = oxNew(\OxidEsales\Eshop\Core\Routing\ModuleControllerMapProvider::class);
         }
 

--- a/source/Core/Routing/Module/ClassProviderStorage.php
+++ b/source/Core/Routing/Module/ClassProviderStorage.php
@@ -68,7 +68,7 @@ class ClassProviderStorage implements ClassProviderStorageInterface
     public function remove($moduleId)
     {
         $controllerMap = $this->get();
-        unset($controllerMap[strtolower($moduleId)]);
+        unset($controllerMap[\strtolower($moduleId)]);
 
         $this->set($controllerMap);
     }
@@ -84,9 +84,9 @@ class ClassProviderStorage implements ClassProviderStorageInterface
     {
         $result = [];
 
-        if (!is_null($modulesControllers)) {
+        if (!\is_null($modulesControllers)) {
             foreach ($modulesControllers as $moduleId => $controllers) {
-                $result[strtolower($moduleId)] = $this->controllerKeysToLowercase($controllers);
+                $result[\strtolower($moduleId)] = $this->controllerKeysToLowercase($controllers);
             }
         }
 
@@ -105,7 +105,7 @@ class ClassProviderStorage implements ClassProviderStorageInterface
         $result = [];
 
         foreach ($controllers as $controllerKey => $controllerClass) {
-            $result[strtolower($controllerKey)] = $controllerClass;
+            $result[\strtolower($controllerKey)] = $controllerClass;
         }
 
         return $result;

--- a/source/Core/Routing/ModuleControllerMapProvider.php
+++ b/source/Core/Routing/ModuleControllerMapProvider.php
@@ -33,7 +33,7 @@ class ModuleControllerMapProvider implements ControllerMapProviderInterface
         $controllerMap = [];
         $moduleControllersByModuleId = Registry::getUtilsObject()->getModuleVar(ClassProviderStorage::STORAGE_KEY);
 
-        if (is_array($moduleControllersByModuleId)) {
+        if (\is_array($moduleControllersByModuleId)) {
             $controllerMap = $this->flattenControllersMap($moduleControllersByModuleId);
         }
 
@@ -49,7 +49,7 @@ class ModuleControllerMapProvider implements ControllerMapProviderInterface
     {
         $moduleControllersFlat = [];
         foreach ($moduleControllersByModuleId as $moduleControllersOfOneModule) {
-            $moduleControllersFlat = array_merge($moduleControllersFlat, $moduleControllersOfOneModule);
+            $moduleControllersFlat = \array_merge($moduleControllersFlat, $moduleControllersOfOneModule);
         }
         return $moduleControllersFlat;
     }

--- a/source/Core/SeoDecoder.php
+++ b/source/Core/SeoDecoder.php
@@ -28,8 +28,8 @@ class SeoDecoder extends \OxidEsales\Eshop\Core\Base
         $aRet = [];
         $sUrl = $oStr->html_entity_decode($sUrl);
 
-        if (($iPos = strpos($sUrl, '?')) !== false) {
-            parse_str($oStr->substr($sUrl, $iPos + 1), $aRet);
+        if (($iPos = \strpos($sUrl, '?')) !== false) {
+            \parse_str($oStr->substr($sUrl, $iPos + 1), $aRet);
         }
 
         return $aRet;
@@ -46,7 +46,7 @@ class SeoDecoder extends \OxidEsales\Eshop\Core\Base
      */
     protected function _getIdent($sSeoUrl, $blIgnore = false) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
-        return md5(strtolower($sSeoUrl));
+        return \md5(\strtolower($sSeoUrl));
     }
 
     /**
@@ -64,7 +64,7 @@ class SeoDecoder extends \OxidEsales\Eshop\Core\Base
         if ($stringObject->strpos($seoUrl, $baseUrl) === 0) {
             $seoUrl = $stringObject->substr($seoUrl, $stringObject->strlen($baseUrl));
         }
-        $seoUrl = rawurldecode($seoUrl);
+        $seoUrl = \rawurldecode($seoUrl);
 
         //extract page number from seo url
         list($seoUrl, $pageNumber) = $this->extractPageNumberFromSeoUrl($seoUrl);
@@ -83,7 +83,7 @@ class SeoDecoder extends \OxidEsales\Eshop\Core\Base
             $urlParameters = $this->parseStdUrl($resultSet->fields['oxstdurl']);
             $urlParameters['lang'] = $resultSet->fields['oxlang'];
         }
-        if (is_array($urlParameters) && !is_null($pageNumber) && ($pageNumber > 0)) {
+        if (\is_array($urlParameters) && !\is_null($pageNumber) && ($pageNumber > 0)) {
             $urlParameters['pgNr'] = $pageNumber;
         }
 
@@ -109,7 +109,7 @@ class SeoDecoder extends \OxidEsales\Eshop\Core\Base
             $seoUrl = $stringObject->substr($seoUrl, $stringObject->strlen($baseUrl));
         }
         $shopId = \OxidEsales\Eshop\Core\Registry::getConfig()->getShopId();
-        $seoUrl = rawurldecode($seoUrl);
+        $seoUrl = \rawurldecode($seoUrl);
 
         //extract page number from seo url
         list($seoUrl, $pageNumber) = $this->extractPageNumberFromSeoUrl($seoUrl);
@@ -137,7 +137,7 @@ class SeoDecoder extends \OxidEsales\Eshop\Core\Base
             // appending with $_SERVER["QUERY_STRING"]
             $url = $this->_addQueryString($url);
         }
-        if ($url && !is_null($pageNumber)) {
+        if ($url && !\is_null($pageNumber)) {
             $url = \OxidEsales\Eshop\Core\Registry::getUtilsUrl()->appendUrl($url, ['pgNr' => $pageNumber]);
         }
 
@@ -155,10 +155,10 @@ class SeoDecoder extends \OxidEsales\Eshop\Core\Base
     protected function _addQueryString($sUrl) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         if (($sQ = $_SERVER["QUERY_STRING"])) {
-            $sUrl = rtrim($sUrl, "&?");
-            $sQ = ltrim($sQ, "&?");
+            $sUrl = \rtrim($sUrl, "&?");
+            $sQ = \ltrim($sQ, "&?");
 
-            $sUrl .= (strpos($sUrl, '?') === false) ? "?" : "&";
+            $sUrl .= (\strpos($sUrl, '?') === false) ? "?" : "&";
             $sUrl .= $sQ;
         }
 
@@ -225,11 +225,11 @@ class SeoDecoder extends \OxidEsales\Eshop\Core\Base
             }
         }
 
-        $sPath = $sPath ? $sPath : str_replace('oxseo.php', '', $_SERVER['SCRIPT_NAME']);
+        $sPath = $sPath ? $sPath : \str_replace('oxseo.php', '', $_SERVER['SCRIPT_NAME']);
         if (($sParams = $this->_getParams($sRequest, $sPath))) {
             // in case SEO url is actual
-            if (is_array($aGet = $this->decodeUrl($sParams))) {
-                $_GET = array_merge($aGet, $_GET);
+            if (\is_array($aGet = $this->decodeUrl($sParams))) {
+                $_GET = \array_merge($aGet, $_GET);
                 \OxidEsales\Eshop\Core\Registry::getLang()->resetBaseLanguage();
             } elseif (($sRedirectUrl = $this->_decodeOldUrl($sParams))) {
                 // in case SEO url was changed - redirecting to new location
@@ -256,7 +256,7 @@ class SeoDecoder extends \OxidEsales\Eshop\Core\Base
      */
     protected function _decodeSimpleUrl($sParams) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
-        $sLastParam = trim($sParams, '/');
+        $sLastParam = \trim($sParams, '/');
 
         // active object id
         $sUrl = null;
@@ -265,7 +265,7 @@ class SeoDecoder extends \OxidEsales\Eshop\Core\Base
             $iLanguage = \OxidEsales\Eshop\Core\Registry::getLang()->getBaseLanguage();
 
             // article ?
-            if (strpos($sLastParam, '.htm') !== false) {
+            if (\strpos($sLastParam, '.htm') !== false) {
                 $sUrl = $this->_getObjectUrl($sLastParam, 'oxarticles', $iLanguage, 'oxarticle');
             } else {
                 // category ?
@@ -329,7 +329,7 @@ class SeoDecoder extends \OxidEsales\Eshop\Core\Base
         $oStr = Str::getStr();
 
         $sParams = $oStr->preg_replace('/\?.*/', '', $sRequest);
-        $sPath = preg_quote($sPath, '/');
+        $sPath = \preg_quote($sPath, '/');
         $sParams = $oStr->preg_replace("/^$sPath/", '', $sParams);
 
         // this should not happen on most cases, because this redirect is handled by .htaccess
@@ -352,7 +352,7 @@ class SeoDecoder extends \OxidEsales\Eshop\Core\Base
     private function extractPageNumberFromSeoUrl($seoUrl)
     {
         $pageNumber = null;
-        if (1 === preg_match('/(.*?)\/(\d+)\/(.*)/', $seoUrl, $matches)) {
+        if (1 === \preg_match('/(.*?)\/(\d+)\/(.*)/', $seoUrl, $matches)) {
             $seoUrl = $matches[1] . '/' . $matches[3];
             $pageNumber = $this->convertSeoPageStringToActualPageNumber($matches[2]);
         }
@@ -368,8 +368,8 @@ class SeoDecoder extends \OxidEsales\Eshop\Core\Base
      */
     private function convertSeoPageStringToActualPageNumber($seoPageNumber)
     {
-        if (!is_null($seoPageNumber)) {
-            $seoPageNumber = max(0, (int) $seoPageNumber - 1);
+        if (!\is_null($seoPageNumber)) {
+            $seoPageNumber = \max(0, (int) $seoPageNumber - 1);
         }
         return $seoPageNumber;
     }

--- a/source/Core/SeoEncoder.php
+++ b/source/Core/SeoEncoder.php
@@ -258,7 +258,7 @@ class SeoEncoder extends \OxidEsales\Eshop\Core\Base
      */
     protected function _getSeoIdent($sSeoUrl) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
-        return md5(strtolower($sSeoUrl));
+        return \md5(\strtolower($sSeoUrl));
     }
 
     /**
@@ -412,7 +412,7 @@ class SeoEncoder extends \OxidEsales\Eshop\Core\Base
         if (self::$_sCacheKey === null) {
             self::$_sCacheKey = false;
             if (!$blAdmin && ($oView = \OxidEsales\Eshop\Core\Registry::getConfig()->getActiveView())) {
-                self::$_sCacheKey = md5($oView->getViewId()) . "seo";
+                self::$_sCacheKey = \md5($oView->getViewId()) . "seo";
             }
         }
 
@@ -542,7 +542,7 @@ class SeoEncoder extends \OxidEsales\Eshop\Core\Base
         $sQ .= " LIMIT 1";
 
         // caching to avoid same queries..
-        $sIdent = md5("_loadFromDb" . serialize($params));
+        $sIdent = \md5("_loadFromDb" . \serialize($params));
 
         // looking in cache
         if (($sSeoUrl = $this->_loadFromCache($sIdent, $sType, $iLang, $iShopId, $sParams)) === false) {
@@ -581,19 +581,19 @@ class SeoEncoder extends \OxidEsales\Eshop\Core\Base
      */
     protected function _getReservedEntryKeys() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
-        if (!isset(self::$_aReservedEntryKeys) || !is_array(self::$_aReservedEntryKeys)) {
+        if (!isset(self::$_aReservedEntryKeys) || !\is_array(self::$_aReservedEntryKeys)) {
             $sDir = getShopBasePath();
-            self::$_aReservedEntryKeys = array_map('preg_quote', self::$_aReservedWords, ['#']);
+            self::$_aReservedEntryKeys = \array_map('preg_quote', self::$_aReservedWords, ['#']);
             $oStr = Str::getStr();
-            foreach (glob("$sDir/*") as $sFile) {
-                if ($oStr->preg_match('/^(.+)\.php[0-9]*$/i', basename($sFile), $aMatches)) {
-                    self::$_aReservedEntryKeys[] = preg_quote($aMatches[0], '#');
-                    self::$_aReservedEntryKeys[] = preg_quote($aMatches[1], '#');
-                } elseif (is_dir($sFile)) {
-                    self::$_aReservedEntryKeys[] = preg_quote(basename($sFile), '#');
+            foreach (\glob("$sDir/*") as $sFile) {
+                if ($oStr->preg_match('/^(.+)\.php[0-9]*$/i', \basename($sFile), $aMatches)) {
+                    self::$_aReservedEntryKeys[] = \preg_quote($aMatches[0], '#');
+                    self::$_aReservedEntryKeys[] = \preg_quote($aMatches[1], '#');
+                } elseif (\is_dir($sFile)) {
+                    self::$_aReservedEntryKeys[] = \preg_quote(\basename($sFile), '#');
                 }
             }
-            self::$_aReservedEntryKeys = array_unique(self::$_aReservedEntryKeys);
+            self::$_aReservedEntryKeys = \array_unique(self::$_aReservedEntryKeys);
         }
 
         return self::$_aReservedEntryKeys;
@@ -641,7 +641,7 @@ class SeoEncoder extends \OxidEsales\Eshop\Core\Base
         $sAdd = '_' . self::$_sPrefix;
         if ('/' != self::$_sSeparator) {
             $sAdd = self::$_sSeparator . self::$_sPrefix;
-            $sUri = trim($sUri, self::$_sSeparator);
+            $sUri = \trim($sUri, self::$_sSeparator);
         }
 
         // binding the ending back
@@ -654,10 +654,10 @@ class SeoEncoder extends \OxidEsales\Eshop\Core\Base
         }
 
         // fix for not having url, which executes through /other/ script then seo decoder
-        $sUri = $oStr->preg_replace("#^(/*)(" . implode('|', $this->_getReservedEntryKeys()) . ")(/|$)#i", "\$1\$2$sAdd\$3", $sUri);
+        $sUri = $oStr->preg_replace("#^(/*)(" . \implode('|', $this->_getReservedEntryKeys()) . ")(/|$)#i", "\$1\$2$sAdd\$3", $sUri);
 
         // cleaning
-        $sQuotedSeparator = preg_quote(self::$_sSeparator, '/');
+        $sQuotedSeparator = \preg_quote(self::$_sSeparator, '/');
 
         return $oStr->preg_replace(
             ['|//+|', '/' . $sQuotedSeparator . $sQuotedSeparator . '+/'],
@@ -685,8 +685,8 @@ class SeoEncoder extends \OxidEsales\Eshop\Core\Base
             $sSep = '_';
         }
 
-        $sRegExp = '/[^A-Za-z0-9\/' . preg_quote(self::$_sPrefix, '/') . preg_quote($sSep, '/') . ']+/';
-        $sTitle = preg_replace(["#/+#", $sRegExp, "# +#", "#(" . preg_quote($sSep, '/') . ")+#"], $sSep, $sTitle);
+        $sRegExp = '/[^A-Za-z0-9\/' . \preg_quote(self::$_sPrefix, '/') . \preg_quote($sSep, '/') . ']+/';
+        $sTitle = \preg_replace(["#/+#", $sRegExp, "# +#", "#(" . \preg_quote($sSep, '/') . ")+#"], $sSep, $sTitle);
 
         $oStr = Str::getStr();
         // smart truncate
@@ -697,7 +697,7 @@ class SeoEncoder extends \OxidEsales\Eshop\Core\Base
             }
         }
 
-        $sTitle = trim($sTitle, $sSep);
+        $sTitle = \trim($sTitle, $sSep);
 
         if (!$sTitle) {
             return self::$_sPrefix;
@@ -846,7 +846,7 @@ class SeoEncoder extends \OxidEsales\Eshop\Core\Base
     {
         $myConfig = \OxidEsales\Eshop\Core\Registry::getConfig();
         $oStr = Str::getStr();
-        $sUrl = str_replace([$myConfig->getShopUrl($iLang, false), $myConfig->getSslShopUrl($iLang)], '', $sUrl);
+        $sUrl = \str_replace([$myConfig->getShopUrl($iLang, false), $myConfig->getSslShopUrl($iLang)], '', $sUrl);
         $sUrl = $oStr->preg_replace('/(\?|&(amp;)?)(force_)?(admin_)?sid=[a-z0-9\.]+&?(amp;)?/i', '\1', $sUrl);
         $sUrl = $oStr->preg_replace('/(\?|&(amp;)?)shp=[0-9]+&?(amp;)?/i', '\1', $sUrl);
         $sUrl = $oStr->preg_replace('/(\?|&(amp;)?)lang=[0-9]+&?(amp;)?/i', '\1', $sUrl);
@@ -854,7 +854,7 @@ class SeoEncoder extends \OxidEsales\Eshop\Core\Base
         $sUrl = $oStr->preg_replace('/(\?|&(amp;)?)stoken=[a-z0-9]+&?(amp;)?/i', '\1', $sUrl);
         $sUrl = $oStr->preg_replace('/(\?|&(amp;)?)&(amp;)?/i', '\1', $sUrl);
         $sUrl = $oStr->preg_replace('/(\?|&(amp;)?)+$/i', '', $sUrl);
-        $sUrl = trim($sUrl);
+        $sUrl = \trim($sUrl);
 
         // max length <= $this->_iMaxUrlLength
         $iLength = $this->_getMaxUrlLength();
@@ -899,16 +899,16 @@ class SeoEncoder extends \OxidEsales\Eshop\Core\Base
         $sString = Str::getStr()->html_entity_decode($sString);
 
         if ($blReplaceChars) {
-            if ($iLang === false || !is_numeric($iLang)) {
+            if ($iLang === false || !\is_numeric($iLang)) {
                 $iLang = \OxidEsales\Eshop\Core\Registry::getLang()->getEditLanguage();
             }
 
             if ($aReplaceChars = \OxidEsales\Eshop\Core\Registry::getLang()->getSeoReplaceChars($iLang)) {
-                $sString = str_replace(array_keys($aReplaceChars), array_values($aReplaceChars), $sString);
+                $sString = \str_replace(\array_keys($aReplaceChars), \array_values($aReplaceChars), $sString);
             }
         }
 
-        return str_replace(['&amp;', '&quot;', '&#039;', '&lt;', '&gt;'], '', $sString);
+        return \str_replace(['&amp;', '&quot;', '&#039;', '&lt;', '&gt;'], '', $sString);
     }
 
     /**
@@ -958,7 +958,7 @@ class SeoEncoder extends \OxidEsales\Eshop\Core\Base
      */
     public function setReservedWords($aReservedWords)
     {
-        self::$_aReservedWords = array_merge(self::$_aReservedWords, $aReservedWords);
+        self::$_aReservedWords = \array_merge(self::$_aReservedWords, $aReservedWords);
     }
 
 
@@ -976,7 +976,7 @@ class SeoEncoder extends \OxidEsales\Eshop\Core\Base
         $oDb = \OxidEsales\Eshop\Core\DatabaseProvider::getDb();
         $sWhere = $sId ? "where oxobjectid =  " . $oDb->quote($sId) : '';
         $sWhere .= isset($iShopId) ? ($sWhere ? " and oxshopid = " . $oDb->quote($iShopId) : "where oxshopid = " . $oDb->quote($iShopId)) : '';
-        $sWhere .= !is_null($iLang) ? ($sWhere ? " and oxlang = '{$iLang}'" : "where oxlang = '{$iLang}'") : '';
+        $sWhere .= !\is_null($iLang) ? ($sWhere ? " and oxlang = '{$iLang}'" : "where oxlang = '{$iLang}'") : '';
         $sWhere .= $sParams ? ($sWhere ? " and {$sParams}" : "where {$sParams}") : '';
 
         $sQ = "update oxseo set oxexpired = :oxexpired $sWhere";
@@ -1029,7 +1029,7 @@ class SeoEncoder extends \OxidEsales\Eshop\Core\Base
      */
     protected function _getStaticObjectId($iShopId, $sStdUrl) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
-        return md5(strtolower($iShopId . $this->_trimUrl($sStdUrl)));
+        return \md5(\strtolower($iShopId . $this->_trimUrl($sStdUrl)));
     }
 
     /**
@@ -1050,7 +1050,7 @@ class SeoEncoder extends \OxidEsales\Eshop\Core\Base
         $sOldObjectId = null;
 
         // standard url
-        $sStdUrl = $this->_trimUrl(trim($aStaticUrl['oxseo__oxstdurl']));
+        $sStdUrl = $this->_trimUrl(\trim($aStaticUrl['oxseo__oxstdurl']));
         $sObjectId = $aStaticUrl['oxseo__oxobjectid'];
 
         if (!$sObjectId || $sObjectId == '-1') {
@@ -1135,7 +1135,7 @@ class SeoEncoder extends \OxidEsales\Eshop\Core\Base
         $iBaseShopId = \OxidEsales\Eshop\Core\Registry::getConfig()->getBaseShopId();
         if ($iShopId != $iBaseShopId) {
             $oDb = \OxidEsales\Eshop\Core\DatabaseProvider::getDb();
-            foreach (array_keys(\OxidEsales\Eshop\Core\Registry::getLang()->getLanguageIds()) as $iLang) {
+            foreach (\array_keys(\OxidEsales\Eshop\Core\Registry::getLang()->getLanguageIds()) as $iLang) {
                 $sQ = "insert into oxseo ( oxobjectid, oxident, oxshopid, oxlang, oxstdurl, oxseourl, oxtype )
                        select MD5( LOWER( CONCAT( :shopId, oxstdurl ) ) ), MD5( LOWER( oxseourl ) ),
                        :shopId, oxlang, oxstdurl, oxseourl, oxtype from oxseo where oxshopid = :baseShopId and oxtype = 'static' and oxlang = :lang";
@@ -1172,7 +1172,7 @@ class SeoEncoder extends \OxidEsales\Eshop\Core\Base
 
         $sFullUrl = '';
         if (($sSeoUrl = $this->_getStaticUri($sStdUrl, $iShopId, $iLang))) {
-            $sFullUrl = $this->_getFullUrl($sSeoUrl, $iLang, strpos($sStdUrl, "https:") === 0);
+            $sFullUrl = $this->_getFullUrl($sSeoUrl, $iLang, \strpos($sStdUrl, "https:") === 0);
         }
 
 
@@ -1321,7 +1321,7 @@ class SeoEncoder extends \OxidEsales\Eshop\Core\Base
     public function getDynamicUrl($sStdUrl, $sSeoUrl, $iLang)
     {
         startProfile("getDynamicUrl");
-        $sDynUrl = $this->_getFullUrl($this->_getDynamicUri($sStdUrl, $sSeoUrl, $iLang), $iLang, strpos($sStdUrl, "https:") === 0);
+        $sDynUrl = $this->_getFullUrl($this->_getDynamicUri($sStdUrl, $sSeoUrl, $iLang), $iLang, \strpos($sStdUrl, "https:") === 0);
         stopProfile("getDynamicUrl");
 
         return $sDynUrl;
@@ -1367,11 +1367,11 @@ class SeoEncoder extends \OxidEsales\Eshop\Core\Base
      */
     protected function replaceSpecialChars($stringWithSpecialChars)
     {
-        if (!is_string($stringWithSpecialChars)) {
+        if (!\is_string($stringWithSpecialChars)) {
             return "";
         }
         $oStr = Str::getStr();
-        $sQuotedPrefix = preg_quote(self::$_sSeparator . self::$_sPrefix, '/');
+        $sQuotedPrefix = \preg_quote(self::$_sSeparator . self::$_sPrefix, '/');
         $sRegExp = '/[^A-Za-z0-9' . $sQuotedPrefix . '\/]+/';
         $sanitized = $oStr->preg_replace(
             ["/\W*\/\W*/", $sRegExp],

--- a/source/Core/SepaBICValidator.php
+++ b/source/Core/SepaBICValidator.php
@@ -29,7 +29,7 @@ class SepaBICValidator
      */
     public function isValid($sBIC)
     {
-        $sBIC = strtoupper(trim($sBIC));
+        $sBIC = \strtoupper(\trim($sBIC));
 
         return (bool) Str::getStr()->preg_match("(^[A-Z]{4}[A-Z]{2}[A-Z0-9]{2}([A-Z0-9]{3})?$)", $sBIC);
     }

--- a/source/Core/SepaIBANValidator.php
+++ b/source/Core/SepaIBANValidator.php
@@ -31,7 +31,7 @@ class SepaIBANValidator
     public function isValid($sIBAN)
     {
         $blValid = false;
-        $sIBAN = strtoupper(trim($sIBAN));
+        $sIBAN = \strtoupper(\trim($sIBAN));
 
         if ($this->_isLengthValid($sIBAN)) {
             $blValid = $this->_isAlgorithmValid($sIBAN);
@@ -100,7 +100,7 @@ class SepaIBANValidator
 
         $iCorrectLength = $this->_getLengthForCountry($sIBAN);
 
-        return !is_null($iCorrectLength) && $iActualLength === $iCorrectLength;
+        return !\is_null($iCorrectLength) && $iActualLength === $iCorrectLength;
     }
 
 
@@ -197,8 +197,8 @@ class SepaIBANValidator
             'Z' => 35
         ];
 
-        return str_replace(
-            array_keys($aReplaceArray),
+        return \str_replace(
+            \array_keys($aReplaceArray),
             $aReplaceArray,
             $sIBAN
         );
@@ -214,7 +214,7 @@ class SepaIBANValidator
      */
     protected function _isIBANChecksumValid($sIBAN) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
-        return (int) bcmod($sIBAN, self::IBAN_ALGORITHM_MOD_VALUE) === 1;
+        return (int) \bcmod($sIBAN, self::IBAN_ALGORITHM_MOD_VALUE) === 1;
     }
 
     /**
@@ -227,7 +227,7 @@ class SepaIBANValidator
      */
     protected function _isNotEmptyArray($aCodeLengths) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
-        return is_array($aCodeLengths) && !empty($aCodeLengths);
+        return \is_array($aCodeLengths) && !empty($aCodeLengths);
     }
 
     /**
@@ -265,7 +265,7 @@ class SepaIBANValidator
      */
     protected function _isCodeLengthKeyValid($sCountryAbbr) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
-        return (int) preg_match("/^[A-Z]{2}$/", $sCountryAbbr) !== 0;
+        return (int) \preg_match("/^[A-Z]{2}$/", $sCountryAbbr) !== 0;
     }
 
     /**
@@ -278,6 +278,6 @@ class SepaIBANValidator
      */
     protected function _isCodeLengthValueValid($iLength) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
-        return is_numeric($iLength) && (int) preg_match("/\./", $iLength) !== 1;
+        return \is_numeric($iLength) && (int) \preg_match("/\./", $iLength) !== 1;
     }
 }

--- a/source/Core/Service/ApplicationServerExporter.php
+++ b/source/Core/Service/ApplicationServerExporter.php
@@ -42,7 +42,7 @@ class ApplicationServerExporter implements \OxidEsales\Eshop\Core\Service\Applic
         $activeServerCollection = [];
 
         $activeServers = $this->appServerService->loadActiveAppServerList();
-        if (is_array($activeServers) && !empty($activeServers)) {
+        if (\is_array($activeServers) && !empty($activeServers)) {
             foreach ($activeServers as $server) {
                 $activeServerCollection[] = $this->convertToArray($server);
             }

--- a/source/Core/Session.php
+++ b/source/Core/Session.php
@@ -209,7 +209,7 @@ class Session extends \OxidEsales\Eshop\Core\Base
         $sid = null;
 
         $forceSidParam = null;
-        if (!in_array($myConfig->getRequestParameter('cl'), $this->orderControllers)) {
+        if (!\in_array($myConfig->getRequestParameter('cl'), $this->orderControllers)) {
             $forceSidParam = $myConfig->getRequestParameter($this->getForcedName());
         }
         $sidParam = $myConfig->getRequestParameter($this->getName());
@@ -251,8 +251,8 @@ class Session extends \OxidEsales\Eshop\Core\Base
             }
 
             //special handling for new ZP cluster session, as in that case session_start() regenerates id
-            if ($this->getId() !== session_id()) {
-                $this->setId(session_id());
+            if ($this->getId() !== \session_id()) {
+                $this->setId(\session_id());
             }
 
             //checking for swapped client
@@ -278,7 +278,7 @@ class Session extends \OxidEsales\Eshop\Core\Base
      */
     public function getRequestChallengeToken()
     {
-        return preg_replace('/[^a-z0-9]/i', '', \OxidEsales\Eshop\Core\Registry::getConfig()->getRequestParameter('stoken'));
+        return \preg_replace('/[^a-z0-9]/i', '', \OxidEsales\Eshop\Core\Registry::getConfig()->getRequestParameter('stoken'));
     }
 
     /**
@@ -288,7 +288,7 @@ class Session extends \OxidEsales\Eshop\Core\Base
      */
     public function getSessionChallengeToken()
     {
-        $sRet = preg_replace('/[^a-z0-9]/i', '', $this->getVariable('sess_stoken'));
+        $sRet = \preg_replace('/[^a-z0-9]/i', '', $this->getVariable('sess_stoken'));
         if (!$sRet) {
             $this->_initNewSessionChallenge();
             $sRet = $this->getVariable('sess_stoken');
@@ -316,7 +316,7 @@ class Session extends \OxidEsales\Eshop\Core\Base
      */
     protected function _initNewSessionChallenge() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
-        $this->setVariable('sess_stoken', sprintf('%X', crc32(Registry::getUtilsObject()->generateUID())));
+        $this->setVariable('sess_stoken', \sprintf('%X', \crc32(Registry::getUtilsObject()->generateUID())));
     }
 
     /**
@@ -329,12 +329,12 @@ class Session extends \OxidEsales\Eshop\Core\Base
     {
         if ($this->needToSetHeaders()) {
             //enforcing no caching when session is started
-            session_cache_limiter('nocache');
+            \session_cache_limiter('nocache');
         } else {
-            session_cache_limiter('');
+            \session_cache_limiter('');
         }
 
-        $this->_blStarted = session_start();
+        $this->_blStarted = \session_start();
         if (!$this->getSessionChallengeToken()) {
             $this->_initNewSessionChallenge();
         }
@@ -404,13 +404,13 @@ class Session extends \OxidEsales\Eshop\Core\Base
      */
     protected function _getNewSessionId($blUnset = true) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
-        session_regenerate_id(true);
+        \session_regenerate_id(true);
 
         if ($blUnset) {
-            session_unset();
+            \session_unset();
         }
 
-        return session_id();
+        return \session_id();
     }
 
     /**
@@ -419,9 +419,9 @@ class Session extends \OxidEsales\Eshop\Core\Base
     public function freeze()
     {
         // storing basket ..
-        $this->setVariable($this->_getBasketName(), serialize($this->getBasket()));
+        $this->setVariable($this->_getBasketName(), \serialize($this->getBasket()));
 
-        session_write_close();
+        \session_write_close();
     }
 
     /**
@@ -430,7 +430,7 @@ class Session extends \OxidEsales\Eshop\Core\Base
     public function destroy()
     {
         unset($_SESSION);
-        session_destroy();
+        \session_destroy();
     }
 
     /**
@@ -495,7 +495,7 @@ class Session extends \OxidEsales\Eshop\Core\Base
         $sRet = '';
 
         $blDisableSid = Registry::getUtils()->isSearchEngine()
-                        && is_array($myConfig->getConfigParam('aCacheViews'))
+                        && \is_array($myConfig->getConfigParam('aCacheViews'))
                         && !$this->isAdmin();
 
         //no cookie?
@@ -551,7 +551,7 @@ class Session extends \OxidEsales\Eshop\Core\Base
 
             $basket =
                 $this->isSerializedBasketValid($serializedBasket) &&
-                ($unserializedBasket = unserialize($serializedBasket)) &&
+                ($unserializedBasket = \unserialize($serializedBasket)) &&
                 $this->isUnserializedBasketValid($unserializedBasket, $emptyBasket) ?
                     $unserializedBasket : $emptyBasket;
 
@@ -570,11 +570,11 @@ class Session extends \OxidEsales\Eshop\Core\Base
      */
     protected function isSerializedBasketValid($serializedBasket)
     {
-        $basketClass = get_class(oxNew(Basket::class));
-        $basketItemClass = get_class(oxNew(BasketItem::class));
-        $priceClass = get_class(oxNew(\OxidEsales\Eshop\Core\Price::class));
-        $priceListClass = get_class(oxNew(\OxidEsales\Eshop\Core\PriceList::class));
-        $userClass = get_class(oxNew(User::class));
+        $basketClass = \get_class(oxNew(Basket::class));
+        $basketItemClass = \get_class(oxNew(BasketItem::class));
+        $priceClass = \get_class(oxNew(\OxidEsales\Eshop\Core\Price::class));
+        $priceListClass = \get_class(oxNew(\OxidEsales\Eshop\Core\PriceList::class));
+        $userClass = \get_class(oxNew(User::class));
 
         return $serializedBasket &&
             $this->isClassInSerializedObject($serializedBasket, $basketClass) &&
@@ -594,9 +594,9 @@ class Session extends \OxidEsales\Eshop\Core\Base
      */
     protected function isClassInSerializedObject($serializedObject, $className)
     {
-        $quotedClassName = sprintf('"%s"', $className);
+        $quotedClassName = \sprintf('"%s"', $className);
 
-        return strpos($serializedObject, $quotedClassName) !== false;
+        return \strpos($serializedObject, $quotedClassName) !== false;
     }
 
     /**
@@ -610,8 +610,8 @@ class Session extends \OxidEsales\Eshop\Core\Base
      */
     protected function isClassOrNullInSerializedObjectAfterField($serializedObject, $fieldName, $className)
     {
-        $fieldAndClassPattern = '/' . preg_quote($fieldName, '/') . '";((?P<null>N);|O:\d+:"(?P<class>[\w\\\\]+)":)/';
-        $matchFound = preg_match($fieldAndClassPattern, $serializedObject, $matches) === 1;
+        $fieldAndClassPattern = '/' . \preg_quote($fieldName, '/') . '";((?P<null>N);|O:\d+:"(?P<class>[\w\\\\]+)":)/';
+        $matchFound = \preg_match($fieldAndClassPattern, $serializedObject, $matches) === 1;
 
         return $matchFound &&
             (
@@ -632,7 +632,7 @@ class Session extends \OxidEsales\Eshop\Core\Base
      */
     protected function isUnserializedBasketValid($basket, $emptyBasket)
     {
-        return $basket && (get_class($basket) === get_class($emptyBasket));
+        return $basket && (\get_class($basket) === \get_class($emptyBasket));
     }
 
     /**
@@ -734,7 +734,7 @@ class Session extends \OxidEsales\Eshop\Core\Base
                     // no cookie, so must check session
                     if ($blSidNeeded = $this->getVariable('blSidNeeded')) {
                         $this->_blSidNeeded = true;
-                    } elseif ($this->_isSessionRequiredAction() && !count($_COOKIE)) {
+                    } elseif ($this->_isSessionRequiredAction() && !\count($_COOKIE)) {
                         $this->_blSidNeeded = true;
 
                         // storing to session, performance..
@@ -778,14 +778,14 @@ class Session extends \OxidEsales\Eshop\Core\Base
                 $this->sidToUrlEvent();
 
                 $oStr = Str::getStr();
-                $aUrlParts = explode('#', $sUrl);
+                $aUrlParts = \explode('#', $sUrl);
                 if (!$oStr->preg_match('/(\?|&(amp;)?)sid=/i', $aUrlParts[0]) && (false === $oStr->strpos($aUrlParts[0], $sSid))) {
                     if (!$oStr->preg_match('/(\?|&(amp;)?)$/', $sUrl)) {
                         $aUrlParts[0] .= ($oStr->strstr($aUrlParts[0], '?') !== false ? '&amp;' : '?');
                     }
                     $aUrlParts[0] .= $sSid . '&amp;';
                 }
-                $sUrl = join('#', $aUrlParts);
+                $sUrl = \join('#', $aUrlParts);
             }
         }
 
@@ -805,8 +805,8 @@ class Session extends \OxidEsales\Eshop\Core\Base
     {
         $sToken = $this->getVariable('_rtoken');
         if (!$sToken && $blGenerateNew) {
-            $sToken = md5(rand() . $this->getId());
-            $sToken = substr($sToken, 0, 8);
+            $sToken = \md5(\rand() . $this->getId());
+            $sToken = \substr($sToken, 0, 8);
             $this->setVariable('_rtoken', $sToken);
         }
 
@@ -934,7 +934,7 @@ class Session extends \OxidEsales\Eshop\Core\Base
         $sCurrUrl = $myConfig->isSsl() ? $myConfig->getSslShopUrl() : $myConfig->getShopUrl();
 
         $blSessCookieSetOnce = false;
-        if (is_array($aSessCookieSetOnce) && isset($aSessCookieSetOnce[$sCurrUrl])) {
+        if (\is_array($aSessCookieSetOnce) && isset($aSessCookieSetOnce[$sCurrUrl])) {
             $blSessCookieSetOnce = $aSessCookieSetOnce[$sCurrUrl];
         }
 
@@ -951,7 +951,7 @@ class Session extends \OxidEsales\Eshop\Core\Base
 
         //if we detect the cookie then set session var for possible later use
         if ($sCookieSid == "oxid" && !$blSessCookieSetOnce) {
-            if (!is_array($aSessCookieSetOnce)) {
+            if (!\is_array($aSessCookieSetOnce)) {
                 $aSessCookieSetOnce = [];
             }
 
@@ -978,11 +978,11 @@ class Session extends \OxidEsales\Eshop\Core\Base
     protected function _setSessionId($sSessId) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         //marking this session as new one, as it might be not writen to db yet
-        if ($sSessId && session_id() != $sSessId) {
+        if ($sSessId && \session_id() != $sSessId) {
             $this->_blNewSession = true;
         }
 
-        session_id($sSessId);
+        \session_id($sSessId);
 
         $this->setId($sSessId);
         $this->setSessionCookie($sSessId);
@@ -1025,15 +1025,15 @@ class Session extends \OxidEsales\Eshop\Core\Base
     protected function _getRequireSessionWithParams() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $aCfgArray = \OxidEsales\Eshop\Core\Registry::getConfig()->getConfigParam('aRequireSessionWithParams');
-        if (is_array($aCfgArray)) {
+        if (\is_array($aCfgArray)) {
             $aDefault = $this->_aRequireSessionWithParams;
             foreach ($aCfgArray as $key => $val) {
-                if (!is_array($val) && $val) {
+                if (!\is_array($val) && $val) {
                     unset($aDefault[$key]);
                 }
             }
 
-            return array_merge_recursive($aCfgArray, $aDefault);
+            return \array_merge_recursive($aCfgArray, $aDefault);
         }
 
         return $this->_aRequireSessionWithParams;
@@ -1050,7 +1050,7 @@ class Session extends \OxidEsales\Eshop\Core\Base
         foreach ($this->_getRequireSessionWithParams() as $sParam => $aValues) {
             $sValue = \OxidEsales\Eshop\Core\Registry::getConfig()->getRequestParameter($sParam);
             if (isset($sValue)) {
-                if (is_array($aValues)) {
+                if (\is_array($aValues)) {
                     if (isset($aValues[$sValue]) && $aValues[$sValue]) {
                         return true;
                     }
@@ -1109,7 +1109,7 @@ class Session extends \OxidEsales\Eshop\Core\Base
      */
     public function isHeaderSent()
     {
-        return headers_sent();
+        return \headers_sent();
     }
 
     /**
@@ -1119,7 +1119,7 @@ class Session extends \OxidEsales\Eshop\Core\Base
      */
     public function isSessionStarted()
     {
-        return session_status() === PHP_SESSION_ACTIVE;
+        return \session_status() === PHP_SESSION_ACTIVE;
     }
 
     /**

--- a/source/Core/SettingsHandler.php
+++ b/source/Core/SettingsHandler.php
@@ -47,7 +47,7 @@ class SettingsHandler extends \OxidEsales\Eshop\Core\Base
     {
         $moduleSettings = $module->getInfo('settings');
         $isTheme = $this->isTheme($module->getId());
-        if (!$isTheme || ($isTheme && is_array($moduleSettings))) {
+        if (!$isTheme || ($isTheme && \is_array($moduleSettings))) {
             $this->addModuleSettings($moduleSettings, $module->getId());
         }
     }
@@ -66,7 +66,7 @@ class SettingsHandler extends \OxidEsales\Eshop\Core\Base
         $moduleConfigs = $this->getModuleConfigs($moduleId);
         $db = \OxidEsales\Eshop\Core\DatabaseProvider::getDb();
 
-        if (is_array($moduleSettings)) {
+        if (\is_array($moduleSettings)) {
             foreach ($moduleSettings as $setting) {
                 $oxid = \OxidEsales\Eshop\Core\Registry::getUtilsObject()->generateUId();
 
@@ -75,9 +75,9 @@ class SettingsHandler extends \OxidEsales\Eshop\Core\Base
                 $type = $setting["type"];
 
                 if ($this->isTheme($moduleId)) {
-                    $value = array_key_exists($name, $moduleConfigs) ? $moduleConfigs[$name] : $setting["value"];
+                    $value = \array_key_exists($name, $moduleConfigs) ? $moduleConfigs[$name] : $setting["value"];
                 } else {
-                    $value = is_null($config->getConfigParam($name)) ? $setting["value"] : $config->getConfigParam($name);
+                    $value = \is_null($config->getConfigParam($name)) ? $setting["value"] : $config->getConfigParam($name);
                 }
 
                 $group = $setting["group"];
@@ -126,7 +126,7 @@ class SettingsHandler extends \OxidEsales\Eshop\Core\Base
     {
         $moduleConfigId = $this->getModuleConfigId($moduleId);
         $themeTypeCondition = "@^" . Config::OXMODULE_THEME_PREFIX . "@i";
-        return (bool)preg_match($themeTypeCondition, $moduleConfigId);
+        return (bool)\preg_match($themeTypeCondition, $moduleConfigId);
     }
 
     /**
@@ -137,10 +137,10 @@ class SettingsHandler extends \OxidEsales\Eshop\Core\Base
      */
     protected function removeNotUsedSettings($moduleSettings, $moduleId)
     {
-        $moduleConfigs = array_keys($this->getModuleConfigs($moduleId));
+        $moduleConfigs = \array_keys($this->getModuleConfigs($moduleId));
         $moduleSettings = $this->parseModuleSettings($moduleSettings);
 
-        $configsToRemove = array_diff($moduleConfigs, $moduleSettings);
+        $configsToRemove = \array_diff($moduleConfigs, $moduleSettings);
         if (!empty($configsToRemove)) {
             $this->removeModuleConfigs($moduleId, $configsToRemove);
         }
@@ -185,7 +185,7 @@ class SettingsHandler extends \OxidEsales\Eshop\Core\Base
     {
         $settings = [];
 
-        if (is_array($moduleSettings)) {
+        if (\is_array($moduleSettings)) {
             foreach ($moduleSettings as $setting) {
                 $settings[] = $setting['name'];
             }
@@ -204,12 +204,12 @@ class SettingsHandler extends \OxidEsales\Eshop\Core\Base
     {
         $db = \OxidEsales\Eshop\Core\DatabaseProvider::getDb();
 
-        $quotedConfigsToRemove = array_map([$db, 'quote'], $configsToRemove);
+        $quotedConfigsToRemove = \array_map([$db, 'quote'], $configsToRemove);
         $deleteSql = "DELETE
                        FROM `oxconfig`
                        WHERE oxmodule = :oxmodule AND
                              oxshopid = :oxshopid AND
-                             oxvarname IN (" . implode(", ", $quotedConfigsToRemove) . ")";
+                             oxvarname IN (" . \implode(", ", $quotedConfigsToRemove) . ")";
 
         $db->execute($deleteSql, [
             ':oxmodule' => $this->getModuleConfigId($moduleId),

--- a/source/Core/Sha512Hasher.php
+++ b/source/Core/Sha512Hasher.php
@@ -30,6 +30,6 @@ class Sha512Hasher extends \OxidEsales\Eshop\Core\Hasher
      */
     public function hash($string)
     {
-        return hash(self::HASHING_ALGORITHM_SHA512, $string);
+        return \hash(self::HASHING_ALGORITHM_SHA512, $string);
     }
 }

--- a/source/Core/ShopControl.php
+++ b/source/Core/ShopControl.php
@@ -133,8 +133,8 @@ class ShopControl extends \OxidEsales\Eshop\Core\Base
         try {
             $this->_runOnce();
 
-            $function = !is_null($function) ? $function : \OxidEsales\Eshop\Core\Registry::getConfig()->getRequestParameter('fnc');
-            $controllerKey = !is_null($controllerKey) ? $controllerKey : $this->getStartControllerKey();
+            $function = !\is_null($function) ? $function : \OxidEsales\Eshop\Core\Registry::getConfig()->getRequestParameter('fnc');
+            $controllerKey = !\is_null($controllerKey) ? $controllerKey : $this->getStartControllerKey();
             $controllerClass = $this->getControllerClass($controllerKey);
 
             $this->_process($controllerClass, $function, $parameters, $viewsChain);
@@ -380,7 +380,7 @@ class ShopControl extends \OxidEsales\Eshop\Core\Base
     protected function _initializeViewObject($class, $function, $parameters = null, $viewsChain = null) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $classKey = Registry::getControllerClassNameResolver()->getIdByClassName($class);
-        $classKey = !is_null($classKey) ? $classKey : $class; //fallback
+        $classKey = !\is_null($classKey) ? $classKey : $class; //fallback
 
         /** @var FrontendController $view */
         $view = oxNew($class);
@@ -419,7 +419,7 @@ class ShopControl extends \OxidEsales\Eshop\Core\Base
     protected function _canExecuteFunction($view, $function) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $canExecute = true;
-        if (method_exists($view, $function)) {
+        if (\method_exists($view, $function)) {
             $reflectionMethod = new ReflectionMethod($view, $function);
             if (!$reflectionMethod->isPublic()) {
                 $canExecute = false;
@@ -441,10 +441,10 @@ class ShopControl extends \OxidEsales\Eshop\Core\Base
     {
         $errors = $this->_getErrors($controllerName);
         $formattedErrors = [];
-        if (is_array($errors) && count($errors)) {
+        if (\is_array($errors) && \count($errors)) {
             foreach ($errors as $location => $ex2) {
                 foreach ($ex2 as $key => $er) {
-                    $error = unserialize($er);
+                    $error = \unserialize($er);
                     $formattedErrors[$location][$key] = $error->getOxMessage();
                 }
             }
@@ -495,7 +495,7 @@ class ShopControl extends \OxidEsales\Eshop\Core\Base
 
         //add all exceptions to display
         $errors = $this->_getErrors($view->getClassName());
-        if (is_array($errors) && count($errors)) {
+        if (\is_array($errors) && \count($errors)) {
             \OxidEsales\Eshop\Core\Registry::getUtilsView()->passAllErrorsToView($viewData, $errors);
         }
 
@@ -558,7 +558,7 @@ class ShopControl extends \OxidEsales\Eshop\Core\Base
             $this->_aAllErrors = $this->_aErrors;
         }
         // resetting errors of current controller or widget from session
-        if (is_array($this->_aControllerErrors) && !empty($this->_aControllerErrors)) {
+        if (\is_array($this->_aControllerErrors) && !empty($this->_aControllerErrors)) {
             foreach ($this->_aControllerErrors as $errorName => $controllerName) {
                 if ($controllerName == $currentControllerName) {
                     unset($this->_aAllErrors[$errorName]);
@@ -587,12 +587,12 @@ class ShopControl extends \OxidEsales\Eshop\Core\Base
         //session is started, a possible SeoUrl is decoded, globals and environment variables are set.
         $config->init();
 
-        error_reporting($this->_getErrorReportingLevel());
+        \error_reporting($this->_getErrorReportingLevel());
 
         $runOnceExecuted = \OxidEsales\Eshop\Core\Registry::getSession()->getVariable('blRunOnceExecuted');
         if (!$runOnceExecuted && !$this->isAdmin() && $config->isProductiveMode()) {
             // check if setup is still there
-            if (file_exists($config->getConfigParam('sShopDir') . '/Setup/index.php')) {
+            if (\file_exists($config->getConfigParam('sShopDir') . '/Setup/index.php')) {
                 $tpl = 'message/err_setup.tpl';
                 $activeView = oxNew(\OxidEsales\Eshop\Application\Controller\FrontendController::class);
                 $context = [
@@ -619,11 +619,11 @@ class ShopControl extends \OxidEsales\Eshop\Core\Base
     {
         $errorReporting = E_ALL ^ E_NOTICE;
         // some 3rd party libraries still use deprecated functions
-        if (defined('E_DEPRECATED')) {
+        if (\defined('E_DEPRECATED')) {
             $errorReporting = $errorReporting ^ E_DEPRECATED;
         }
 
-        if (\OxidEsales\Eshop\Core\Registry::getConfig()->isProductiveMode() && !ini_get('log_errors')) {
+        if (\OxidEsales\Eshop\Core\Registry::getConfig()->isProductiveMode() && !\ini_get('log_errors')) {
             $errorReporting = 0;
         }
 
@@ -649,7 +649,7 @@ class ShopControl extends \OxidEsales\Eshop\Core\Base
     protected function _startMonitor() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         if ($this->_isDebugMode()) {
-            $this->_dTimeStart = microtime(true);
+            $this->_dTimeStart = \microtime(true);
         }
     }
 
@@ -666,7 +666,7 @@ class ShopControl extends \OxidEsales\Eshop\Core\Base
      */
     protected function _stopMonitor($isCallForCache = false, $isCached = false, $viewId = null, $viewData = [], $view = null) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
-        if (is_null($view)) {
+        if (\is_null($view)) {
             $controllerKey = $this->getStartControllerKey();
             $controllerClass = $this->getControllerClass($controllerKey);
             $view = oxNew($controllerClass);
@@ -685,7 +685,7 @@ class ShopControl extends \OxidEsales\Eshop\Core\Base
             $debugLevel = \OxidEsales\Eshop\Core\Registry::getConfig()->getConfigParam('iDebug');
             $debugInfo = oxNew(\OxidEsales\Eshop\Core\DebugInfo::class);
 
-            $logId = md5(time() . rand() . rand());
+            $logId = \md5(\time() . \rand() . \rand());
             $header = $debugInfo->formatGeneralInfo();
             $display = ($debugLevel == -1) ? 'none' : 'block';
             $monitorMessage = $this->formMonitorMessage($view);
@@ -731,7 +731,7 @@ class ShopControl extends \OxidEsales\Eshop\Core\Base
         }
 
         // Output timing
-        $this->_dTimeEnd = microtime(true);
+        $this->_dTimeEnd = \microtime(true);
 
         $message .= $debugInfo->formatMemoryUsage();
         $message .= $debugInfo->formatTimeStamp();
@@ -874,7 +874,7 @@ class ShopControl extends \OxidEsales\Eshop\Core\Base
 
         $result = $this->sendOfflineWarning($exception);
         if ($result) {
-            file_put_contents($this->offlineWarningTimestampFile, time());
+            \file_put_contents($this->offlineWarningTimestampFile, \time());
         }
     }
 
@@ -891,9 +891,9 @@ class ShopControl extends \OxidEsales\Eshop\Core\Base
 
         /** @var int $threshold Threshold in seconds */
         $threshold = Registry::get(\OxidEsales\Eshop\Core\ConfigFile::class)->getVar('offlineWarningInterval');
-        if (file_exists($this->offlineWarningTimestampFile)) {
-            $lastSentTimestamp = (int) file_get_contents($this->offlineWarningTimestampFile);
-            $lastSentBefore = time() - $lastSentTimestamp;
+        if (\file_exists($this->offlineWarningTimestampFile)) {
+            $lastSentTimestamp = (int) \file_get_contents($this->offlineWarningTimestampFile);
+            $lastSentBefore = \time() - $lastSentTimestamp;
             if ($lastSentBefore < $threshold) {
                 $wasSentWithinThreshold = true;
             }
@@ -920,9 +920,9 @@ class ShopControl extends \OxidEsales\Eshop\Core\Base
 
         if ($emailAddress) {
             /** As we are inside the exception handling process, any further exceptions must be caught */
-            $failedShop = isset($_REQUEST['shp']) ? addslashes($_REQUEST['shp']) : 'Base shop';
+            $failedShop = isset($_REQUEST['shp']) ? \addslashes($_REQUEST['shp']) : 'Base shop';
 
-            $date = date(DATE_RFC822); // RFC 822 (example: Mon, 15 Aug 05 15:52:01 +0000)
+            $date = \date(DATE_RFC822); // RFC 822 (example: Mon, 15 Aug 05 15:52:01 +0000)
             $script = $_SERVER['SCRIPT_NAME'] . '?' . $_SERVER['QUERY_STRING'];
             $referrer = $_SERVER['HTTP_REFERER'];
 

--- a/source/Core/ShopIdCalculator.php
+++ b/source/Core/ShopIdCalculator.php
@@ -57,7 +57,7 @@ class ShopIdCalculator
 
         //get from file cache
         $aMap = $this->getVariablesCache()->getFromCache("urlMap");
-        if (!is_null($aMap)) {
+        if (!\is_null($aMap)) {
             self::$urlMap = $aMap;
 
             return $aMap;
@@ -81,11 +81,11 @@ class ShopIdCalculator
                 $sURL = $oRs->fields[2];
 
                 if ($sVar == 'aLanguageURLs') {
-                    $aUrls = unserialize($sURL);
-                    if (is_array($aUrls) && count($aUrls)) {
-                        $aUrls = array_filter($aUrls);
-                        $aUrls = array_fill_keys($aUrls, $iShp);
-                        $aMap = array_merge($aMap, $aUrls);
+                    $aUrls = \unserialize($sURL);
+                    if (\is_array($aUrls) && \count($aUrls)) {
+                        $aUrls = \array_filter($aUrls);
+                        $aUrls = \array_fill_keys($aUrls, $iShp);
+                        $aMap = \array_merge($aMap, $aUrls);
                     }
                 } elseif ($sURL) {
                     $aMap[$sURL] = $iShp;

--- a/source/Core/SimpleXml.php
+++ b/source/Core/SimpleXml.php
@@ -57,7 +57,7 @@ class SimpleXml
      */
     public function xmlToObject($sXml)
     {
-        return simplexml_load_string($sXml);
+        return \simplexml_load_string($sXml);
     }
 
     /**
@@ -72,7 +72,7 @@ class SimpleXml
      */
     protected function _addSimpleXmlElement($oXml, $oInput, $sPreferredKey = null) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
-        $aElements = is_object($oInput) ? get_object_vars($oInput) : (array) $oInput;
+        $aElements = \is_object($oInput) ? \get_object_vars($oInput) : (array) $oInput;
 
         foreach ($aElements as $sKey => $mElement) {
             $oXml = $this->_addChildNode($oXml, $sKey, $mElement, $sPreferredKey);
@@ -95,13 +95,13 @@ class SimpleXml
     protected function _addChildNode($oXml, $sKey, $mElement, $sPreferredKey = null) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $aAttributes = [];
-        if (is_array($mElement) && array_key_exists('attributes', $mElement) && is_array($mElement['attributes'])) {
+        if (\is_array($mElement) && \array_key_exists('attributes', $mElement) && \is_array($mElement['attributes'])) {
             $aAttributes = $mElement['attributes'];
             $mElement = $mElement['value'];
         }
 
-        if (is_object($mElement) || is_array($mElement)) {
-            if (is_int(key($mElement))) {
+        if (\is_object($mElement) || \is_array($mElement)) {
+            if (\is_int(\key($mElement))) {
                 $this->_addSimpleXmlElement($oXml, $mElement, $sKey);
             } else {
                 $oChildNode = $oXml->addChild($sPreferredKey ? $sPreferredKey : $sKey);

--- a/source/Core/Smarty/Plugin/Emos.php
+++ b/source/Core/Smarty/Plugin/Emos.php
@@ -338,7 +338,7 @@ class Emos
      */
     public function addRegister($sUserId, $sResult)
     {
-        $this->_registerUser = md5($sUserId);
+        $this->_registerUser = \md5($sUserId);
         $this->_registerResult = $sResult;
     }
 
@@ -351,7 +351,7 @@ class Emos
      */
     public function addLogin($sUserId, $sResult)
     {
-        $this->_loginUser = md5($sUserId);
+        $this->_loginUser = \md5($sUserId);
         $this->_loginResult = $sResult;
     }
 
@@ -384,7 +384,7 @@ class Emos
      */
     public function addEmosBasketPageArray($aBasket)
     {
-        if (!is_array($aBasket)) {
+        if (!\is_array($aBasket)) {
             return;
         }
 
@@ -459,7 +459,7 @@ class Emos
     {
         /******************* prepare data *************************************/
         /* md5 the customer id to fullfill requirements of german datenschutzgeesetz */
-        $sCustomerNumber = md5($sCustomerNumber);
+        $sCustomerNumber = \md5($sCustomerNumber);
 
         $sCountry = $this->_emos_DataFormat($sCountry);
         $sCip = $this->_emos_DataFormat($sCip) ;
@@ -534,36 +534,36 @@ class Emos
     protected function _emos_DataFormat($sStr) //phpcs:ignore PSR1.Methods.CamelCapsMethodName.NotCamelCaps,PSR2.Methods.MethodDeclaration.Underscore
     {
         //null check
-        if (is_null($sStr)) {
+        if (\is_null($sStr)) {
             return null;
         }
 
         //$sStr = urldecode($sStr);
-        $sStr = htmlspecialchars_decode($sStr, ENT_QUOTES);
+        $sStr = \htmlspecialchars_decode($sStr, ENT_QUOTES);
         $sStr = Str::getStr()->html_entity_decode($sStr);
-        $sStr = strip_tags($sStr);
-        $sStr = trim($sStr);
+        $sStr = \strip_tags($sStr);
+        $sStr = \trim($sStr);
 
         //2007-05-10 replace translated &nbsp; with spaces
-        $nbsp = chr(0xa0);
-        $sStr = str_replace($nbsp, " ", $sStr);
-        $sStr = str_replace("\"", "", $sStr);
-        $sStr = str_replace("'", "", $sStr);
-        $sStr = str_replace("%", "", $sStr);
-        $sStr = str_replace(",", "", $sStr);
-        $sStr = str_replace(";", "", $sStr);
+        $nbsp = \chr(0xa0);
+        $sStr = \str_replace($nbsp, " ", $sStr);
+        $sStr = \str_replace("\"", "", $sStr);
+        $sStr = \str_replace("'", "", $sStr);
+        $sStr = \str_replace("%", "", $sStr);
+        $sStr = \str_replace(",", "", $sStr);
+        $sStr = \str_replace(";", "", $sStr);
         /* remove unnecessary white spaces*/
         while (true) {
             $sStr_temp = $sStr;
-            $sStr = str_replace("  ", " ", $sStr);
+            $sStr = \str_replace("  ", " ", $sStr);
 
             if ($sStr == $sStr_temp) {
                 break;
             }
         }
-        $sStr = str_replace(" / ", "/", $sStr);
-        $sStr = str_replace(" /", "/", $sStr);
-        $sStr = str_replace("/ ", "/", $sStr);
+        $sStr = \str_replace(" / ", "/", $sStr);
+        $sStr = \str_replace(" /", "/", $sStr);
+        $sStr = \str_replace("/ ", "/", $sStr);
 
         $sStr = Str::getStr()->substr($sStr, 0, 254);
         //$sStr = rawurlencode( $sStr );
@@ -618,11 +618,11 @@ class Emos
     {
         //get the first non array $mContents element
         $mVal = $mContents;
-        while (is_array($mVal)) {
+        while (\is_array($mVal)) {
             $mVal = $mVal[0];
         }
 
-        if (is_null($mVal)) {
+        if (\is_null($mVal)) {
             return;
         }
 
@@ -641,6 +641,6 @@ class Emos
      */
     protected function _jsEncode($mContents) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
-        return json_encode($mContents);
+        return \json_encode($mContents);
     }
 }

--- a/source/Core/Smarty/Plugin/EmosAdapter.php
+++ b/source/Core/Smarty/Plugin/EmosAdapter.php
@@ -212,7 +212,7 @@ class EmosAdapter extends \OxidEsales\Eshop\Core\Base
     {
         $myConfig = \OxidEsales\Eshop\Core\Registry::getConfig();
         if (!$myConfig->isUtf()) {
-            $sContent = iconv(\OxidEsales\Eshop\Core\Registry::getLang()->translateString('charset'), 'UTF-8', $sContent);
+            $sContent = \iconv(\OxidEsales\Eshop\Core\Registry::getLang()->translateString('charset'), 'UTF-8', $sContent);
         }
 
         return $sContent;
@@ -291,13 +291,13 @@ class EmosAdapter extends \OxidEsales\Eshop\Core\Base
     {
         $oActView = \OxidEsales\Eshop\Core\Registry::getConfig()->getActiveView();
         // showLogin function is deprecated, but just in case if it is called
-        if (strcasecmp('showLogin', (string)$oActView->getFncName()) == 0) {
+        if (\strcasecmp('showLogin', (string)$oActView->getFncName()) == 0) {
             $sCl = 'account';
         } else {
             $sCl = $oActView->getClassName();
         }
 
-        return $sCl ? strtolower($sCl) : 'start';
+        return $sCl ? \strtolower($sCl) : 'start';
     }
 
     /**
@@ -316,7 +316,7 @@ class EmosAdapter extends \OxidEsales\Eshop\Core\Base
                     $aCatTitle[] = $aCatPathParts['title'];
                 }
             }
-            $this->_sEmosCatPath = (count($aCatTitle) ? strip_tags(implode('/', $aCatTitle)) : 'NULL');
+            $this->_sEmosCatPath = (\count($aCatTitle) ? \strip_tags(\implode('/', $aCatTitle)) : 'NULL');
         }
 
         return $this->_sEmosCatPath;
@@ -352,7 +352,7 @@ class EmosAdapter extends \OxidEsales\Eshop\Core\Base
                     if ($sCatPath) {
                         $sCatPath .= '/';
                     }
-                    $sCatPath .= strip_tags($oRs->fields['oxtitle']);
+                    $sCatPath .= \strip_tags($oRs->fields['oxtitle']);
                     $oRs->fetchRow();
                 }
             }
@@ -378,7 +378,7 @@ class EmosAdapter extends \OxidEsales\Eshop\Core\Base
             \OxidEsales\Eshop\Core\Registry::getConfig()->getRequestParameter('anid') .
             \OxidEsales\Eshop\Core\Registry::getConfig()->getRequestParameter('option');
 
-        return md5($sPageId);
+        return \md5($sPageId);
     }
 
     /**
@@ -389,7 +389,7 @@ class EmosAdapter extends \OxidEsales\Eshop\Core\Base
      */
     protected function _getTplName() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
-        if (!($sCurrTpl = basename((string)\OxidEsales\Eshop\Core\Registry::getConfig()->getRequestParameter('tpl')))) {
+        if (!($sCurrTpl = \basename((string)\OxidEsales\Eshop\Core\Registry::getConfig()->getRequestParameter('tpl')))) {
             // in case template was not defined in request
             $sCurrTpl = \OxidEsales\Eshop\Core\Registry::getConfig()->getActiveView()->getTemplateName();
         }
@@ -452,11 +452,11 @@ class EmosAdapter extends \OxidEsales\Eshop\Core\Base
                 $sOption = \OxidEsales\Eshop\Core\Registry::getConfig()->getRequestParameter('option');
                 $sOption = (isset($sOption)) ? $sOption : $session->getVariable('option');
 
-                if (isset($sOption) && array_key_exists('user_' . $sOption, $aContent)) {
+                if (isset($sOption) && \array_key_exists('user_' . $sOption, $aContent)) {
                     $aContent['user'] = $aContent['user_' . $sOption];
                 }
 
-                if (isset($sOption) && array_key_exists('user_' . $sOption, $aOrderSteps)) {
+                if (isset($sOption) && \array_key_exists('user_' . $sOption, $aOrderSteps)) {
                     $aOrderSteps['user'] = $aOrderSteps['user_' . $sOption];
                 }
                 break;
@@ -473,7 +473,7 @@ class EmosAdapter extends \OxidEsales\Eshop\Core\Base
                 if ($oProduct) {
                     $sPath = $this->_getBasketProductCatPath($oProduct);
                     $sTitle = $this->_prepareProductTitle($oProduct);
-                    $aContent['oxwarticledetails'] = "Shop/{$sPath}/" . strip_tags($sTitle);
+                    $aContent['oxwarticledetails'] = "Shop/{$sPath}/" . \strip_tags($sTitle);
                     $oEmos->addDetailView($this->_convProd2EmosItem($oProduct, $sPath, 1));
                 }
                 break;
@@ -504,7 +504,7 @@ class EmosAdapter extends \OxidEsales\Eshop\Core\Base
                 $aContent['newsletter'] = $oCurrentView->getNewsletterStatus() ? $aContent['newsletter_success'] : $aContent['newsletter_failure'];
                 break;
             case 'info':
-                if (array_key_exists('info_' . $sTplName, $aContent)) {
+                if (\array_key_exists('info_' . $sTplName, $aContent)) {
                     $aContent['info'] = $aContent['info_' . $sTplName];
                 } else {
                     $aContent['info'] = 'Content/' . $oStr->preg_replace('/\.tpl$/', '', $sTplName);
@@ -515,7 +515,7 @@ class EmosAdapter extends \OxidEsales\Eshop\Core\Base
                 $oContent = ($oCurrentView instanceof \OxidEsales\Eshop\Application\Controller\ContentController) ? $oCurrentView->getContent() : null;
                 $sContentId = $oContent ? $oContent->oxcontents__oxloadid->value : null;
 
-                if (array_key_exists('content_' . $sContentId, $aContent)) {
+                if (\array_key_exists('content_' . $sContentId, $aContent)) {
                     $aContent['content'] = $aContent['content_' . $sContentId];
                 } else {
                     $aContent['content'] = 'Content/' . $this->_getEmosPageTitle($aParams);
@@ -526,13 +526,13 @@ class EmosAdapter extends \OxidEsales\Eshop\Core\Base
                 break;
         }
 
-        if (is_string($sControllerName) && array_key_exists($sControllerName, $aContent)) {
+        if (\is_string($sControllerName) && \array_key_exists($sControllerName, $aContent)) {
             $oEmos->addContent($aContent[$sControllerName]);
         } else {
             $oEmos->addContent('Content/' . $oStr->preg_replace('/\.tpl$/', '', $sTplName));
         }
 
-        if (is_string($sControllerName) && array_key_exists($sControllerName, $aOrderSteps)) {
+        if (\is_string($sControllerName) && \array_key_exists($sControllerName, $aOrderSteps)) {
             $oEmos->addOrderProcess($aOrderSteps[$sControllerName]);
         }
 
@@ -619,7 +619,7 @@ class EmosAdapter extends \OxidEsales\Eshop\Core\Base
         $iSuccess = \OxidEsales\Eshop\Core\Registry::getConfig()->getRequestParameter('success');
 
         if ($iError && $iError < 0) {
-            $oEmos->addRegister($oUser ? $oUser->getId() : 'NULL', abs($iError));
+            $oEmos->addRegister($oUser ? $oUser->getId() : 'NULL', \abs($iError));
         }
 
         if ($iSuccess && $iSuccess > 0 && $oUser) {
@@ -641,9 +641,9 @@ class EmosAdapter extends \OxidEsales\Eshop\Core\Base
         }
 
         // ADD To Basket and Remove from Basket
-        if (is_array($aLastCall) && count($aLastCall)) {
-            $sCallAction = key($aLastCall);
-            $aCallData = current($aLastCall);
+        if (\is_array($aLastCall) && \count($aLastCall)) {
+            $sCallAction = \key($aLastCall);
+            $aCallData = \current($aLastCall);
 
             switch ($sCallAction) {
                 case 'changebasket':

--- a/source/Core/Smarty/Plugin/block.oxifcontent.php
+++ b/source/Core/Smarty/Plugin/block.oxifcontent.php
@@ -70,7 +70,7 @@ function smarty_block_oxifcontent($params, $content, &$smarty, &$repeat)
         $oStr = Str::getStr();
         $blHasSmarty = $oStr->strstr($content, '[{');
         if ($blHasSmarty) {
-            $content = \OxidEsales\Eshop\Core\Registry::getUtilsView()->parseThroughSmarty($content, $sIdent . md5($content), $myConfig->getActiveView());
+            $content = \OxidEsales\Eshop\Core\Registry::getUtilsView()->parseThroughSmarty($content, $sIdent . \md5($content), $myConfig->getActiveView());
         }
 
         if ($sAssign) {

--- a/source/Core/Smarty/Plugin/compiler.defun.php
+++ b/source/Core/Smarty/Plugin/compiler.defun.php
@@ -27,8 +27,8 @@ $this->register_compiler_function('fun', 'smarty_compiler_fun');
 function smarty_compiler_defun($tag_args, &$compiler)
 {
     $attrs = $compiler->_parse_attrs($tag_args);
-    $func_key = '"' . md5('php-5') . '[[' . md5(uniqid('sucks')) . '";';
-    array_push($compiler->_tag_stack, ['defun', $attrs, $tag_args, $func_key]);
+    $func_key = '"' . \md5('php-5') . '[[' . \md5(\uniqid('sucks')) . '";';
+    \array_push($compiler->_tag_stack, ['defun', $attrs, $tag_args, $func_key]);
     if (!isset($attrs['name'])) {
         $compiler->_syntax_error("defun: missing name parameter");
     }
@@ -42,7 +42,7 @@ function smarty_compiler_defun($tag_args, &$compiler)
 /* create code for closing a function definition and calling said function */
 function smarty_compiler_defun_close($tag_args, &$compiler)
 {
-    list($name, $attrs, $open_tag_args, $func_key) = array_pop($compiler->_tag_stack);
+    list($name, $attrs, $open_tag_args, $func_key) = \array_pop($compiler->_tag_stack);
     if ($name != 'defun') {
         $compiler->_syntax_error("unexpected {/defun}");
     }
@@ -54,13 +54,13 @@ $this->register_compiler_function('/defun', 'smarty_compiler_defun_close');
 /* callback to replace all $this with $smarty */
 function smarty_replace_fun($match)
 {
-    $tokens = token_get_all('<?php ' . $match[2]);
+    $tokens = \token_get_all('<?php ' . $match[2]);
 
     /* remove trailing <?php */
     $open_tag = '';
     while ($tokens) {
-        $token = array_shift($tokens);
-        if (is_array($token)) {
+        $token = \array_shift($tokens);
+        if (\is_array($token)) {
             $open_tag .= $token[1];
         } else {
             $open_tag .= $token;
@@ -71,8 +71,8 @@ function smarty_replace_fun($match)
     }
 
     /* replace */
-    for ($i = 0, $count = count($tokens); $i < $count; $i++) {
-        if (is_array($tokens[$i])) {
+    for ($i = 0, $count = \count($tokens); $i < $count; $i++) {
+        if (\is_array($tokens[$i])) {
             if ($tokens[$i][0] == T_VARIABLE && $tokens[$i][1] == '$this') {
                 $tokens[$i] = '$smarty';
             } else {
@@ -80,27 +80,27 @@ function smarty_replace_fun($match)
             }
         }
     }
-    return implode('', $tokens);
+    return \implode('', $tokens);
 }
 
 
 /* postfilter to squeeze the code to make php5 happy */
 function smarty_postfilter_defun($source, &$compiler)
 {
-    $search = '("' . md5('php-5') . '\[\[[0-9a-f]{32}";)';
-    if ((double)phpversion() >= 5.0) {
+    $search = '("' . \md5('php-5') . '\[\[[0-9a-f]{32}";)';
+    if ((double)\phpversion() >= 5.0) {
         /* filter sourcecode. look for func_keys and replace all $this
            in-between with $smarty */
         while (1) {
-            $new_source = preg_replace_callback('/' . $search . '(.*)\\1/Us', 'smarty_replace_fun', $source);
-            if (strcmp($new_source, $source) == 0) {
+            $new_source = \preg_replace_callback('/' . $search . '(.*)\\1/Us', 'smarty_replace_fun', $source);
+            if (\strcmp($new_source, $source) == 0) {
                 break;
             }
             $source = $new_source;
         }
     } else {
         /* remove func_keys */
-        $source = preg_replace('/' . $search . '/', '', $source);
+        $source = \preg_replace('/' . $search . '/', '', $source);
     }
     return $source;
 }

--- a/source/Core/Smarty/Plugin/function.assign_adv.php
+++ b/source/Core/Smarty/Plugin/function.assign_adv.php
@@ -80,21 +80,21 @@
  */
 function smarty_function_assign_adv($params, &$smarty)
 {
-    extract($params);
+    \extract($params);
 
     if (empty($var)) {
         $smarty->trigger_error("assign_adv: missing 'var' parameter");
         return;
     }
 
-    if (!in_array('value', array_keys($params))) {
+    if (!\in_array('value', \array_keys($params))) {
         $smarty->trigger_error("assign_adv: missing 'value' parameter");
         return;
     }
-    if (preg_match('/^\s*array\s*\(\s*(.*)\s*\)\s*$/s', $value, $match)) {
-        eval('$value=array(' . str_replace("\n", "", $match[1]) . ');');
-    } elseif (preg_match('/^\s*range\s*\(\s*(.*)\s*\)\s*$/s', $value, $match)) {
-        eval('$value=range(' . str_replace("\n", "", $match[1]) . ');');
+    if (\preg_match('/^\s*array\s*\(\s*(.*)\s*\)\s*$/s', $value, $match)) {
+        eval('$value=array(' . \str_replace("\n", "", $match[1]) . ');');
+    } elseif (\preg_match('/^\s*range\s*\(\s*(.*)\s*\)\s*$/s', $value, $match)) {
+        eval('$value=range(' . \str_replace("\n", "", $match[1]) . ');');
     }
 
     $smarty->assign($var, $value);

--- a/source/Core/Smarty/Plugin/function.oxeval.php
+++ b/source/Core/Smarty/Plugin/function.oxeval.php
@@ -20,7 +20,7 @@
 function smarty_function_oxeval($aParams, &$oSmarty)
 {
     if ($aParams['var'] && ($aParams['var'] instanceof \OxidEsales\Eshop\Core\Field)) {
-        $aParams['var'] = trim($aParams['var']->getRawValue());
+        $aParams['var'] = \trim($aParams['var']->getRawValue());
     }
 
     // processign only if enabled

--- a/source/Core/Smarty/Plugin/function.oxgetseourl.php
+++ b/source/Core/Smarty/Plugin/function.oxgetseourl.php
@@ -32,7 +32,7 @@ function smarty_function_oxgetseourl($params, &$smarty)
             $sUrl = $oObject->getLink();
         } elseif ($sOxid) {
             //minimising aricle object loading
-            if (strtolower($sType) == "oxarticle") {
+            if (\strtolower($sType) == "oxarticle") {
                 $oObject->disablePriceLoad();
                 $oObject->setNoVariantLoading(true);
             }

--- a/source/Core/Smarty/Plugin/function.oxid_include_dynamic.php
+++ b/source/Core/Smarty/Plugin/function.oxid_include_dynamic.php
@@ -20,7 +20,7 @@
  */
 function smarty_function_oxid_include_dynamic($params, &$smarty)
 {
-    $params = array_change_key_case($params, CASE_LOWER);
+    $params = \array_change_key_case($params, CASE_LOWER);
 
     if (!isset($params['file'])) {
         $smarty->trigger_error("oxid_include_dynamic: missing 'file' parameter");
@@ -30,13 +30,13 @@ function smarty_function_oxid_include_dynamic($params, &$smarty)
     if (!empty($smarty->_tpl_vars["_render4cache"])) {
         $sContent = "<oxid_dynamic>";
         foreach ($params as $key => $val) {
-            $sContent .= " $key='" . base64_encode($val) . "'";
+            $sContent .= " $key='" . \base64_encode($val) . "'";
         }
         $sContent .= "</oxid_dynamic>";
         return $sContent;
     } else {
         $sPrefix = "_";
-        if (array_key_exists('type', $params)) {
+        if (\array_key_exists('type', $params)) {
             $sPrefix .= $params['type'] . "_";
         }
 

--- a/source/Core/Smarty/Plugin/function.oxid_include_widget.php
+++ b/source/Core/Smarty/Plugin/function.oxid_include_widget.php
@@ -19,12 +19,12 @@
  */
 function smarty_function_oxid_include_widget($params, &$oSmarty)
 {
-    $class = isset($params['cl']) ? strtolower($params['cl']) : '';
+    $class = isset($params['cl']) ? \strtolower($params['cl']) : '';
     unset($params['cl']);
 
     $parentViews = null;
     if (!empty($params["_parent"])) {
-        $parentViews = explode("|", $params["_parent"]);
+        $parentViews = \explode("|", $params["_parent"]);
         unset($params["_parent"]);
     }
 

--- a/source/Core/Smarty/Plugin/function.oxmailto.php
+++ b/source/Core/Smarty/Plugin/function.oxmailto.php
@@ -26,29 +26,29 @@ function smarty_function_oxmailto($aParams, &$oSmarty)
                 case 'bcc':
                 case 'followupto':
                     if ($sValue) {
-                        $aMailParms[] = $sVarName . '=' . str_replace([ '%40', '%2C' ], [ '@', ',' ], rawurlencode($sValue));
+                        $aMailParms[] = $sVarName . '=' . \str_replace([ '%40', '%2C' ], [ '@', ',' ], \rawurlencode($sValue));
                     }
                     break;
                 case 'subject':
                 case 'newsgroups':
-                    $aMailParms[] = $sVarName . '=' . rawurlencode($sValue);
+                    $aMailParms[] = $sVarName . '=' . \rawurlencode($sValue);
                     break;
                 case 'extra':
                 case 'text':
-                    $sName  = "s" . ucfirst($sVarName);
+                    $sName  = "s" . \ucfirst($sVarName);
                     $$sName = $sValue;
                     // no break
                 default:
             }
         }
 
-        for ($iCtr = 0; $iCtr < count($aMailParms); $iCtr++) {
+        for ($iCtr = 0; $iCtr < \count($aMailParms); $iCtr++) {
             $sAddress .= ($iCtr == 0) ? '?' : '&';
             $sAddress .= $aMailParms[$iCtr];
         }
 
         $sString = 'document.write(\'<a href="mailto:' . $sAddress . '" ' . $sExtra . '>' . $sText . '</a>\');';
-        $sEncodedString = "%" . wordwrap(current(unpack("H*", $sString)), 2, "%", true);
+        $sEncodedString = "%" . \wordwrap(\current(\unpack("H*", $sString)), 2, "%", true);
         return '<script type="text/javascript">eval(decodeURIComponent(\'' . $sEncodedString . '\'))</script>';
     } else {
         include_once $oSmarty->_get_plugin_filepath('function', 'mailto');

--- a/source/Core/Smarty/Plugin/function.oxmultilang.php
+++ b/source/Core/Smarty/Plugin/function.oxmultilang.php
@@ -56,10 +56,10 @@ function smarty_function_oxmultilang($params, &$smarty)
 
     if (!$blTranslationNotFound) {
         if ($aArgs !== false) {
-            if (is_array($aArgs)) {
-                $sTranslation = vsprintf($sTranslation, $aArgs);
+            if (\is_array($aArgs)) {
+                $sTranslation = \vsprintf($sTranslation, $aArgs);
             } else {
-                $sTranslation = sprintf($sTranslation, $aArgs);
+                $sTranslation = \sprintf($sTranslation, $aArgs);
             }
         }
 

--- a/source/Core/Smarty/Plugin/function.oxprice.php
+++ b/source/Core/Smarty/Plugin/function.oxprice.php
@@ -31,13 +31,13 @@ function smarty_function_oxprice($params, &$smarty)
     $sSide = '';
     $mPrice = $params['price'];
 
-    if (!is_null($mPrice)) {
+    if (!\is_null($mPrice)) {
         $oConfig = Registry::getConfig();
 
-        $sPrice = ($mPrice instanceof \OxidEsales\Eshop\Core\Price) ? $mPrice->getPrice() : floatval($mPrice);
+        $sPrice = ($mPrice instanceof \OxidEsales\Eshop\Core\Price) ? $mPrice->getPrice() : \floatval($mPrice);
         $oCurrency = isset($params['currency']) ? $params['currency'] : $oConfig->getActShopCurrencyObject();
 
-        if (!is_null($oCurrency)) {
+        if (!\is_null($oCurrency)) {
             $sDecimalsSeparator = isset($oCurrency->dec) ? $oCurrency->dec : $sDecimalsSeparator;
             $sThousandSeparator = isset($oCurrency->thousand) ? $oCurrency->thousand : $sThousandSeparator;
             $sCurrencySign = isset($oCurrency->sign) ? $oCurrency->sign : $sCurrencySign;
@@ -45,13 +45,13 @@ function smarty_function_oxprice($params, &$smarty)
             $iDecimals = isset($oCurrency->decimal) ? (int) $oCurrency->decimal : $iDecimals;
         }
 
-        if (is_numeric($sPrice)) {
+        if (\is_numeric($sPrice)) {
             if ((float) $sPrice > 0 || $sCurrencySign) {
-                $sPrice = number_format($sPrice, $iDecimals, $sDecimalsSeparator, $sThousandSeparator);
+                $sPrice = \number_format($sPrice, $iDecimals, $sDecimalsSeparator, $sThousandSeparator);
                 $sOutput = (isset($sSide) && $sSide == 'Front') ? $sCurrencySign . $sPrice : $sPrice . ' ' . $sCurrencySign;
             }
 
-            $sOutput = trim($sOutput);
+            $sOutput = \trim($sOutput);
         }
     }
 

--- a/source/Core/Smarty/Plugin/function.oxstyle.php
+++ b/source/Core/Smarty/Plugin/function.oxstyle.php
@@ -34,7 +34,7 @@ function smarty_function_oxstyle($params, &$smarty)
         'if' => null,
         'include' => null,
     ];
-    $params = array_merge($defaults, $params);
+    $params = \array_merge($defaults, $params);
 
     $widget = $params['widget'];
     $forceRender = $params['inWidget'];

--- a/source/Core/Smarty/Plugin/function.oxvariantselect.php
+++ b/source/Core/Smarty/Plugin/function.oxvariantselect.php
@@ -35,7 +35,7 @@ function smarty_function_oxvariantselect($params, &$smarty)
     //real variants to MD variants
     $aRealVariants = [];
 
-    if (count($oMdVariants->getMdSubvariants())) {
+    if (\count($oMdVariants->getMdSubvariants())) {
         $sOutput = oxvariantselect_addSubvariants($oMdVariants->getMdSubvariants(), 0, $aSelectBoxes, $aRealVariants, $sSeparator, $sCallMethod, $sArtId);
         $sOutput .= oxvariantselect_formatJsSelecBoxesArray($aSelectBoxes);
         $sOutput .= oxvariantselect_formatJsRealVariantArray($aRealVariants);
@@ -61,7 +61,7 @@ function oxvariantselect_addSubvariants($oMdVariants, $iLevel, &$aSelectBoxes, &
 {
     $sRes = '';
     $aOptions = [];
-    if (count($oMdVariants)) {
+    if (\count($oMdVariants)) {
         $blVisible = false;
         $sSelectedVariant = null;
         foreach ($oMdVariants as $sKey => $oVariant) {
@@ -85,7 +85,7 @@ function oxvariantselect_addSubvariants($oMdVariants, $iLevel, &$aSelectBoxes, &
             $sRes .= oxvariantselect_addSubvariants($oVariant->getMdSubvariants(), $iLevel + 1, $aSelectBoxes, $aRealVariants, $sSeparator, $sCallMethod, $sArtId);
 
             //no more subvariants? Mseans we are the last level select box, good enought to register a real variant now
-            if (!count($oVariant->getMdSubvariants())) {
+            if (!\count($oVariant->getMdSubvariants())) {
                 $aRealVariants[$oVariant->getId()]['id'] = $oVariant->getArticleId();
                 $aRealVariants[$oVariant->getId()]['link'] = $oVariant->getlink();
             }
@@ -129,10 +129,10 @@ function oxvariantselect_formatSelectBox($sId, $aOptions, $iLevel, $blVisible, $
 function oxvariantselect_formatJsSelecBoxesArray($aSelectBoxes)
 {
     $sRes = "<script language=JavaScript><!--\n";
-    $iLevelCount = count($aSelectBoxes);
+    $iLevelCount = \count($aSelectBoxes);
     $sRes .= "mdVariantSelectIds = Array($iLevelCount);\n";
     foreach ($aSelectBoxes as $iLevel => $aSelects) {
-        $sSelectCount = count($aSelects);
+        $sSelectCount = \count($aSelects);
         $sRes .= " mdVariantSelectIds[$iLevel] = Array($sSelectCount);\n";
         foreach ($aSelects as $iSelect => $sSelect) {
             $sRes .= " mdVariantSelectIds[$iLevel][$iSelect] = '$sSelect';\n";
@@ -154,12 +154,12 @@ function oxvariantselect_formatJsSelecBoxesArray($aSelectBoxes)
 function oxvariantselect_formatJsRealVariantArray($aRealVariants)
 {
     $sRes = "<script language=JavaScript><!--\n";
-    $iCount = count($aRealVariants);
+    $iCount = \count($aRealVariants);
     $sRes .= "mdRealVariants = Array($iCount);\n";
     $sRes .= "mdRealVariantsLinks = Array($iCount);\n";
     foreach ($aRealVariants as $sMdVarian => $sRealVariant) {
         $sRes .= " mdRealVariants['$sMdVarian'] = '" . $sRealVariant['id'] . "';\n";
-        $sRes .= " mdRealVariantsLinks['$sMdVarian'] = '" . str_replace('&amp;', '&', $sRealVariant['link']) . "';\n";
+        $sRes .= " mdRealVariantsLinks['$sMdVarian'] = '" . \str_replace('&amp;', '&', $sRealVariant['link']) . "';\n";
     }
 
     $sRes .= "--></script>";

--- a/source/Core/Smarty/Plugin/insert.oxid_cssmanager.php
+++ b/source/Core/Smarty/Plugin/insert.oxid_cssmanager.php
@@ -61,7 +61,7 @@ function smarty_insert_oxid_cssmanager($params, &$smarty)
 
     $sOutput = "";
     // checking if alternative CSS file exists and returning URL to CSS file
-    if ($sTplName && file_exists($sAltFullPath) && is_file($sAltFullPath)) {
+    if ($sTplName && \file_exists($sAltFullPath) && \is_file($sAltFullPath)) {
         $sOutput = '<link rel="stylesheet" href="' . $sTplURL . $sAltCss . '">';
     }
 

--- a/source/Core/Smarty/Plugin/insert.oxid_nocache.php
+++ b/source/Core/Smarty/Plugin/insert.oxid_nocache.php
@@ -25,7 +25,7 @@ function smarty_insert_oxid_nocache($params, &$smarty)
 
     // #1184M - specialchar search
     $sSearchParamForHTML = \OxidEsales\Eshop\Core\Registry::getConfig()->getRequestParameter("searchparam");
-    $sSearchParamForLink = rawurlencode(\OxidEsales\Eshop\Core\Registry::getConfig()->getRequestParameter("searchparam", true));
+    $sSearchParamForLink = \rawurlencode(\OxidEsales\Eshop\Core\Registry::getConfig()->getRequestParameter("searchparam", true));
     if ($sSearchParamForHTML) {
         $smarty->assign_by_ref("searchparamforhtml", $sSearchParamForHTML);
         $smarty->assign_by_ref("searchparam", $sSearchParamForLink);
@@ -33,10 +33,10 @@ function smarty_insert_oxid_nocache($params, &$smarty)
 
     $sSearchCat = \OxidEsales\Eshop\Core\Registry::getConfig()->getRequestParameter("searchcnid");
     if ($sSearchCat) {
-        $smarty->assign_by_ref("searchcnid", rawurldecode($sSearchCat));
+        $smarty->assign_by_ref("searchcnid", \rawurldecode($sSearchCat));
     }
 
-    foreach (array_keys($params) as $key) {
+    foreach (\array_keys($params) as $key) {
         $viewData = & $params[$key];
         $smarty->assign_by_ref($key, $viewData);
     }

--- a/source/Core/Smarty/Plugin/insert.oxid_nocache.php
+++ b/source/Core/Smarty/Plugin/insert.oxid_nocache.php
@@ -33,7 +33,7 @@ function smarty_insert_oxid_nocache($params, &$smarty)
 
     $sSearchCat = \OxidEsales\Eshop\Core\Registry::getConfig()->getRequestParameter("searchcnid");
     if ($sSearchCat) {
-        $smarty->assign_by_ref("searchcnid", \rawurldecode($sSearchCat));
+        $smarty->assign_by_ref("searchcnid", rawurldecode($sSearchCat));
     }
 
     foreach (\array_keys($params) as $key) {

--- a/source/Core/Smarty/Plugin/insert.oxid_tracker.php
+++ b/source/Core/Smarty/Plugin/insert.oxid_tracker.php
@@ -29,7 +29,7 @@ function smarty_insert_oxid_tracker($params, &$smarty)
         $output = \OxidEsales\Eshop\Core\Registry::get(\OxidEsales\Eshop\Core\Smarty\Plugin\EmosAdapter::class)->getCode($params, $smarty);
 
         // returning JS code to output
-        if (strlen(trim($output))) {
+        if (\strlen(\trim($output))) {
             return "<div style=\"display:none;\">{$output}</div>";
         }
     }

--- a/source/Core/Smarty/Plugin/modifier.oxaddparams.php
+++ b/source/Core/Smarty/Plugin/modifier.oxaddparams.php
@@ -25,7 +25,7 @@ function smarty_modifier_oxaddparams($sUrl, $sDynParams)
     // removing empty parameters
     $sDynParams = $sDynParams ? $oStr->preg_replace([ '/^\?/', '/^\&(amp;)?$/' ], '', $sDynParams) : false;
     if ($sDynParams) {
-        $sUrl .= ((strpos($sUrl, '?') !== false) ? "&amp;" : "?") . $sDynParams;
+        $sUrl .= ((\strpos($sUrl, '?') !== false) ? "&amp;" : "?") . $sDynParams;
     }
     return \OxidEsales\Eshop\Core\Registry::getUtilsUrl()->processSeoUrl($sUrl);
 }

--- a/source/Core/Smarty/Plugin/modifier.oxaddslashes.php
+++ b/source/Core/Smarty/Plugin/modifier.oxaddslashes.php
@@ -18,5 +18,5 @@
  */
 function smarty_modifier_oxaddslashes($string)
 {
-    return addslashes($string);
+    return \addslashes($string);
 }

--- a/source/Core/Smarty/Plugin/modifier.oxfilesize.php
+++ b/source/Core/Smarty/Plugin/modifier.oxfilesize.php
@@ -25,16 +25,16 @@ function smarty_modifier_oxfilesize($iSize)
     $iSize = $iSize / 1024;
 
     if ($iSize < 1024) {
-        return sprintf("%.1f KB", $iSize);
+        return \sprintf("%.1f KB", $iSize);
     }
 
     $iSize = $iSize / 1024;
 
     if ($iSize < 1024) {
-        return sprintf("%.1f MB", $iSize);
+        return \sprintf("%.1f MB", $iSize);
     }
 
     $iSize = $iSize / 1024;
 
-    return sprintf("%.1f GB", $iSize);
+    return \sprintf("%.1f GB", $iSize);
 }

--- a/source/Core/Smarty/Plugin/modifier.oxformattime.php
+++ b/source/Core/Smarty/Plugin/modifier.oxformattime.php
@@ -19,11 +19,11 @@
  */
 function smarty_modifier_oxformattime($iSeconds)
 {
-    $iHours = floor($iSeconds / 3600);
-    $iMins  = floor($iSeconds % 3600 / 60);
+    $iHours = \floor($iSeconds / 3600);
+    $iMins  = \floor($iSeconds % 3600 / 60);
     $iSecs  = $iSeconds % 60;
 
-    return sprintf("%02d:%02d:%02d", $iHours, $iMins, $iSecs);
+    return \sprintf("%02d:%02d:%02d", $iHours, $iMins, $iSecs);
 }
 
 /* vim: set expandtab: */

--- a/source/Core/Smarty/Plugin/modifier.oxformdate.php
+++ b/source/Core/Smarty/Plugin/modifier.oxformdate.php
@@ -23,7 +23,7 @@
 function smarty_modifier_oxformdate($oConvObject, $sFieldType = null, $blPassedValue = false)
 {
    // creating fake object
-    if ($blPassedValue || is_string($oConvObject)) {
+    if ($blPassedValue || \is_string($oConvObject)) {
         $sValue = $oConvObject;
         $oConvObject = new \OxidEsales\Eshop\Core\Field();
         $oConvObject->fldmax_length = "0";

--- a/source/Core/Smarty/Plugin/modifier.oxmultilangassign.php
+++ b/source/Core/Smarty/Plugin/modifier.oxmultilangassign.php
@@ -42,10 +42,10 @@ function smarty_modifier_oxmultilangassign($sIdent, $args = null)
 
     if (!$blTranslationNotFound) {
         if ($args) {
-            if (is_array($args)) {
-                $sTranslation = vsprintf($sTranslation, $args);
+            if (\is_array($args)) {
+                $sTranslation = \vsprintf($sTranslation, $args);
             } else {
-                $sTranslation = sprintf($sTranslation, $args);
+                $sTranslation = \sprintf($sTranslation, $args);
             }
         }
     } elseif ($blShowError) {

--- a/source/Core/Smarty/Plugin/modifier.oxnumberformat.php
+++ b/source/Core/Smarty/Plugin/modifier.oxnumberformat.php
@@ -21,19 +21,19 @@
 function smarty_modifier_oxnumberformat($sFormat = "EUR@ 1.00@ ,@ .@ EUR@ 2", $sValue = 0)
 {
     // logic copied from \OxidEsales\Eshop\Core\Config::getCurrencyArray()
-    $sCur = explode("@", $sFormat);
+    $sCur = \explode("@", $sFormat);
     $oCur           = new stdClass();
     $oCur->id       = 0;
-    $oCur->name     = @trim($sCur[0]);
-    $oCur->rate     = @trim($sCur[1]);
-    $oCur->dec      = @trim($sCur[2]);
-    $oCur->thousand = @trim($sCur[3]);
-    $oCur->sign     = @trim($sCur[4]);
-    $oCur->decimal  = @trim($sCur[5]);
+    $oCur->name     = @\trim($sCur[0]);
+    $oCur->rate     = @\trim($sCur[1]);
+    $oCur->dec      = @\trim($sCur[2]);
+    $oCur->thousand = @\trim($sCur[3]);
+    $oCur->sign     = @\trim($sCur[4]);
+    $oCur->decimal  = @\trim($sCur[5]);
 
     // change for US version
     if (isset($sCur[6])) {
-        $oCur->side = @trim($sCur[6]);
+        $oCur->side = @\trim($sCur[6]);
     }
 
     return \OxidEsales\Eshop\Core\Registry::getLang()->formatCurrency($sValue, $oCur);

--- a/source/Core/Smarty/Plugin/modifier.oxtruncate.php
+++ b/source/Core/Smarty/Plugin/modifier.oxtruncate.php
@@ -35,7 +35,7 @@ function smarty_modifier_oxtruncate($sString, $iLength = 80, $sSufix = '...', $b
     } elseif ($iLength > 0 && Str::getStr()->strlen($sString) > $iLength) {
         $iLength -= Str::getStr()->strlen($sSufix);
 
-        $sString = str_replace(['&#039;', '&quot;'], [ "'",'"' ], $sString);
+        $sString = \str_replace(['&#039;', '&quot;'], [ "'",'"' ], $sString);
 
         if (!$blBreakWords) {
             $sString = Str::getStr()->preg_replace('/\s+?(\S+)?$/', '', Str::getStr()->substr($sString, 0, $iLength + 1));
@@ -43,7 +43,7 @@ function smarty_modifier_oxtruncate($sString, $iLength = 80, $sSufix = '...', $b
 
         $sString = Str::getStr()->substr($sString, 0, $iLength) . $sSufix;
 
-        return str_replace([ "'",'"' ], ['&#039;', '&quot;'], $sString);
+        return \str_replace([ "'",'"' ], ['&#039;', '&quot;'], $sString);
     }
 
     return $sString;

--- a/source/Core/Smarty/Plugin/modifier.smartwordwrap.php
+++ b/source/Core/Smarty/Plugin/modifier.smartwordwrap.php
@@ -26,33 +26,33 @@ function smarty_modifier_smartwordwrap($string, $length = 80, $break = "\n", $cu
     $afterwrapchars = ["-" . $wraptag];
     
     
-    $string = trim($string);
+    $string = \trim($string);
     
-    if (strlen($string) <= $length) {
+    if (\strlen($string) <= $length) {
         return $string;
     }
     
     //trying to wrap without cut
-    $str  = wordwrap($string, $length, $wraptag, false);
-    $arr  = explode($wraptag, $str);
+    $str  = \wordwrap($string, $length, $wraptag, false);
+    $arr  = \explode($wraptag, $str);
     
     $alt  = [];
     
     $ok = true;
     foreach ($arr as $row) {
-        if (strlen($row) > ($length + $tollerance)) {
-            $tmpstr = str_replace($wrapchars, $afterwrapchars, $row);
-            $tmparr = explode($wraptag, $tmpstr);
+        if (\strlen($row) > ($length + $tollerance)) {
+            $tmpstr = \str_replace($wrapchars, $afterwrapchars, $row);
+            $tmparr = \explode($wraptag, $tmpstr);
             
             foreach ($tmparr as $altrow) {
-                array_push($alt, $altrow);
+                \array_push($alt, $altrow);
                  
-                if (strlen($altrow) > ($length + $tollerance)) {
+                if (\strlen($altrow) > ($length + $tollerance)) {
                     $ok = false;
                 }
             }
         } else {
-            array_push($alt, $row);
+            \array_push($alt, $row);
         }
     }
     
@@ -60,19 +60,19 @@ function smarty_modifier_smartwordwrap($string, $length = 80, $break = "\n", $cu
            
     if (!$ok) {
         //trying to wrap with cut
-        $str  = wordwrap($string, $length, $wraptag, true);
-        $arr  = explode($wraptag, $str);
+        $str  = \wordwrap($string, $length, $wraptag, true);
+        $arr  = \explode($wraptag, $str);
     }
     
-    if ($cutrows && count($arr) > $cutrows) {
-        $arr = array_splice($arr, 0, $cutrows);
+    if ($cutrows && \count($arr) > $cutrows) {
+        $arr = \array_splice($arr, 0, $cutrows);
         
-        if (strlen($arr[$cutrows] . $etc) > $length + $tollerance) {
-            $arr[$cutrows - 1] = substr($arr[$cutrows - 1], 0, $length - strlen($etc));
+        if (\strlen($arr[$cutrows] . $etc) > $length + $tollerance) {
+            $arr[$cutrows - 1] = \substr($arr[$cutrows - 1], 0, $length - \strlen($etc));
         }
         
         $arr[$cutrows - 1] = $arr[$cutrows - 1] . $etc;
     }
     
-    return implode($break, $arr);
+    return \implode($break, $arr);
 }

--- a/source/Core/Smarty/Plugin/prefilter.oxblock.php
+++ b/source/Core/Smarty/Plugin/prefilter.oxblock.php
@@ -19,7 +19,7 @@
 function smarty_prefilter_oxblock($sSource, &$oSmartyCompiler)
 {
     $blUseSmarty3 = false;
-    if (strpos($oSmartyCompiler->_version, 'Smarty3') === 0) {
+    if (\strpos($oSmartyCompiler->_version, 'Smarty3') === 0) {
         $blUseSmarty3 = true;
     }
     $blDebugTemplateBlocks = (bool)\OxidEsales\Eshop\Core\Registry::getConfig()->getConfigParam('blDebugTemplateBlocks');
@@ -28,11 +28,11 @@ function smarty_prefilter_oxblock($sSource, &$oSmartyCompiler)
 
     $iLimit = 500;
 
-    while (--$iLimit && preg_match('/\[\{\s*block\s+name\s*=\s*([\'"])([a-z0-9_]+)\1\s*\}\](.*?)\[\{\s*\/block\s*\}\]/is', $sSource, $m)) {
+    while (--$iLimit && \preg_match('/\[\{\s*block\s+name\s*=\s*([\'"])([a-z0-9_]+)\1\s*\}\](.*?)\[\{\s*\/block\s*\}\]/is', $sSource, $m)) {
         $sBlock = $m[0];
         $sBlockName = $m[2];
         $sBlockContent = $m[3];
-        if (preg_match('/^.+(\[\{\s*block\s+name\s*=\s*([\'"])([a-z0-9_]+)\2\s*\}\](.*?)\[\{\s*\/block\s*\}\])$/is', $sBlock, $m)) {
+        if (\preg_match('/^.+(\[\{\s*block\s+name\s*=\s*([\'"])([a-z0-9_]+)\2\s*\}\](.*?)\[\{\s*\/block\s*\}\])$/is', $sBlock, $m)) {
             // shift to (deepest) nested tag opening
             $sBlock = $m[1];
             $sBlockName = $m[3];
@@ -45,31 +45,31 @@ function smarty_prefilter_oxblock($sSource, &$oSmartyCompiler)
             $sAppend .= '[{/__smartyblock__}]';
         }
         if ($blDebugTemplateBlocks) {
-            $sTplDir = trim(\OxidEsales\Eshop\Core\Registry::getConfig()->getConfigParam('_sTemplateDir'), '/\\');
-            $sFile = str_replace(['\\', '//'], '/', $oSmartyCompiler->_current_file);
-            if (preg_match('@/' . preg_quote($sTplDir, '@') . '/(.*)$@', $sFile, $m)) {
+            $sTplDir = \trim(\OxidEsales\Eshop\Core\Registry::getConfig()->getConfigParam('_sTemplateDir'), '/\\');
+            $sFile = \str_replace(['\\', '//'], '/', $oSmartyCompiler->_current_file);
+            if (\preg_match('@/' . \preg_quote($sTplDir, '@') . '/(.*)$@', $sFile, $m)) {
                 $sFile = $m[1];
             }
 
             $sDbgName = $sFile . '-&gt;' . $sBlockName;
             $sPrepend = '[{capture name="_dbg_blocks"}]' . $sPrepend;
-            $sDbgId = 'block_' . sprintf("%u", crc32($sDbgName)) . '_[{$_dbg_block_idr1}][{$_dbg_block_idr2}]';
+            $sDbgId = 'block_' . \sprintf("%u", \crc32($sDbgName)) . '_[{$_dbg_block_idr1}][{$_dbg_block_idr2}]';
             $sAppend .= '[{/capture}][{math equation="rand()" assign="_dbg_block_idr1"}][{math equation="rand()" assign="_dbg_block_idr2"}]'
                        . '<hr style="visibility:hidden;height:0;margin:0;padding:0;border:0;line-height:0;font-size:0;" class="debugBlocksStart" id="' . $sDbgId . '" title="' . $sDbgName . '">'
                        . '[{$smarty.capture._dbg_blocks}]'
                        . '<hr style="visibility:hidden;height:0;margin:0;padding:0;border:0;line-height:0;font-size:0;" class="debugBlocksEnd" title="' . $sDbgId . '">';
         }
-        if (!isset($aBlocks[$sBlockName]) || !is_array($aBlocks[$sBlockName])) {
+        if (!isset($aBlocks[$sBlockName]) || !\is_array($aBlocks[$sBlockName])) {
             // block is unused, just use its content
-            $sSource = str_replace($sBlock, $sPrepend . $sBlockContent . $sAppend, $sSource);
+            $sSource = \str_replace($sBlock, $sPrepend . $sBlockContent . $sAppend, $sSource);
         } else {
             // go through the replacement array and fill in parent values
             // specified by [{$smarty.block.parent}] tag
             $sCurrBlock = $sBlockContent;
             foreach ($aBlocks[$sBlockName] as $sOverBlock) {
-                $sCurrBlock = preg_replace('/\[\{\s*\$smarty\.block\.parent\s*\}\]/i', $sCurrBlock, $sOverBlock);
+                $sCurrBlock = \preg_replace('/\[\{\s*\$smarty\.block\.parent\s*\}\]/i', $sCurrBlock, $sOverBlock);
             }
-            $sSource = str_replace($sBlock, $sPrepend . $sCurrBlock . $sAppend, $sSource);
+            $sSource = \str_replace($sBlock, $sPrepend . $sCurrBlock . $sAppend, $sSource);
         }
     }
     if (!$iLimit) {
@@ -80,7 +80,7 @@ function smarty_prefilter_oxblock($sSource, &$oSmartyCompiler)
         }
     }
     if ($blUseSmarty3) {
-        $sSource = str_replace('__smartyblock__', 'block', $sSource);
+        $sSource = \str_replace('__smartyblock__', 'block', $sSource);
     }
     return $sSource;
 }

--- a/source/Core/SortingValidator.php
+++ b/source/Core/SortingValidator.php
@@ -23,8 +23,8 @@ class SortingValidator
         if (
             $sortBy
             && $sortOrder
-            && in_array(strtolower($sortOrder), $this->getSortingOrders())
-            && in_array($sortBy, \OxidEsales\Eshop\Core\Registry::getConfig()->getConfigParam('aSortCols'))
+            && \in_array(\strtolower($sortOrder), $this->getSortingOrders())
+            && \in_array($sortBy, \OxidEsales\Eshop\Core\Registry::getConfig()->getConfigParam('aSortCols'))
         ) {
             $isValid = true;
         }

--- a/source/Core/Str.php
+++ b/source/Core/Str.php
@@ -57,7 +57,7 @@ class Str
      */
     protected function _getStrHandler() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
-        if (function_exists('mb_strlen')) {
+        if (\function_exists('mb_strlen')) {
             return oxNew(\OxidEsales\Eshop\Core\StrMb::class);
         }
 

--- a/source/Core/StrMb.php
+++ b/source/Core/StrMb.php
@@ -49,7 +49,7 @@ class StrMb
      */
     public function strlen($sStr)
     {
-        return mb_strlen($sStr, $this->_sEncoding);
+        return \mb_strlen($sStr, $this->_sEncoding);
     }
 
     /**
@@ -63,9 +63,9 @@ class StrMb
      */
     public function substr($sStr, $iStart, $iLength = null)
     {
-        $iLength = is_null($iLength) ? $this->strlen($sStr) : $iLength;
+        $iLength = \is_null($iLength) ? $this->strlen($sStr) : $iLength;
 
-        return mb_substr($sStr, $iStart, $iLength, $this->_sEncoding);
+        return \mb_substr($sStr, $iStart, $iLength, $this->_sEncoding);
     }
 
     /**
@@ -81,8 +81,8 @@ class StrMb
     {
         $iPos = false;
         if ($sHaystack && $sNeedle) {
-            $iOffset = is_null($iOffset) ? 0 : $iOffset;
-            $iPos = mb_strpos($sHaystack, $sNeedle, $iOffset, $this->_sEncoding);
+            $iOffset = \is_null($iOffset) ? 0 : $iOffset;
+            $iPos = \mb_strpos($sHaystack, $sNeedle, $iOffset, $this->_sEncoding);
         }
 
         return $iPos;
@@ -103,7 +103,7 @@ class StrMb
             return false;
         }
 
-        return mb_strstr($sHaystack, $sNeedle, false, $this->_sEncoding);
+        return \mb_strstr($sHaystack, $sNeedle, false, $this->_sEncoding);
     }
 
     /**
@@ -115,7 +115,7 @@ class StrMb
      */
     public function strtolower($sString)
     {
-        return mb_strtolower($sString, $this->_sEncoding);
+        return \mb_strtolower($sString, $this->_sEncoding);
     }
 
     /**
@@ -127,7 +127,7 @@ class StrMb
      */
     public function strtoupper($sString)
     {
-        return mb_strtoupper($sString, $this->_sEncoding);
+        return \mb_strtoupper($sString, $this->_sEncoding);
     }
 
     /**
@@ -140,7 +140,7 @@ class StrMb
      */
     public function htmlspecialchars($sString, $iQuotStyle = ENT_QUOTES)
     {
-        return htmlspecialchars($sString, $iQuotStyle, $this->_sEncoding);
+        return \htmlspecialchars($sString, $iQuotStyle, $this->_sEncoding);
     }
 
     /**
@@ -153,7 +153,7 @@ class StrMb
      */
     public function htmlentities($sString, $iQuotStyle = ENT_QUOTES)
     {
-        return htmlentities($sString, $iQuotStyle, $this->_sEncoding);
+        return \htmlentities($sString, $iQuotStyle, $this->_sEncoding);
     }
 
     // @codingStandardsIgnoreStart
@@ -167,7 +167,7 @@ class StrMb
      */
     public function html_entity_decode($sString, $iQuotStyle = ENT_QUOTES)
     {
-        return html_entity_decode($sString, $iQuotStyle, $this->_sEncoding);
+        return \html_entity_decode($sString, $iQuotStyle, $this->_sEncoding);
     }
 
     /**
@@ -182,7 +182,7 @@ class StrMb
      */
     public function preg_split($sPattern, $sString, $iLimit = -1, $iFlag = 0)
     {
-        return preg_split($sPattern . 'u', $sString, $iLimit, $iFlag);
+        return \preg_split($sPattern . 'u', $sString, $iLimit, $iFlag);
     }
 
     /**
@@ -198,7 +198,7 @@ class StrMb
      */
     public function preg_replace($aPattern, $sString, $sSubject, $iLimit = -1, $iCount = null)
     {
-        if (is_array($aPattern)) {
+        if (\is_array($aPattern)) {
             foreach ($aPattern as &$sPattern) {
                 $sPattern = $sPattern . 'u';
             }
@@ -206,7 +206,7 @@ class StrMb
             $aPattern = $aPattern . 'u';
         }
 
-        return preg_replace($aPattern, $sString, $sSubject, $iLimit, $iCount);
+        return \preg_replace($aPattern, $sString, $sSubject, $iLimit, $iCount);
     }
 
     /**
@@ -222,7 +222,7 @@ class StrMb
      */
     public function preg_replace_callback($pattern, $callback, $subject, $limit = -1, &$count = null)
     {
-        if (is_array($pattern)) {
+        if (\is_array($pattern)) {
             foreach ($pattern as &$item) {
                 $item = $item . 'u';
             }
@@ -230,7 +230,7 @@ class StrMb
             $pattern = $pattern . 'u';
         }
 
-        return preg_replace_callback($pattern, $callback, $subject, $limit, $count);
+        return \preg_replace_callback($pattern, $callback, $subject, $limit, $count);
     }
 
     /**
@@ -246,7 +246,7 @@ class StrMb
      */
     public function preg_match($sPattern, $sSubject, &$aMatches = null, $iFlags = null, $iOffset = null)
     {
-        return preg_match($sPattern . 'u', $sSubject, $aMatches, $iFlags, $iOffset);
+        return \preg_match($sPattern . 'u', $sSubject, $aMatches, $iFlags, $iOffset);
     }
 
     /**
@@ -262,7 +262,7 @@ class StrMb
      */
     public function preg_match_all($sPattern, $sSubject, &$aMatches = null, $iFlags = null, $iOffset = null)
     {
-        return preg_match_all($sPattern . 'u', $sSubject, $aMatches, $iFlags, $iOffset);
+        return \preg_match_all($sPattern . 'u', $sSubject, $aMatches, $iFlags, $iOffset);
     }
     // @codingStandardsIgnoreEnd
 
@@ -298,26 +298,26 @@ class StrMb
             $sRegexp = "/^([^\s]{{$iLength}}|.{1,{$iLength}}\s)/u";
         }
 
-        $iStrLen = mb_strlen($sString, $this->_sEncoding);
-        $iWraps = floor($iStrLen / $iLength);
+        $iStrLen = \mb_strlen($sString, $this->_sEncoding);
+        $iWraps = \floor($iStrLen / $iLength);
 
         $i = $iWraps;
         $sReturn = '';
         $aMatches = [];
         while ($i > 0) {
-            $iWraps = floor(mb_strlen($sString, $this->_sEncoding) / $iLength);
+            $iWraps = \floor(\mb_strlen($sString, $this->_sEncoding) / $iLength);
 
             $i = $iWraps;
-            if (preg_match($sRegexp, $sString, $aMatches)) {
+            if (\preg_match($sRegexp, $sString, $aMatches)) {
                 $sStr = $aMatches[0];
-                $sReturn .= preg_replace('/\s$/s', '', $sStr) . $sBreak;
-                $sString = $this->substr($sString, mb_strlen($sStr, $this->_sEncoding));
+                $sReturn .= \preg_replace('/\s$/s', '', $sStr) . $sBreak;
+                $sString = $this->substr($sString, \mb_strlen($sStr, $this->_sEncoding));
             } else {
                 break;
             }
             $i--;
         }
-        $sReturn = preg_replace("/$sBreak$/", '', $sReturn);
+        $sReturn = \preg_replace("/$sBreak$/", '', $sReturn);
         if ($sString) {
             $sReturn .= $sBreak . $sString;
         }
@@ -339,10 +339,10 @@ class StrMb
      */
     public function recodeEntities($sInput, $blToHtmlEntities = false, $aUmls = [], $aUmlEntities = [])
     {
-        $aUmls = (count($aUmls) > 0) ? array_merge($this->_aUmls, $aUmls) : $this->_aUmls;
-        $aUmlEntities = (count($aUmlEntities) > 0) ? array_merge($this->_aUmlEntities, $aUmlEntities) : $this->_aUmlEntities;
+        $aUmls = (\count($aUmls) > 0) ? \array_merge($this->_aUmls, $aUmls) : $this->_aUmls;
+        $aUmlEntities = (\count($aUmlEntities) > 0) ? \array_merge($this->_aUmlEntities, $aUmlEntities) : $this->_aUmlEntities;
 
-        return $blToHtmlEntities ? str_replace($aUmls, $aUmlEntities, $sInput) : str_replace($aUmlEntities, $aUmls, $sInput);
+        return $blToHtmlEntities ? \str_replace($aUmls, $aUmlEntities, $sInput) : \str_replace($aUmlEntities, $aUmls, $sInput);
     }
 
     /**
@@ -354,7 +354,7 @@ class StrMb
      */
     public function hasSpecialChars($sStr)
     {
-        return $this->preg_match("/(" . implode("|", $this->_aUmls) . "|(&amp;))/", $sStr);
+        return $this->preg_match("/(" . \implode("|", $this->_aUmls) . "|(&amp;))/", $sStr);
     }
 
     /**
@@ -380,7 +380,7 @@ class StrMb
      */
     public function jsonEncode($data)
     {
-        return json_encode($data);
+        return \json_encode($data);
     }
 
     // @codingStandardsIgnoreStart
@@ -394,12 +394,12 @@ class StrMb
      */
     public function strip_tags($sString, $sAllowableTags = '')
     {
-        if (stripos($sAllowableTags, '<style>') === false) {
+        if (\stripos($sAllowableTags, '<style>') === false) {
             // strip style tags with definitions within
             $sString = $this->preg_replace("'<style[^>]*>.*</style>'siU", '', $sString);
         }
 
-        return strip_tags($sString, $sAllowableTags);
+        return \strip_tags($sString, $sAllowableTags);
     }
     // @codingStandardsIgnoreEnd
 
@@ -414,6 +414,6 @@ class StrMb
      */
     public function strrcmp($sStr1, $sStr2)
     {
-        return -strcmp($sStr1, $sStr2);
+        return -\strcmp($sStr1, $sStr2);
     }
 }

--- a/source/Core/StrRegular.php
+++ b/source/Core/StrRegular.php
@@ -49,7 +49,7 @@ class StrRegular
      */
     public function strlen($sStr)
     {
-        return strlen($sStr);
+        return \strlen($sStr);
     }
 
     /**
@@ -63,10 +63,10 @@ class StrRegular
      */
     public function substr($sStr, $iStart, $iLength = null)
     {
-        if (is_null($iLength)) {
-            return substr($sStr, $iStart);
+        if (\is_null($iLength)) {
+            return \substr($sStr, $iStart);
         }
-        return substr($sStr, $iStart, $iLength);
+        return \substr($sStr, $iStart, $iLength);
     }
 
     /**
@@ -82,10 +82,10 @@ class StrRegular
     {
         $iPos = false;
         if ($sHaystack && $sNeedle) {
-            if (is_null($iOffset)) {
-                $iPos = strpos($sHaystack, $sNeedle);
+            if (\is_null($iOffset)) {
+                $iPos = \strpos($sHaystack, $sNeedle);
             } else {
-                $iPos = strpos($sHaystack, $sNeedle, $iOffset);
+                $iPos = \strpos($sHaystack, $sNeedle, $iOffset);
             }
         }
 
@@ -102,7 +102,7 @@ class StrRegular
      */
     public function strstr($sHaystack, $sNeedle)
     {
-        return strstr($sHaystack, $sNeedle);
+        return \strstr($sHaystack, $sNeedle);
     }
 
     /**
@@ -114,7 +114,7 @@ class StrRegular
      */
     public function strtolower($sString)
     {
-        return strtolower($sString);
+        return \strtolower($sString);
     }
 
     /**
@@ -126,7 +126,7 @@ class StrRegular
      */
     public function strtoupper($sString)
     {
-        return strtoupper($sString);
+        return \strtoupper($sString);
     }
 
     /**
@@ -139,7 +139,7 @@ class StrRegular
      */
     public function htmlspecialchars($sString, $iQuotStyle = ENT_QUOTES)
     {
-        return htmlspecialchars($sString, $iQuotStyle, $this->_sEncoding);
+        return \htmlspecialchars($sString, $iQuotStyle, $this->_sEncoding);
     }
 
     /**
@@ -152,7 +152,7 @@ class StrRegular
      */
     public function htmlentities($sString, $iQuotStyle = ENT_QUOTES)
     {
-        return htmlentities($sString, $iQuotStyle, $this->_sEncoding);
+        return \htmlentities($sString, $iQuotStyle, $this->_sEncoding);
     }
 
     /**
@@ -167,7 +167,7 @@ class StrRegular
      */
     public function html_entity_decode($sString, $iQuotStyle = ENT_QUOTES)
     {
-        return html_entity_decode($sString, $iQuotStyle, $this->_sEncoding);
+        return \html_entity_decode($sString, $iQuotStyle, $this->_sEncoding);
     }
 
     /**
@@ -184,7 +184,7 @@ class StrRegular
      */
     public function preg_split($sPattern, $sString, $iLimit = -1, $iFlag = 0)
     {
-        return preg_split($sPattern, $sString, $iLimit, $iFlag);
+        return \preg_split($sPattern, $sString, $iLimit, $iFlag);
     }
 
     /**
@@ -202,7 +202,7 @@ class StrRegular
      */
     public function preg_replace($sPattern, $sString, $sSubject, $iLimit = -1, $iCount = null)
     {
-        return preg_replace($sPattern, $sString, $sSubject, $iLimit, $iCount);
+        return \preg_replace($sPattern, $sString, $sSubject, $iLimit, $iCount);
     }
 
     /**
@@ -220,7 +220,7 @@ class StrRegular
      */
     public function preg_replace_callback($pattern, $callback, $subject, $limit = -1, &$count = null)
     {
-        return preg_replace_callback($pattern, $callback, $subject, $limit, $count);
+        return \preg_replace_callback($pattern, $callback, $subject, $limit, $count);
     }
 
     /**
@@ -238,7 +238,7 @@ class StrRegular
      */
     public function preg_match($sPattern, $sSubject, &$aMatches = null, $iFlags = null, $iOffset = null)
     {
-        return preg_match($sPattern, $sSubject, $aMatches, $iFlags, $iOffset);
+        return \preg_match($sPattern, $sSubject, $aMatches, $iFlags, $iOffset);
     }
 
     /**
@@ -256,7 +256,7 @@ class StrRegular
      */
     public function preg_match_all($sPattern, $sSubject, &$aMatches = null, $iFlags = null, $iOffset = null)
     {
-        return preg_match_all($sPattern, $sSubject, $aMatches, $iFlags, $iOffset);
+        return \preg_match_all($sPattern, $sSubject, $aMatches, $iFlags, $iOffset);
     }
 
     /**
@@ -285,7 +285,7 @@ class StrRegular
      */
     public function wordwrap($sString, $iLength = 75, $sBreak = "\n", $blCut = null)
     {
-        return wordwrap($sString, $iLength, $sBreak, $blCut);
+        return \wordwrap($sString, $iLength, $sBreak, $blCut);
     }
 
     /**
@@ -302,14 +302,14 @@ class StrRegular
      */
     public function recodeEntities($sInput, $blToHtmlEntities = false, $aUmls = [], $aUmlEntities = [])
     {
-        $aUmls = (count($aUmls) > 0) ? array_merge($this->_aUmls, $aUmls) : $this->_aUmls;
-        $aUmlEntities = (count($aUmlEntities) > 0)
-            ? array_merge($this->_aUmlEntities, $aUmlEntities)
+        $aUmls = (\count($aUmls) > 0) ? \array_merge($this->_aUmls, $aUmls) : $this->_aUmls;
+        $aUmlEntities = (\count($aUmlEntities) > 0)
+            ? \array_merge($this->_aUmlEntities, $aUmlEntities)
             : $this->_aUmlEntities;
 
         return $blToHtmlEntities
-            ? str_replace($aUmls, $aUmlEntities, $sInput)
-            : str_replace($aUmlEntities, $aUmls, $sInput);
+            ? \str_replace($aUmls, $aUmlEntities, $sInput)
+            : \str_replace($aUmlEntities, $aUmls, $sInput);
     }
 
     /**
@@ -321,7 +321,7 @@ class StrRegular
      */
     public function hasSpecialChars($sStr)
     {
-        return $this->preg_match("/(" . implode("|", $this->_aUmls) . "|(&amp;))/", $sStr);
+        return $this->preg_match("/(" . \implode("|", $this->_aUmls) . "|(&amp;))/", $sStr);
     }
 
     /**
@@ -347,16 +347,16 @@ class StrRegular
      */
     public function jsonEncode($data)
     {
-        if (is_array($data)) {
+        if (\is_array($data)) {
             $ret = "";
             $blWasOne = false;
             $blNumerical = true;
-            reset($data);
-            while ($blNumerical && $key = key($data)) {
-                $blNumerical = !is_string($key);
+            \reset($data);
+            while ($blNumerical && $key = \key($data)) {
+                $blNumerical = !\is_string($key);
             }
             if ($blNumerical) {
-                return '[' . implode(',', array_map([$this, 'jsonEncode'], $data)) . ']';
+                return '[' . \implode(',', \array_map([$this, 'jsonEncode'], $data)) . ']';
             } else {
                 foreach ($data as $key => $val) {
                     if ($blWasOne) {
@@ -364,13 +364,13 @@ class StrRegular
                     } else {
                         $blWasOne = true;
                     }
-                    $ret .= '"' . addslashes($key) . '":' . $this->jsonEncode($val);
+                    $ret .= '"' . \addslashes($key) . '":' . $this->jsonEncode($val);
                 }
 
                 return "{" . $ret . "}";
             }
         } else {
-            return '"' . addcslashes((string) $data, "\r\n\t\"\\") . '"';
+            return '"' . \addcslashes((string) $data, "\r\n\t\"\\") . '"';
         }
     }
 
@@ -386,12 +386,12 @@ class StrRegular
      */
     public function strip_tags($sString, $sAllowableTags = '')
     {
-        if (stripos($sAllowableTags, '<style>') === false) {
+        if (\stripos($sAllowableTags, '<style>') === false) {
             // strip style tags with definitions within
             $sString = $this->preg_replace("'<style[^>]*>.*</style>'siU", '', $sString);
         }
 
-        return strip_tags($sString, $sAllowableTags);
+        return \strip_tags($sString, $sAllowableTags);
     }
 
     /**
@@ -405,6 +405,6 @@ class StrRegular
      */
     public function strrcmp($sStr1, $sStr2)
     {
-        return -strcmp($sStr1, $sStr2);
+        return -\strcmp($sStr1, $sStr2);
     }
 }

--- a/source/Core/SubShopSpecificFileCache.php
+++ b/source/Core/SubShopSpecificFileCache.php
@@ -35,8 +35,8 @@ class SubShopSpecificFileCache extends \OxidEsales\Eshop\Core\FileCache
      */
     protected function getCacheFileName($key)
     {
-        $name = strtolower(basename($key));
-        $shopId = strtolower(basename($this->getShopIdCalculator()->getShopId()));
+        $name = \strtolower(\basename($key));
+        $shopId = \strtolower(\basename($this->getShopIdCalculator()->getShopId()));
 
         return parent::CACHE_FILE_PREFIX . ".$shopId.$name.txt";
     }

--- a/source/Core/SystemEventHandler.php
+++ b/source/Core/SystemEventHandler.php
@@ -252,9 +252,9 @@ class SystemEventHandler
     {
         $checkTime = Registry::getConfig()->getSystemConfigParameter('sOnlineLicenseCheckTime');
         if (!$checkTime) {
-            $hourToCheck = rand(8, 23);
-            $minuteToCheck = rand(0, 59);
-            $secondToCheck = rand(0, 59);
+            $hourToCheck = \rand(8, 23);
+            $minuteToCheck = \rand(0, 59);
+            $secondToCheck = \rand(0, 59);
 
             $checkTime = $hourToCheck . ':' . $minuteToCheck . ':' . $secondToCheck;
             Registry::getConfig()->saveSystemConfigParameter('str', 'sOnlineLicenseCheckTime', $checkTime);

--- a/source/Core/SystemRequirements.php
+++ b/source/Core/SystemRequirements.php
@@ -162,17 +162,17 @@ class SystemRequirements
      */
     public function __call($sMethod, $aArgs)
     {
-        if (defined('OXID_PHP_UNIT')) {
-            if (substr($sMethod, 0, 4) == "UNIT") {
-                $sMethod = str_replace("UNIT", "_", $sMethod);
+        if (\defined('OXID_PHP_UNIT')) {
+            if (\substr($sMethod, 0, 4) == "UNIT") {
+                $sMethod = \str_replace("UNIT", "_", $sMethod);
             }
-            if (method_exists($this, $sMethod)) {
-                return call_user_func_array([& $this, $sMethod], $aArgs);
+            if (\method_exists($this, $sMethod)) {
+                return \call_user_func_array([& $this, $sMethod], $aArgs);
             }
         }
 
         throw new \OxidEsales\Eshop\Core\Exception\SystemComponentException(
-            "Function '$sMethod' does not exist or is not accessible! (" . get_class($this) . ")" . PHP_EOL
+            "Function '$sMethod' does not exist or is not accessible! (" . \get_class($this) . ")" . PHP_EOL
         );
     }
 
@@ -223,9 +223,9 @@ class SystemRequirements
                 'server_permissions'
             ];
 
-            $this->_aRequiredModules = array_fill_keys($aRequiredServerConfigs, 'server_config') +
-                                       array_fill_keys($aRequiredPHPConfigs, 'php_config') +
-                                       array_fill_keys($aRequiredPHPExtensions, 'php_extennsions')
+            $this->_aRequiredModules = \array_fill_keys($aRequiredServerConfigs, 'server_config') +
+                                       \array_fill_keys($aRequiredPHPConfigs, 'php_config') +
+                                       \array_fill_keys($aRequiredPHPExtensions, 'php_extennsions')
                                        ;
         }
 
@@ -239,7 +239,7 @@ class SystemRequirements
      */
     public function checkCurl()
     {
-        return extension_loaded('curl') ? 2 : 1;
+        return \extension_loaded('curl') ? 2 : 1;
     }
 
     /**
@@ -249,7 +249,7 @@ class SystemRequirements
      */
     public function checkMbString()
     {
-        return extension_loaded('mbstring') ? 2 : 1;
+        return \extension_loaded('mbstring') ? 2 : 1;
     }
 
     /**
@@ -262,21 +262,21 @@ class SystemRequirements
      */
     public function checkServerPermissions($path = null, $minPerm = 777)
     {
-        clearstatcache();
+        \clearstatcache();
         $path = $path ? $path : getShopBasePath();
         // special config file check
         $configFilePath = $path . "config.inc.php";
         if (
-            !is_readable($configFilePath) ||
-            ($this->isAdmin() && is_writable($configFilePath)) ||
-            (!$this->isAdmin() && !is_writable($configFilePath))
+            !\is_readable($configFilePath) ||
+            ($this->isAdmin() && \is_writable($configFilePath)) ||
+            (!$this->isAdmin() && !\is_writable($configFilePath))
         ) {
             return 0;
         }
 
         $modStat = 2;
         $permissionIssues = $this->getPermissionIssuesList($path, $minPerm);
-        if (count($permissionIssues['missing']) + count($permissionIssues['not_writable'])) {
+        if (\count($permissionIssues['missing']) + \count($permissionIssues['not_writable'])) {
             $modStat = 0;
         }
 
@@ -293,7 +293,7 @@ class SystemRequirements
      */
     public function getPermissionIssuesList($shopPath = null, $minPerm = 777)
     {
-        clearstatcache();
+        \clearstatcache();
         $shopPath = $shopPath ? $shopPath : getShopBasePath();
         $pathCheckResults = [
             'missing' => [],
@@ -303,7 +303,7 @@ class SystemRequirements
         $tmpPath = "$shopPath/tmp/";
         $config = new \OxidEsales\Eshop\Core\ConfigFile(getShopBasePath() . "/config.inc.php");
         $configTmpPath = $config->getVar('sCompileDir');
-        if ($configTmpPath && strpos($configTmpPath, '<sCompileDir') === false) {
+        if ($configTmpPath && \strpos($configTmpPath, '<sCompileDir') === false) {
             $tmpPath = $configTmpPath;
         }
 
@@ -318,17 +318,17 @@ class SystemRequirements
             $tmpPath
         ];
 
-        $onePathToCheck = reset($pathsToCheck);
+        $onePathToCheck = \reset($pathsToCheck);
         while ($onePathToCheck) {
             // missing file/folder?
-            if (!file_exists($onePathToCheck)) {
-                $pathCheckResults['missing'][] = str_replace($shopPath, '', $onePathToCheck);
+            if (!\file_exists($onePathToCheck)) {
+                $pathCheckResults['missing'][] = \str_replace($shopPath, '', $onePathToCheck);
             }
 
-            if (is_dir($onePathToCheck)) {
+            if (\is_dir($onePathToCheck)) {
                 // adding subfolders
-                $subDirectories = glob($onePathToCheck . '*', GLOB_ONLYDIR);
-                if (is_array($subDirectories)) {
+                $subDirectories = \glob($onePathToCheck . '*', GLOB_ONLYDIR);
+                if (\is_array($subDirectories)) {
                     foreach ($subDirectories as $oneSubDirectory) {
                         $pathsToCheck[] = $oneSubDirectory . '/';
                     }
@@ -336,11 +336,11 @@ class SystemRequirements
             }
 
             // testing if file permissions >= $iMinPerm
-            if (!is_readable($onePathToCheck) || !is_writable($onePathToCheck)) {
-                $pathCheckResults['not_writable'][] = str_replace($shopPath, '', $onePathToCheck);
+            if (!\is_readable($onePathToCheck) || !\is_writable($onePathToCheck)) {
+                $pathCheckResults['not_writable'][] = \str_replace($shopPath, '', $onePathToCheck);
             }
 
-            $onePathToCheck = next($pathsToCheck);
+            $onePathToCheck = \next($pathsToCheck);
         }
 
         return $pathCheckResults;
@@ -356,14 +356,14 @@ class SystemRequirements
     protected function _getShopHostInfoFromConfig() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $sShopURL = Registry::getConfig()->getConfigParam('sShopURL');
-        if (preg_match('#^(https?://)?([^/:]+)(:([0-9]+))?(/.*)?$#i', $sShopURL, $m)) {
+        if (\preg_match('#^(https?://)?([^/:]+)(:([0-9]+))?(/.*)?$#i', $sShopURL, $m)) {
             $sHost = $m[2];
             $iPort = (int) $m[4];
-            $blSsl = (strtolower($m[1]) == 'https://');
+            $blSsl = (\strtolower($m[1]) == 'https://');
             if (!$iPort) {
                 $iPort = $blSsl ? 443 : 80;
             }
-            $sScript = rtrim($m[5], '/') . '/';
+            $sScript = \rtrim($m[5], '/') . '/';
 
             return [
                 'host' => $sHost,
@@ -386,14 +386,14 @@ class SystemRequirements
     protected function _getShopSSLHostInfoFromConfig() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $sSSLShopURL = Registry::getConfig()->getConfigParam('sSSLShopURL');
-        if (preg_match('#^(https?://)?([^/:]+)(:([0-9]+))?(/.*)?$#i', $sSSLShopURL, $m)) {
+        if (\preg_match('#^(https?://)?([^/:]+)(:([0-9]+))?(/.*)?$#i', $sSSLShopURL, $m)) {
             $sHost = $m[2];
             $iPort = (int) $m[4];
-            $blSsl = (strtolower($m[1]) == 'https://');
+            $blSsl = (\strtolower($m[1]) == 'https://');
             if (!$iPort) {
                 $iPort = $blSsl ? 443 : 80;
             }
-            $sScript = rtrim($m[5], '/') . '/';
+            $sScript = \rtrim($m[5], '/') . '/';
 
             return [
                 'host' => $sHost,
@@ -422,7 +422,7 @@ class SystemRequirements
         if (!$iPort) {
             $iPort = $blSsl ? 443 : 80;
         }
-        $sScript = rtrim(dirname(dirname($sScript)), '/') . '/';
+        $sScript = \rtrim(\dirname(\dirname($sScript)), '/') . '/';
 
         return [
             'host' => $_SERVER['HTTP_HOST'],
@@ -487,7 +487,7 @@ class SystemRequirements
                 return 1;
             }
 
-            return min($iModStat, $iSSLModStat);
+            return \min($iModStat, $iSSLModStat);
         }
 
         return $iModStat;
@@ -505,7 +505,7 @@ class SystemRequirements
     protected function _checkModRewrite($aHostInfo) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $sHostname = ($aHostInfo['ssl'] ? 'ssl://' : '') . $aHostInfo['host'];
-        if ($rFp = @fsockopen($sHostname, $aHostInfo['port'], $iErrNo, $sErrStr, 10)) {
+        if ($rFp = @\fsockopen($sHostname, $aHostInfo['port'], $iErrNo, $sErrStr, 10)) {
             $sReq = "POST {$aHostInfo['dir']}oxseo.php?mod_rewrite_module_is=off HTTP/1.1\r\n";
             $sReq .= "Host: {$aHostInfo['host']}\r\n";
             $sReq .= "User-Agent: OXID eShop setup\r\n";
@@ -514,17 +514,17 @@ class SystemRequirements
             $sReq .= "Connection: close\r\n\r\n";
 
             $sOut = '';
-            fwrite($rFp, $sReq);
-            while (!feof($rFp)) {
-                $sOut .= fgets($rFp, 100);
+            \fwrite($rFp, $sReq);
+            while (!\feof($rFp)) {
+                $sOut .= \fgets($rFp, 100);
             }
-            fclose($rFp);
+            \fclose($rFp);
 
-            $iModStat = (strpos($sOut, 'mod_rewrite_on') !== false) ? 2 : 0;
+            $iModStat = (\strpos($sOut, 'mod_rewrite_on') !== false) ? 2 : 0;
         } else {
-            if (function_exists('apache_get_modules')) {
+            if (\function_exists('apache_get_modules')) {
                 // it does not assure that mod_rewrite is enabled on current host, so setting 1
-                $iModStat = in_array('mod_rewrite', apache_get_modules()) ? 1 : 0;
+                $iModStat = \in_array('mod_rewrite', apache_get_modules()) ? 1 : 0;
             } else {
                 $iModStat = -1;
             }
@@ -540,8 +540,8 @@ class SystemRequirements
      */
     public function checkAllowUrlFopen()
     {
-        $resultAllowUrlFopen = @ini_get('allow_url_fopen');
-        $resultAllowUrlFopen = strcasecmp('1', $resultAllowUrlFopen);
+        $resultAllowUrlFopen = @\ini_get('allow_url_fopen');
+        $resultAllowUrlFopen = \strcasecmp('1', $resultAllowUrlFopen);
 
         if (0 === $resultAllowUrlFopen && 2 === $this->checkFsockopen()) {
             return 2;
@@ -559,9 +559,9 @@ class SystemRequirements
         $result = 1;
         $iErrNo = 0;
         $sErrStr = '';
-        if ($oRes = @fsockopen('olc.oxid-esales.com', 80, $iErrNo, $sErrStr, 10)) {
+        if ($oRes = @\fsockopen('olc.oxid-esales.com', 80, $iErrNo, $sErrStr, 10)) {
             $result = 2;
-            fclose($oRes);
+            \fclose($oRes);
         }
         return $result;
     }
@@ -593,7 +593,7 @@ class SystemRequirements
      */
     public function checkPhpXml()
     {
-        return extension_loaded('dom') ? 2 : 0;
+        return \extension_loaded('dom') ? 2 : 0;
     }
 
     /**
@@ -603,7 +603,7 @@ class SystemRequirements
      */
     public function checkJSon()
     {
-        return extension_loaded('json') ? 2 : 0;
+        return \extension_loaded('json') ? 2 : 0;
     }
 
     /**
@@ -613,7 +613,7 @@ class SystemRequirements
      */
     public function checkIConv()
     {
-        return extension_loaded('iconv') ? 2 : 0;
+        return \extension_loaded('iconv') ? 2 : 0;
     }
 
     /**
@@ -623,7 +623,7 @@ class SystemRequirements
      */
     public function checkTokenizer()
     {
-        return extension_loaded('tokenizer') ? 2 : 0;
+        return \extension_loaded('tokenizer') ? 2 : 0;
     }
 
     /**
@@ -633,7 +633,7 @@ class SystemRequirements
      */
     public function checkBcMath()
     {
-        return extension_loaded('bcmath') ? 2 : 1;
+        return \extension_loaded('bcmath') ? 2 : 1;
     }
 
     /**
@@ -643,7 +643,7 @@ class SystemRequirements
      */
     public function checkOpenSsl()
     {
-        return extension_loaded('openssl') ? 2 : 1;
+        return \extension_loaded('openssl') ? 2 : 1;
     }
 
     /**
@@ -653,7 +653,7 @@ class SystemRequirements
      */
     public function checkSoap()
     {
-        return extension_loaded('soap') ? 2 : 1;
+        return \extension_loaded('soap') ? 2 : 1;
     }
 
     /**
@@ -663,7 +663,7 @@ class SystemRequirements
      */
     public function checkMysqlConnect()
     {
-        $iModStat = extension_loaded('pdo_mysql') ? 2 : 0;
+        $iModStat = \extension_loaded('pdo_mysql') ? 2 : 0;
         return $iModStat;
     }
 
@@ -674,11 +674,11 @@ class SystemRequirements
      */
     public function checkGdInfo()
     {
-        $iModStat = extension_loaded('gd') ? 1 : 0;
-        $iModStat = function_exists('imagecreatetruecolor') ? 2 : $iModStat;
-        $iModStat = function_exists('imagecreatefromgif') ? $iModStat : 0;
-        $iModStat = function_exists('imagecreatefromjpeg') ? $iModStat : 0;
-        $iModStat = function_exists('imagecreatefrompng') ? $iModStat : 0;
+        $iModStat = \extension_loaded('gd') ? 1 : 0;
+        $iModStat = \function_exists('imagecreatetruecolor') ? 2 : $iModStat;
+        $iModStat = \function_exists('imagecreatefromgif') ? $iModStat : 0;
+        $iModStat = \function_exists('imagecreatefromjpeg') ? $iModStat : 0;
+        $iModStat = \function_exists('imagecreatefrompng') ? $iModStat : 0;
 
         return $iModStat;
     }
@@ -690,7 +690,7 @@ class SystemRequirements
      */
     public function checkIniSet()
     {
-        return (@ini_set('memory_limit', @ini_get('memory_limit')) !== false) ? 2 : 0;
+        return (@\ini_set('memory_limit', @\ini_get('memory_limit')) !== false) ? 2 : 0;
     }
 
     /**
@@ -703,7 +703,7 @@ class SystemRequirements
     public function checkMemoryLimit($sMemLimit = null)
     {
         if ($sMemLimit === null) {
-            $sMemLimit = @ini_get('memory_limit');
+            $sMemLimit = @\ini_get('memory_limit');
         }
 
         if ($sMemLimit) {
@@ -755,7 +755,7 @@ class SystemRequirements
         $sCollation = '';
         $sSelect = 'select TABLE_NAME, COLUMN_NAME, COLLATION_NAME from INFORMATION_SCHEMA.columns
                     where TABLE_NAME not like "oxv\_%" and table_schema = "' . $myConfig->getConfigParam('dbName') . '"
-                    and COLUMN_NAME in ("' . implode('", "', $this->_aColumns) . '") ' . $this->_getAdditionalCheck() .
+                    and COLUMN_NAME in ("' . \implode('", "', $this->_aColumns) . '") ' . $this->_getAdditionalCheck() .
                    'ORDER BY TABLE_NAME, COLUMN_NAME DESC;';
         $aRez = DatabaseConnectionProvider::getDb()->getAll($sSelect);
         foreach ($aRez as $aRetTable) {
@@ -771,7 +771,7 @@ class SystemRequirements
         if ($this->_blSysReqStatus === null) {
             $this->_blSysReqStatus = true;
         }
-        if (count($aCollations) > 0) {
+        if (\count($aCollations) > 0) {
             $this->_blSysReqStatus = false;
         }
 
@@ -795,7 +795,7 @@ class SystemRequirements
      */
     public function checkUnicodeSupport()
     {
-        return (@preg_match('/\pL/u', 'a') == 1) ? 2 : 1;
+        return (@\preg_match('/\pL/u', 'a') == 1) ? 2 : 1;
     }
 
     /**
@@ -806,9 +806,9 @@ class SystemRequirements
     public function checkFileUploads()
     {
         $dUploadFile = -1;
-        $sFileUploads = @ini_get('file_uploads');
+        $sFileUploads = @\ini_get('file_uploads');
         if ($sFileUploads !== false) {
-            if ($sFileUploads && ($sFileUploads == '1' || strtolower($sFileUploads) == 'on')) {
+            if ($sFileUploads && ($sFileUploads == '1' || \strtolower($sFileUploads) == 'on')) {
                 $dUploadFile = 2;
             } else {
                 $dUploadFile = 1;
@@ -859,7 +859,7 @@ class SystemRequirements
             }
             $iModuleState = $this->getModuleInfo($sModule);
             $aSysInfo[$sGroup][$sModule] = $iModuleState;
-            $this->_blSysReqStatus = $this->_blSysReqStatus && (bool) abs($iModuleState);
+            $this->_blSysReqStatus = $this->_blSysReqStatus && (bool) \abs($iModuleState);
         }
 
         return $aSysInfo;
@@ -897,7 +897,7 @@ class SystemRequirements
     {
         if ($sModule) {
             $iModStat = null;
-            $sCheckFunction = "check" . str_replace(" ", "", ucwords(str_replace("_", " ", $sModule)));
+            $sCheckFunction = "check" . \str_replace(" ", "", \ucwords(\str_replace("_", " ", $sModule)));
             $iModStat = $this->$sCheckFunction();
 
             return $iModStat;
@@ -972,8 +972,8 @@ class SystemRequirements
      */
     protected function _getBytes($sBytes) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
-        $sBytes = trim($sBytes);
-        $sLast = strtolower($sBytes[strlen($sBytes) - 1]);
+        $sBytes = \trim($sBytes);
+        $sLast = \strtolower($sBytes[\strlen($sBytes) - 1]);
         switch ($sLast) {
             // The 'G' modifier is available since PHP 5.1.0
             // gigabytes
@@ -1016,9 +1016,9 @@ class SystemRequirements
         }
 
         $sFile = $templateLoader->getContext($sTemplate);
-        $sBlockNameQuoted = preg_quote($sBlockName, '/');
+        $sBlockNameQuoted = \preg_quote($sBlockName, '/');
 
-        return (bool) preg_match('/\[\{\s*block\s+name\s*=\s*([\'"])' . $sBlockNameQuoted . '\1\s*\}\]/is', $sFile);
+        return (bool) \preg_match('/\[\{\s*block\s+name\s*=\s*([\'"])' . $sBlockNameQuoted . '\1\s*\}\]/is', $sFile);
     }
 
     /**
@@ -1092,9 +1092,9 @@ class SystemRequirements
      */
     public function checkSessionAutostart()
     {
-        $sStatus = (strtolower((string) @ini_get('session.auto_start')));
+        $sStatus = (\strtolower((string) @\ini_get('session.auto_start')));
 
-        return in_array($sStatus, ['on', '1']) ? 0 : 2;
+        return \in_array($sStatus, ['on', '1']) ? 0 : 2;
     }
 
     /**

--- a/source/Core/TableViewNameGenerator.php
+++ b/source/Core/TableViewNameGenerator.php
@@ -54,7 +54,7 @@ class TableViewNameGenerator
             $language = $this->getLanguage();
             $languageId = $languageId !== null ? $languageId : $language->getBaseLanguage();
             $shopId = $shopId !== null ? $shopId : $config->getShopId();
-            $isMultiLang = in_array($table, $language->getMultiLangTables());
+            $isMultiLang = \in_array($table, $language->getMultiLangTables());
             $viewSuffix = $this->getViewSuffix($table, $languageId, $shopId, $isMultiLang);
 
             if ($viewSuffix || (($languageId == -1 || $shopId == -1) && $isMultiLang)) {

--- a/source/Core/Theme.php
+++ b/source/Core/Theme.php
@@ -39,7 +39,7 @@ class Theme extends \OxidEsales\Eshop\Core\Base
     public function load($sOXID)
     {
         $sFilePath = \OxidEsales\Eshop\Core\Registry::getConfig()->getViewsDir() . $sOXID . "/theme.php";
-        if (file_exists($sFilePath) && is_readable($sFilePath)) {
+        if (\file_exists($sFilePath) && \is_readable($sFilePath)) {
             $aTheme = [];
             include $sFilePath;
             $this->_aTheme = $aTheme;
@@ -84,9 +84,9 @@ class Theme extends \OxidEsales\Eshop\Core\Base
     {
         $this->_aThemeList = [];
         $sOutDir = \OxidEsales\Eshop\Core\Registry::getConfig()->getViewsDir();
-        foreach (glob($sOutDir . "*", GLOB_ONLYDIR) as $sDir) {
+        foreach (\glob($sOutDir . "*", GLOB_ONLYDIR) as $sDir) {
             $oTheme = oxNew(\OxidEsales\Eshop\Core\Theme::class);
-            if ($oTheme->load(basename($sDir))) {
+            if ($oTheme->load(\basename($sDir))) {
                 $this->_aThemeList[$sDir] = $oTheme;
             }
         }
@@ -186,10 +186,10 @@ class Theme extends \OxidEsales\Eshop\Core\Base
                 return 'EXCEPTION_PARENT_VERSION_UNSPECIFIED';
             }
             $aMyParentVersions = $this->getInfo('parentVersions');
-            if (!$aMyParentVersions || !is_array($aMyParentVersions)) {
+            if (!$aMyParentVersions || !\is_array($aMyParentVersions)) {
                 return 'EXCEPTION_UNSPECIFIED_PARENT_VERSIONS';
             }
-            if (!in_array($sParentVersion, $aMyParentVersions)) {
+            if (!\in_array($sParentVersion, $aMyParentVersions)) {
                 return 'EXCEPTION_PARENT_VERSION_MISMATCH';
             }
         } elseif ($this->getInfo('parentTheme')) {

--- a/source/Core/UniversallyUniqueIdGenerator.php
+++ b/source/Core/UniversallyUniqueIdGenerator.php
@@ -24,7 +24,7 @@ class UniversallyUniqueIdGenerator
      */
     public function __construct(\OxidEsales\Eshop\Core\OpenSSLFunctionalityChecker $openSSLChecker = null)
     {
-        if (is_null($openSSLChecker)) {
+        if (\is_null($openSSLChecker)) {
             $openSSLChecker = oxNew(\OxidEsales\Eshop\Core\OpenSSLFunctionalityChecker::class);
         }
         $this->_openSSLChecker = $openSSLChecker;
@@ -39,7 +39,7 @@ class UniversallyUniqueIdGenerator
     {
         $sSeed = $this->generateV4();
 
-        return $this->generateV5($sSeed, php_uname('n'));
+        return $this->generateV5($sSeed, \php_uname('n'));
     }
 
     /**
@@ -66,19 +66,19 @@ class UniversallyUniqueIdGenerator
      */
     public function generateV5($sSeed, $sSalt)
     {
-        $sSeed = str_replace(['-', '{', '}'], '', $sSeed);
+        $sSeed = \str_replace(['-', '{', '}'], '', $sSeed);
         $sBinarySeed = '';
-        for ($i = 0; $i < strlen($sSeed); $i += 2) {
-            $sBinarySeed .= chr(hexdec($sSeed[$i] . $sSeed[$i + 1]));
+        for ($i = 0; $i < \strlen($sSeed); $i += 2) {
+            $sBinarySeed .= \chr(\hexdec($sSeed[$i] . $sSeed[$i + 1]));
         }
-        $sHash = sha1($sBinarySeed . $sSalt);
-        $sUUID = sprintf(
+        $sHash = \sha1($sBinarySeed . $sSalt);
+        $sUUID = \sprintf(
             '%08s-%04s-%04x-%04x-%12s',
-            substr($sHash, 0, 8),
-            substr($sHash, 8, 4),
-            (hexdec(substr($sHash, 12, 4)) & 0x0fff) | 0x3000,
-            (hexdec(substr($sHash, 16, 4)) & 0x3fff) | 0x8000,
-            substr($sHash, 20, 12)
+            \substr($sHash, 0, 8),
+            \substr($sHash, 8, 4),
+            (\hexdec(\substr($sHash, 12, 4)) & 0x0fff) | 0x3000,
+            (\hexdec(\substr($sHash, 16, 4)) & 0x3fff) | 0x8000,
+            \substr($sHash, 20, 12)
         );
 
         return $sUUID;
@@ -103,11 +103,11 @@ class UniversallyUniqueIdGenerator
      */
     protected function _generateBasedOnOpenSSL() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
-        $sRandomData = openssl_random_pseudo_bytes(16);
-        $sRandomData[6] = chr(ord($sRandomData[6]) & 0x0f | 0x40); // set version to 0100
-        $sRandomData[8] = chr(ord($sRandomData[8]) & 0x3f | 0x80); // set bits 6-7 to 10
+        $sRandomData = \openssl_random_pseudo_bytes(16);
+        $sRandomData[6] = \chr(\ord($sRandomData[6]) & 0x0f | 0x40); // set version to 0100
+        $sRandomData[8] = \chr(\ord($sRandomData[8]) & 0x3f | 0x80); // set bits 6-7 to 10
 
-        return vsprintf('%s%s-%s-%s-%s-%s%s%s', str_split(bin2hex($sRandomData), 4));
+        return \vsprintf('%s%s-%s-%s-%s-%s%s%s', \str_split(\bin2hex($sRandomData), 4));
     }
 
     /**
@@ -118,16 +118,16 @@ class UniversallyUniqueIdGenerator
      */
     protected function _generateBasedOnMtRand() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
-        return sprintf(
+        return \sprintf(
             '%04x%04x-%04x-%04x-%04x-%04x%04x%04x',
-            mt_rand(0, 0xffff),
-            mt_rand(0, 0xffff),
-            mt_rand(0, 0xffff),
-            mt_rand(0, 0x0fff) | 0x4000,
-            mt_rand(0, 0x3fff) | 0x8000,
-            mt_rand(0, 0xffff),
-            mt_rand(0, 0xffff),
-            mt_rand(0, 0xffff)
+            \mt_rand(0, 0xffff),
+            \mt_rand(0, 0xffff),
+            \mt_rand(0, 0xffff),
+            \mt_rand(0, 0x0fff) | 0x4000,
+            \mt_rand(0, 0x3fff) | 0x8000,
+            \mt_rand(0, 0xffff),
+            \mt_rand(0, 0xffff),
+            \mt_rand(0, 0xffff)
         );
     }
 }

--- a/source/Core/Utils.php
+++ b/source/Core/Utils.php
@@ -90,7 +90,7 @@ class Utils extends \OxidEsales\Eshop\Core\Base
      */
     public function getArrFldName($sName)
     {
-        return str_replace(".", "__", $sName);
+        return \str_replace(".", "__", $sName);
     }
 
     /**
@@ -104,10 +104,10 @@ class Utils extends \OxidEsales\Eshop\Core\Base
     public function assignValuesFromText($sIn, $dVat = null)
     {
         $aRet = [];
-        $aPieces = explode('@@', $sIn);
+        $aPieces = \explode('@@', $sIn);
         foreach ($aPieces as $sVal) {
             if ($sVal) {
-                $aName = explode('__', $sVal);
+                $aName = \explode('__', $sVal);
                 if (isset($aName[0]) && isset($aName[1])) {
                     $aRet[] = $this->_fillExplodeArray($aName, $dVat);
                 }
@@ -127,7 +127,7 @@ class Utils extends \OxidEsales\Eshop\Core\Base
     public function assignValuesToText($aIn)
     {
         $sRet = "";
-        reset($aIn);
+        \reset($aIn);
         foreach ($aIn as $sKey => $sVal) {
             $sRet .= $sKey;
             $sRet .= "__";
@@ -148,15 +148,15 @@ class Utils extends \OxidEsales\Eshop\Core\Base
     public function currency2Float($sValue)
     {
         $fRet = $sValue;
-        $iPos = strrpos($sValue, ".");
-        if ($iPos && ((strlen($sValue) - 1 - $iPos) < 2 + 1)) {
+        $iPos = \strrpos($sValue, ".");
+        if ($iPos && ((\strlen($sValue) - 1 - $iPos) < 2 + 1)) {
             // replace decimal with ","
-            $fRet = substr_replace($fRet, ",", $iPos, 1);
+            $fRet = \substr_replace($fRet, ",", $iPos, 1);
         }
         // remove thousands
-        $fRet = str_replace([" ", "."], "", $fRet);
+        $fRet = \str_replace([" ", "."], "", $fRet);
 
-        return (float) str_replace(",", ".", $fRet);
+        return (float) \str_replace(",", ".", $fRet);
     }
 
     /**
@@ -168,24 +168,24 @@ class Utils extends \OxidEsales\Eshop\Core\Base
      */
     public function string2Float($sValue)
     {
-        $fRet = str_replace(" ", "", $sValue);
-        $iCommaPos = strpos($fRet, ",");
-        $iDotPos = strpos($fRet, ".");
+        $fRet = \str_replace(" ", "", $sValue);
+        $iCommaPos = \strpos($fRet, ",");
+        $iDotPos = \strpos($fRet, ".");
         if (!$iDotPos xor !$iCommaPos) {
-            if (substr_count($fRet, ",") > 1 || substr_count($fRet, ".") > 1) {
-                $fRet = str_replace([",", "."], "", $fRet);
+            if (\substr_count($fRet, ",") > 1 || \substr_count($fRet, ".") > 1) {
+                $fRet = \str_replace([",", "."], "", $fRet);
             } else {
-                $fRet = str_replace(",", ".", $fRet);
+                $fRet = \str_replace(",", ".", $fRet);
             }
         } else {
             if ($iDotPos < $iCommaPos) {
-                $fRet = str_replace(".", "", $fRet);
-                $fRet = str_replace(",", ".", $fRet);
+                $fRet = \str_replace(".", "", $fRet);
+                $fRet = \str_replace(",", ".", $fRet);
             }
         }
 
         // remove thousands
-        return (float) str_replace([" ", ","], "", $fRet);
+        return (float) \str_replace([" ", ","], "", $fRet);
     }
 
     /**
@@ -197,7 +197,7 @@ class Utils extends \OxidEsales\Eshop\Core\Base
      */
     public function isSearchEngine($sClient = null)
     {
-        if (is_null($this->_blIsSe)) {
+        if (\is_null($this->_blIsSe)) {
             $this->setSearchEngine(null, $sClient);
         }
 
@@ -226,16 +226,16 @@ class Utils extends \OxidEsales\Eshop\Core\Base
 
         if (!($myConfig->getConfigParam('iDebug') && $this->isAdmin())) {
             $aRobots = $myConfig->getConfigParam('aRobots');
-            $aRobots = is_array($aRobots) ? $aRobots : [];
+            $aRobots = \is_array($aRobots) ? $aRobots : [];
 
             $aRobotsExcept = $myConfig->getConfigParam('aRobotsExcept');
-            $aRobotsExcept = is_array($aRobotsExcept) ? $aRobotsExcept : [];
+            $aRobotsExcept = \is_array($aRobotsExcept) ? $aRobotsExcept : [];
 
-            $sClient = $sClient ? $sClient : strtolower(getenv('HTTP_USER_AGENT'));
+            $sClient = $sClient ? $sClient : \strtolower(\getenv('HTTP_USER_AGENT'));
             $blIsSe = false;
-            $aRobots = array_merge($aRobots, $aRobotsExcept);
+            $aRobots = \array_merge($aRobots, $aRobotsExcept);
             foreach ($aRobots as $sRobot) {
-                if (strpos($sClient, $sRobot) !== false) {
+                if (\strpos($sClient, $sRobot) !== false) {
                     $blIsSe = true;
                     break;
                 }
@@ -258,11 +258,11 @@ class Utils extends \OxidEsales\Eshop\Core\Base
     {
         // improved #533
         // checking for available profiles list
-        if (is_array($aInterfaceProfiles)) {
+        if (\is_array($aInterfaceProfiles)) {
             //checking for previous profiles
             $sPrevProfile = \OxidEsales\Eshop\Core\Registry::getUtilsServer()->getOxCookie('oxidadminprofile');
             if (isset($sPrevProfile)) {
-                $aPrevProfile = @explode("@", trim($sPrevProfile));
+                $aPrevProfile = @\explode("@", \trim($sPrevProfile));
             }
 
             //array to store profiles
@@ -299,7 +299,7 @@ class Utils extends \OxidEsales\Eshop\Core\Base
         //cached currency precision, this saves about 1% of execution time
         $iCurPrecision = $this->_iCurPrecision;
 
-        if (is_null($iCurPrecision)) {
+        if (\is_null($iCurPrecision)) {
             if (!$oCur) {
                 $oCur = \OxidEsales\Eshop\Core\Registry::getConfig()->getActShopCurrencyObject();
             }
@@ -311,17 +311,17 @@ class Utils extends \OxidEsales\Eshop\Core\Base
         // if < 5.3.x this is a workaround for #36008 bug in php - incorrect round() & number_format() result (R)
         static $dprez = null;
         if (!$dprez) {
-            $prez = @ini_get("precision");
+            $prez = @\ini_get("precision");
             if (!$prez || $prez > 12) {
                 $prez = 12;
             }
-            $dprez = pow(10, -$prez);
+            $dprez = \pow(10, -$prez);
         }
         stopProfile('fround');
 
         $sVal = (float) $sVal;
 
-        return round($sVal + $dprez * ($sVal >= 0 ? 1 : -1), $iCurPrecision);
+        return \round($sVal + $dprez * ($sVal >= 0 ? 1 : -1), $iCurPrecision);
     }
 
     /**
@@ -340,8 +340,8 @@ class Utils extends \OxidEsales\Eshop\Core\Base
      */
     public function arrayStringSearch($needle, $haystack)
     {
-        $result = array_search((string) $needle, $haystack);
-        $second = array_search((string) $needle, $haystack, true);
+        $result = \array_search((string) $needle, $haystack);
+        $second = \array_search((string) $needle, $haystack, true);
 
         //got a different result when using strict and not strict?
         //do a detail check
@@ -350,7 +350,7 @@ class Utils extends \OxidEsales\Eshop\Core\Base
             foreach ($haystack as $value) {
                 $stringstack[] = (string) $value;
             }
-            $result = array_search((string) $needle, $stringstack, true);
+            $result = \array_search((string) $needle, $stringstack, true);
         }
 
         return $result;
@@ -411,7 +411,7 @@ class Utils extends \OxidEsales\Eshop\Core\Base
     public function toPhpFileCache($sKey, $mContents)
     {
         //only simple arrays are supported
-        if (is_array($mContents) && ($sCachePath = $this->getCacheFilePath($sKey, false, 'php'))) {
+        if (\is_array($mContents) && ($sCachePath = $this->getCacheFilePath($sKey, false, 'php'))) {
             // setting meta
             $this->setCacheMeta($sKey, ["serialize" => false, "cachepath" => $sCachePath]);
 
@@ -494,12 +494,12 @@ class Utils extends \OxidEsales\Eshop\Core\Base
      */
     public function fromFileCache($sKey)
     {
-        if (!array_key_exists($sKey, $this->_aFileCacheContents)) {
+        if (!\array_key_exists($sKey, $this->_aFileCacheContents)) {
             $aMeta = $this->getCacheMeta($sKey);
             $sCachePath = isset($aMeta["cachepath"]) ? $aMeta["cachepath"] : $this->getCacheFilePath($sKey);
 
-            clearstatcache();
-            if (is_readable($sCachePath)) {
+            \clearstatcache();
+            if (\is_readable($sCachePath)) {
                 $this->_lockFile($sCachePath, $sKey, LOCK_SH);
 
                 $blInclude = isset($aMeta["include"]) ? $aMeta["include"] : false;
@@ -534,9 +534,9 @@ class Utils extends \OxidEsales\Eshop\Core\Base
      */
     protected function _readFile($sFilePath) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
-        $sRes = file_get_contents($sFilePath);
+        $sRes = \file_get_contents($sFilePath);
 
-        return $sRes ? unserialize($sRes) : null;
+        return $sRes ? \unserialize($sRes) : null;
     }
 
     /**
@@ -571,9 +571,9 @@ class Utils extends \OxidEsales\Eshop\Core\Base
         $blSerialize = isset($aCacheMeta["serialize"]) ? $aCacheMeta["serialize"] : true;
 
         if ($blSerialize) {
-            $mContents = serialize($mContents);
+            $mContents = \serialize($mContents);
         } else {
-            $mContents = "<?php\n//automatically generated file\n//" . date("Y-m-d H:i:s") . "\n\n\$_aCacheContents = " . var_export($mContents, true) . "\n?>";
+            $mContents = "<?php\n//automatically generated file\n//" . \date("Y-m-d H:i:s") . "\n\n\$_aCacheContents = " . \var_export($mContents, true) . "\n?>";
         }
 
         return $mContents;
@@ -590,10 +590,10 @@ class Utils extends \OxidEsales\Eshop\Core\Base
             foreach ($this->_aLockedFileHandles[LOCK_EX] as $sKey => $rHandle) {
                 if ($rHandle !== false && isset($this->_aFileCacheContents[$sKey])) {
                     // #0002931A truncate file once more before writing
-                    ftruncate($rHandle, 0);
+                    \ftruncate($rHandle, 0);
 
                     // writing cache
-                    fwrite($rHandle, $this->_processCache($sKey, $this->_aFileCacheContents[$sKey]));
+                    \fwrite($rHandle, $this->_processCache($sKey, $this->_aFileCacheContents[$sKey]));
 
                     // releasing locks
                     $this->_releaseFile($sKey);
@@ -622,22 +622,22 @@ class Utils extends \OxidEsales\Eshop\Core\Base
         $rHandle = isset($this->_aLockedFileHandles[$iLockMode][$sIdent]) ? $this->_aLockedFileHandles[$iLockMode][$sIdent] : null;
         if ($rHandle === null) {
             $blLocked = false;
-            $rHandle = @fopen($sFilePath, "a+");
+            $rHandle = @\fopen($sFilePath, "a+");
 
             if ($rHandle !== false) {
-                if (flock($rHandle, $iLockMode | LOCK_NB)) {
+                if (\flock($rHandle, $iLockMode | LOCK_NB)) {
                     if ($iLockMode === LOCK_EX) {
                         // truncate file
-                        $blLocked = ftruncate($rHandle, 0);
+                        $blLocked = \ftruncate($rHandle, 0);
                     } else {
                         // move to a start position
-                        $blLocked = fseek($rHandle, 0) === 0;
+                        $blLocked = \fseek($rHandle, 0) === 0;
                     }
                 }
 
                 // on failure - closing and setting false..
                 if (!$blLocked) {
-                    fclose($rHandle);
+                    \fclose($rHandle);
                     $rHandle = false;
                 }
             }
@@ -645,13 +645,13 @@ class Utils extends \OxidEsales\Eshop\Core\Base
             // in case system does not support file locking
             if (!$blLocked && $iLockMode === LOCK_EX) {
                 // clearing on first call
-                if (count($this->_aLockedFileHandles) == 0) {
-                    clearstatcache();
+                if (\count($this->_aLockedFileHandles) == 0) {
+                    \clearstatcache();
                 }
 
                 // start a blank file to inform other processes we are dealing with it.
-                if (!(file_exists($sFilePath) && !filesize($sFilePath) && abs(time() - filectime($sFilePath) < 40))) {
-                    $rHandle = @fopen($sFilePath, "w");
+                if (!(\file_exists($sFilePath) && !\filesize($sFilePath) && \abs(\time() - \filectime($sFilePath) < 40))) {
+                    $rHandle = @\fopen($sFilePath, "w");
                 }
             }
 
@@ -678,8 +678,8 @@ class Utils extends \OxidEsales\Eshop\Core\Base
             $this->_aLockedFileHandles[$iLockMode][$sIdent] !== false
         ) {
             // release the lock and close file
-            $blSuccess = flock($this->_aLockedFileHandles[$iLockMode][$sIdent], LOCK_UN) &&
-                         fclose($this->_aLockedFileHandles[$iLockMode][$sIdent]);
+            $blSuccess = \flock($this->_aLockedFileHandles[$iLockMode][$sIdent], LOCK_UN) &&
+                         \fclose($this->_aLockedFileHandles[$iLockMode][$sIdent]);
             unset($this->_aLockedFileHandles[$iLockMode][$sIdent]);
         }
 
@@ -693,12 +693,12 @@ class Utils extends \OxidEsales\Eshop\Core\Base
      */
     public function oxResetFileCache()
     {
-        $aFiles = glob($this->getCacheFilePath(null, true) . '*');
-        if (is_array($aFiles)) {
+        $aFiles = \glob($this->getCacheFilePath(null, true) . '*');
+        if (\is_array($aFiles)) {
             // delete all the files, except cached tables field names
-            $aFiles = preg_grep($this->_sPermanentCachePattern, $aFiles, PREG_GREP_INVERT);
+            $aFiles = \preg_grep($this->_sPermanentCachePattern, $aFiles, PREG_GREP_INVERT);
             foreach ($aFiles as $sFile) {
-                @unlink($sFile);
+                @\unlink($sFile);
             }
         }
     }
@@ -712,20 +712,20 @@ class Utils extends \OxidEsales\Eshop\Core\Base
     {
         $sSmartyDir = \OxidEsales\Eshop\Core\Registry::getUtilsView()->getSmartyDir();
         //$aFiles = glob( $this->getCacheFilePath( null, true ) . '*' );
-        $aFiles = glob($sSmartyDir . '*');
+        $aFiles = \glob($sSmartyDir . '*');
 
-        if (is_array($aFiles) && is_array($aTemplates) && count($aTemplates)) {
+        if (\is_array($aFiles) && \is_array($aTemplates) && \count($aTemplates)) {
             // delete all template cache files
             foreach ($aTemplates as &$sTemplate) {
-                $sTemplate = preg_quote(basename(strtolower($sTemplate), '.tpl'));
+                $sTemplate = \preg_quote(\basename(\strtolower($sTemplate), '.tpl'));
             }
 
-            $sPattern = sprintf("/%%(%s)\.tpl\.php$/i", implode('|', $aTemplates));
-            $aFiles = preg_grep($sPattern, $aFiles);
+            $sPattern = \sprintf("/%%(%s)\.tpl\.php$/i", \implode('|', $aTemplates));
+            $aFiles = \preg_grep($sPattern, $aFiles);
 
-            if (is_array($aFiles)) {
+            if (\is_array($aFiles)) {
                 foreach ($aFiles as $sFile) {
-                    @unlink($sFile);
+                    @\unlink($sFile);
                 }
             }
         }
@@ -736,13 +736,13 @@ class Utils extends \OxidEsales\Eshop\Core\Base
      */
     public function resetLanguageCache()
     {
-        $aFiles = glob($this->getCacheFilePath(null, true) . '*');
-        if (is_array($aFiles)) {
+        $aFiles = \glob($this->getCacheFilePath(null, true) . '*');
+        if (\is_array($aFiles)) {
             // delete all language cache files
             $sPattern = $this->_sLanguageCachePattern;
-            $aFiles = preg_grep($sPattern, $aFiles);
+            $aFiles = \preg_grep($sPattern, $aFiles);
             foreach ($aFiles as $sFile) {
-                @unlink($sFile);
+                @\unlink($sFile);
             }
         }
     }
@@ -752,13 +752,13 @@ class Utils extends \OxidEsales\Eshop\Core\Base
      */
     public function resetMenuCache()
     {
-        $aFiles = glob($this->getCacheFilePath(null, true) . '*');
-        if (is_array($aFiles)) {
+        $aFiles = \glob($this->getCacheFilePath(null, true) . '*');
+        if (\is_array($aFiles)) {
             // delete all menu cache files
             $sPattern = $this->_sMenuCachePattern;
-            $aFiles = preg_grep($sPattern, $aFiles);
+            $aFiles = \preg_grep($sPattern, $aFiles);
             foreach ($aFiles as $sFile) {
-                @unlink($sFile);
+                @\unlink($sFile);
             }
         }
     }
@@ -774,20 +774,20 @@ class Utils extends \OxidEsales\Eshop\Core\Base
      */
     public function getRemoteCachePath($sRemote, $sLocal)
     {
-        clearstatcache();
-        if (file_exists($sLocal) && filemtime($sLocal) && filemtime($sLocal) > time() - 86400) {
+        \clearstatcache();
+        if (\file_exists($sLocal) && \filemtime($sLocal) && \filemtime($sLocal) > \time() - 86400) {
             return $sLocal;
         }
-        $hRemote = @fopen($sRemote, "rb");
+        $hRemote = @\fopen($sRemote, "rb");
         $blSuccess = false;
-        if (is_resource($hRemote) && $hLocal = @fopen($sLocal, "wb")) {
-            stream_copy_to_stream($hRemote, $hLocal);
-            fclose($hRemote);
-            fclose($hLocal);
+        if (\is_resource($hRemote) && $hLocal = @\fopen($sLocal, "wb")) {
+            \stream_copy_to_stream($hRemote, $hLocal);
+            \fclose($hRemote);
+            \fclose($hLocal);
             $blSuccess = true;
         } else {
             // try via fsockopen
-            $aUrl = @parse_url($sRemote);
+            $aUrl = @\parse_url($sRemote);
             if (!empty($aUrl["host"])) {
                 $sPath = $aUrl["path"];
                 if (empty($sPath)) {
@@ -795,23 +795,23 @@ class Utils extends \OxidEsales\Eshop\Core\Base
                 }
                 $sHost = $aUrl["host"];
 
-                $hSocket = @fsockopen($sHost, 80, $iErrorNumber, $iErrStr, 5);
+                $hSocket = @\fsockopen($sHost, 80, $iErrorNumber, $iErrStr, 5);
                 if ($hSocket) {
-                    fputs($hSocket, "GET " . $sPath . " HTTP/1.0\r\nHost: $sHost\r\n\r\n");
-                    $headers = stream_get_line($hSocket, 4096, "\r\n\r\n");
-                    if (($hLocal = @fopen($sLocal, "wb")) !== false) {
-                        rewind($hLocal);
+                    \fputs($hSocket, "GET " . $sPath . " HTTP/1.0\r\nHost: $sHost\r\n\r\n");
+                    $headers = \stream_get_line($hSocket, 4096, "\r\n\r\n");
+                    if (($hLocal = @\fopen($sLocal, "wb")) !== false) {
+                        \rewind($hLocal);
                         // does not copy all the data
                         // stream_copy_to_stream($hSocket, $hLocal);
-                        fwrite($hLocal, stream_get_contents($hSocket));
-                        fclose($hLocal);
-                        fclose($hSocket);
+                        \fwrite($hLocal, \stream_get_contents($hSocket));
+                        \fclose($hLocal);
+                        \fclose($hSocket);
                         $blSuccess = true;
                     }
                 }
             }
         }
-        if ($blSuccess || file_exists($sLocal)) {
+        if ($blSuccess || \file_exists($sLocal)) {
             return $sLocal;
         }
 
@@ -850,7 +850,7 @@ class Utils extends \OxidEsales\Eshop\Core\Base
     {
         $sAdminSid = \OxidEsales\Eshop\Core\Registry::getUtilsServer()->getOxCookie('admin_sid');
         if (($oUser = $this->getUser())) {
-            return md5($sAdminSid . $oUser->getId() . $oUser->oxuser__oxpassword->value . $oUser->oxuser__oxrights->value);
+            return \md5($sAdminSid . $oUser->getId() . $oUser->oxuser__oxpassword->value . $oUser->oxuser__oxrights->value);
         }
     }
 
@@ -974,7 +974,7 @@ class Utils extends \OxidEsales\Eshop\Core\Base
      */
     public function seoIsActive($blReset = false, $sShopId = null, $iActLang = null)
     {
-        if (!is_null($this->_blSeoIsActive) && !$blReset) {
+        if (!\is_null($this->_blSeoIsActive) && !$blReset) {
             return $this->_blSeoIsActive;
         }
 
@@ -988,7 +988,7 @@ class Utils extends \OxidEsales\Eshop\Core\Base
             $iActLang = $iActLang ? $iActLang : (int) \OxidEsales\Eshop\Core\Registry::getLang()->getBaseLanguage();
 
             // checking special config param for active shop and language
-            if (is_array($aSeoModes) && isset($aSeoModes[$sActShopId]) && isset($aSeoModes[$sActShopId][$iActLang])) {
+            if (\is_array($aSeoModes) && isset($aSeoModes[$sActShopId]) && isset($aSeoModes[$sActShopId][$iActLang])) {
                 $this->_blSeoIsActive = (bool) $aSeoModes[$sActShopId][$iActLang];
             }
         }
@@ -1067,7 +1067,7 @@ class Utils extends \OxidEsales\Eshop\Core\Base
             $sUrl = $this->_addUrlParameters($sUrl, ['redirected' => 1]);
         }
 
-        $sUrl = str_ireplace("&amp;", "&", $sUrl);
+        $sUrl = \str_ireplace("&amp;", "&", $sUrl);
 
         switch ($iHeaderCode) {
             case 301:
@@ -1134,7 +1134,7 @@ class Utils extends \OxidEsales\Eshop\Core\Base
      */
     public function setHeader($sHeader)
     {
-        header($sHeader);
+        \header($sHeader);
     }
 
     /**
@@ -1173,7 +1173,7 @@ class Utils extends \OxidEsales\Eshop\Core\Base
     {
         $myConfig = \OxidEsales\Eshop\Core\Registry::getConfig();
         $oObject = new stdClass();
-        $aPrice = explode('!P!', $aName[0]);
+        $aPrice = \explode('!P!', $aName[0]);
 
         if (($myConfig->getConfigParam('bl_perfLoadSelectLists') && $myConfig->getConfigParam('bl_perfUseSelectlistPrice') && isset($aPrice[0]) && isset($aPrice[1])) || $this->isAdmin()) {
             // yes, price is there
@@ -1184,10 +1184,10 @@ class Utils extends \OxidEsales\Eshop\Core\Base
             if ($iPercPos !== false) {
                 $oObject->priceUnit = '%';
                 $oObject->fprice = $oObject->price;
-                $oObject->price = substr($oObject->price, 0, $iPercPos);
+                $oObject->price = \substr($oObject->price, 0, $iPercPos);
             } else {
                 $oCur = $myConfig->getActShopCurrencyObject();
-                $oObject->price = str_replace(',', '.', $oObject->price);
+                $oObject->price = \str_replace(',', '.', $oObject->price);
                 $oObject->fprice = \OxidEsales\Eshop\Core\Registry::getLang()->formatCurrency($oObject->price * $oCur->rate, $oCur);
                 $oObject->priceUnit = 'abs';
             }
@@ -1241,9 +1241,9 @@ class Utils extends \OxidEsales\Eshop\Core\Base
 
         $blEnterNetPrice = \OxidEsales\Eshop\Core\Registry::getConfig()->getConfigParam('blEnterNetPrice');
         if ($blCalculationModeNetto && !$blEnterNetPrice) {
-            $dPrice = round(\OxidEsales\Eshop\Core\Price::brutto2Netto($dPrice, $dVat), $oCurrency->decimal);
+            $dPrice = \round(\OxidEsales\Eshop\Core\Price::brutto2Netto($dPrice, $dVat), $oCurrency->decimal);
         } elseif (!$blCalculationModeNetto && $blEnterNetPrice) {
-            $dPrice = round(\OxidEsales\Eshop\Core\Price::netto2Brutto($dPrice, $dVat), $oCurrency->decimal);
+            $dPrice = \round(\OxidEsales\Eshop\Core\Price::netto2Brutto($dPrice, $dVat), $oCurrency->decimal);
         }
 
         return $dPrice;
@@ -1290,11 +1290,11 @@ class Utils extends \OxidEsales\Eshop\Core\Base
      */
     public function oxMimeContentType($sFileName)
     {
-        $sFileName = strtolower($sFileName);
-        $iLastDot = strrpos($sFileName, '.');
+        $sFileName = \strtolower($sFileName);
+        $iLastDot = \strrpos($sFileName, '.');
 
         if ($iLastDot !== false) {
-            $sType = substr($sFileName, $iLastDot + 1);
+            $sType = \substr($sFileName, $iLastDot + 1);
             switch ($sType) {
                 case 'gif':
                     $sType = 'image/gif';
@@ -1328,8 +1328,8 @@ class Utils extends \OxidEsales\Eshop\Core\Base
         $myConfig = \OxidEsales\Eshop\Core\Registry::getConfig();
 
         if ($myConfig->getConfigParam('iDebug') == -2) {
-            if (gettype($sText) != 'string') {
-                $sText = var_export($sText, true);
+            if (\gettype($sText) != 'string') {
+                $sText = \var_export($sText, true);
             }
             $logMessage = "----------------------------------------------\n{$sText}" . (($blNewline) ? "\n" : "") . "\n";
             $logger = Registry::getLogger();
@@ -1352,7 +1352,7 @@ class Utils extends \OxidEsales\Eshop\Core\Base
     {
         $versionPrefix = $this->getEditionCacheFilePrefix();
 
-        $sPath = realpath(\OxidEsales\Eshop\Core\Registry::getConfig()->getConfigParam('sCompileDir'));
+        $sPath = \realpath(\OxidEsales\Eshop\Core\Registry::getConfig()->getConfigParam('sCompileDir'));
 
         if (!$sPath) {
             return false;
@@ -1381,7 +1381,7 @@ class Utils extends \OxidEsales\Eshop\Core\Base
     {
         $aLangCache = null;
         $sFilePath = $this->getCacheFilePath($sCacheName);
-        if (file_exists($sFilePath) && is_readable($sFilePath)) {
+        if (\file_exists($sFilePath) && \is_readable($sFilePath)) {
             include $sFilePath;
         }
 
@@ -1398,14 +1398,14 @@ class Utils extends \OxidEsales\Eshop\Core\Base
      */
     public function setLangCache($sCacheName, $aLangCache)
     {
-        $sCache = "<?php\n\$aLangCache = " . var_export($aLangCache, true) . ";\n?>";
+        $sCache = "<?php\n\$aLangCache = " . \var_export($aLangCache, true) . ";\n?>";
         $sFileName = $this->getCacheFilePath($sCacheName);
         $cacheDirectory = \OxidEsales\Eshop\Core\Registry::getConfig()->getConfigParam('sCompileDir');
 
-        $tmpFile = $cacheDirectory . basename($sFileName) . uniqid('.temp', true) . '.txt';
-        $blRes = file_put_contents($tmpFile, $sCache, LOCK_EX);
+        $tmpFile = $cacheDirectory . \basename($sFileName) . \uniqid('.temp', true) . '.txt';
+        $blRes = \file_put_contents($tmpFile, $sCache, LOCK_EX);
 
-        rename($tmpFile, $sFileName);
+        \rename($tmpFile, $sFileName);
 
         return $blRes;
     }
@@ -1460,11 +1460,11 @@ class Utils extends \OxidEsales\Eshop\Core\Base
         $oStr = Str::getStr();
         if (
             !$oStr->preg_match('/[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}/', $sHost) &&
-            ($iLastDot = strrpos($sHost, '.')) !== false
+            ($iLastDot = \strrpos($sHost, '.')) !== false
         ) {
             $iLen = $oStr->strlen($sHost);
-            if (($iNextDot = strrpos($sHost, '.', ($iLen - $iLastDot + 1) * -1)) !== false) {
-                $sHost = trim($oStr->substr($sHost, $iNextDot), '.');
+            if (($iNextDot = \strrpos($sHost, '.', ($iLen - $iLastDot + 1) * -1)) !== false) {
+                $sHost = \trim($oStr->substr($sHost, $iNextDot), '.');
             }
         }
 

--- a/source/Core/UtilsCount.php
+++ b/source/Core/UtilsCount.php
@@ -243,12 +243,12 @@ class UtilsCount extends \OxidEsales\Eshop\Core\Base
         $result = [];
 
         foreach ($rows as $row) {
-            $firstColumn = array_keys($row)[0];
+            $firstColumn = \array_keys($row)[0];
             $key = $row[$firstColumn];
 
-            $values = array_values($row);
+            $values = \array_values($row);
 
-            if (2 <= count($values)) {
+            if (2 <= \count($values)) {
                 $result[$key] = $values[1];
             }
         }
@@ -511,7 +511,7 @@ class UtilsCount extends \OxidEsales\Eshop\Core\Base
 
         // loading R&R data from session
         $userSessionGroups = $this->getCurrentUserSessionGroups();
-        $this->_sUserViewId = md5(\OxidEsales\Eshop\Core\Registry::getConfig()->getShopID() . \OxidEsales\Eshop\Core\Registry::getLang()->getLanguageTag() . serialize($userSessionGroups) . (int) $this->isAdmin());
+        $this->_sUserViewId = \md5(\OxidEsales\Eshop\Core\Registry::getConfig()->getShopID() . \OxidEsales\Eshop\Core\Registry::getLang()->getLanguageTag() . \serialize($userSessionGroups) . (int) $this->isAdmin());
 
         return $this->_sUserViewId;
     }

--- a/source/Core/UtilsDate.php
+++ b/source/Core/UtilsDate.php
@@ -42,27 +42,27 @@ class UtilsDate extends \OxidEsales\Eshop\Core\Base
         }
 
         // is it a timestamp ?
-        if (is_numeric($sDBDateIn)) {
+        if (\is_numeric($sDBDateIn)) {
             // db timestamp : 20030322100409
-            $sNew = substr($sDBDateIn, 0, 4) . '-' . substr($sDBDateIn, 4, 2) . '-' . substr($sDBDateIn, 6, 2) . ' ';
+            $sNew = \substr($sDBDateIn, 0, 4) . '-' . \substr($sDBDateIn, 4, 2) . '-' . \substr($sDBDateIn, 6, 2) . ' ';
             // check if it is a timestamp or wrong data: 20030322
-            if (strlen($sDBDateIn) > 8) {
-                $sNew .= substr($sDBDateIn, 8, 2) . ':' . substr($sDBDateIn, 10, 2) . ':' . substr($sDBDateIn, 12, 2);
+            if (\strlen($sDBDateIn) > 8) {
+                $sNew .= \substr($sDBDateIn, 8, 2) . ':' . \substr($sDBDateIn, 10, 2) . ':' . \substr($sDBDateIn, 12, 2);
             }
             // convert it to english format
             $sDBDateIn = $sNew;
         }
 
         // remove time as it is same in english as in german
-        $aData = explode(' ', trim($sDBDateIn));
+        $aData = \explode(' ', \trim($sDBDateIn));
 
         // preparing time array
         $sTime = (isset($aData[1]) && $oStr->strstr($aData[1], ':')) ? $aData[1] : '';
-        $aTime = $sTime ? explode(':', $sTime) : [0, 0, 0];
+        $aTime = $sTime ? \explode(':', $sTime) : [0, 0, 0];
 
         // preparing date array
         $sDate = isset($aData[0]) ? $aData[0] : '';
-        $aDate = preg_split('/[\/.-]/', $sDate);
+        $aDate = \preg_split('/[\/.-]/', $sDate);
 
         // choosing format..
         if ($sTime) {
@@ -71,8 +71,8 @@ class UtilsDate extends \OxidEsales\Eshop\Core\Base
             $sFormat = $blForceEnglishRet ? 'Y-m-d' : \OxidEsales\Eshop\Core\Registry::getLang()->translateString('simpleDateFormat');
         }
 
-        if (count($aDate) != 3) {
-            return date($sFormat);
+        if (\count($aDate) != 3) {
+            return \date($sFormat);
         } else {
             return $this->_processDate($aTime, $aDate, $oStr->strstr($sDate, '.'), $sFormat);
         }
@@ -117,7 +117,7 @@ class UtilsDate extends \OxidEsales\Eshop\Core\Base
         $oStr = Str::getStr();
 
         // looking for default values that are formatted by MySQL
-        foreach (array_keys($aDefDatePatterns) as $sDefDatePattern) {
+        foreach (\array_keys($aDefDatePatterns) as $sDefDatePattern) {
             if ($oStr->preg_match($sDefDatePattern, $sDate)) {
                 $blDefDateFound = true;
                 break;
@@ -179,7 +179,7 @@ class UtilsDate extends \OxidEsales\Eshop\Core\Base
                         $iIntVal = 0;
                     }
 
-                    $aTimeMatches[1] = sprintf("%02d", $iIntVal);
+                    $aTimeMatches[1] = \sprintf("%02d", $iIntVal);
                 }
 
                 break;
@@ -228,7 +228,7 @@ class UtilsDate extends \OxidEsales\Eshop\Core\Base
             if ($oStr->preg_match($sISOTimeStampPattern, $oObject->value, $aMatches)) {
                 // changing layout
                 $oObject->setValue($aMatches[1] . $aMatches[2] . $aMatches[3] . $aMatches[4] . $aMatches[5] . $aMatches[6]);
-                $oObject->fldmax_length = strlen($oObject->value);
+                $oObject->fldmax_length = \strlen($oObject->value);
 
                 return $oObject->value;
             }
@@ -237,7 +237,7 @@ class UtilsDate extends \OxidEsales\Eshop\Core\Base
             // checking and parsing SQL timestamp value
             //$sSQLTimeStampPattern = "/^([0-9]{4})([0-9]{2})([0-9]{2})([0-9]{2})([0-9]{2})([0-9]{2})$/";
             if ($oStr->preg_match($sSQLTimeStampPattern, $oObject->value, $aMatches)) {
-                $iTimestamp = mktime(
+                $iTimestamp = \mktime(
                     $aMatches[4], //h
                     $aMatches[5], //m
                     $aMatches[6], //s
@@ -249,8 +249,8 @@ class UtilsDate extends \OxidEsales\Eshop\Core\Base
                     $iTimestamp = "0";
                 }
 
-                $oObject->setValue(trim(date("Y-m-d H:i:s", $iTimestamp)));
-                $oObject->fldmax_length = strlen($oObject->value);
+                $oObject->setValue(\trim(\date("Y-m-d H:i:s", $iTimestamp)));
+                $oObject->fldmax_length = \strlen($oObject->value);
                 $this->convertDBDateTime($oObject, $blToTimeStamp);
 
                 return $oObject->value;
@@ -290,7 +290,7 @@ class UtilsDate extends \OxidEsales\Eshop\Core\Base
         $aTFormats = $this->_defineTimeFormattingRules();
         $oStr = Str::getStr();
 
-        foreach (array_keys($aDefTimePatterns) as $sDefTimePattern) {
+        foreach (\array_keys($aDefTimePatterns) as $sDefTimePattern) {
             if ($oStr->preg_match($sDefTimePattern, $sDate)) {
                 $blDefTimeFound = true;
                 break;
@@ -299,16 +299,16 @@ class UtilsDate extends \OxidEsales\Eshop\Core\Base
 
         // setting and returning default formatted value
         if ($blOnlyDate) {
-            $oObject->setValue(trim($aDFormats[$sLocalDateFormat][2])); // . " " . @$aTFormats[$sLocalTimeFormat][2]);
+            $oObject->setValue(\trim($aDFormats[$sLocalDateFormat][2])); // . " " . @$aTFormats[$sLocalTimeFormat][2]);
             // increasing(decreasing) field length
-            $oObject->fldmax_length = strlen($oObject->value);
+            $oObject->fldmax_length = \strlen($oObject->value);
 
             return;
         } elseif ($blDefTimeFound) {
             // setting value
-            $oObject->setValue(trim($aDFormats[$sLocalDateFormat][2] . " " . $aTFormats[$sLocalTimeFormat][2]));
+            $oObject->setValue(\trim($aDFormats[$sLocalDateFormat][2] . " " . $aTFormats[$sLocalTimeFormat][2]));
             // increasing(decreasing) field length
-            $oObject->fldmax_length = strlen($oObject->value);
+            $oObject->fldmax_length = \strlen($oObject->value);
 
             return;
         }
@@ -458,12 +458,12 @@ class UtilsDate extends \OxidEsales\Eshop\Core\Base
         }
 
         if ($oObject instanceof \OxidEsales\Eshop\Core\Field) {
-            $oObject->setValue(trim($sReturn));
+            $oObject->setValue(\trim($sReturn));
         } else {
-            $oObject->value = trim($sReturn);
+            $oObject->value = \trim($sReturn);
         }
         // increasing(decreasing) field lenght
-        $oObject->fldmax_length = strlen($oObject->value);
+        $oObject->fldmax_length = \strlen($oObject->value);
     }
 
     /**
@@ -478,7 +478,7 @@ class UtilsDate extends \OxidEsales\Eshop\Core\Base
     protected function _setDate($oObject, $sDateFormat, $aDFields, $aDateMatches) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         // formatting correct time value
-        $iTimestamp = mktime(
+        $iTimestamp = \mktime(
             0,
             0,
             0,
@@ -488,12 +488,12 @@ class UtilsDate extends \OxidEsales\Eshop\Core\Base
         );
 
         if ($oObject instanceof \OxidEsales\Eshop\Core\Field) {
-            $oObject->setValue(@date($sDateFormat, $iTimestamp));
+            $oObject->setValue(@\date($sDateFormat, $iTimestamp));
         } else {
-            $oObject->value = @date($sDateFormat, $iTimestamp);
+            $oObject->value = @\date($sDateFormat, $iTimestamp);
         }
         // we should increase (decrease) field lenght
-        $oObject->fldmax_length = strlen($oObject->value);
+        $oObject->fldmax_length = \strlen($oObject->value);
     }
 
     /**
@@ -511,7 +511,7 @@ class UtilsDate extends \OxidEsales\Eshop\Core\Base
     protected function _formatCorrectTimeValue($oObject, $sDateFormat, $sTimeFormat, $aDateMatches, $aTimeMatches, $aTFields, $aDFields) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         // formatting correct time value
-        $iTimestamp = @mktime(
+        $iTimestamp = @\mktime(
             (int) $aTimeMatches[$aTFields[0]],
             (int) $aTimeMatches[$aTFields[1]],
             (int) $aTimeMatches[$aTFields[2]],
@@ -521,13 +521,13 @@ class UtilsDate extends \OxidEsales\Eshop\Core\Base
         );
 
         if ($oObject instanceof \OxidEsales\Eshop\Core\Field) {
-            $oObject->setValue(trim(@date($sDateFormat . " " . $sTimeFormat, $iTimestamp)));
+            $oObject->setValue(\trim(@\date($sDateFormat . " " . $sTimeFormat, $iTimestamp)));
         } else {
-            $oObject->value = trim(@date($sDateFormat . " " . $sTimeFormat, $iTimestamp));
+            $oObject->value = \trim(@\date($sDateFormat . " " . $sTimeFormat, $iTimestamp));
         }
 
         // we should increase (decrease) field lenght
-        $oObject->fldmax_length = strlen($oObject->value);
+        $oObject->fldmax_length = \strlen($oObject->value);
     }
 
     /**
@@ -538,7 +538,7 @@ class UtilsDate extends \OxidEsales\Eshop\Core\Base
      */
     public function getTime()
     {
-        return $this->shiftServerTime(time());
+        return $this->shiftServerTime(\time());
     }
 
     /**
@@ -561,7 +561,7 @@ class UtilsDate extends \OxidEsales\Eshop\Core\Base
      */
     public function formatDBTimestamp($iTimestamp)
     {
-        return date('Y-m-d H:i:s', $iTimestamp);
+        return \date('Y-m-d H:i:s', $iTimestamp);
     }
 
     /**
@@ -574,7 +574,7 @@ class UtilsDate extends \OxidEsales\Eshop\Core\Base
     {
         $timestamp = $this->getRequestTime();
         //round up x minutes so query cache can work
-        $timestamp = ceil($timestamp / $roundTo) * $roundTo;
+        $timestamp = \ceil($timestamp / $roundTo) * $roundTo;
 
         //format date for sql query
         return $this->formatDBTimestamp($timestamp);
@@ -603,7 +603,7 @@ class UtilsDate extends \OxidEsales\Eshop\Core\Base
         $oDate = new DateTime($sTime);
 
         if ($sTime2) {
-            $aHourToCheck = explode(':', $sTime2);
+            $aHourToCheck = \explode(':', $sTime2);
             $iHour = $aHourToCheck[0];
             $iMinutes = $aHourToCheck[1];
             $iSecond = $aHourToCheck[2];
@@ -643,7 +643,7 @@ class UtilsDate extends \OxidEsales\Eshop\Core\Base
     public function getWeekNumber($iFirstWeekDay, $sTimestamp = null, $sFormat = null)
     {
         if ($sTimestamp == null) {
-            $sTimestamp = time();
+            $sTimestamp = \time();
         }
         if ($sFormat == null) {
             $sFormat = '%W';
@@ -652,7 +652,7 @@ class UtilsDate extends \OxidEsales\Eshop\Core\Base
             }
         }
 
-        return (int) strftime($sFormat, $sTimestamp);
+        return (int) \strftime($sFormat, $sTimestamp);
     }
 
     /**
@@ -664,10 +664,10 @@ class UtilsDate extends \OxidEsales\Eshop\Core\Base
      */
     public function german2English($sDate)
     {
-        $aDate = explode(".", $sDate);
+        $aDate = \explode(".", $sDate);
 
-        if (isset($aDate) && count($aDate) > 1) {
-            if (count($aDate) == 2) {
+        if (isset($aDate) && \count($aDate) > 1) {
+            if (\count($aDate) == 2) {
                 $sDate = $aDate[1] . "-" . $aDate[0];
             } else {
                 $sDate = $aDate[2] . "-" . $aDate[1] . "-" . $aDate[0];
@@ -688,8 +688,8 @@ class UtilsDate extends \OxidEsales\Eshop\Core\Base
     public function isEmptyDate($sDate)
     {
         if (!empty($sDate)) {
-            $sDate = preg_replace("/[^0-9a-z]/i", "", $sDate);
-            if (!is_numeric($sDate) || $sDate != 0) {
+            $sDate = \preg_replace("/[^0-9a-z]/i", "", $sDate);
+            if (!\is_numeric($sDate) || $sDate != 0) {
                 return false;
             }
         }
@@ -711,9 +711,9 @@ class UtilsDate extends \OxidEsales\Eshop\Core\Base
     protected function _processDate($aTime, $aDate, $blGerman, $sFormat) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         if ($blGerman) {
-            return date($sFormat, mktime($aTime[0], $aTime[1], $aTime[2], $aDate[1], $aDate[0], $aDate[2]));
+            return \date($sFormat, \mktime($aTime[0], $aTime[1], $aTime[2], $aDate[1], $aDate[0], $aDate[2]));
         }
 
-        return date($sFormat, mktime($aTime[0], $aTime[1], $aTime[2], $aDate[1], $aDate[2], $aDate[0]));
+        return \date($sFormat, \mktime($aTime[0], $aTime[1], $aTime[2], $aDate[1], $aDate[2], $aDate[0]));
     }
 }

--- a/source/Core/UtilsFile.php
+++ b/source/Core/UtilsFile.php
@@ -157,7 +157,7 @@ class UtilsFile extends \OxidEsales\Eshop\Core\Base
      */
     public function normalizeDir($sDir)
     {
-        if (isset($sDir) && $sDir != "" && substr($sDir, -1) !== '/') {
+        if (isset($sDir) && $sDir != "" && \substr($sDir, -1) !== '/') {
             $sDir .= "/";
         }
 
@@ -173,15 +173,15 @@ class UtilsFile extends \OxidEsales\Eshop\Core\Base
     public function copyDir($sSourceDir, $sTargetDir)
     {
         $oStr = Str::getStr();
-        $handle = opendir($sSourceDir);
-        while (false !== ($file = readdir($handle))) {
+        $handle = \opendir($sSourceDir);
+        while (false !== ($file = \readdir($handle))) {
             if ($file != '.' && $file != '..') {
-                if (is_dir($sSourceDir . '/' . $file)) {
+                if (\is_dir($sSourceDir . '/' . $file)) {
                     // recursive
                     $sNewSourceDir = $sSourceDir . '/' . $file;
                     $sNewTargetDir = $sTargetDir . '/' . $file;
-                    if (strcasecmp($file, 'CVS') && strcasecmp($file, '.svn')) {
-                        @mkdir($sNewTargetDir, 0777);
+                    if (\strcasecmp($file, 'CVS') && \strcasecmp($file, '.svn')) {
+                        @\mkdir($sNewTargetDir, 0777);
                         $this->copyDir($sNewSourceDir, $sNewTargetDir);
                     }
                 } else {
@@ -190,12 +190,12 @@ class UtilsFile extends \OxidEsales\Eshop\Core\Base
 
                     //do not copy files within dyn_images
                     if (!$oStr->strstr($sSourceDir, 'dyn_images') || $file == 'nopic.jpg' || $file == 'nopic_ico.jpg') {
-                        @copy($sSourceFile, $sTargetFile);
+                        @\copy($sSourceFile, $sTargetFile);
                     }
                 }
             }
         }
-        closedir($handle);
+        \closedir($handle);
     }
 
     /**
@@ -207,8 +207,8 @@ class UtilsFile extends \OxidEsales\Eshop\Core\Base
      */
     public function deleteDir($sSourceDir)
     {
-        if (is_dir($sSourceDir)) {
-            if ($oDir = dir($sSourceDir)) {
+        if (\is_dir($sSourceDir)) {
+            if ($oDir = \dir($sSourceDir)) {
                 while (false !== $sFile = $oDir->read()) {
                     if ($sFile == '.' || $sFile == '..') {
                         continue;
@@ -223,10 +223,10 @@ class UtilsFile extends \OxidEsales\Eshop\Core\Base
 
                 $oDir->close();
 
-                return rmdir($sSourceDir);
+                return \rmdir($sSourceDir);
             }
-        } elseif (file_exists($sSourceDir)) {
-            return unlink($sSourceDir);
+        } elseif (\file_exists($sSourceDir)) {
+            return \unlink($sSourceDir);
         }
     }
 
@@ -240,14 +240,14 @@ class UtilsFile extends \OxidEsales\Eshop\Core\Base
     public function readRemoteFileAsString($sPath)
     {
         $sRet = '';
-        $hFile = @fopen($sPath, 'r');
+        $hFile = @\fopen($sPath, 'r');
         if ($hFile) {
-            socket_set_timeout($hFile, 2);
-            while (!feof($hFile)) {
-                $sLine = fgets($hFile, 4096);
+            \socket_set_timeout($hFile, 2);
+            while (!\feof($hFile)) {
+                $sLine = \fgets($hFile, 4096);
                 $sRet .= $sLine;
             }
-            fclose($hFile);
+            \fclose($hFile);
         }
 
         return $sRet;
@@ -269,24 +269,24 @@ class UtilsFile extends \OxidEsales\Eshop\Core\Base
     {
         if ($sValue) {
             // add type to name
-            $aFilename = explode(".", $sValue);
+            $aFilename = \explode(".", $sValue);
 
-            $sFileType = trim($aFilename[count($aFilename) - 1]);
+            $sFileType = \trim($aFilename[\count($aFilename) - 1]);
 
             if (isset($sFileType)) {
                 // unallowed files ?
-                if (in_array($sFileType, $this->_aBadFiles) || ($blDemo && !in_array($sFileType, $this->_aAllowedFiles))) {
+                if (\in_array($sFileType, $this->_aBadFiles) || ($blDemo && !\in_array($sFileType, $this->_aAllowedFiles))) {
                     \OxidEsales\Eshop\Core\Registry::getUtils()->showMessageAndExit("File didn't pass our allowed files filter.");
                 }
 
                 // removing file type
-                if (count($aFilename) > 0) {
-                    unset($aFilename[count($aFilename) - 1]);
+                if (\count($aFilename) > 0) {
+                    unset($aFilename[\count($aFilename) - 1]);
                 }
 
                 $sFName = '';
                 if (isset($aFilename[0])) {
-                    $sFName = Str::getStr()->preg_replace('/[^a-zA-Z0-9()_\.-]/', '', implode('.', $aFilename));
+                    $sFName = Str::getStr()->preg_replace('/[^a-zA-Z0-9()_\.-]/', '', \implode('.', $aFilename));
                 }
 
                 $sValue = $this->_getUniqueFileName($sImagePath, "{$sFName}", $sFileType, "", $blUnique);
@@ -306,7 +306,7 @@ class UtilsFile extends \OxidEsales\Eshop\Core\Base
      */
     protected function _getImagePath($sType) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
-        $sFolder = array_key_exists($sType, $this->_aTypeToPath) ? $this->_aTypeToPath[$sType] : '0';
+        $sFolder = \array_key_exists($sType, $this->_aTypeToPath) ? $this->_aTypeToPath[$sType] : '0';
 
         return $this->normalizeDir(\OxidEsales\Eshop\Core\Registry::getConfig()->getPictureDir(false)) . "{$sFolder}/";
     }
@@ -339,7 +339,7 @@ class UtilsFile extends \OxidEsales\Eshop\Core\Base
                 break;
         }
         if ($sSize) {
-            return explode('*', $sSize);
+            return \explode('*', $sSize);
         }
     }
 
@@ -354,17 +354,17 @@ class UtilsFile extends \OxidEsales\Eshop\Core\Base
      */
     protected function _copyFile($sSource, $sTarget) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
-        if (!is_dir(dirname($sTarget))) {
-            mkdir(dirname($sTarget), 0744, true);
+        if (!\is_dir(\dirname($sTarget))) {
+            \mkdir(\dirname($sTarget), 0744, true);
         }
 
         $blDone = true;
         if ($sSource !== $sTarget) {
-            $blDone = copy($sSource, $sTarget);
+            $blDone = \copy($sSource, $sTarget);
         }
 
         if ($blDone) {
-            $blDone = @chmod($sTarget, 0644);
+            $blDone = @\chmod($sTarget, 0644);
         }
 
         return $blDone;
@@ -381,17 +381,17 @@ class UtilsFile extends \OxidEsales\Eshop\Core\Base
      */
     protected function _moveImage($sSource, $sTarget) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
-        if (!is_dir(dirname($sTarget))) {
-            mkdir(dirname($sTarget), 0744, true);
+        if (!\is_dir(\dirname($sTarget))) {
+            \mkdir(\dirname($sTarget), 0744, true);
         }
 
         $blDone = true;
         if ($sSource !== $sTarget) {
-            $blDone = move_uploaded_file($sSource, $sTarget);
+            $blDone = \move_uploaded_file($sSource, $sTarget);
         }
 
         if ($blDone) {
-            $blDone = @chmod($sTarget, 0644);
+            $blDone = @\chmod($sTarget, 0644);
         }
 
         return $blDone;
@@ -429,11 +429,11 @@ class UtilsFile extends \OxidEsales\Eshop\Core\Base
             foreach ($aFiles['myfile']['name'] as $sKey => $sValue) {
                 $sSource = $aSource[$sKey];
                 $iError = $aError[$sKey];
-                $aFiletype = explode("@", $sKey);
+                $aFiletype = \explode("@", $sKey);
                 $sKey = $aFiletype[1];
                 $sType = $aFiletype[0];
 
-                $sValue = strtolower($sValue);
+                $sValue = \strtolower($sValue);
                 $sImagePath = $this->_getImagePath($sType);
 
                 // Should translate error to user if file was uploaded
@@ -447,7 +447,7 @@ class UtilsFile extends \OxidEsales\Eshop\Core\Base
                 if ($sSource && ($sValue = $this->_prepareImageName($sValue, $sType, $blDemo, $sImagePath, $blUnique))) {
                     // moving to tmp folder for processing as safe mode or spec. open_basedir setup
                     // usually does not allow file modification in php's temp folder
-                    $sProcessPath = $sTmpFolder . basename($sSource);
+                    $sProcessPath = $sTmpFolder . \basename($sSource);
 
                     if ($sProcessPath) {
                         if ($blUseMasterImage) {
@@ -492,7 +492,7 @@ class UtilsFile extends \OxidEsales\Eshop\Core\Base
         }
 
         $blRet = true;
-        if (!is_readable($sFile)) {
+        if (!\is_readable($sFile)) {
             $blRet = $this->urlValidate($sFile);
         }
 
@@ -546,15 +546,15 @@ class UtilsFile extends \OxidEsales\Eshop\Core\Base
             throw oxNew(\OxidEsales\Eshop\Core\Exception\StandardException::class, 'EXCEPTION_FILEUPLOADERROR_' . ((int) $aFileInfo['error']));
         }
 
-        $aPathInfo = pathinfo($aFileInfo['name']);
+        $aPathInfo = \pathinfo($aFileInfo['name']);
 
         $sExt = $aPathInfo['extension'];
         $sFileName = $aPathInfo['filename'];
 
         $aAllowedUploadTypes = (array) \OxidEsales\Eshop\Core\Registry::getConfig()->getConfigParam('aAllowedUploadTypes');
-        $aAllowedUploadTypes = array_map("strtolower", $aAllowedUploadTypes);
+        $aAllowedUploadTypes = \array_map("strtolower", $aAllowedUploadTypes);
 
-        if (!in_array(strtolower($sExt), $aAllowedUploadTypes)) {
+        if (!\in_array(\strtolower($sExt), $aAllowedUploadTypes)) {
             throw oxNew(\OxidEsales\Eshop\Core\Exception\StandardException::class, 'EXCEPTION_NOTALLOWEDTYPE');
         }
 
@@ -588,7 +588,7 @@ class UtilsFile extends \OxidEsales\Eshop\Core\Base
         $oStr = Str::getStr();
 
         //file exists ?
-        while ($blUnique && file_exists($sFilePath . "/" . $sFileName . $sSufix . "." . $sFileExt)) {
+        while ($blUnique && \file_exists($sFilePath . "/" . $sFileName . $sSufix . "." . $sFileExt)) {
             $iFileCounter++;
 
             //removing "(any digit)" from file name end
@@ -610,11 +610,11 @@ class UtilsFile extends \OxidEsales\Eshop\Core\Base
      */
     public function getImageDirByType($sType, $blGenerated = false)
     {
-        $sFolder = array_key_exists($sType, $this->_aTypeToPath) ? $this->_aTypeToPath[$sType] : '0';
+        $sFolder = \array_key_exists($sType, $this->_aTypeToPath) ? $this->_aTypeToPath[$sType] : '0';
         $sDir = $this->normalizeDir($sFolder);
 
         if ($blGenerated === true) {
-            $sDir = str_replace('master/', 'generated/', $sDir);
+            $sDir = \str_replace('master/', 'generated/', $sDir);
         }
 
         return $sDir;
@@ -644,7 +644,7 @@ class UtilsFile extends \OxidEsales\Eshop\Core\Base
      */
     private function isUrlSchemaValid(string $url): bool
     {
-        return filter_var($url, FILTER_VALIDATE_URL) === false ? false : true;
+        return \filter_var($url, FILTER_VALIDATE_URL) === false ? false : true;
     }
 
     /**
@@ -653,14 +653,14 @@ class UtilsFile extends \OxidEsales\Eshop\Core\Base
      */
     private function isUrlAccessible(string $url): bool
     {
-        $curl = curl_init($url);
+        $curl = \curl_init($url);
 
-        curl_setopt($curl, CURLOPT_NOBODY, true);
+        \curl_setopt($curl, CURLOPT_NOBODY, true);
 
-        $result = curl_exec($curl);
+        $result = \curl_exec($curl);
 
         if ($result !== false) {
-            $statusCode = curl_getinfo($curl, CURLINFO_HTTP_CODE);
+            $statusCode = \curl_getinfo($curl, CURLINFO_HTTP_CODE);
 
             if ($statusCode === 200) {
                 return true;

--- a/source/Core/UtilsObject.php
+++ b/source/Core/UtilsObject.php
@@ -87,7 +87,7 @@ class UtilsObject
     public static function getInstance()
     {
         // disable caching for test modules
-        if (defined('OXID_PHP_UNIT')) {
+        if (\defined('OXID_PHP_UNIT')) {
             static::$_instance = null;
         }
 
@@ -144,7 +144,7 @@ class UtilsObject
         }
 
         //looping due to possible memory "leak".
-        if (is_array(static::$_aInstanceCache)) {
+        if (\is_array(static::$_aInstanceCache)) {
             foreach (static::$_aInstanceCache as $key => $instance) {
                 unset(static::$_aInstanceCache[$key]);
             }
@@ -193,32 +193,32 @@ class UtilsObject
      */
     public function oxNew($className, ...$arguments)
     {
-        $argumentsCount = count($arguments);
+        $argumentsCount = \count($arguments);
         $shouldUseCache = $this->shouldCacheObject($className, $arguments);
         if (!\OxidEsales\Eshop\Core\NamespaceInformationProvider::isNamespacedClass($className)) {
-            $className = strtolower($className);
+            $className = \strtolower($className);
         }
 
         //Get storage key as the class might be aliased.
         $storageKey = Registry::getStorageKey($className);
 
         //UtilsObject::$_aClassInstances is only intended to be used in unit tests.
-        if (defined('OXID_PHP_UNIT') && isset(static::$_aClassInstances[$storageKey])) {
+        if (\defined('OXID_PHP_UNIT') && isset(static::$_aClassInstances[$storageKey])) {
             return static::$_aClassInstances[$storageKey];
         }
-        if (!defined('OXID_PHP_UNIT') && $shouldUseCache) {
-            $cacheKey = ($argumentsCount) ? $storageKey . md5(serialize($arguments)) : $storageKey;
+        if (!\defined('OXID_PHP_UNIT') && $shouldUseCache) {
+            $cacheKey = ($argumentsCount) ? $storageKey . \md5(\serialize($arguments)) : $storageKey;
             if (isset(static::$_aInstanceCache[$cacheKey])) {
                 return clone static::$_aInstanceCache[$cacheKey];
             }
         }
 
-        if (!defined('OXID_PHP_UNIT') && isset($this->_aClassNameCache[$className])) {
+        if (!\defined('OXID_PHP_UNIT') && isset($this->_aClassNameCache[$className])) {
             $realClassName = $this->_aClassNameCache[$className];
         } else {
             $realClassName = $this->getClassName($className);
             //expect __autoload() (oxfunctions.php) to do its job when class_exists() is called
-            if (!class_exists($realClassName)) {
+            if (!\class_exists($realClassName)) {
                 $exception =  new \OxidEsales\Eshop\Core\Exception\SystemComponentException();
                 /** Use setMessage here instead of passing it in constructor in order to test exception message */
                 $exception->setMessage('EXCEPTION_SYSTEMCOMPONENT_CLASSNOTFOUND' . ' ' . $realClassName);
@@ -243,7 +243,7 @@ class UtilsObject
      */
     public function generateUId()
     {
-        return md5(uniqid('', true) . '|' . microtime());
+        return \md5(\uniqid('', true) . '|' . \microtime());
     }
 
     /**
@@ -308,7 +308,7 @@ class UtilsObject
      */
     protected function getClassNameProvider()
     {
-        if (is_null($this->classNameProvider)) {
+        if (\is_null($this->classNameProvider)) {
             $backwardsCompatibleClassMap = include 'Autoload/BackwardsCompatibilityClassMap.php';
             $this->classNameProvider = new BackwardsCompatibleClassNameProvider($backwardsCompatibleClassMap);
         }
@@ -320,7 +320,7 @@ class UtilsObject
      */
     protected function getModuleChainsGenerator()
     {
-        if (is_null($this->moduleChainsGenerator)) {
+        if (\is_null($this->moduleChainsGenerator)) {
             $subShopSpecificCache = new \OxidEsales\Eshop\Core\SubShopSpecificFileCache($this->getShopIdCalculator());
             $moduleVariablesLocator = new \OxidEsales\Eshop\Core\Module\ModuleVariablesLocator($subShopSpecificCache, $this->getShopIdCalculator());
             $this->moduleChainsGenerator = new \OxidEsales\Eshop\Core\Module\ModuleChainsGenerator($moduleVariablesLocator);
@@ -333,7 +333,7 @@ class UtilsObject
      */
     protected function getShopIdCalculator()
     {
-        if (is_null($this->shopIdCalculator)) {
+        if (\is_null($this->shopIdCalculator)) {
             $moduleVariablesCache = new \OxidEsales\Eshop\Core\FileCache();
             $this->shopIdCalculator = new \OxidEsales\Eshop\Core\ShopIdCalculator($moduleVariablesCache);
         }
@@ -351,6 +351,6 @@ class UtilsObject
      */
     protected function shouldCacheObject($className, $arguments)
     {
-        return count($arguments) < 2 && (!isset($arguments[0]) || is_scalar($arguments[0]));
+        return \count($arguments) < 2 && (!isset($arguments[0]) || \is_scalar($arguments[0]));
     }
 }

--- a/source/Core/UtilsPic.php
+++ b/source/Core/UtilsPic.php
@@ -36,7 +36,7 @@ class UtilsPic extends \OxidEsales\Eshop\Core\Base
      */
     public function resizeImage($sSrc, $sTarget, $iDesiredWidth, $iDesiredHeight)
     {
-        if (file_exists($sSrc) && ($aImageInfo = @getimagesize($sSrc))) {
+        if (\file_exists($sSrc) && ($aImageInfo = @\getimagesize($sSrc))) {
             $myConfig = \OxidEsales\Eshop\Core\Registry::getConfig();
             list($iWidth, $iHeight) = calcImageSize($iDesiredWidth, $iDesiredHeight, $aImageInfo[0], $aImageInfo[1]);
 
@@ -81,22 +81,22 @@ class UtilsPic extends \OxidEsales\Eshop\Core\Base
         $myConfig = \OxidEsales\Eshop\Core\Registry::getConfig();
 
         if (
-            !$myConfig->isDemoShop() && (strpos($sPicName, 'nopic.jpg') === false ||
-                                         strpos($sPicName, 'nopic_ico.jpg') === false)
+            !$myConfig->isDemoShop() && (\strpos($sPicName, 'nopic.jpg') === false ||
+                                         \strpos($sPicName, 'nopic_ico.jpg') === false)
         ) {
             $sFile = "$sAbsDynImageDir/$sPicName";
 
-            if (file_exists($sFile) && is_file($sFile)) {
-                $blDeleted = unlink($sFile);
+            if (\file_exists($sFile) && \is_file($sFile)) {
+                $blDeleted = \unlink($sFile);
             }
 
             if (!$myConfig->getConfigParam('sAltImageUrl')) {
                 // deleting various size generated images
-                $sGenPath = str_replace('/master/', '/generated/', $sAbsDynImageDir);
-                $aFiles = glob("{$sGenPath}*/{$sPicName}");
-                if (is_array($aFiles)) {
+                $sGenPath = \str_replace('/master/', '/generated/', $sAbsDynImageDir);
+                $aFiles = \glob("{$sGenPath}*/{$sPicName}");
+                if (\is_array($aFiles)) {
                     foreach ($aFiles as $sFile) {
-                        $blDeleted = unlink($sFile);
+                        $blDeleted = \unlink($sFile);
                     }
                 }
             }
@@ -119,7 +119,7 @@ class UtilsPic extends \OxidEsales\Eshop\Core\Base
      */
     protected function _isPicDeletable($sPicName, $sTable, $sField) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
-        if (!$sPicName || strpos($sPicName, 'nopic.jpg') !== false || strpos($sPicName, 'nopic_ico.jpg') !== false) {
+        if (!$sPicName || \strpos($sPicName, 'nopic.jpg') !== false || \strpos($sPicName, 'nopic_ico.jpg') !== false) {
             return false;
         }
 
@@ -220,7 +220,7 @@ class UtilsPic extends \OxidEsales\Eshop\Core\Base
         switch ($aImageInfo[2]) { //Image type
             case ($this->_aImageTypes["GIF"]):
                 //php does not process gifs until 7th July 2004 (see lzh licensing)
-                if (function_exists("imagegif")) {
+                if (\function_exists("imagegif")) {
                     $blSuccess = resizeGif($sSrc, $sTarget, $iNewWidth, $iNewHeight, $aImageInfo[0], $aImageInfo[1], $iGdVer);
                 }
                 break;
@@ -234,7 +234,7 @@ class UtilsPic extends \OxidEsales\Eshop\Core\Base
         }
 
         if ($blSuccess && !$blDisableTouch) {
-            @touch($sTarget);
+            @\touch($sTarget);
         }
 
         stopProfile("PICTURE_RESIZE");
@@ -261,7 +261,7 @@ class UtilsPic extends \OxidEsales\Eshop\Core\Base
     {
         $blSuccess = copyAlteredImage($sDestinationImage, $sSourceImage, $iNewWidth, $iNewHeight, $aImageInfo, $sTarget, $iGdVer);
         if (!$blDisableTouch && $blSuccess) {
-            @touch($sTarget);
+            @\touch($sTarget);
         }
 
         return $blSuccess;

--- a/source/Core/UtilsServer.php
+++ b/source/Core/UtilsServer.php
@@ -56,14 +56,14 @@ class UtilsServer extends \OxidEsales\Eshop\Core\Base
             $this->_saveSessionCookie($sName, $sValue, $iExpire, $sPath, $sDomain);
         }
 
-        if (defined('OXID_PHP_UNIT') || php_sapi_name() === 'cli') {
+        if (\defined('OXID_PHP_UNIT') || \php_sapi_name() === 'cli') {
             // do NOT set cookies in php unit or in cli because it would issue warnings
             return;
         }
         $config = \OxidEsales\Eshop\Core\Registry::getConfig();
         //if shop runs in https only mode we can set secure flag to all cookies
         $blSecure = $blSecure || ($config->isSsl() && $config->getSslShopUrl() == $config->getShopUrl());
-        return setcookie(
+        return \setcookie(
             $sName,
             $sValue,
             $iExpire,
@@ -91,8 +91,8 @@ class UtilsServer extends \OxidEsales\Eshop\Core\Base
             if ($sSslUrl = $myConfig->getSslShopUrl()) {
                 $sUrl = $myConfig->getShopUrl();
 
-                $sHost = parse_url($sUrl, PHP_URL_HOST);
-                $sSslHost = parse_url($sSslUrl, PHP_URL_HOST);
+                $sHost = \parse_url($sUrl, PHP_URL_HOST);
+                $sSslHost = \parse_url($sSslUrl, PHP_URL_HOST);
 
                 // testing if domains matches..
                 if ($sHost != $sSslHost) {
@@ -250,7 +250,7 @@ class UtilsServer extends \OxidEsales\Eshop\Core\Base
     {
         if (isset($_SERVER["HTTP_X_FORWARDED_FOR"])) {
             $sIP = $_SERVER["HTTP_X_FORWARDED_FOR"];
-            $sIP = preg_replace('/,.*$/', '', $sIP);
+            $sIP = \preg_replace('/,.*$/', '', $sIP);
         } elseif (isset($_SERVER["HTTP_CLIENT_IP"])) {
             $sIP = $_SERVER["HTTP_CLIENT_IP"];
         } else {
@@ -295,13 +295,13 @@ class UtilsServer extends \OxidEsales\Eshop\Core\Base
         $myConfig = \OxidEsales\Eshop\Core\Registry::getConfig();
         $shopId = $shopId ?? $myConfig->getShopId();
         $sSslUrl = $myConfig->getSslShopUrl();
-        if (stripos($sSslUrl, 'https') === 0) {
+        if (\stripos($sSslUrl, 'https') === 0) {
             $blSsl = true;
         } else {
             $blSsl = false;
         }
 
-        $this->_aUserCookie[$shopId] = $userName . '@@@' . crypt($passwordHash, $salt);
+        $this->_aUserCookie[$shopId] = $userName . '@@@' . \crypt($passwordHash, $salt);
         $this->setOxCookie('oxid_' . $shopId, $this->_aUserCookie[$shopId], \OxidEsales\Eshop\Core\Registry::getUtilsDate()->getTime() + $timeout, '/', null, true, $blSsl);
         $this->setOxCookie('oxid_' . $shopId . '_autologin', '1', \OxidEsales\Eshop\Core\Registry::getUtilsDate()->getTime() + $timeout, '/', null, true, false);
     }
@@ -316,7 +316,7 @@ class UtilsServer extends \OxidEsales\Eshop\Core\Base
         $myConfig = \OxidEsales\Eshop\Core\Registry::getConfig();
         $sShopId = (!$sShopId) ? \OxidEsales\Eshop\Core\Registry::getConfig()->getShopId() : $sShopId;
         $sSslUrl = $myConfig->getSslShopUrl();
-        if (stripos($sSslUrl, 'https') === 0) {
+        if (\stripos($sSslUrl, 'https') === 0) {
             $blSsl = true;
         } else {
             $blSsl = false;
@@ -340,13 +340,13 @@ class UtilsServer extends \OxidEsales\Eshop\Core\Base
         $sShopId = (!$sShopId) ? $myConfig->getShopId() : $sShopId;
         // check for SSL connection
         if (!$myConfig->isSsl() && $this->getOxCookie('oxid_' . $sShopId . '_autologin') == '1') {
-            $sSslUrl = rtrim($myConfig->getSslShopUrl(), '/') . $_SERVER['REQUEST_URI'];
-            if (stripos($sSslUrl, 'https') === 0) {
+            $sSslUrl = \rtrim($myConfig->getSslShopUrl(), '/') . $_SERVER['REQUEST_URI'];
+            if (\stripos($sSslUrl, 'https') === 0) {
                 \OxidEsales\Eshop\Core\Registry::getUtils()->redirect($sSslUrl, true, 302);
             }
         }
 
-        if (array_key_exists($sShopId, $this->_aUserCookie) && $this->_aUserCookie[$sShopId] !== null) {
+        if (\array_key_exists($sShopId, $this->_aUserCookie) && $this->_aUserCookie[$sShopId] !== null) {
             return $this->_aUserCookie[$sShopId] ? $this->_aUserCookie[$sShopId] : null;
         }
 
@@ -363,8 +363,8 @@ class UtilsServer extends \OxidEsales\Eshop\Core\Base
     {
         $blTrusted = false;
         $aTrustedIPs = (array) \OxidEsales\Eshop\Core\Registry::getConfig()->getConfigParam("aTrustedIPs");
-        if (count($aTrustedIPs)) {
-            $blTrusted = in_array($this->getRemoteAddress(), $aTrustedIPs);
+        if (\count($aTrustedIPs)) {
+            $blTrusted = \in_array($this->getRemoteAddress(), $aTrustedIPs);
         }
 
         return $blTrusted;
@@ -396,7 +396,7 @@ class UtilsServer extends \OxidEsales\Eshop\Core\Base
     public function isCurrentUrl($sURL)
     {
         // Missing protocol, cannot proceed, assuming true.
-        if (!$sURL || (strpos($sURL, "http") !== 0)) {
+        if (!$sURL || (\strpos($sURL, "http") !== 0)) {
             return true;
         }
 
@@ -427,22 +427,22 @@ class UtilsServer extends \OxidEsales\Eshop\Core\Base
     public function _isCurrentUrl($sURL, $sServerHost) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         // #4010: force_sid added in https to every link
-        preg_match("/^(https?:\/\/)?(www\.)?([^\/]+)/i", $sURL, $matches);
+        \preg_match("/^(https?:\/\/)?(www\.)?([^\/]+)/i", $sURL, $matches);
         $sUrlHost = isset($matches[3]) ? $matches[3] : null;
 
-        preg_match("/^(https?:\/\/)?(www\.)?([^\/]+)/i", $sServerHost, $matches);
+        \preg_match("/^(https?:\/\/)?(www\.)?([^\/]+)/i", $sServerHost, $matches);
         $sRealHost =  isset($matches[3]) ? $matches[3] : null;
 
 
         //fetch the path from SCRIPT_NAME and ad it to the $sServerHost
         $sScriptName = $this->getServerVar('SCRIPT_NAME');
-        $sCurrentHost = preg_replace('/\/(modules\/[\w\/]*)?\w*\.php.*/', '', $sServerHost . $sScriptName);
+        $sCurrentHost = \preg_replace('/\/(modules\/[\w\/]*)?\w*\.php.*/', '', $sServerHost . $sScriptName);
 
         //remove double slashes all the way
-        $sCurrentHost = str_replace('/', '', $sCurrentHost);
-        $sURL = str_replace('/', '', $sURL);
+        $sCurrentHost = \str_replace('/', '', $sCurrentHost);
+        $sURL = \str_replace('/', '', $sURL);
 
-        if ($sURL && $sCurrentHost && strpos($sURL, $sCurrentHost) !== false) {
+        if ($sURL && $sCurrentHost && \strpos($sURL, $sCurrentHost) !== false) {
             //bug fix #0002991
             if ($sUrlHost == $sRealHost) {
                 return true;
@@ -459,7 +459,7 @@ class UtilsServer extends \OxidEsales\Eshop\Core\Base
      */
     public function getServerNodeId()
     {
-        return md5($this->getServerName() . $this->getServerIp());
+        return \md5($this->getServerName() . $this->getServerIp());
     }
 
     /**
@@ -479,6 +479,6 @@ class UtilsServer extends \OxidEsales\Eshop\Core\Base
      */
     private function getServerName()
     {
-        return php_uname();
+        return \php_uname();
     }
 }

--- a/source/Core/UtilsString.php
+++ b/source/Core/UtilsString.php
@@ -32,7 +32,7 @@ class UtilsString
     {
         $oStr = Str::getStr();
         if ($oStr->strstr($sInField, '"')) {
-            return '"' . str_replace('"', '""', $sInField) . '"';
+            return '"' . \str_replace('"', '""', $sInField) . '"';
         } elseif ($oStr->strstr($sInField, ';')) {
             return '"' . $sInField . '"';
         }
@@ -53,7 +53,7 @@ class UtilsString
     public function minimizeTruncateString($sString, $iLength)
     {
         //leading and ending whitespaces
-        $sString = trim($sString);
+        $sString = \trim($sString);
         $oStr = Str::getStr();
 
         //multiple whitespaces

--- a/source/Core/UtilsUrl.php
+++ b/source/Core/UtilsUrl.php
@@ -153,19 +153,19 @@ class UtilsUrl extends \OxidEsales\Eshop\Core\Base
         $paramSeparator = self::PARAMETER_SEPARATOR;
         $finalParameters = $this->removeNotSetParameters($parametersToAdd);
 
-        if (is_array($finalParameters) && !empty($finalParameters)) {
+        if (\is_array($finalParameters) && !empty($finalParameters)) {
             $urlWithoutQuery = $sUrl;
-            $separatorPlace = strpos($sUrl, '?');
+            $separatorPlace = \strpos($sUrl, '?');
             if ($separatorPlace !== false) {
-                $urlWithoutQuery = substr($sUrl, 0, $separatorPlace);
-                $urlQueryEscaped = substr($sUrl, $separatorPlace + 1);
-                $urlQuery = str_replace($paramSeparator, '&', $urlQueryEscaped);
+                $urlWithoutQuery = \substr($sUrl, 0, $separatorPlace);
+                $urlQueryEscaped = \substr($sUrl, $separatorPlace + 1);
+                $urlQuery = \str_replace($paramSeparator, '&', $urlQueryEscaped);
 
                 $finalParameters = $this->mergeDuplicatedParameters($finalParameters, $urlQuery, $allowParameterOverwrite);
             }
 
             $sUrl = $this->appendParamSeparator($urlWithoutQuery);
-            $sUrl .= http_build_query($finalParameters, null, $paramSeparator);
+            $sUrl .= \http_build_query($finalParameters, null, $paramSeparator);
         }
 
         if ($sUrl && !$blFinalUrl) {
@@ -186,10 +186,10 @@ class UtilsUrl extends \OxidEsales\Eshop\Core\Base
     public function cleanUrl($sUrl, $aParams = null)
     {
         $oStr = Str::getStr();
-        if (is_array($aParams)) {
+        if (\is_array($aParams)) {
             foreach ($aParams as $sParam) {
                 $sUrl = $oStr->preg_replace(
-                    '/(\?|&(amp;)?)' . preg_quote($sParam) . '=[a-z0-9\.]+&?(amp;)?/i',
+                    '/(\?|&(amp;)?)' . \preg_quote($sParam) . '=[a-z0-9\.]+&?(amp;)?/i',
                     '\1',
                     $sUrl
                 );
@@ -198,7 +198,7 @@ class UtilsUrl extends \OxidEsales\Eshop\Core\Base
             $sUrl = $oStr->preg_replace('/(\?|&(amp;)?).+/i', '\1', $sUrl);
         }
 
-        return trim($sUrl, "?");
+        return \trim($sUrl, "?");
     }
 
 
@@ -211,7 +211,7 @@ class UtilsUrl extends \OxidEsales\Eshop\Core\Base
      */
     public function addShopHost($sUrl)
     {
-        if (!preg_match("#^https?://#i", $sUrl)) {
+        if (!\preg_match("#^https?://#i", $sUrl)) {
             $sShopUrl = \OxidEsales\Eshop\Core\Registry::getConfig()->getSslShopUrl();
             $sUrl = $sShopUrl . $sUrl;
         }
@@ -322,9 +322,9 @@ class UtilsUrl extends \OxidEsales\Eshop\Core\Base
     public function isCurrentShopHost($sUrl)
     {
         $blCurrent = false;
-        $sUrlHost = @parse_url($sUrl, PHP_URL_HOST);
+        $sUrlHost = @\parse_url($sUrl, PHP_URL_HOST);
         // checks if it is relative url.
-        if (is_null($sUrlHost)) {
+        if (\is_null($sUrlHost)) {
             $blCurrent = true;
         } else {
             $aHosts = $this->_getHosts();
@@ -351,11 +351,11 @@ class UtilsUrl extends \OxidEsales\Eshop\Core\Base
      */
     private function parseUrlAndAppendSchema($url, $flag, $appendScheme = 'http')
     {
-        if (!filter_var($url, FILTER_VALIDATE_URL)) {
+        if (!\filter_var($url, FILTER_VALIDATE_URL)) {
             $url = $appendScheme . '://' . $url;
         }
 
-        return parse_url($url, $flag);
+        return \parse_url($url, $flag);
     }
 
     /**
@@ -387,10 +387,10 @@ class UtilsUrl extends \OxidEsales\Eshop\Core\Base
      */
     public function cleanUrlParams($sUrl, $sConnector = '&amp;')
     {
-        $aUrlParts = explode('?', $sUrl);
+        $aUrlParts = \explode('?', $sUrl);
 
         // check for params part
-        if (!is_array($aUrlParts) || count($aUrlParts) != 2) {
+        if (!\is_array($aUrlParts) || \count($aUrlParts) != 2) {
             return $sUrl;
         }
 
@@ -405,11 +405,11 @@ class UtilsUrl extends \OxidEsales\Eshop\Core\Base
         );
 
         // remove duplicate entries
-        parse_str($sUrlParams, $aUrlParams);
-        $sUrl .= '?' . http_build_query($aUrlParams, '', $sConnector);
+        \parse_str($sUrlParams, $aUrlParams);
+        $sUrl .= '?' . \http_build_query($aUrlParams, '', $sConnector);
 
         // replace brackets
-        $sUrl = str_replace(
+        $sUrl = \str_replace(
             ['%5B', '%5D'],
             ['[', ']'],
             $sUrl
@@ -469,12 +469,12 @@ class UtilsUrl extends \OxidEsales\Eshop\Core\Base
     {
         // url building
         // replace possible ampersands, explode, and filter out empty values
-        $sValue = str_replace("&amp;", "&", $sValue);
-        $aNavParams = explode("&", $sValue);
-        $aNavParams = array_filter($aNavParams);
+        $sValue = \str_replace("&amp;", "&", $sValue);
+        $aNavParams = \explode("&", $sValue);
+        $aNavParams = \array_filter($aNavParams);
         $aParams = [];
         foreach ($aNavParams as $sValue) {
-            $exp = explode("=", $sValue);
+            $exp = \explode("=", $sValue);
             $aParams[$exp[0]] = $exp[1];
         }
 
@@ -502,8 +502,8 @@ class UtilsUrl extends \OxidEsales\Eshop\Core\Base
      */
     protected function _addHost($sUrl, &$aHosts) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
-        if ($sUrl && ($sHost = @parse_url($sUrl, PHP_URL_HOST))) {
-            if (!in_array($sHost, $aHosts)) {
+        if ($sUrl && ($sHost = @\parse_url($sUrl, PHP_URL_HOST))) {
+            if (!\in_array($sHost, $aHosts)) {
                 $aHosts[] = $sHost;
             }
         }
@@ -595,9 +595,9 @@ class UtilsUrl extends \OxidEsales\Eshop\Core\Base
      */
     private function removeNotSetParameters($parametersToAdd)
     {
-        if (is_array($parametersToAdd) && !empty($parametersToAdd)) {
+        if (\is_array($parametersToAdd) && !empty($parametersToAdd)) {
             foreach ($parametersToAdd as $key => $value) {
-                if (is_null($value)) {
+                if (\is_null($value)) {
                     unset($parametersToAdd[$key]);
                 }
             }
@@ -615,12 +615,12 @@ class UtilsUrl extends \OxidEsales\Eshop\Core\Base
      */
     private function mergeDuplicatedParameters($aAddParams, $query, $allowParameterOverwrite = true)
     {
-        parse_str($query, $currentUrlParameters);
+        \parse_str($query, $currentUrlParameters);
         if ($allowParameterOverwrite) {
-            $newParameters = array_merge($currentUrlParameters, $aAddParams);
+            $newParameters = \array_merge($currentUrlParameters, $aAddParams);
         } else {
-            $newFilteredParameters = array_diff_key($aAddParams, $currentUrlParameters);
-            $newParameters = array_merge($currentUrlParameters, $newFilteredParameters);
+            $newFilteredParameters = \array_diff_key($aAddParams, $currentUrlParameters);
+            $newParameters = \array_merge($currentUrlParameters, $newFilteredParameters);
         }
 
         return $newParameters;

--- a/source/Core/UtilsView.php
+++ b/source/Core/UtilsView.php
@@ -111,12 +111,12 @@ class UtilsView extends \OxidEsales\Eshop\Core\Base
 
         // assign
         $viewData = $oObject->getViewData();
-        if (is_array($viewData)) {
-            foreach (array_keys($viewData) as $viewName) {
+        if (\is_array($viewData)) {
+            foreach (\array_keys($viewData) as $viewName) {
                 // show debug information
                 if ($debugMode == 4) {
                     echo("TemplateData[$viewName] : \n");
-                    var_export($viewData[$viewName]);
+                    \var_export($viewData[$viewName]);
                 }
             }
         } else {
@@ -134,10 +134,10 @@ class UtilsView extends \OxidEsales\Eshop\Core\Base
      */
     public function passAllErrorsToView(&$aView, $errors)
     {
-        if (count($errors) > 0) {
+        if (\count($errors) > 0) {
             foreach ($errors as $sLocation => $aEx2) {
                 foreach ($aEx2 as $sKey => $oEr) {
-                    $aView['Errors'][$sLocation][$sKey] = unserialize($oEr);
+                    $aView['Errors'][$sLocation][$sKey] = \unserialize($oEr);
                 }
             }
         }
@@ -204,7 +204,7 @@ class UtilsView extends \OxidEsales\Eshop\Core\Base
         }
 
         if ($exception) {
-            $sessionErrors[$destination][] = serialize($exception);
+            $sessionErrors[$destination][] = \serialize($exception);
             \OxidEsales\Eshop\Core\Registry::getSession()->setVariable('Errors', $sessionErrors);
 
             if ($activeController == '') {
@@ -262,7 +262,7 @@ class UtilsView extends \OxidEsales\Eshop\Core\Base
     {
         startProfile("parseThroughSmarty");
 
-        if (!is_array($sDesc) && strpos($sDesc, "[{") === false) {
+        if (!\is_array($sDesc) && \strpos($sDesc, "[{") === false) {
             stopProfile("parseThroughSmarty");
 
             return $sDesc;
@@ -273,7 +273,7 @@ class UtilsView extends \OxidEsales\Eshop\Core\Base
             $oActView->addGlobalParams();
         }
 
-        if (is_array($sDesc)) {
+        if (\is_array($sDesc)) {
             foreach ($sDesc as $name => $aData) {
                 $result[$name] = $this->getRenderedContent($aData[1], $oActView->getViewData(), $sOxid);
             }
@@ -293,7 +293,7 @@ class UtilsView extends \OxidEsales\Eshop\Core\Base
      */
     public function setTemplateDir($templatesDirectory)
     {
-        if ($templatesDirectory && !in_array($templatesDirectory, $this->_aTemplateDir)) {
+        if ($templatesDirectory && !\in_array($templatesDirectory, $this->_aTemplateDir)) {
             $this->_aTemplateDir[] = $templatesDirectory;
         }
     }
@@ -331,7 +331,7 @@ class UtilsView extends \OxidEsales\Eshop\Core\Base
         $shopId = \OxidEsales\Eshop\Core\Registry::getConfig()->getShopId();
         $templateDirectories = $this->getTemplateDirs();
 
-        return md5(reset($templateDirectories) . '__' . $shopId);
+        return \md5(\reset($templateDirectories) . '__' . $shopId);
     }
 
     /**
@@ -346,11 +346,11 @@ class UtilsView extends \OxidEsales\Eshop\Core\Base
         //check for the Smarty dir
         $compileDir = $config->getConfigParam('sCompileDir');
         $smartyDir = $compileDir . "/smarty/";
-        if (!is_dir($smartyDir)) {
-            @mkdir($smartyDir);
+        if (!\is_dir($smartyDir)) {
+            @\mkdir($smartyDir);
         }
 
-        if (!is_writable($smartyDir)) {
+        if (!\is_writable($smartyDir)) {
             $smartyDir = $compileDir;
         }
 
@@ -389,7 +389,7 @@ class UtilsView extends \OxidEsales\Eshop\Core\Base
         $smarty->compile_id = $this->getTemplateCompileId();
         $smarty->default_template_handler_func = [\OxidEsales\Eshop\Core\Registry::getUtilsView(), '_smartyDefaultTemplateHandler'];
 
-        $smarty->plugins_dir = array_merge(
+        $smarty->plugins_dir = \array_merge(
             $this->getSmartyPluginDirectories(),
             $smarty->plugins_dir
         );
@@ -438,7 +438,7 @@ class UtilsView extends \OxidEsales\Eshop\Core\Base
      */
     public function getSmartyPluginDirectories()
     {
-        return array_merge(
+        return \array_merge(
             $this->getModuleSmartyPluginDirectories(),
             $this->getShopSmartyPluginDirectories()
         );
@@ -491,12 +491,12 @@ class UtilsView extends \OxidEsales\Eshop\Core\Base
     public function _smartyDefaultTemplateHandler($resourceType, $resourceName, &$resourceContent, &$resourceTimestamp, $smarty) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $config = \OxidEsales\Eshop\Core\Registry::getConfig();
-        if ($resourceType == 'file' && !is_readable($resourceName)) {
+        if ($resourceType == 'file' && !\is_readable($resourceName)) {
             $resourceName = $config->getTemplatePath($resourceName, $config->isAdmin());
             $resourceContent = $smarty->_read_file($resourceName);
-            $resourceTimestamp = filemtime($resourceName);
+            $resourceTimestamp = \filemtime($resourceName);
 
-            return is_file($resourceName) && is_readable($resourceName);
+            return \is_file($resourceName) && \is_readable($resourceName);
         }
 
         return false;
@@ -542,9 +542,9 @@ class UtilsView extends \OxidEsales\Eshop\Core\Base
 
         $config = \OxidEsales\Eshop\Core\Registry::getConfig();
 
-        $tplDir = trim($config->getConfigParam('_sTemplateDir'), '/\\');
-        $templateFileName = str_replace(['\\', '//'], '/', $templateFileName);
-        if (preg_match('@/' . preg_quote($tplDir, '@') . '/(.*)$@', $templateFileName, $m)) {
+        $tplDir = \trim($config->getConfigParam('_sTemplateDir'), '/\\');
+        $templateFileName = \str_replace(['\\', '//'], '/', $templateFileName);
+        if (\preg_match('@/' . \preg_quote($tplDir, '@') . '/(.*)$@', $templateFileName, $m)) {
             $templateFileName = $m[1];
         }
 
@@ -553,7 +553,7 @@ class UtilsView extends \OxidEsales\Eshop\Core\Base
 
             $ids = $this->_getActiveModuleInfo();
 
-            $activeModulesId = array_keys($ids);
+            $activeModulesId = \array_keys($ids);
             $activeThemeIds = oxNew(\OxidEsales\Eshop\Core\Theme::class)->getActiveThemesList();
 
             $templateBlockRepository = oxNew(ModuleTemplateBlockRepository::class);
@@ -725,7 +725,7 @@ class UtilsView extends \OxidEsales\Eshop\Core\Base
         $templateBlocks = [];
         foreach ($activeBlockTemplates as $activeBlockTemplate) {
             if (
-                !in_array($this->prepareBlockKey($activeBlockTemplate), $templateBlocksToExchange['theme'])
+                !\in_array($this->prepareBlockKey($activeBlockTemplate), $templateBlocksToExchange['theme'])
                 || $activeBlockTemplate['OXTHEME']
             ) {
                 $templateBlocks[] = $activeBlockTemplate;
@@ -750,7 +750,7 @@ class UtilsView extends \OxidEsales\Eshop\Core\Base
         $customThemeId = \OxidEsales\Eshop\Core\Registry::getConfig()->getConfigParam('sCustomTheme');
         foreach ($activeBlockTemplates as $activeBlockTemplate) {
             if (
-                !in_array($this->prepareBlockKey($activeBlockTemplate), $templateBlocksToExchange['custom_theme'])
+                !\in_array($this->prepareBlockKey($activeBlockTemplate), $templateBlocksToExchange['custom_theme'])
                 || $activeBlockTemplate['OXTHEME'] === $customThemeId
             ) {
                 $templateBlocks[] = $activeBlockTemplate;
@@ -799,7 +799,7 @@ class UtilsView extends \OxidEsales\Eshop\Core\Base
 
         foreach ($blockTemplates as $activeBlockTemplate) {
             try {
-                if (!is_array($templateBlocksWithContent[$activeBlockTemplate['OXBLOCKNAME']])) {
+                if (!\is_array($templateBlocksWithContent[$activeBlockTemplate['OXBLOCKNAME']])) {
                     $templateBlocksWithContent[$activeBlockTemplate['OXBLOCKNAME']] = [];
                 }
                 $templateBlocksWithContent[$activeBlockTemplate['OXBLOCKNAME']][] = $this->_getTemplateBlock($activeBlockTemplate['OXMODULE'], $activeBlockTemplate['OXFILE']);
@@ -828,10 +828,10 @@ class UtilsView extends \OxidEsales\Eshop\Core\Base
         $moduleOverridesTemplate = false;
 
         $ids = $this->_getActiveModuleInfo();
-        if (count($ids)) {
+        if (\count($ids)) {
             $templateBlockRepository = oxNew(ModuleTemplateBlockRepository::class);
             $shopId = \OxidEsales\Eshop\Core\Registry::getConfig()->getShopId();
-            $activeModulesId = array_keys($ids);
+            $activeModulesId = \array_keys($ids);
             $blocksCount = $templateBlockRepository->getBlocksCount($activeModulesId, $shopId);
 
             if ($blocksCount) {
@@ -897,7 +897,7 @@ class UtilsView extends \OxidEsales\Eshop\Core\Base
      */
     private function getShopIdCalculator()
     {
-        if (is_null($this->shopIdCalculator)) {
+        if (\is_null($this->shopIdCalculator)) {
             $moduleVariablesCache = oxNew(\OxidEsales\Eshop\Core\FileCache::class);
 
             $this->shopIdCalculator = oxNew(

--- a/source/Core/UtilsXml.php
+++ b/source/Core/UtilsXml.php
@@ -29,11 +29,11 @@ class UtilsXml extends \OxidEsales\Eshop\Core\Base
             $oDomDocument = new DOMDocument('1.0', 'utf-8');
         }
 
-        libxml_use_internal_errors(true);
+        \libxml_use_internal_errors(true);
         $oDomDocument->loadXML($sXml);
-        $errors = libxml_get_errors();
+        $errors = \libxml_get_errors();
         $blLoaded = empty($errors);
-        libxml_clear_errors();
+        \libxml_clear_errors();
 
         if ($blLoaded) {
             return $oDomDocument;

--- a/source/Core/ViewConfig.php
+++ b/source/Core/ViewConfig.php
@@ -124,7 +124,7 @@ class ViewConfig extends \OxidEsales\Eshop\Core\Base
             $sTplName = Registry::getConfig()->getTopActiveView()->getViewConfig()->getViewConfigParam('oxloadid');
         }
 
-        return $sTplName ? basename($sTplName) : null;
+        return $sTplName ? \basename($sTplName) : null;
     }
 
     /**
@@ -179,7 +179,7 @@ class ViewConfig extends \OxidEsales\Eshop\Core\Base
                // END deprecated
                . ($sListType ? "&amp;listtype={$sListType}" : '')
                . "&amp;fnc=logout"
-               . ($sTplName ? "&amp;tpl=" . basename($sTplName) : '')
+               . ($sTplName ? "&amp;tpl=" . \basename($sTplName) : '')
                . ($sContentLoadId ? "&amp;oxloadid=" . $sContentLoadId : '')
                . "&amp;redirect=1";
     }
@@ -194,7 +194,7 @@ class ViewConfig extends \OxidEsales\Eshop\Core\Base
     {
         $sClass = $this->getActiveClassName();
 
-        return ['oxhelp' . strtolower($sClass), 'oxhelpdefault'];
+        return ['oxhelp' . \strtolower($sClass), 'oxhelpdefault'];
     }
 
     /**
@@ -739,7 +739,7 @@ class ViewConfig extends \OxidEsales\Eshop\Core\Base
     public function getPopupIdent()
     {
         if (($sValue = $this->getViewConfigParam('popupident')) === null) {
-            $sValue = md5(Registry::getConfig()->getShopUrl());
+            $sValue = \md5(Registry::getConfig()->getShopUrl());
             $this->setViewConfigParam('popupident', $sValue);
         }
 
@@ -754,7 +754,7 @@ class ViewConfig extends \OxidEsales\Eshop\Core\Base
     public function getPopupIdentRand()
     {
         if (($sValue = $this->getViewConfigParam('popupidentrand')) === null) {
-            $sValue = md5(time());
+            $sValue = \md5(\time());
             $this->setViewConfigParam('popupidentrand', $sValue);
         }
 
@@ -805,7 +805,7 @@ class ViewConfig extends \OxidEsales\Eshop\Core\Base
     {
         $sListType = \OxidEsales\Eshop\Core\Registry::getSession()->getVariable('ldtype');
 
-        if (is_null($sListType)) {
+        if (\is_null($sListType)) {
             $sListType = Registry::getConfig()->getConfigParam('sDefaultListDisplayType');
         }
 
@@ -952,7 +952,7 @@ class ViewConfig extends \OxidEsales\Eshop\Core\Base
                     if ($sParams) {
                         $sParams .= '&amp;';
                     }
-                    $sParams .= "{$sName}=" . rawurlencode($sValue);
+                    $sParams .= "{$sName}=" . \rawurlencode($sValue);
                 }
             }
             if ($sParams) {
@@ -1164,7 +1164,7 @@ class ViewConfig extends \OxidEsales\Eshop\Core\Base
         $oModule = oxNew(\OxidEsales\Eshop\Core\Module\Module::class);
         $sModulePath = $oModule->getModulePath($sModule);
         $sFile = Registry::getConfig()->getModulesDir() . $sModulePath . $sFile;
-        if (file_exists($sFile) || is_dir($sFile)) {
+        if (\file_exists($sFile) || \is_dir($sFile)) {
             return $sFile;
         } else {
             /**
@@ -1206,7 +1206,7 @@ class ViewConfig extends \OxidEsales\Eshop\Core\Base
                 if ($shopUrl) {
                     // but we don't need the admin directory
                     $adminDir = '/' . $c->getConfigParam('sAdminDir');
-                    $shopUrl = substr($shopUrl, 0, -strlen($adminDir));
+                    $shopUrl = \substr($shopUrl, 0, -\strlen($adminDir));
                 } else {
                     // if no sAdminSSLURL directive were defined we use sSSLShopURL config directive instead
                     $shopUrl = $c->getConfigParam('sSSLShopURL');
@@ -1221,10 +1221,10 @@ class ViewConfig extends \OxidEsales\Eshop\Core\Base
         if (!$shopUrl) {
             $shopUrl = $c->getCurrentShopUrl();
         }
-        $shopUrl = rtrim($shopUrl, '/');
+        $shopUrl = \rtrim($shopUrl, '/');
 
-        $sUrl = str_replace(
-            rtrim($c->getConfigParam('sShopDir'), '/'),
+        $sUrl = \str_replace(
+            \rtrim($c->getConfigParam('sShopDir'), '/'),
             $shopUrl,
             $this->getModulePath($sModule, $sFile)
         );
@@ -1249,7 +1249,7 @@ class ViewConfig extends \OxidEsales\Eshop\Core\Base
         // use aModuleVersions instead of aModules, because aModules gives only modules which extend oxid classes
         $aModuleVersions = Registry::getConfig()->getConfigParam('aModuleVersions');
 
-        if (is_array($aModuleVersions)) {
+        if (\is_array($aModuleVersions)) {
             $blModuleIsActive = $this->_moduleExists($sModuleId, $aModuleVersions);
 
             if ($blModuleIsActive) {
@@ -1345,11 +1345,11 @@ class ViewConfig extends \OxidEsales\Eshop\Core\Base
      */
     public function getShopLogo()
     {
-        if (is_null($this->_sShopLogo)) {
+        if (\is_null($this->_sShopLogo)) {
             $sLogoImage = Registry::getConfig()->getConfigParam('sShopLogo');
             if (empty($sLogoImage)) {
                 $editionSelector = new EditionSelector();
-                $sLogoImage = "logo_" . strtolower($editionSelector->getEdition()) . ".png";
+                $sLogoImage = "logo_" . \strtolower($editionSelector->getEdition()) . ".png";
             }
 
             $this->setShopLogo($sLogoImage);
@@ -1396,7 +1396,7 @@ class ViewConfig extends \OxidEsales\Eshop\Core\Base
      */
     private function _moduleExists($sModuleId, $aModuleVersions) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
-        return (in_array($sModuleId, array_keys($aModuleVersions)));
+        return (\in_array($sModuleId, \array_keys($aModuleVersions)));
     }
 
     /**
@@ -1433,11 +1433,11 @@ class ViewConfig extends \OxidEsales\Eshop\Core\Base
 
         $aModuleVersions = Registry::getConfig()->getConfigParam('aModuleVersions');
 
-        if ($sVersionFrom && !version_compare($aModuleVersions[$sModuleId], $sVersionFrom, '>=')) {
+        if ($sVersionFrom && !\version_compare($aModuleVersions[$sModuleId], $sVersionFrom, '>=')) {
             $blModuleIsActive = false;
         }
 
-        if ($blModuleIsActive && $sVersionTo && !version_compare($aModuleVersions[$sModuleId], $sVersionTo, '<')) {
+        if ($blModuleIsActive && $sVersionTo && !\version_compare($aModuleVersions[$sModuleId], $sVersionTo, '<')) {
             $blModuleIsActive = false;
         }
 

--- a/source/Core/ViewHelper/JavaScriptRegistrator.php
+++ b/source/Core/ViewHelper/JavaScriptRegistrator.php
@@ -29,8 +29,8 @@ class JavaScriptRegistrator
         $suffix = $isDynamic ? '_dynamic' : '';
         $scriptsParameterName = static::SNIPPETS_PARAMETER_NAME . $suffix;
         $scripts = (array) $config->getGlobalParameter($scriptsParameterName);
-        $script = trim($script);
-        if (!in_array($script, $scripts)) {
+        $script = \trim($script);
+        if (!\in_array($script, $scripts)) {
             $scripts[] = $script;
         }
         $config->setGlobalParameter($scriptsParameterName, $scripts);
@@ -50,13 +50,13 @@ class JavaScriptRegistrator
         $filesParameterName = static::FILES_PARAMETER_NAME . $suffix;
         $includes = (array) $config->getGlobalParameter($filesParameterName);
 
-        if (!preg_match('#^https?://#', $file)) {
+        if (!\preg_match('#^https?://#', $file)) {
             $file = $this->formLocalFileUrl($file);
         }
 
         if ($file) {
             $includes[$priority][] = $file;
-            $includes[$priority] = array_unique($includes[$priority]);
+            $includes[$priority] = \array_unique($includes[$priority]);
             $config->setGlobalParameter($filesParameterName, $includes);
         }
     }
@@ -71,18 +71,18 @@ class JavaScriptRegistrator
     protected function formLocalFileUrl($file)
     {
         $config = \OxidEsales\Eshop\Core\Registry::getConfig();
-        $parts = explode('?', $file);
+        $parts = \explode('?', $file);
         $url = $config->getResourceUrl($parts[0], $config->isAdmin());
         if (isset($parts[1])) {
             $parameters = $parts[1];
         } else {
             $path = $config->getResourcePath($file, $config->isAdmin());
-            $parameters = filemtime($path);
+            $parameters = \filemtime($path);
         }
 
         if (empty($url) && $config->getConfigParam('iDebug') != 0) {
             $error = "{oxscript} resource not found: " . Str::getStr()->htmlspecialchars($file);
-            trigger_error($error, E_USER_WARNING);
+            \trigger_error($error, E_USER_WARNING);
         }
 
         return $url ? "$url?$parameters" : '';

--- a/source/Core/ViewHelper/JavaScriptRenderer.php
+++ b/source/Core/ViewHelper/JavaScriptRenderer.php
@@ -66,7 +66,7 @@ class JavaScriptRenderer
      */
     protected function isAjaxRequest()
     {
-        return isset($_SERVER['HTTP_X_REQUESTED_WITH']) && strtolower($_SERVER['HTTP_X_REQUESTED_WITH']) === 'xmlhttprequest';
+        return isset($_SERVER['HTTP_X_REQUESTED_WITH']) && \strtolower($_SERVER['HTTP_X_REQUESTED_WITH']) === 'xmlhttprequest';
     }
 
     /**
@@ -105,24 +105,24 @@ class JavaScriptRenderer
      */
     protected function formFilesOutput($includes, $widget)
     {
-        if (!count($includes)) {
+        if (!\count($includes)) {
             return '';
         }
 
-        ksort($includes); // Sort by priority.
+        \ksort($includes); // Sort by priority.
         $usedSources = [];
         $widgets = [];
         $widgetTemplate = "WidgetsHandler.registerFile('%s', '%s');";
         $scriptTemplate = '<script type="text/javascript" src="%s"></script>';
         foreach ($includes as $priority) {
             foreach ($priority as $source) {
-                if (!in_array($source, $usedSources)) {
-                    $widgets[] = sprintf(($widget ? $widgetTemplate : $scriptTemplate), $source, $widget);
+                if (!\in_array($source, $usedSources)) {
+                    $widgets[] = \sprintf(($widget ? $widgetTemplate : $scriptTemplate), $source, $widget);
                     $usedSources[] = $source;
                 }
             }
         }
-        $output = implode(PHP_EOL, $widgets);
+        $output = \implode(PHP_EOL, $widgets);
         if ($widget && !empty($output)) {
             $output = <<<JS
 <script type='text/javascript'>
@@ -157,7 +157,7 @@ JS;
             $preparedScripts[] = $script;
         }
 
-        return implode(PHP_EOL, $preparedScripts);
+        return \implode(PHP_EOL, $preparedScripts);
     }
 
     /**
@@ -169,7 +169,7 @@ JS;
      */
     protected function sanitize($scripts)
     {
-        return strtr($scripts, ['\\' => '\\\\', "'" => "\\'", "\r" => '', "\n" => '\n']);
+        return \strtr($scripts, ['\\' => '\\\\', "'" => "\\'", "\r" => '', "\n" => '\n']);
     }
 
     /**

--- a/source/Core/ViewHelper/StyleRegistrator.php
+++ b/source/Core/ViewHelper/StyleRegistrator.php
@@ -29,7 +29,7 @@ class StyleRegistrator
         $config = \OxidEsales\Eshop\Core\Registry::getConfig();
         $suffix = $isDynamic ? '_dynamic' : '';
 
-        if (!preg_match('#^https?://#', $style)) {
+        if (!\preg_match('#^https?://#', $style)) {
             $style = $this->formLocalFileUrl($style);
         }
 
@@ -43,7 +43,7 @@ class StyleRegistrator
                 $stylesParameterName = static::STYLES_PARAMETER_NAME . $suffix;
                 $styles = (array) $config->getGlobalParameter($stylesParameterName);
                 $styles[] = $style;
-                $styles = array_unique($styles);
+                $styles = \array_unique($styles);
                 $config->setGlobalParameter($stylesParameterName, $styles);
             }
         }
@@ -59,17 +59,17 @@ class StyleRegistrator
     protected function formLocalFileUrl($file)
     {
         $config = \OxidEsales\Eshop\Core\Registry::getConfig();
-        $parts = explode('?', $file);
+        $parts = \explode('?', $file);
         $url = $config->getResourceUrl($parts[0], $config->isAdmin());
         $parameters = $parts[1];
         if (empty($parameters)) {
             $path = $config->getResourcePath($file, $config->isAdmin());
-            $parameters = filemtime($path);
+            $parameters = \filemtime($path);
         }
 
         if (empty($url) && $config->getConfigParam('iDebug') != 0) {
             $error = "{oxstyle} resource not found: " . Str::getStr()->htmlspecialchars($file);
-            trigger_error($error, E_USER_WARNING);
+            \trigger_error($error, E_USER_WARNING);
         }
 
         return $url ? "$url?$parameters" : '';

--- a/source/Core/ViewHelper/StyleRenderer.php
+++ b/source/Core/ViewHelper/StyleRenderer.php
@@ -58,10 +58,10 @@ class StyleRenderer
         $preparedStyles = [];
         $template = '<link rel="stylesheet" type="text/css" href="%s" />';
         foreach ($styles as $style) {
-            $preparedStyles[] = sprintf($template, $style);
+            $preparedStyles[] = \sprintf($template, $style);
         }
 
-        return implode(PHP_EOL, $preparedStyles);
+        return \implode(PHP_EOL, $preparedStyles);
     }
 
     /**
@@ -74,9 +74,9 @@ class StyleRenderer
         $preparedStyles = [];
         $template = '<!--[if %s]><link rel="stylesheet" type="text/css" href="%s"><![endif]-->';
         foreach ($styles as $style => $condition) {
-            $preparedStyles[] = sprintf($template, $condition, $style);
+            $preparedStyles[] = \sprintf($template, $condition, $style);
         }
 
-        return implode(PHP_EOL, $preparedStyles);
+        return \implode(PHP_EOL, $preparedStyles);
     }
 }

--- a/source/Core/WidgetControl.php
+++ b/source/Core/WidgetControl.php
@@ -59,7 +59,7 @@ class WidgetControl extends \OxidEsales\Eshop\Core\ShopControl
         //$aParams = ( isset($aParams) ) ? $aParams : \OxidEsales\Eshop\Core\Registry::getConfig()->getRequestParameter( 'oxwparams' );
 
         if (!isset($viewsChain) && \OxidEsales\Eshop\Core\Registry::getConfig()->getRequestParameter('oxwparent')) {
-            $viewsChain = explode("|", \OxidEsales\Eshop\Core\Registry::getConfig()->getRequestParameter('oxwparent'));
+            $viewsChain = \explode("|", \OxidEsales\Eshop\Core\Registry::getConfig()->getRequestParameter('oxwparent'));
         }
 
         parent::start($class, $function, $parameters, $viewsChain);
@@ -107,19 +107,19 @@ class WidgetControl extends \OxidEsales\Eshop\Core\ShopControl
     {
         $config = \OxidEsales\Eshop\Core\Registry::getConfig();
         $activeViewsIds = $config->getActiveViewsIds();
-        $activeViewsIds = array_map("strtolower", $activeViewsIds);
+        $activeViewsIds = \array_map("strtolower", $activeViewsIds);
         $classKey = Registry::getControllerClassNameResolver()->getIdByClassName($class);
-        $classKey = !is_null($classKey) ? $classKey : $class; //fallback
+        $classKey = !\is_null($classKey) ? $classKey : $class; //fallback
 
         // if exists views chain, initializing these view at first
-        if (is_array($viewsChain) && !empty($viewsChain)) {
+        if (\is_array($viewsChain) && !empty($viewsChain)) {
             foreach ($viewsChain as $parentClassKey) {
                 $parentClass = Registry::getControllerClassNameResolver()->getClassNameById($parentClassKey);
 
-                if ($parentClassKey != $classKey && !in_array(strtolower($parentClassKey), $activeViewsIds) && $parentClass) {
+                if ($parentClassKey != $classKey && !\in_array(\strtolower($parentClassKey), $activeViewsIds) && $parentClass) {
                     // creating parent view object
                     $viewObject = oxNew($parentClass);
-                    if ('oxubase' != strtolower($parentClassKey)) {
+                    if ('oxubase' != \strtolower($parentClassKey)) {
                         $viewObject->setClassKey($parentClassKey);
                     }
                     $config->setActiveView($viewObject);
@@ -130,9 +130,9 @@ class WidgetControl extends \OxidEsales\Eshop\Core\ShopControl
 
         $widgetViewObject = parent::_initializeViewObject($class, $function, $parameters, null);
 
-        if (!is_a($widgetViewObject, WidgetController::class)) {
+        if (!\is_a($widgetViewObject, WidgetController::class)) {
             /** @var ObjectException $exception */
-            $exception = oxNew(ObjectException::class, get_class($widgetViewObject) . ' is not an instance of ' . WidgetController::class);
+            $exception = oxNew(ObjectException::class, \get_class($widgetViewObject) . ' is not an instance of ' . WidgetController::class);
             throw $exception;
         }
 

--- a/source/Core/utils/oxpicgenerator.php
+++ b/source/Core/utils/oxpicgenerator.php
@@ -6,7 +6,7 @@
  */
 
 // checks if GD library version getter does not exist
-if (!function_exists("getGdVersion")) {
+if (!\function_exists("getGdVersion")) {
     /**
      * Returns GD library version
      *
@@ -19,7 +19,7 @@ if (!function_exists("getGdVersion")) {
 }
 
 // checks if image creation function does not exist
-if (!function_exists("copyAlteredImage")) {
+if (!\function_exists("copyAlteredImage")) {
     /**
      * Creates and copies the resized image
      *
@@ -35,12 +35,12 @@ if (!function_exists("copyAlteredImage")) {
      */
     function copyAlteredImage($sDestinationImage, $sSourceImage, $iNewWidth, $iNewHeight, $aImageInfo, $sTarget, $iGdVer)
     {
-        return imagecopyresampled($sDestinationImage, $sSourceImage, 0, 0, 0, 0, $iNewWidth, $iNewHeight, $aImageInfo[0], $aImageInfo[1]);
+        return \imagecopyresampled($sDestinationImage, $sSourceImage, 0, 0, 0, 0, $iNewWidth, $iNewHeight, $aImageInfo[0], $aImageInfo[1]);
     }
 }
 
 // checks if image size calculator does nor exist
-if (!function_exists("calcImageSize")) {
+if (!\function_exists("calcImageSize")) {
     /**
      * Calculates proportional new image size
      *
@@ -56,11 +56,11 @@ if (!function_exists("calcImageSize")) {
         // #1837/1177M - do not resize smaller pictures
         if ($iDesiredWidth < $iPrefWidth || $iDesiredHeight < $iPrefHeight) {
             if ($iPrefWidth >= $iPrefHeight * ((float) ($iDesiredWidth / $iDesiredHeight))) {
-                $iNewHeight = round(($iPrefHeight * (float) ($iDesiredWidth / $iPrefWidth)), 0);
+                $iNewHeight = \round(($iPrefHeight * (float) ($iDesiredWidth / $iPrefWidth)), 0);
                 $iNewWidth = $iDesiredWidth;
             } else {
                 $iNewHeight = $iDesiredHeight;
-                $iNewWidth = round(($iPrefWidth * (float) ($iDesiredHeight / $iPrefHeight)), 0);
+                $iNewWidth = \round(($iPrefWidth * (float) ($iDesiredHeight / $iPrefHeight)), 0);
             }
         } else {
             $iNewWidth = $iPrefWidth;
@@ -72,7 +72,7 @@ if (!function_exists("calcImageSize")) {
 }
 
 // sets 0755 permissions for given file
-if (!function_exists("makeReadable")) {
+if (!\function_exists("makeReadable")) {
     /**
      * Sets 0755 permissions for given file and returns name of affected file
      *
@@ -83,10 +83,10 @@ if (!function_exists("makeReadable")) {
     function makeReadable($sTarget)
     {
         $blChmodState = false;
-        if (file_exists($sTarget) && is_readable($sTarget)) {
-            $blChmodState = @chmod($sTarget, 0755);
-            if (defined('OXID_PHP_UNIT')) {
-                @chmod($sTarget, 0777);
+        if (\file_exists($sTarget) && \is_readable($sTarget)) {
+            $blChmodState = @\chmod($sTarget, 0755);
+            if (\defined('OXID_PHP_UNIT')) {
+                @\chmod($sTarget, 0777);
             }
         }
 
@@ -94,7 +94,7 @@ if (!function_exists("makeReadable")) {
     }
 }
 
-if (!function_exists("checkSizeAndCopy")) {
+if (!\function_exists("checkSizeAndCopy")) {
     /**
      * Checks if preferred image dimensions size matches defined in config;
      * in case it matches - copies original image to new location, returns
@@ -114,7 +114,7 @@ if (!function_exists("checkSizeAndCopy")) {
     {
         list($iNewWidth, $iNewHeight) = calcImageSize($iWidth, $iHeight, $iOrigWidth, $iOrigHeight);
         if ($iNewWidth == $iOrigWidth && $iNewHeight == $iOrigHeight) {
-            return copy($sSrc, $sTarget);
+            return \copy($sSrc, $sTarget);
         } else {
             return [$iNewWidth, $iNewHeight];
         }
@@ -122,7 +122,7 @@ if (!function_exists("checkSizeAndCopy")) {
 }
 
 // checks if GIF resizer does not exist
-if (!function_exists("resizeGif")) {
+if (!\function_exists("resizeGif")) {
     /**
      * Creates resized GIF image. Returns path of new file if creation
      * succeed. On error returns FALSE
@@ -140,20 +140,20 @@ if (!function_exists("resizeGif")) {
     function resizeGif($sSrc, $sTarget, $iWidth, $iHeight, $iOriginalWidth, $iOriginalHeight, $iGDVer)
     {
         $aResult = checkSizeAndCopy($sSrc, $sTarget, $iWidth, $iHeight, $iOriginalWidth, $iOriginalHeight);
-        if (is_array($aResult)) {
+        if (\is_array($aResult)) {
             list($iNewWidth, $iNewHeight) = $aResult;
-            $hDestinationImage = imagecreatetruecolor($iNewWidth, $iNewHeight);
-            $hSourceImage = imagecreatefromgif($sSrc);
+            $hDestinationImage = \imagecreatetruecolor($iNewWidth, $iNewHeight);
+            $hSourceImage = \imagecreatefromgif($sSrc);
 
-            $iFillColor = imagecolorresolve($hDestinationImage, 255, 255, 255);
-            imagefill($hDestinationImage, 0, 0, $iFillColor);
-            imagecolortransparent($hDestinationImage, $iFillColor);
+            $iFillColor = \imagecolorresolve($hDestinationImage, 255, 255, 255);
+            \imagefill($hDestinationImage, 0, 0, $iFillColor);
+            \imagecolortransparent($hDestinationImage, $iFillColor);
 
-            imagecopyresampled($hDestinationImage, $hSourceImage, 0, 0, 0, 0, $iNewWidth, $iNewHeight, $iOriginalWidth, $iOriginalHeight);
+            \imagecopyresampled($hDestinationImage, $hSourceImage, 0, 0, 0, 0, $iNewWidth, $iNewHeight, $iOriginalWidth, $iOriginalHeight);
 
-            imagegif($hDestinationImage, $sTarget);
-            imagedestroy($hDestinationImage);
-            imagedestroy($hSourceImage);
+            \imagegif($hDestinationImage, $sTarget);
+            \imagedestroy($hDestinationImage);
+            \imagedestroy($hSourceImage);
         }
 
         return makeReadable($sTarget);
@@ -161,7 +161,7 @@ if (!function_exists("resizeGif")) {
 }
 
 // checks if PNG resizer does not exist
-if (!function_exists("resizePng")) {
+if (!\function_exists("resizePng")) {
     /**
      * Creates resized PNG image. Returns path of new file if creation
      * succeded. On error returns FALSE
@@ -179,27 +179,27 @@ if (!function_exists("resizePng")) {
     function resizePng($sSrc, $sTarget, $iWidth, $iHeight, $aImageInfo, $iGdVer, $hDestinationImage)
     {
         $aResult = checkSizeAndCopy($sSrc, $sTarget, $iWidth, $iHeight, $aImageInfo[0], $aImageInfo[1]);
-        if (is_array($aResult)) {
+        if (\is_array($aResult)) {
             list($iNewWidth, $iNewHeight) = $aResult;
             if ($hDestinationImage === null) {
-                $hDestinationImage = imagecreatetruecolor($iNewWidth, $iNewHeight);
+                $hDestinationImage = \imagecreatetruecolor($iNewWidth, $iNewHeight);
             }
-            $hSourceImage = imagecreatefrompng($sSrc);
-            if (!imageistruecolor($hSourceImage)) {
-                $hDestinationImage = imagecreate($iNewWidth, $iNewHeight);
+            $hSourceImage = \imagecreatefrompng($sSrc);
+            if (!\imageistruecolor($hSourceImage)) {
+                $hDestinationImage = \imagecreate($iNewWidth, $iNewHeight);
                 // fix for transparent images sets image to transparent
-                $imgWhite = imagecolorallocate($hDestinationImage, 255, 255, 255);
-                imagefill($hDestinationImage, 0, 0, $imgWhite);
-                imagecolortransparent($hDestinationImage, $imgWhite);
+                $imgWhite = \imagecolorallocate($hDestinationImage, 255, 255, 255);
+                \imagefill($hDestinationImage, 0, 0, $imgWhite);
+                \imagecolortransparent($hDestinationImage, $imgWhite);
             //end of fix
             } else {
-                imagealphablending($hDestinationImage, false);
-                imagesavealpha($hDestinationImage, true);
+                \imagealphablending($hDestinationImage, false);
+                \imagesavealpha($hDestinationImage, true);
             }
             if (copyAlteredImage($hDestinationImage, $hSourceImage, $iNewWidth, $iNewHeight, $aImageInfo, $sTarget, $iGdVer)) {
-                imagepng($hDestinationImage, $sTarget);
-                imagedestroy($hDestinationImage);
-                imagedestroy($hSourceImage);
+                \imagepng($hDestinationImage, $sTarget);
+                \imagedestroy($hDestinationImage);
+                \imagedestroy($hSourceImage);
             }
         }
 
@@ -208,7 +208,7 @@ if (!function_exists("resizePng")) {
 }
 
 // checks if JPG resizer does not exist
-if (!function_exists("resizeJpeg")) {
+if (!\function_exists("resizeJpeg")) {
     /**
      * Creates resized JPG image. Returns path of new file if creation
      * succeed. On error returns FALSE
@@ -227,16 +227,16 @@ if (!function_exists("resizeJpeg")) {
     function resizeJpeg($sSrc, $sTarget, $iWidth, $iHeight, $aImageInfo, $iGdVer, $hDestinationImage, $iDefQuality)
     {
         $aResult = checkSizeAndCopy($sSrc, $sTarget, $iWidth, $iHeight, $aImageInfo[0], $aImageInfo[1]);
-        if (is_array($aResult)) {
+        if (\is_array($aResult)) {
             list($iNewWidth, $iNewHeight) = $aResult;
             if ($hDestinationImage === null) {
-                $hDestinationImage = imagecreatetruecolor($iNewWidth, $iNewHeight);
+                $hDestinationImage = \imagecreatetruecolor($iNewWidth, $iNewHeight);
             }
-            $hSourceImage = imagecreatefromstring(file_get_contents($sSrc));
+            $hSourceImage = \imagecreatefromstring(\file_get_contents($sSrc));
             if (copyAlteredImage($hDestinationImage, $hSourceImage, $iNewWidth, $iNewHeight, $aImageInfo, $sTarget, $iGdVer)) {
-                imagejpeg($hDestinationImage, $sTarget, $iDefQuality);
-                imagedestroy($hDestinationImage);
-                imagedestroy($hSourceImage);
+                \imagejpeg($hDestinationImage, $sTarget, $iDefQuality);
+                \imagedestroy($hDestinationImage);
+                \imagedestroy($hSourceImage);
             }
         }
 

--- a/source/Internal/Container/ContainerFactory.php
+++ b/source/Internal/Container/ContainerFactory.php
@@ -59,7 +59,7 @@ class ContainerFactory
     {
         $cacheFilePath = $this::getCacheFilePath();
 
-        if (file_exists($cacheFilePath)) {
+        if (\file_exists($cacheFilePath)) {
             $this->loadContainerFromCache($cacheFilePath);
         } else {
             $this->getCompiledSymfonyContainer();
@@ -94,7 +94,7 @@ class ContainerFactory
     private function saveContainerToCache($cachefile)
     {
         $dumper = new PhpDumper($this->symfonyContainer);
-        file_put_contents($cachefile, $dumper->dump());
+        \file_put_contents($cachefile, $dumper->dump());
     }
 
     /**
@@ -121,8 +121,8 @@ class ContainerFactory
      */
     public static function resetContainer()
     {
-        if (file_exists(self::getCacheFilePath())) {
-            unlink(self::getCacheFilePath());
+        if (\file_exists(self::getCacheFilePath())) {
+            \unlink(self::getCacheFilePath());
         }
         self::$instance = null;
     }

--- a/source/Internal/Domain/Admin/Exception/InvalidEmailException.php
+++ b/source/Internal/Domain/Admin/Exception/InvalidEmailException.php
@@ -15,6 +15,6 @@ class InvalidEmailException extends \Exception
 {
     public function __construct(string $email)
     {
-        parent::__construct(sprintf('Provided email string %s is not a valid email.', $email));
+        parent::__construct(\sprintf('Provided email string %s is not a valid email.', $email));
     }
 }

--- a/source/Internal/Domain/Admin/Exception/InvalidRightsException.php
+++ b/source/Internal/Domain/Admin/Exception/InvalidRightsException.php
@@ -15,6 +15,6 @@ class InvalidRightsException extends \Exception
 {
     public function __construct(string $right)
     {
-        parent::__construct(sprintf('Provided right %s is not a valid shop right.', $right));
+        parent::__construct(\sprintf('Provided right %s is not a valid shop right.', $right));
     }
 }

--- a/source/Internal/Domain/Admin/Exception/InvalidShopException.php
+++ b/source/Internal/Domain/Admin/Exception/InvalidShopException.php
@@ -15,6 +15,6 @@ class InvalidShopException extends \Exception
 {
     public function __construct(int $id)
     {
-        parent::__construct(sprintf('Provided shopId %d is not a valid shop id.', $id));
+        parent::__construct(\sprintf('Provided shopId %d is not a valid shop id.', $id));
     }
 }

--- a/source/Internal/Domain/Admin/Factory/AdminFactory.php
+++ b/source/Internal/Domain/Admin/Factory/AdminFactory.php
@@ -86,7 +86,7 @@ class AdminFactory implements AdminFactoryInterface
     {
         if (
             $rights != Admin::MALL_ADMIN &&
-            !is_numeric($rights) &&
+            !\is_numeric($rights) &&
             !$this->shopAdapter->validateShopId((int) $rights)
         ) {
             throw new InvalidRightsException($rights);

--- a/source/Internal/Domain/Authentication/Service/PasswordVerificationService.php
+++ b/source/Internal/Domain/Authentication/Service/PasswordVerificationService.php
@@ -40,6 +40,6 @@ class PasswordVerificationService implements PasswordVerificationServiceInterfac
     {
         $this->passwordPolicy->enforcePasswordPolicy($password);
 
-        return password_verify($password, $passwordHash);
+        return \password_verify($password, $passwordHash);
     }
 }

--- a/source/Internal/Domain/Contact/Form/ContactFormConfigurationFactory.php
+++ b/source/Internal/Domain/Contact/Form/ContactFormConfigurationFactory.php
@@ -85,7 +85,7 @@ class ContactFormConfigurationFactory implements FormConfigurationFactoryInterfa
      */
     private function isFieldRequired(FieldConfigurationInterface $fieldConfiguration)
     {
-        return in_array(
+        return \in_array(
             $fieldConfiguration->getName(),
             $this->context->getRequiredContactFormFields()
         );

--- a/source/Internal/Domain/Contact/Form/ContactFormMessageBuilder.php
+++ b/source/Internal/Domain/Contact/Form/ContactFormMessageBuilder.php
@@ -52,7 +52,7 @@ class ContactFormMessageBuilder implements ContactFormMessageBuilderInterface
         $message .= '(' . $form->email->getValue() . ')<br /><br />';
 
         if ($form->message->getValue()) {
-            $message .= nl2br($form->message->getValue());
+            $message .= \nl2br($form->message->getValue());
         }
 
         return $message;

--- a/source/Internal/Domain/Review/Bridge/UserReviewAndRatingBridge.php
+++ b/source/Internal/Domain/Review/Bridge/UserReviewAndRatingBridge.php
@@ -87,7 +87,7 @@ class UserReviewAndRatingBridge implements UserReviewAndRatingBridgeInterface
      */
     private function formatReviewText(ReviewAndRating $reviewAndRating)
     {
-        $preparedText = htmlspecialchars($reviewAndRating->getReviewText());
+        $preparedText = \htmlspecialchars($reviewAndRating->getReviewText());
 
         $reviewAndRating->setReviewText($preparedText);
     }

--- a/source/Internal/Domain/Review/Dao/ProductRatingDao.php
+++ b/source/Internal/Domain/Review/Dao/ProductRatingDao.php
@@ -90,7 +90,7 @@ class ProductRatingDao implements ProductRatingDaoInterface
      */
     private function validateProductId($productId)
     {
-        if (empty($productId) || !is_string($productId)) {
+        if (empty($productId) || !\is_string($productId)) {
             throw new InvalidObjectIdDaoException();
         }
     }

--- a/source/Internal/Domain/Review/Service/ReviewAndRatingMergingService.php
+++ b/source/Internal/Domain/Review/Service/ReviewAndRatingMergingService.php
@@ -26,7 +26,7 @@ class ReviewAndRatingMergingService implements ReviewAndRatingMergingServiceInte
      */
     public function mergeReviewAndRating(ArrayCollection $reviews, ArrayCollection $ratings)
     {
-        $ratingAndReviewList = array_merge(
+        $ratingAndReviewList = \array_merge(
             $this->getReviewDataWithRating($reviews, $ratings),
             $this->getRatingWithoutReviewData($reviews, $ratings)
         );

--- a/source/Internal/Domain/Review/Service/UserReviewAndRatingService.php
+++ b/source/Internal/Domain/Review/Service/UserReviewAndRatingService.php
@@ -103,7 +103,7 @@ class UserReviewAndRatingService implements UserReviewAndRatingServiceInterface
     {
         $reviewAndRatingListArray = $reviewAndRatingList->toArray();
 
-        usort($reviewAndRatingListArray, function (ReviewAndRating $first, ReviewAndRating $second) {
+        \usort($reviewAndRatingListArray, function (ReviewAndRating $first, ReviewAndRating $second) {
             return $first->getCreatedAt() < $second->getCreatedAt() ? 1 : -1;
         });
 

--- a/source/Internal/Framework/Config/Utility/ShopSettingEncoder.php
+++ b/source/Internal/Framework/Config/Utility/ShopSettingEncoder.php
@@ -29,7 +29,7 @@ class ShopSettingEncoder implements ShopSettingEncoderInterface
         switch ($encodingType) {
             case ShopSettingType::ARRAY:
             case ShopSettingType::ASSOCIATIVE_ARRAY:
-                $encodedValue = serialize($value);
+                $encodedValue = \serialize($value);
                 break;
             case ShopSettingType::BOOLEAN:
                 $encodedValue = $value === true ? '1' : '';
@@ -51,7 +51,7 @@ class ShopSettingEncoder implements ShopSettingEncoderInterface
         switch ($encodingType) {
             case ShopSettingType::ARRAY:
             case ShopSettingType::ASSOCIATIVE_ARRAY:
-                $decodedValue = unserialize($value, ['allowed_classes' => false]);
+                $decodedValue = \unserialize($value, ['allowed_classes' => false]);
                 break;
             case ShopSettingType::BOOLEAN:
                 $decodedValue = ($value === 'true' || $value === '1');
@@ -69,7 +69,7 @@ class ShopSettingEncoder implements ShopSettingEncoderInterface
      */
     private function validateSettingValue($value)
     {
-        if (is_object($value)) {
+        if (\is_object($value)) {
             throw new InvalidShopSettingValueException(
                 'Shop setting value must not be an object.'
             );

--- a/source/Internal/Framework/DIContainer/Dao/ProjectYamlDao.php
+++ b/source/Internal/Framework/DIContainer/Dao/ProjectYamlDao.php
@@ -57,7 +57,7 @@ class ProjectYamlDao implements ProjectYamlDaoInterface
             $this->filesystem->mkdir($this->getGeneratedServicesFileDirectory());
         }
 
-        file_put_contents(
+        \file_put_contents(
             $this->context->getGeneratedServicesFilePath(),
             Yaml::dump($config->getConfigAsArray(), 3, 2)
         );
@@ -72,8 +72,8 @@ class ProjectYamlDao implements ProjectYamlDaoInterface
     {
         $yamlArray = [];
 
-        if (file_exists($path)) {
-            $yamlArray = Yaml::parse(file_get_contents($path), Yaml::PARSE_CUSTOM_TAGS) ?? [];
+        if (\file_exists($path)) {
+            $yamlArray = Yaml::parse(\file_get_contents($path), Yaml::PARSE_CUSTOM_TAGS) ?? [];
         }
 
         return new DIConfigWrapper($yamlArray);

--- a/source/Internal/Framework/DIContainer/DataObject/DIConfigWrapper.php
+++ b/source/Internal/Framework/DIContainer/DataObject/DIConfigWrapper.php
@@ -170,7 +170,7 @@ class DIConfigWrapper
      */
     private function getImports(): array
     {
-        if (!array_key_exists(static::IMPORTS_SECTION, $this->configArray)) {
+        if (!\array_key_exists(static::IMPORTS_SECTION, $this->configArray)) {
             return [];
         }
 
@@ -182,7 +182,7 @@ class DIConfigWrapper
      */
     public function getServices(): array
     {
-        if (!array_key_exists(static::SERVICE_SECTION, $this->configArray)) {
+        if (!\array_key_exists(static::SERVICE_SECTION, $this->configArray)) {
             return [];
         }
         $services = [];
@@ -210,8 +210,8 @@ class DIConfigWrapper
         $sections = [static::IMPORTS_SECTION, static::SERVICE_SECTION];
         foreach ($sections as $section) {
             if (
-                array_key_exists($section, $this->configArray) &&
-                (!$this->configArray[$section] || !count($this->configArray[$section]))
+                \array_key_exists($section, $this->configArray) &&
+                (!$this->configArray[$section] || !\count($this->configArray[$section]))
             ) {
                 unset($this->configArray[$section]);
             }
@@ -241,8 +241,8 @@ class DIConfigWrapper
      */
     private function addSectionIfMissing($section)
     {
-        if (!array_key_exists($section, $this->configArray)) {
-            if (array_key_exists($section, $this->sectionDefaults)) {
+        if (!\array_key_exists($section, $this->configArray)) {
+            if (\array_key_exists($section, $this->sectionDefaults)) {
                 $this->configArray[$section] = $this->sectionDefaults[$section];
             } else {
                 $this->configArray[$section] = [];

--- a/source/Internal/Framework/DIContainer/DataObject/DIServiceWrapper.php
+++ b/source/Internal/Framework/DIContainer/DataObject/DIServiceWrapper.php
@@ -58,12 +58,12 @@ class DIServiceWrapper
 
     private function checkIfIdIsResolvableClassName(): bool
     {
-        return class_exists($this->id);
+        return \class_exists($this->id);
     }
 
     private function setCalls(): void
     {
-        if (array_key_exists(self::CALLS_SECTION, $this->serviceArguments)) {
+        if (\array_key_exists(self::CALLS_SECTION, $this->serviceArguments)) {
             $this->calls = $this->serviceArguments[self::CALLS_SECTION];
         }
     }
@@ -86,7 +86,7 @@ class DIServiceWrapper
         if (!$this->hasClass()) {
             return false;
         }
-        return in_array(ShopAwareInterface::class, class_implements($this->getClass()), true);
+        return \in_array(ShopAwareInterface::class, \class_implements($this->getClass()), true);
     }
 
     public function addActiveShops(array $shops): array
@@ -94,7 +94,7 @@ class DIServiceWrapper
         $this->addShopAwareCallsIfMissing();
         $setActiveShopsCall = $this->getCall(self::SET_ACTIVE_SHOPS_METHOD);
         $currentlyActiveShops = $setActiveShopsCall->getParameter(0);
-        $newActiveShops = array_merge($currentlyActiveShops, $shops);
+        $newActiveShops = \array_merge($currentlyActiveShops, $shops);
         $setActiveShopsCall->setParameter(0, $newActiveShops);
         $this->updateCall($setActiveShopsCall);
         return $newActiveShops;
@@ -106,7 +106,7 @@ class DIServiceWrapper
         $currentlyActiveShops = $setActiveShopsCall->getParameter(0);
         $newActiveShops = [];
         foreach ($currentlyActiveShops as $shopId) {
-            if (array_search($shopId, $shops) === false) {
+            if (\array_search($shopId, $shops) === false) {
                 $newActiveShops[] = $shopId;
             }
         }
@@ -121,7 +121,7 @@ class DIServiceWrapper
         $this->addShopAwareCallsIfMissing();
         $setActiveShopsCall = $this->getCall(self::SET_ACTIVE_SHOPS_METHOD);
         $currentlyActiveShops = $setActiveShopsCall->getParameter(0);
-        return count($currentlyActiveShops) > 0;
+        return \count($currentlyActiveShops) > 0;
     }
 
     public function getKey(): string
@@ -138,7 +138,7 @@ class DIServiceWrapper
         if (! $this->hasClass()) {
             return true;
         }
-        return class_exists($this->getClass());
+        return \class_exists($this->getClass());
     }
 
     private function addShopAwareCallsIfMissing(): void
@@ -191,7 +191,7 @@ class DIServiceWrapper
      */
     private function updateCall(DICallWrapper $call): void
     {
-        $callsCount = count($this->calls);
+        $callsCount = \count($this->calls);
 
         for ($i = 0; $i < $callsCount; $i++) {
             $existingCall = new DICallWrapper($this->calls[$i]);

--- a/source/Internal/Framework/DIContainer/Service/ProjectYamlImportService.php
+++ b/source/Internal/Framework/DIContainer/Service/ProjectYamlImportService.php
@@ -42,7 +42,7 @@ class ProjectYamlImportService implements ProjectYamlImportServiceInterface
      */
     public function addImport(string $serviceDir)
     {
-        if (!realpath($serviceDir)) {
+        if (!\realpath($serviceDir)) {
             throw new NoServiceYamlException();
         }
         $projectConfig = $this->projectYamlDao->loadProjectConfigFile();
@@ -72,7 +72,7 @@ class ProjectYamlImportService implements ProjectYamlImportServiceInterface
 
         $configChanged = false;
         foreach ($projectConfig->getImportFileNames() as $fileName) {
-            if (file_exists($this->getAbsolutePath($fileName))) {
+            if (\file_exists($this->getAbsolutePath($fileName))) {
                 continue;
             }
             $projectConfig->removeImport($fileName);

--- a/source/Internal/Framework/DIContainer/Service/ShopStateService.php
+++ b/source/Internal/Framework/DIContainer/Service/ShopStateService.php
@@ -57,7 +57,7 @@ class ShopStateService implements ShopStateServiceInterface
      */
     private function areUnifiedNamespacesGenerated(): bool
     {
-        return class_exists($this->anyUnifiedNamespace);
+        return \class_exists($this->anyUnifiedNamespace);
     }
 
     /**
@@ -65,7 +65,7 @@ class ShopStateService implements ShopStateServiceInterface
      */
     private function doesConfigFileExist(): bool
     {
-        return file_exists($this->basicContext->getConfigFilePath());
+        return \file_exists($this->basicContext->getConfigFilePath());
     }
 
     /**
@@ -92,7 +92,7 @@ class ShopStateService implements ShopStateServiceInterface
     {
         include $this->basicContext->getConfigFilePath();
 
-        $dsn = sprintf('mysql:host=%s;port=%s', $this->dbHost, $this->dbPort);
+        $dsn = \sprintf('mysql:host=%s;port=%s', $this->dbHost, $this->dbPort);
 
         $connection = new \PDO(
             $dsn,

--- a/source/Internal/Framework/Database/Logger/QueryFilter.php
+++ b/source/Internal/Framework/Database/Logger/QueryFilter.php
@@ -39,7 +39,7 @@ class QueryFilter implements QueryFilterInterface
      */
     public function shouldLogQuery(string $query, array $skipLogTags): bool
     {
-        return (bool) preg_match($this->getSearchPattern($skipLogTags), $query);
+        return (bool) \preg_match($this->getSearchPattern($skipLogTags), $query);
     }
 
     /**
@@ -51,11 +51,11 @@ class QueryFilter implements QueryFilterInterface
      */
     private function getSearchPattern(array $skipLogTags): string
     {
-        $pattern = '/(.?)(' . implode('|', $this->logThese) . ')(?!.*' .
-                   implode(')(?!.*', $this->skipThese) . ')';
+        $pattern = '/(.?)(' . \implode('|', $this->logThese) . ')(?!.*' .
+                   \implode(')(?!.*', $this->skipThese) . ')';
 
         if (!empty($skipLogTags)) {
-            $pattern .= '(?!.*' . implode(')(?!.*', $skipLogTags) . ')';
+            $pattern .= '(?!.*' . \implode(')(?!.*', $skipLogTags) . ')';
         }
         $pattern .= '/i';
 

--- a/source/Internal/Framework/Database/Logger/QueryLogger.php
+++ b/source/Internal/Framework/Database/Logger/QueryLogger.php
@@ -87,8 +87,8 @@ class QueryLogger implements SQLLogger
 
         foreach ((new \Exception())->getTrace() as $item) {
             if (
-                (false === stripos($item['class'], get_class($this))) &&
-                (false === stripos($item['class'], 'Doctrine'))
+                (false === \stripos($item['class'], \get_class($this))) &&
+                (false === \stripos($item['class'], 'Doctrine'))
             ) {
                 $queryTraceItem = $item;
                 break;
@@ -117,7 +117,7 @@ class QueryLogger implements SQLLogger
             'file'        => $backTraceInfo['file'] ?? '',
             'line'        => $backTraceInfo['line'] ?? '',
             'query'       => $query,
-            'params'      => serialize($params)
+            'params'      => \serialize($params)
         ];
 
         return $queryData;

--- a/source/Internal/Framework/Event/ShopAwareEventDispatcher.php
+++ b/source/Internal/Framework/Event/ShopAwareEventDispatcher.php
@@ -33,9 +33,9 @@ class ShopAwareEventDispatcher extends EventDispatcher
                 break;
             }
             if (
-                is_array($listener) &&
-                is_object($listener[0]) &&
-                in_array(ShopAwareInterface::class, class_implements($listener[0])) &&
+                \is_array($listener) &&
+                \is_object($listener[0]) &&
+                \in_array(ShopAwareInterface::class, \class_implements($listener[0])) &&
                 ! $listener[0]->isActive()
             ) {
                 continue;

--- a/source/Internal/Framework/Event/ShopAwareServiceTrait.php
+++ b/source/Internal/Framework/Event/ShopAwareServiceTrait.php
@@ -56,6 +56,6 @@ trait ShopAwareServiceTrait
      */
     public function isActive()
     {
-        return in_array(strval($this->context->getCurrentShopId()), $this->activeShops);
+        return \in_array(\strval($this->context->getCurrentShopId()), $this->activeShops);
     }
 }

--- a/source/Internal/Framework/Form/Form.php
+++ b/source/Internal/Framework/Form/Form.php
@@ -80,7 +80,7 @@ class Form implements FormInterface
             if ($validator->isValid($this) !== true) {
                 $isValid = false;
 
-                $this->errors = array_merge(
+                $this->errors = \array_merge(
                     $this->errors,
                     $validator->getErrors()
                 );

--- a/source/Internal/Framework/Logger/Validator/PsrLoggerConfigurationValidator.php
+++ b/source/Internal/Framework/Logger/Validator/PsrLoggerConfigurationValidator.php
@@ -45,9 +45,9 @@ class PsrLoggerConfigurationValidator implements LoggerConfigurationValidatorInt
     {
         $logLevel = $configuration->getLogLevel();
 
-        if (!in_array($logLevel, $this->validLogLevels, true)) {
+        if (!\in_array($logLevel, $this->validLogLevels, true)) {
             throw new \InvalidArgumentException(
-                'Log level "' . var_export($logLevel, true) . '" is not a PSR-3 compliant log level'
+                'Log level "' . \var_export($logLevel, true) . '" is not a PSR-3 compliant log level'
             );
         }
     }

--- a/source/Internal/Framework/Module/Command/InstallModuleConfigurationCommand.php
+++ b/source/Internal/Framework/Module/Command/InstallModuleConfigurationCommand.php
@@ -154,7 +154,7 @@ class InstallModuleConfigurationCommand extends Command
      */
     private function validatePath(string $path)
     {
-        if (!file_exists($path) || !is_dir($path)) {
+        if (!\file_exists($path) || !\is_dir($path)) {
             throw PathNotFoundException::byPath($path);
         }
     }
@@ -166,7 +166,7 @@ class InstallModuleConfigurationCommand extends Command
     private function getAbsolutePath(string $path): string
     {
         return Path::isRelative($path)
-            ? Path::makeAbsolute($path, getcwd())
+            ? Path::makeAbsolute($path, \getcwd())
             : $path;
     }
 }

--- a/source/Internal/Framework/Module/Command/ModuleActivateCommand.php
+++ b/source/Internal/Framework/Module/Command/ModuleActivateCommand.php
@@ -81,7 +81,7 @@ class ModuleActivateCommand extends Command
         if ($this->isInstalled($moduleId)) {
             $this->activateModule($output, $moduleId);
         } else {
-            $output->writeLn('<error>' . sprintf(static::MESSAGE_MODULE_NOT_FOUND, $moduleId) . '</error>');
+            $output->writeLn('<error>' . \sprintf(static::MESSAGE_MODULE_NOT_FOUND, $moduleId) . '</error>');
         }
 
         return 0;
@@ -95,10 +95,10 @@ class ModuleActivateCommand extends Command
     {
         try {
             $this->moduleActivationService->activate($moduleId, $this->context->getCurrentShopId());
-            $output->writeLn('<info>' . sprintf(static::MESSAGE_MODULE_ACTIVATED, $moduleId) . '</info>');
+            $output->writeLn('<info>' . \sprintf(static::MESSAGE_MODULE_ACTIVATED, $moduleId) . '</info>');
         } catch (ModuleSetupException $exception) {
             $output->writeLn(
-                '<info>' . sprintf(static::MESSAGE_MODULE_ALREADY_ACTIVE, $moduleId) . '</info>'
+                '<info>' . \sprintf(static::MESSAGE_MODULE_ALREADY_ACTIVE, $moduleId) . '</info>'
             );
         }
     }

--- a/source/Internal/Framework/Module/Command/ModuleDeactivateCommand.php
+++ b/source/Internal/Framework/Module/Command/ModuleDeactivateCommand.php
@@ -82,7 +82,7 @@ class ModuleDeactivateCommand extends Command
         if ($this->isInstalled($moduleId)) {
             $this->deactivateModule($output, $moduleId);
         } else {
-            $output->writeLn('<error>' . sprintf(static::MESSAGE_MODULE_NOT_FOUND, $moduleId) . '</error>');
+            $output->writeLn('<error>' . \sprintf(static::MESSAGE_MODULE_NOT_FOUND, $moduleId) . '</error>');
         }
 
         return 0;
@@ -97,11 +97,11 @@ class ModuleDeactivateCommand extends Command
         try {
             $this->moduleActivationService->deactivate($moduleId, $this->context->getCurrentShopId());
             $output->writeLn(
-                '<info>' . sprintf(static::MESSAGE_MODULE_DEACTIVATED, $moduleId) . '</info>'
+                '<info>' . \sprintf(static::MESSAGE_MODULE_DEACTIVATED, $moduleId) . '</info>'
             );
         } catch (ModuleSetupException $exception) {
             $output->writeLn(
-                '<info>' . sprintf(static::MESSAGE_NOT_POSSIBLE_TO_DEACTIVATE, $moduleId) . '</info>'
+                '<info>' . \sprintf(static::MESSAGE_NOT_POSSIBLE_TO_DEACTIVATE, $moduleId) . '</info>'
             );
         }
     }

--- a/source/Internal/Framework/Module/Command/UninstallModuleConfigurationCommand.php
+++ b/source/Internal/Framework/Module/Command/UninstallModuleConfigurationCommand.php
@@ -62,9 +62,9 @@ class UninstallModuleConfigurationCommand extends Command
         try {
             $moduleId = $input->getArgument('module-id');
             $this->moduleConfigurationInstaller->uninstallById($moduleId);
-            $output->writeln('<info>' . sprintf(self::MESSAGE_REMOVE_WAS_SUCCESSFULL, $moduleId) . '</info>');
+            $output->writeln('<info>' . \sprintf(self::MESSAGE_REMOVE_WAS_SUCCESSFULL, $moduleId) . '</info>');
         } catch (\Throwable $throwable) {
-            $output->writeln('<error>' . sprintf(self::MESSAGE_REMOVE_FAILED, $moduleId) . '</error>');
+            $output->writeln('<error>' . \sprintf(self::MESSAGE_REMOVE_FAILED, $moduleId) . '</error>');
 
             throw $throwable;
         }

--- a/source/Internal/Framework/Module/Configuration/Dao/ShopConfigurationDao.php
+++ b/source/Internal/Framework/Module/Configuration/Dao/ShopConfigurationDao.php
@@ -155,7 +155,7 @@ class ShopConfigurationDao implements ShopConfigurationDaoInterface
     {
         $shopIds = [];
 
-        if (file_exists($this->getShopsConfigurationDirectory())) {
+        if (\file_exists($this->getShopsConfigurationDirectory())) {
             $dir = new \DirectoryIterator($this->getShopsConfigurationDirectory());
 
             foreach ($dir as $fileInfo) {
@@ -219,7 +219,7 @@ class ShopConfigurationDao implements ShopConfigurationDaoInterface
         array $shopConfigurationData,
         array $environmentShopConfigurationData
     ): array {
-        return array_replace_recursive($shopConfigurationData, $environmentShopConfigurationData);
+        return \array_replace_recursive($shopConfigurationData, $environmentShopConfigurationData);
     }
 
     /**
@@ -229,7 +229,7 @@ class ShopConfigurationDao implements ShopConfigurationDaoInterface
      */
     private function isShopIdExists(int $shopId): bool
     {
-        return in_array($shopId, $this->getShopIds(), true);
+        return \in_array($shopId, $this->getShopIds(), true);
     }
 
     /**

--- a/source/Internal/Framework/Module/Configuration/DataMapper/ModuleConfigurationDataMapper.php
+++ b/source/Internal/Framework/Module/Configuration/DataMapper/ModuleConfigurationDataMapper.php
@@ -44,7 +44,7 @@ class ModuleConfigurationDataMapper implements ModuleConfigurationDataMapperInte
         ];
 
         foreach ($this->dataMappers as $dataMapper) {
-            $data = array_merge($data, $dataMapper->toData($configuration));
+            $data = \array_merge($data, $dataMapper->toData($configuration));
         }
 
         return $data;

--- a/source/Internal/Framework/Module/Configuration/DataObject/ClassExtensionsChain.php
+++ b/source/Internal/Framework/Module/Configuration/DataObject/ClassExtensionsChain.php
@@ -95,7 +95,7 @@ class ClassExtensionsChain implements \IteratorAggregate
     {
         if (\array_key_exists($extension->getShopClassName(), $this->chain)) {
             if (!$this->isModuleExtensionClassNameInChain($extension)) {
-                array_push(
+                \array_push(
                     $this->chain[$extension->getShopClassName()],
                     $extension->getModuleExtensionClassName()
                 );

--- a/source/Internal/Framework/Module/Configuration/DataObject/ProjectConfiguration.php
+++ b/source/Internal/Framework/Module/Configuration/DataObject/ProjectConfiguration.php
@@ -42,7 +42,7 @@ class ProjectConfiguration
      */
     public function getShopConfigurationIds(): array
     {
-        return array_keys($this->projectConfiguration);
+        return \array_keys($this->projectConfiguration);
     }
 
     /**

--- a/source/Internal/Framework/Module/Configuration/DataObject/ShopConfiguration.php
+++ b/source/Internal/Framework/Module/Configuration/DataObject/ShopConfiguration.php
@@ -83,7 +83,7 @@ class ShopConfiguration
      */
     public function getModuleIdsOfModuleConfigurations(): array
     {
-        return array_keys($this->moduleConfigurations);
+        return \array_keys($this->moduleConfigurations);
     }
 
     /**

--- a/source/Internal/Framework/Module/Configuration/Service/SettingsMergingService.php
+++ b/source/Internal/Framework/Module/Configuration/Service/SettingsMergingService.php
@@ -78,7 +78,7 @@ class SettingsMergingService implements SettingsMergingServiceInterface
             && !empty($settingToMerge->getConstraints())
             && ($settingToMerge->getType() === 'select')
         ) {
-            $resultPosition = array_search($existingSetting->getValue(), $settingToMerge->getConstraints(), true);
+            $resultPosition = \array_search($existingSetting->getValue(), $settingToMerge->getConstraints(), true);
             $shouldMerge = $resultPosition !== false;
         }
 

--- a/source/Internal/Framework/Module/Exception/PathNotFoundException.php
+++ b/source/Internal/Framework/Module/Exception/PathNotFoundException.php
@@ -13,6 +13,6 @@ final class PathNotFoundException extends \Exception
 {
     public static function byPath(string $path): self
     {
-        return new self(sprintf('Path %s does not exist', $path));
+        return new self(\sprintf('Path %s does not exist', $path));
     }
 }

--- a/source/Internal/Framework/Module/Install/Service/ModuleFilesInstaller.php
+++ b/source/Internal/Framework/Module/Install/Service/ModuleFilesInstaller.php
@@ -110,7 +110,7 @@ class ModuleFilesInstaller implements ModuleFilesInstallerInterface
      */
     private function checkTwoStars(string $filter): void
     {
-        if (strpos($filter, '**') !== false) {
+        if (\strpos($filter, '**') !== false) {
             throw new TwoStarsWithinBlacklistFilterException(
                 "Invalid 'blacklist-filter' value in composer.json. "
                 . "Glob patterns (**) are not allowed here: $filter"

--- a/source/Internal/Framework/Module/MetaData/Converter/ModuleSettingsBooleanConverter.php
+++ b/source/Internal/Framework/Module/MetaData/Converter/ModuleSettingsBooleanConverter.php
@@ -40,7 +40,7 @@ class ModuleSettingsBooleanConverter implements MetaDataConverterInterface
     private function updateValue($setting)
     {
         if (isset($setting['type']) && $setting['type'] === 'bool') {
-            $value = is_string($setting['value']) ? strtolower($setting['value']) : $setting['value'];
+            $value = \is_string($setting['value']) ? \strtolower($setting['value']) : $setting['value'];
             $setting['value'] = self::CONVERSION_MAP[$value] ?? $setting['value'];
         }
         return $setting;

--- a/source/Internal/Framework/Module/MetaData/Dao/MetaDataNormalizer.php
+++ b/source/Internal/Framework/Module/MetaData/Dao/MetaDataNormalizer.php
@@ -59,7 +59,7 @@ class MetaDataNormalizer implements MetaDataNormalizerInterface
     {
         foreach ($metadataModuleSettings as $key => $setting) {
             if (isset($setting['constraints'])) {
-                $metadataModuleSettings[$key]['constraints'] = explode('|', $setting['constraints']);
+                $metadataModuleSettings[$key]['constraints'] = \explode('|', $setting['constraints']);
             }
         }
 
@@ -75,7 +75,7 @@ class MetaDataNormalizer implements MetaDataNormalizerInterface
     {
         $title = $normalizedMetaData[$fieldName];
 
-        if (is_string($title)) {
+        if (\is_string($title)) {
             $defaultLanguage = $normalizedMetaData[MetaDataProvider::METADATA_LANG] ?? 'en';
             $normalizedTitle = [
                 $defaultLanguage => $title,
@@ -95,10 +95,10 @@ class MetaDataNormalizer implements MetaDataNormalizerInterface
     private function lowerCaseFileClassesNames($key, $value)
     {
         $normalizedValue = $value;
-        if (is_array($value) && $key === MetaDataProvider::METADATA_FILES) {
+        if (\is_array($value) && $key === MetaDataProvider::METADATA_FILES) {
             $normalizedValue = [];
             foreach ($value as $className => $path) {
-                $normalizedValue[strtolower($className)] = $path;
+                $normalizedValue[\strtolower($className)] = $path;
             }
         }
 

--- a/source/Internal/Framework/Module/MetaData/Dao/MetaDataProvider.php
+++ b/source/Internal/Framework/Module/MetaData/Dao/MetaDataProvider.php
@@ -93,7 +93,7 @@ class MetaDataProvider implements MetaDataProviderInterface
      */
     public function getData(string $filePath): array
     {
-        if (!is_readable($filePath) || is_dir($filePath)) {
+        if (!\is_readable($filePath) || \is_dir($filePath)) {
             throw new \InvalidArgumentException('File ' . $filePath . ' is not readable or not even a file.');
         }
         $this->filePath = $filePath;
@@ -153,7 +153,7 @@ class MetaDataProvider implements MetaDataProviderInterface
      */
     private function validateMetaDataFileVariables($metaDataVersion, $moduleData): void
     {
-        if ($metaDataVersion === null || !is_scalar($metaDataVersion)) {
+        if ($metaDataVersion === null || !\is_scalar($metaDataVersion)) {
             throw new InvalidMetaDataException(
                 'The variable $sMetadataVersion must be present in '
                 . $this->filePath . ' and it must be a scalar.'
@@ -178,7 +178,7 @@ class MetaDataProvider implements MetaDataProviderInterface
         $extendedClasses = $normalizedMetaData[static::METADATA_EXTEND] ?? [];
         foreach ($extendedClasses as $shopClass => $moduleClass) {
             if ($this->isBackwardsCompatibleClass($shopClass)) {
-                $sanitizedShopClass = $this->getBackwardsCompatibilityClassMap()[strtolower($shopClass)];
+                $sanitizedShopClass = $this->getBackwardsCompatibilityClassMap()[\strtolower($shopClass)];
             } else {
                 $sanitizedShopClass = $shopClass;
             }
@@ -195,7 +195,7 @@ class MetaDataProvider implements MetaDataProviderInterface
      */
     private function isBackwardsCompatibleClass(string $className): bool
     {
-        return \array_key_exists(strtolower($className), $this->getBackwardsCompatibilityClassMap());
+        return \array_key_exists(\strtolower($className), $this->getBackwardsCompatibilityClassMap());
     }
 
     /**

--- a/source/Internal/Framework/Module/MetaData/Dao/MetaDataSchemataProvider.php
+++ b/source/Internal/Framework/Module/MetaData/Dao/MetaDataSchemataProvider.php
@@ -45,7 +45,7 @@ class MetaDataSchemataProvider implements MetaDataSchemataProviderInterface
      */
     public function getMetaDataSchemaForVersion(string $metaDataVersion): array
     {
-        if (false === array_key_exists($metaDataVersion, $this->metaDataSchemata)) {
+        if (false === \array_key_exists($metaDataVersion, $this->metaDataSchemata)) {
             throw new UnsupportedMetaDataVersionException("Metadata version $metaDataVersion is not supported");
         }
 
@@ -61,7 +61,7 @@ class MetaDataSchemataProvider implements MetaDataSchemataProviderInterface
      */
     public function getFlippedMetaDataSchemaForVersion(string $metaDataVersion): array
     {
-        if (false === array_key_exists($metaDataVersion, $this->metaDataSchemata)) {
+        if (false === \array_key_exists($metaDataVersion, $this->metaDataSchemata)) {
             throw new UnsupportedMetaDataVersionException("Metadata version $metaDataVersion is not supported");
         }
 
@@ -80,7 +80,7 @@ class MetaDataSchemataProvider implements MetaDataSchemataProviderInterface
         $transposedArray = [];
 
         foreach ($metaDataVersion as $key => $item) {
-            if (is_numeric($key) && \is_string($item)) {
+            if (\is_numeric($key) && \is_string($item)) {
                 $transposedArray[$item] = $key;
             } elseif (\is_string($key) && \is_array($item)) {
                 $transposedArray[$key] = $this->arrayFlipRecursive($item);

--- a/source/Internal/Framework/Module/MetaData/DataMapper/MetaDataMapper.php
+++ b/source/Internal/Framework/Module/MetaData/DataMapper/MetaDataMapper.php
@@ -131,7 +131,7 @@ class MetaDataMapper implements MetaDataToModuleConfigurationDataMapperInterface
         }
 
         if (isset($moduleData[MetaDataProvider::METADATA_FILES])) {
-            if (count($moduleData[MetaDataProvider::METADATA_FILES]) === 0) {
+            if (\count($moduleData[MetaDataProvider::METADATA_FILES]) === 0) {
                 $moduleConfiguration->addClassWithoutNamespace(
                     new ClassWithoutNamespace(
                         '',

--- a/source/Internal/Framework/Module/MetaData/Validator/MetaDataSchemaValidator.php
+++ b/source/Internal/Framework/Module/MetaData/Validator/MetaDataSchemaValidator.php
@@ -71,7 +71,7 @@ class MetaDataSchemaValidator implements MetaDataSchemaValidatorInterface
             $this->currentValidationMetaDataVersion
         );
         foreach ($metaData as $metaDataKey => $value) {
-            if (is_scalar($value)) {
+            if (\is_scalar($value)) {
                 $this->validateMetaDataKey($supportedMetaDataKeys, (string) $metaDataKey);
             } elseif (true === \is_array($value)) {
                 $this->validateMetaDataSection($supportedMetaDataKeys, $metaDataKey, $value);
@@ -92,7 +92,7 @@ class MetaDataSchemaValidator implements MetaDataSchemaValidatorInterface
      */
     private function validateMetaDataKey(array $supportedMetaDataKeys, string $metaDataKey): void
     {
-        if (false === array_key_exists($metaDataKey, $supportedMetaDataKeys)) {
+        if (false === \array_key_exists($metaDataKey, $supportedMetaDataKeys)) {
             throw new UnsupportedMetaDataKeyException(
                 'The metadata key "' . $metaDataKey . '" is not supported in metadata version "'
                 . $this->currentValidationMetaDataVersion . '".'
@@ -113,7 +113,7 @@ class MetaDataSchemaValidator implements MetaDataSchemaValidatorInterface
     {
         foreach ($sectionData as $sectionItem) {
             if (\is_array($sectionItem)) {
-                $metaDataKeys = array_keys($sectionItem);
+                $metaDataKeys = \array_keys($sectionItem);
                 foreach ($metaDataKeys as $metaDataKey) {
                     $this->validateMetaDataKey($supportedMetaDataKeys[$sectionName], $metaDataKey);
                 }

--- a/source/Internal/Framework/Module/MetaData/Validator/ModuleSettingBooleanValidator.php
+++ b/source/Internal/Framework/Module/MetaData/Validator/ModuleSettingBooleanValidator.php
@@ -48,8 +48,8 @@ class ModuleSettingBooleanValidator implements MetaDataValidatorInterface
     private function validateSetting(array $metaData, array $setting): void
     {
         if (isset($setting['type']) && $setting['type'] === 'bool') {
-            $value = is_string($setting['value']) ? strtolower($setting['value']) : $setting['value'];
-            if (!in_array($value, self::ALLOWED_VALUES, true)) {
+            $value = \is_string($setting['value']) ? \strtolower($setting['value']) : $setting['value'];
+            if (!\in_array($value, self::ALLOWED_VALUES, true)) {
                 throw new SettingNotValidException(
                     'Invalid boolean value- "' . $setting['value'] . '" was used for module setting. '
                     . 'Please update setting value in module "' . $metaData[MetaDataProvider::METADATA_ID] . '".'

--- a/source/Internal/Framework/Module/Setting/Setting.php
+++ b/source/Internal/Framework/Module/Setting/Setting.php
@@ -65,7 +65,7 @@ class Setting
     public function getType(): string
     {
         if ($this->type === null) {
-            return gettype($this->value);
+            return \gettype($this->value);
         }
 
         return $this->type;

--- a/source/Internal/Framework/Module/Setting/SettingDao.php
+++ b/source/Internal/Framework/Module/Setting/SettingDao.php
@@ -118,7 +118,7 @@ class SettingDao implements SettingDaoInterface
          * The same entity was splitted between two tables.
          * Till we can't refactor tables we have to get data from both.
          */
-        $settingsData = array_merge(
+        $settingsData = \array_merge(
             $this->getDataFromOxConfigTable($name, $moduleId, $shopId),
             $this->getDataFromOxConfigDisplayTable($name, $moduleId)
         );
@@ -131,11 +131,11 @@ class SettingDao implements SettingDaoInterface
 
         if (
             isset($settingsData['oxvarconstraint'])
-            && is_string($settingsData['oxvarconstraint'])
+            && \is_string($settingsData['oxvarconstraint'])
             && $settingsData['oxvarconstraint'] !== ''
         ) {
             $setting->setConstraints(
-                explode('|', $settingsData['oxvarconstraint'])
+                \explode('|', $settingsData['oxvarconstraint'])
             );
         }
 
@@ -208,7 +208,7 @@ class SettingDao implements SettingDaoInterface
                 'name'          => $shopModuleSetting->getName(),
                 'groupName'     => $shopModuleSetting->getGroupName(),
                 'position'      => $shopModuleSetting->getPositionInGroup(),
-                'constraints'   => implode('|', $shopModuleSetting->getConstraints()),
+                'constraints'   => \implode('|', $shopModuleSetting->getConstraints()),
             ]);
 
         $queryBuilder->execute();

--- a/source/Internal/Framework/Module/Setup/EventSubscriber/DispatchLegacyEventsSubscriber.php
+++ b/source/Internal/Framework/Module/Setup/EventSubscriber/DispatchLegacyEventsSubscriber.php
@@ -79,7 +79,7 @@ class DispatchLegacyEventsSubscriber implements EventSubscriberInterface
                 $events[$event->getAction()] = $event->getMethod();
             }
 
-            if (\is_array($events) && array_key_exists($eventName, $events)) {
+            if (\is_array($events) && \array_key_exists($eventName, $events)) {
                 \call_user_func($events[$eventName]);
             }
         }

--- a/source/Internal/Framework/Module/Setup/Handler/ControllersModuleSettingHandler.php
+++ b/source/Internal/Framework/Module/Setup/Handler/ControllersModuleSettingHandler.php
@@ -36,10 +36,10 @@ class ControllersModuleSettingHandler implements ModuleConfigurationHandlerInter
         if ($configuration->hasControllers()) {
             $shopControllers = $this->getShopConfigurationSetting($shopId);
 
-            $shopSettingValue = array_merge(
+            $shopSettingValue = \array_merge(
                 $shopControllers->getValue(),
                 [
-                    strtolower($configuration->getId()) => $this->controllerKeysToLowercase(
+                    \strtolower($configuration->getId()) => $this->controllerKeysToLowercase(
                         $configuration->getControllers()
                     ),
                 ]
@@ -60,7 +60,7 @@ class ControllersModuleSettingHandler implements ModuleConfigurationHandlerInter
         $shopControllers = $this->getShopConfigurationSetting($shopId);
 
         $shopSettingValue = $shopControllers->getValue();
-        unset($shopSettingValue[strtolower($configuration->getId())]);
+        unset($shopSettingValue[\strtolower($configuration->getId())]);
 
         $shopControllers->setValue($shopSettingValue);
 
@@ -76,7 +76,7 @@ class ControllersModuleSettingHandler implements ModuleConfigurationHandlerInter
         $result = [];
 
         foreach ($controllers as $controller) {
-            $result[strtolower($controller->getId())] = $controller->getControllerClassNameSpace();
+            $result[\strtolower($controller->getId())] = $controller->getControllerClassNameSpace();
         }
 
         return $result;

--- a/source/Internal/Framework/Module/Setup/Handler/ShopConfigurationClassExtensionsHandler.php
+++ b/source/Internal/Framework/Module/Setup/Handler/ShopConfigurationClassExtensionsHandler.php
@@ -42,7 +42,7 @@ class ShopConfigurationClassExtensionsHandler implements ModuleConfigurationHand
             $shopConfigurationSetting = $this->getClassExtensionsShopConfigurationSetting($shopId);
 
             $shopConfigurationSettingValue = $shopConfigurationSetting->getValue();
-            $shopConfigurationSettingValue[$configuration->getId()] = array_values($classExtensions);
+            $shopConfigurationSettingValue[$configuration->getId()] = \array_values($classExtensions);
 
             $shopConfigurationSetting->setValue($shopConfigurationSettingValue);
 

--- a/source/Internal/Framework/Module/Setup/Handler/ShopConfigurationClassesWithoutNamespaceHandler.php
+++ b/source/Internal/Framework/Module/Setup/Handler/ShopConfigurationClassesWithoutNamespaceHandler.php
@@ -44,7 +44,7 @@ class ShopConfigurationClassesWithoutNamespaceHandler implements ModuleConfigura
                 }
             }
 
-            $shopSettingValue = array_merge(
+            $shopSettingValue = \array_merge(
                 $shopConfigurationSetting->getValue(),
                 [
                     $configuration->getId() => $classes

--- a/source/Internal/Framework/Module/Setup/Handler/ShopConfigurationSmartyPluginDirectoryHandler.php
+++ b/source/Internal/Framework/Module/Setup/Handler/ShopConfigurationSmartyPluginDirectoryHandler.php
@@ -41,7 +41,7 @@ class ShopConfigurationSmartyPluginDirectoryHandler implements ModuleConfigurati
                 $smartyPluginsDirectory[] = $directory->getDirectory();
             }
 
-            $shopSettingValue = array_merge(
+            $shopSettingValue = \array_merge(
                 $shopConfigurationSetting->getValue(),
                 [
                     $configuration->getId() => $smartyPluginsDirectory,

--- a/source/Internal/Framework/Module/Setup/Handler/TemplatesModuleSettingHandler.php
+++ b/source/Internal/Framework/Module/Setup/Handler/TemplatesModuleSettingHandler.php
@@ -42,7 +42,7 @@ class TemplatesModuleSettingHandler implements ModuleConfigurationHandlerInterfa
 
             $shopConfigurationSetting = $this->getShopConfigurationSetting($shopId);
 
-            $shopSettingValue = array_merge(
+            $shopSettingValue = \array_merge(
                 $shopConfigurationSetting->getValue(),
                 [
                     $configuration->getId() => $templates,

--- a/source/Internal/Framework/Module/Setup/Service/ClassExtensionChainService.php
+++ b/source/Internal/Framework/Module/Setup/Service/ClassExtensionChainService.php
@@ -62,7 +62,7 @@ class ClassExtensionChainService implements ExtensionChainServiceInterface
         $classExtensions = [];
 
         foreach ($chain as $shopClass => $moduleExtensionClasses) {
-            $classExtensions[$shopClass] = implode('&', $moduleExtensionClasses);
+            $classExtensions[$shopClass] = \implode('&', $moduleExtensionClasses);
         }
 
         return $classExtensions;

--- a/source/Internal/Framework/Module/Setup/Service/ModuleServicesActivationService.php
+++ b/source/Internal/Framework/Module/Setup/Service/ModuleServicesActivationService.php
@@ -172,7 +172,7 @@ class ModuleServicesActivationService implements ModuleServicesActivationService
      */
     private function getModuleConfig(string $moduleConfigFile): DIConfigWrapper
     {
-        if (!file_exists($moduleConfigFile)) {
+        if (!\file_exists($moduleConfigFile)) {
             throw new NoServiceYamlException();
         }
 

--- a/source/Internal/Framework/Module/Setup/Validator/ClassExtensionsValidator.php
+++ b/source/Internal/Framework/Module/Setup/Validator/ClassExtensionsValidator.php
@@ -58,7 +58,7 @@ class ClassExtensionsValidator implements ModuleConfigurationValidatorInterface
             );
         }
 
-        if ($this->shopAdapter->isShopUnifiedNamespace($namespace) && !class_exists($namespace)) {
+        if ($this->shopAdapter->isShopUnifiedNamespace($namespace) && !\class_exists($namespace)) {
             throw new InvalidClassExtensionNamespaceException(
                 'Module tries to extend non existent shop class: ' . $namespace
             );

--- a/source/Internal/Framework/Module/Setup/Validator/ControllersValidator.php
+++ b/source/Internal/Framework/Module/Setup/Validator/ControllersValidator.php
@@ -88,8 +88,8 @@ class ControllersValidator implements ModuleConfigurationValidatorInterface
 
     private function controllerAlreadyExistsInMap(Controller $controller, array $controllerClassMap): bool
     {
-        return array_key_exists(strtolower($controller->getId()), $controllerClassMap)
-            && $controllerClassMap[strtolower($controller->getId())] === $controller->getControllerClassNameSpace();
+        return \array_key_exists(\strtolower($controller->getId()), $controllerClassMap)
+            && $controllerClassMap[\strtolower($controller->getId())] === $controller->getControllerClassNameSpace();
     }
 
     /**
@@ -105,9 +105,9 @@ class ControllersValidator implements ModuleConfigurationValidatorInterface
                 ->shopConfigurationSettingDao
                 ->get(ShopConfigurationSetting::MODULE_CONTROLLERS, $shopId);
 
-            if (is_array($controllersGroupedByModule->getValue())) {
+            if (\is_array($controllersGroupedByModule->getValue())) {
                 foreach ($controllersGroupedByModule->getValue() as $moduleControllers) {
-                    $moduleControllersClassMap = array_merge($moduleControllersClassMap, $moduleControllers);
+                    $moduleControllersClassMap = \array_merge($moduleControllersClassMap, $moduleControllers);
                 }
             }
         } catch (EntryDoesNotExistDaoException $exception) {
@@ -123,7 +123,7 @@ class ControllersValidator implements ModuleConfigurationValidatorInterface
      */
     private function validateKeyDuplication(Controller $controller, array $controllerClassMap): void
     {
-        if (array_key_exists(strtolower($controller->getId()), $controllerClassMap)) {
+        if (\array_key_exists(\strtolower($controller->getId()), $controllerClassMap)) {
             throw new ControllersDuplicationModuleConfigurationException(
                 'Controller key duplication: ' . $controller->getId()
             );
@@ -137,7 +137,7 @@ class ControllersValidator implements ModuleConfigurationValidatorInterface
      */
     private function validateNamespaceDuplication(Controller $controller, array $controllerClassMap): void
     {
-        if (in_array($controller->getControllerClassNameSpace(), $controllerClassMap, true)) {
+        if (\in_array($controller->getControllerClassNameSpace(), $controllerClassMap, true)) {
             throw new ControllersDuplicationModuleConfigurationException(
                 'Controller namespace duplication: ' . $controller->getControllerClassNameSpace()
             );
@@ -150,7 +150,7 @@ class ControllersValidator implements ModuleConfigurationValidatorInterface
      */
     private function getControllersClassMap(int $shopId): array
     {
-        return array_merge(
+        return \array_merge(
             $this->shopAdapter->getShopControllerClassMap(),
             $this->getModulesControllerClassMap($shopId)
         );

--- a/source/Internal/Framework/Module/Setup/Validator/EventsValidator.php
+++ b/source/Internal/Framework/Module/Setup/Validator/EventsValidator.php
@@ -49,7 +49,7 @@ class EventsValidator implements ModuleConfigurationValidatorInterface
                 $events[$event->getAction()] = $event->getMethod();
             }
             foreach ($this->validEvents as $validEventName) {
-                if (is_array($events) && \array_key_exists($validEventName, $events)) {
+                if (\is_array($events) && \array_key_exists($validEventName, $events)) {
                     $this->checkIfMethodIsCallable($events[$validEventName]);
                 }
             }
@@ -78,7 +78,7 @@ class EventsValidator implements ModuleConfigurationValidatorInterface
      */
     private function isNamespacedClass(string $method): bool
     {
-        $className = explode('::', $method)[0];
+        $className = \explode('::', $method)[0];
         if ($this->shopAdapter->isNamespace($className)) {
             return true;
         }

--- a/source/Internal/Framework/Module/Setup/Validator/SmartyPluginDirectoriesValidator.php
+++ b/source/Internal/Framework/Module/Setup/Validator/SmartyPluginDirectoriesValidator.php
@@ -55,7 +55,7 @@ class SmartyPluginDirectoriesValidator implements ModuleConfigurationValidatorIn
                     'Module setting ' .
                     SmartyPluginDirectoriesDataMapper::MAPPING_KEY .
                     ' must be of type array but ' .
-                    gettype($directories[0]) .
+                    \gettype($directories[0]) .
                     ' given'
                 );
             }
@@ -67,12 +67,12 @@ class SmartyPluginDirectoriesValidator implements ModuleConfigurationValidatorIn
 
             foreach ($directories as $directory) {
                 $fullPathSmartyPluginDirectory = $fullPathToModule . DIRECTORY_SEPARATOR . $directory;
-                if (!is_dir($fullPathSmartyPluginDirectory)) {
+                if (!\is_dir($fullPathSmartyPluginDirectory)) {
                     throw new DirectoryNotExistentException(
                         'Directory ' . $fullPathSmartyPluginDirectory . ' does not exist.'
                     );
                 }
-                if (!is_readable($fullPathSmartyPluginDirectory)) {
+                if (!\is_readable($fullPathSmartyPluginDirectory)) {
                     throw new DirectoryNotReadableException(
                         'Directory ' . $fullPathSmartyPluginDirectory . ' not readable.'
                     );
@@ -88,6 +88,6 @@ class SmartyPluginDirectoriesValidator implements ModuleConfigurationValidatorIn
      */
     private function isEmptyArray(array $directories): bool
     {
-        return count($directories) === 1 && $directories[0] === '';
+        return \count($directories) === 1 && $directories[0] === '';
     }
 }

--- a/source/Internal/Framework/Module/State/ModuleStateService.php
+++ b/source/Internal/Framework/Module/State/ModuleStateService.php
@@ -42,7 +42,7 @@ class ModuleStateService implements ModuleStateServiceInterface
     {
         $activeModuleIdsSetting = $this->getActiveModulesShopConfigurationSetting($shopId);
 
-        return in_array($moduleId, $activeModuleIdsSetting->getValue(), true);
+        return \in_array($moduleId, $activeModuleIdsSetting->getValue(), true);
     }
 
     /**
@@ -86,7 +86,7 @@ class ModuleStateService implements ModuleStateServiceInterface
 
         $activeModuleIds = $activeModuleIdsSetting->getValue();
 
-        $activeModuleIds = array_diff($activeModuleIds, [$moduleId]);
+        $activeModuleIds = \array_diff($activeModuleIds, [$moduleId]);
         $activeModuleIdsSetting->setValue($activeModuleIds);
 
         $this->shopConfigurationSettingDao->save($activeModuleIdsSetting);

--- a/source/Internal/Framework/Smarty/Extension/CacheResourcePlugin.php
+++ b/source/Internal/Framework/Smarty/Extension/CacheResourcePlugin.php
@@ -66,7 +66,7 @@ class CacheResourcePlugin
      */
     public static function getTimestamp($templateName, &$templateTimestamp, $smarty)
     {
-        $templateTimestamp = isset($smarty->oxidtimecache->value) ? $smarty->oxidtimecache->value : time();
+        $templateTimestamp = isset($smarty->oxidtimecache->value) ? $smarty->oxidtimecache->value : \time();
 
         return true;
     }

--- a/source/Internal/Framework/Smarty/Extension/SmartyDefaultTemplateHandler.php
+++ b/source/Internal/Framework/Smarty/Extension/SmartyDefaultTemplateHandler.php
@@ -45,12 +45,12 @@ class SmartyDefaultTemplateHandler
     public function handleTemplate($resourceType, $resourceName, &$resourceContent, &$resourceTimestamp, $smarty)
     {
         $loader = self::$loader;
-        if ($resourceType === 'file' && !is_readable($resourceName)) {
+        if ($resourceType === 'file' && !\is_readable($resourceName)) {
             $resourceName = $loader->getPath($resourceName);
-            $fileLoaded = is_file($resourceName) && is_readable($resourceName);
+            $fileLoaded = \is_file($resourceName) && \is_readable($resourceName);
             if ($fileLoaded) {
                 $resourceContent = $smarty->_read_file($resourceName);
-                $resourceTimestamp = filemtime($resourceName);
+                $resourceTimestamp = \filemtime($resourceName);
             }
 
             return $fileLoaded;

--- a/source/Internal/Framework/Smarty/Legacy/LegacySmartyEngine.php
+++ b/source/Internal/Framework/Smarty/Legacy/LegacySmartyEngine.php
@@ -132,7 +132,7 @@ class LegacySmartyEngine implements LegacySmartyEngineInterface, TemplateEngineI
      */
     public function __set($name, $value)
     {
-        if (property_exists($this->engine, $name)) {
+        if (\property_exists($this->engine, $name)) {
             $this->engine->$name = $value;
         }
     }

--- a/source/Internal/Framework/Smarty/SmartyBuilder.php
+++ b/source/Internal/Framework/Smarty/SmartyBuilder.php
@@ -49,11 +49,11 @@ class SmartyBuilder implements SmartyBuilderInterface
     public function setSecuritySettings(array $settings)
     {
         foreach ($settings as $key => $value) {
-            if (is_array($value)) {
+            if (\is_array($value)) {
                 foreach ($value as $subKey => $subValue) {
-                    if (is_array($subValue)) {
+                    if (\is_array($subValue)) {
                         $originalSettings = $this->smarty->{$key}[$subKey];
-                        $this->smarty->{$key}[$subKey] = array_merge($originalSettings, $subValue);
+                        $this->smarty->{$key}[$subKey] = \array_merge($originalSettings, $subValue);
                     } else {
                         $this->smarty->{$key}[$subKey] = $subValue;
                     }
@@ -90,7 +90,7 @@ class SmartyBuilder implements SmartyBuilderInterface
     public function registerPrefilters(array $prefilters)
     {
         foreach ($prefilters as $prefilter => $path) {
-            if (file_exists($path)) {
+            if (\file_exists($path)) {
                 include_once $path;
                 $this->smarty->register_prefilter($prefilter);
             }
@@ -107,8 +107,8 @@ class SmartyBuilder implements SmartyBuilderInterface
      */
     public function registerPlugins(array $plugins)
     {
-        if (is_array($plugins)) {
-            $this->smarty->plugins_dir = array_merge(
+        if (\is_array($plugins)) {
+            $this->smarty->plugins_dir = \array_merge(
                 $plugins,
                 $this->smarty->plugins_dir
             );

--- a/source/Internal/Framework/Smarty/SmartyEngine.php
+++ b/source/Internal/Framework/Smarty/SmartyEngine.php
@@ -128,7 +128,7 @@ class SmartyEngine implements TemplateEngineInterface
      */
     public function __set($name, $value)
     {
-        if (property_exists($this->engine, $name)) {
+        if (\property_exists($this->engine, $name)) {
             $this->engine->$name = $value;
         }
     }

--- a/source/Internal/Framework/Storage/YamlFileStorage.php
+++ b/source/Internal/Framework/Storage/YamlFileStorage.php
@@ -61,7 +61,7 @@ class YamlFileStorage implements ArrayStorageInterface
      */
     public function get(): array
     {
-        $fileContent = file_get_contents($this->getLocatedFilePath());
+        $fileContent = \file_get_contents($this->getLocatedFilePath());
 
         $yaml = Yaml::parse(
             $fileContent
@@ -79,7 +79,7 @@ class YamlFileStorage implements ArrayStorageInterface
 
         if ($lock->acquire(true)) {
             try {
-                file_put_contents(
+                \file_put_contents(
                     $this->getLocatedFilePath(),
                     Yaml::dump($data, 10, 2)
                 );
@@ -128,6 +128,6 @@ class YamlFileStorage implements ArrayStorageInterface
      */
     private function getLockId(): string
     {
-        return md5($this->filePath);
+        return \md5($this->filePath);
     }
 }

--- a/source/Internal/Framework/Templating/Loader/TemplateLoader.php
+++ b/source/Internal/Framework/Templating/Loader/TemplateLoader.php
@@ -74,7 +74,7 @@ class TemplateLoader implements TemplateLoaderInterface
     {
         $path = $this->findTemplate($name);
 
-        return file_get_contents($path);
+        return \file_get_contents($path);
     }
 
     /**
@@ -104,7 +104,7 @@ class TemplateLoader implements TemplateLoaderInterface
         $file = $this->fileLocator->locate($templateName);
 
         if (false === $file || null === $file || '' === $file) {
-            throw new TemplateFileNotFoundException(sprintf('Template "%s" not found', $name));
+            throw new TemplateFileNotFoundException(\sprintf('Template "%s" not found', $name));
         }
         return $file;
     }

--- a/source/Internal/Framework/Templating/Locator/AdminNavigationFileLocator.php
+++ b/source/Internal/Framework/Templating/Locator/AdminNavigationFileLocator.php
@@ -43,6 +43,6 @@ class AdminNavigationFileLocator implements NavigationFileLocatorInterface
         foreach ($this->menuFileLocators as $locator) {
             $menuFilePaths[] = $locator->locate();
         }
-        return array_merge([], ...$menuFilePaths);
+        return \array_merge([], ...$menuFilePaths);
     }
 }

--- a/source/Internal/Framework/Templating/Resolver/LegacyTemplateNameResolver.php
+++ b/source/Internal/Framework/Templating/Resolver/LegacyTemplateNameResolver.php
@@ -47,9 +47,9 @@ class LegacyTemplateNameResolver implements TemplateNameResolverInterface
      */
     private function getFileNameWithoutExtension(string $fileName): string
     {
-        $pos = strrpos($fileName, '.tpl');
+        $pos = \strrpos($fileName, '.tpl');
         if (false !== $pos) {
-            $fileName = substr($fileName, 0, $pos);
+            $fileName = \substr($fileName, 0, $pos);
         }
         return $fileName;
     }

--- a/source/Internal/Setup/ConfigFile/ConfigFileDao.php
+++ b/source/Internal/Setup/ConfigFile/ConfigFileDao.php
@@ -38,9 +38,9 @@ class ConfigFileDao implements ConfigFileDaoInterface
         $placeholder = $this->getPlaceholder($placeholderName);
         $originalContents = $this->getConfigFileContent();
         $this->checkPlaceholderPresent($placeholder, $originalContents);
-        $replacedContents = str_replace($placeholder, $value, $originalContents);
+        $replacedContents = \str_replace($placeholder, $value, $originalContents);
 
-        file_put_contents($this->context->getConfigFilePath(), $replacedContents);
+        \file_put_contents($this->context->getConfigFilePath(), $replacedContents);
     }
 
     /** @inheritDoc */
@@ -58,11 +58,11 @@ class ConfigFileDao implements ConfigFileDaoInterface
      */
     private function getConfigFileContent(): string
     {
-        if (!file_exists($this->context->getConfigFilePath())) {
+        if (!\file_exists($this->context->getConfigFilePath())) {
             throw new ConfigFileNotFoundException('File not found ' . $this->context->getConfigFilePath());
         }
 
-        return file_get_contents($this->context->getConfigFilePath());
+        return \file_get_contents($this->context->getConfigFilePath());
     }
 
     /**
@@ -81,7 +81,7 @@ class ConfigFileDao implements ConfigFileDaoInterface
      */
     private function checkPlaceholderPresent(string $placeholder, string $fileContents): void
     {
-        if (strpos($fileContents, $placeholder) === false) {
+        if (\strpos($fileContents, $placeholder) === false) {
             throw new FileNotEditableException("Configuration file is not editable - value for $placeholder can not be set.");
         }
     }

--- a/source/Internal/Setup/Database/Service/DatabaseChecker.php
+++ b/source/Internal/Setup/Database/Service/DatabaseChecker.php
@@ -58,7 +58,7 @@ class DatabaseChecker implements DatabaseCheckerInterface
     private function getDatabaseConnection(string $host, int $port, string $user, string $password): PDO
     {
         return new \PDO(
-            sprintf('mysql:host=%s;port=%s', $host, $port),
+            \sprintf('mysql:host=%s;port=%s', $host, $port),
             $user,
             $password,
             [\PDO::ATTR_ERRMODE => \PDO::ERRMODE_EXCEPTION]

--- a/source/Internal/Setup/Database/Service/DatabaseCreator.php
+++ b/source/Internal/Setup/Database/Service/DatabaseCreator.php
@@ -57,7 +57,7 @@ class DatabaseCreator implements DatabaseCreatorInterface
     {
         try {
             $this->dbConnection = new PDO(
-                sprintf('mysql:host=%s;port=%s', $host, $port),
+                \sprintf('mysql:host=%s;port=%s', $host, $port),
                 $username,
                 $password,
                 [PDO::MYSQL_ATTR_INIT_COMMAND => 'SET NAMES utf8']

--- a/source/Internal/Setup/Database/Service/DatabaseInitiator.php
+++ b/source/Internal/Setup/Database/Service/DatabaseInitiator.php
@@ -95,7 +95,7 @@ class DatabaseInitiator implements DatabaseInitiatorInterface
      */
     private function executeSqlQueryFromFile(string $sqlFilePath): void
     {
-        $queries = file_get_contents($sqlFilePath);
+        $queries = \file_get_contents($sqlFilePath);
         if (!$queries) {
             throw new InitiateDatabaseException(InitiateDatabaseException::READ_SQL_FILE_PROBLEM);
         }
@@ -111,7 +111,7 @@ class DatabaseInitiator implements DatabaseInitiatorInterface
         string $name
     ): PDO {
         $dbConnection = new PDO(
-            sprintf('mysql:host=%s;port=%s;dbname=%s', $host, $port, $name),
+            \sprintf('mysql:host=%s;port=%s;dbname=%s', $host, $port, $name),
             $username,
             $password,
             [PDO::MYSQL_ATTR_INIT_COMMAND => 'SET NAMES utf8']

--- a/source/Internal/Setup/Database/Service/DatabaseInstaller.php
+++ b/source/Internal/Setup/Database/Service/DatabaseInstaller.php
@@ -110,8 +110,8 @@ class DatabaseInstaller implements DatabaseInstallerInterface
 
     private function resetConfigFileOpcache(): void
     {
-        if (opcache_get_status() !== false) {
-            opcache_invalidate($this->basicContext->getConfigFilePath());
+        if (\opcache_get_status() !== false) {
+            \opcache_invalidate($this->basicContext->getConfigFilePath());
         }
     }
 }

--- a/source/Internal/Setup/Directory/Service/DirectoryValidator.php
+++ b/source/Internal/Setup/Directory/Service/DirectoryValidator.php
@@ -69,7 +69,7 @@ class DirectoryValidator implements DirectoryValidatorInterface
     private function checkDirectoriesExistent(array $directories): void
     {
         foreach ($directories as $directory) {
-            if (!is_dir($directory)) {
+            if (!\is_dir($directory)) {
                 throw new NonExistenceDirectoryException(
                     NonExistenceDirectoryException::NON_EXISTENCE_DIRECTORY . ': ' . $directory
                 );
@@ -88,7 +88,7 @@ class DirectoryValidator implements DirectoryValidatorInterface
         $subDirectories = $this->getDirectoriesAndSubDirectories($directories);
 
         foreach ($subDirectories as $subDirectory) {
-            if (!is_readable($subDirectory) || !is_writable($subDirectory)) {
+            if (!\is_readable($subDirectory) || !\is_writable($subDirectory)) {
                 throw new NoPermissionDirectoryException(
                     NoPermissionDirectoryException::NO_PERMISSION_DIRECTORY . ': ' . $subDirectory
                 );
@@ -112,7 +112,7 @@ class DirectoryValidator implements DirectoryValidatorInterface
 
             foreach ($recursiveIterator as $path => $dir) {
                 if ($dir->isDir()) {
-                    $directories[] = rtrim($path, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR;
+                    $directories[] = \rtrim($path, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR;
                 }
             }
         }
@@ -128,16 +128,16 @@ class DirectoryValidator implements DirectoryValidatorInterface
      */
     private function getDirectories(string $shopSourcePath, string $compileDirectory): array
     {
-        $shopSourcePath = rtrim($shopSourcePath, DIRECTORY_SEPARATOR) .  DIRECTORY_SEPARATOR;
+        $shopSourcePath = \rtrim($shopSourcePath, DIRECTORY_SEPARATOR) .  DIRECTORY_SEPARATOR;
 
-        $directories = array_map(
+        $directories = \array_map(
             static function ($value) use ($shopSourcePath) {
                 return $shopSourcePath . $value;
             },
             self::DIRECTORIES_LIST
         );
 
-        $directories[] = rtrim($compileDirectory, DIRECTORY_SEPARATOR) .  DIRECTORY_SEPARATOR;
+        $directories[] = \rtrim($compileDirectory, DIRECTORY_SEPARATOR) .  DIRECTORY_SEPARATOR;
 
         return $directories;
     }

--- a/source/Internal/Setup/Htaccess/HtaccessDao.php
+++ b/source/Internal/Setup/Htaccess/HtaccessDao.php
@@ -34,7 +34,7 @@ class HtaccessDao implements HtaccessDaoInterface
     private function readFile(): void
     {
         $this->checkFileAccess();
-        $this->contents = file_get_contents($this->filePath);
+        $this->contents = \file_get_contents($this->filePath);
     }
 
     /**
@@ -43,19 +43,19 @@ class HtaccessDao implements HtaccessDaoInterface
      */
     private function updateDirective(string $key, string $value): void
     {
-        $this->contents = preg_replace("/$key.*/", "$key $value", $this->contents);
+        $this->contents = \preg_replace("/$key.*/", "$key $value", $this->contents);
     }
 
     private function writeFile(): void
     {
-        file_put_contents($this->filePath, $this->contents);
+        \file_put_contents($this->filePath, $this->contents);
     }
 
     /** @throws HtaccessAccessException */
     private function checkFileAccess(): void
     {
-        clearstatcache();
-        if (!is_readable($this->filePath) || !is_writable($this->filePath)) {
+        \clearstatcache();
+        if (!\is_readable($this->filePath) || !\is_writable($this->filePath)) {
             throw new HtaccessAccessException("File not found or not accessible: `{$this->filePath}`");
         }
     }

--- a/source/Internal/Setup/Htaccess/HtaccessDaoFactory.php
+++ b/source/Internal/Setup/Htaccess/HtaccessDaoFactory.php
@@ -39,11 +39,11 @@ class HtaccessDaoFactory implements HtaccessDaoFactoryInterface
      */
     private function getRootHtaccessPath(): string
     {
-        clearstatcache();
-        $path = realpath($this->basicContext->getSourcePath() . DIRECTORY_SEPARATOR . self::FILENAME);
-        if (!$path || !is_file($path)) {
+        \clearstatcache();
+        $path = \realpath($this->basicContext->getSourcePath() . DIRECTORY_SEPARATOR . self::FILENAME);
+        if (!$path || !\is_file($path)) {
             throw new HtaccessAccessException(
-                sprintf('Root %s file not found or not accessible', self::FILENAME)
+                \sprintf('Root %s file not found or not accessible', self::FILENAME)
             );
         }
         return $path;

--- a/source/Internal/Setup/Language/DefaultLanguage.php
+++ b/source/Internal/Setup/Language/DefaultLanguage.php
@@ -27,10 +27,10 @@ class DefaultLanguage
      */
     public function __construct(string $language)
     {
-        if (!in_array($language, $this->availableLanguages)) {
+        if (!\in_array($language, $this->availableLanguages)) {
             throw new IncorrectLanguageException(
                 'Invalid language argument: ' . $language
-                . ', available languages: ' . implode(', ', $this->availableLanguages)
+                . ', available languages: ' . \implode(', ', $this->availableLanguages)
             );
         }
 

--- a/source/Internal/Transition/Adapter/ShopAdapter.php
+++ b/source/Internal/Transition/Adapter/ShopAdapter.php
@@ -48,7 +48,7 @@ class ShopAdapter implements ShopAdapterInterface
 
         ModuleVariablesLocator::resetModuleVariables();
 
-        if (extension_loaded('apc') && ini_get('apc.enabled')) {
+        if (\extension_loaded('apc') && \ini_get('apc.enabled')) {
             apc_clear_cache();
         }
     }

--- a/source/Internal/Transition/Adapter/TemplateLogic/AddUrlParametersLogic.php
+++ b/source/Internal/Transition/Adapter/TemplateLogic/AddUrlParametersLogic.php
@@ -25,7 +25,7 @@ class AddUrlParametersLogic
         // removing empty parameters
         $sDynParams = $sDynParams ? Str::getStr()->preg_replace(['/^\?/', '/^\&(amp;)?$/'], '', $sDynParams) : false;
         if ($sDynParams) {
-            $sUrl .= ((strpos($sUrl, '?') !== false) ? "&amp;" : "?") . $sDynParams;
+            $sUrl .= ((\strpos($sUrl, '?') !== false) ? "&amp;" : "?") . $sDynParams;
         }
 
         return \OxidEsales\Eshop\Core\Registry::getUtilsUrl()->processSeoUrl($sUrl);

--- a/source/Internal/Transition/Adapter/TemplateLogic/AssignAdvancedLogic.php
+++ b/source/Internal/Transition/Adapter/TemplateLogic/AssignAdvancedLogic.php
@@ -19,10 +19,10 @@ class AssignAdvancedLogic
      */
     public function formatValue(string $value)
     {
-        if (preg_match('/^\s*array\s*\(\s*(.*)\s*\)\s*$/s', $value, $match)) {
-            eval('$value=array(' . str_replace("\n", "", $match[1]) . ');');
-        } elseif (preg_match('/^\s*range\s*\(\s*(.*)\s*\)\s*$/s', $value, $match)) {
-            eval('$value=range(' . str_replace("\n", "", $match[1]) . ');');
+        if (\preg_match('/^\s*array\s*\(\s*(.*)\s*\)\s*$/s', $value, $match)) {
+            eval('$value=array(' . \str_replace("\n", "", $match[1]) . ');');
+        } elseif (\preg_match('/^\s*range\s*\(\s*(.*)\s*\)\s*$/s', $value, $match)) {
+            eval('$value=range(' . \str_replace("\n", "", $match[1]) . ');');
         }
 
         return $value;

--- a/source/Internal/Transition/Adapter/TemplateLogic/DateFormatHelper.php
+++ b/source/Internal/Transition/Adapter/TemplateLogic/DateFormatHelper.php
@@ -20,15 +20,15 @@ class DateFormatHelper
     {
         $winFormatSearch = ['%D', '%h', '%n', '%r', '%R', '%t', '%T'];
         $winFormatReplace = ['%m/%d/%y', '%b', "\n", '%I:%M:%S %p', '%H:%M', "\t", '%H:%M:%S'];
-        if (strpos($format, '%e') !== false) {
+        if (\strpos($format, '%e') !== false) {
             $winFormatSearch[] = '%e';
-            $winFormatReplace[] = sprintf('%\' 2d', date('j', $timestamp));
+            $winFormatReplace[] = \sprintf('%\' 2d', \date('j', $timestamp));
         }
-        if (strpos($format, '%l') !== false) {
+        if (\strpos($format, '%l') !== false) {
             $winFormatSearch[] = '%l';
-            $winFormatReplace[] = sprintf('%\' 2d', date('h', $timestamp));
+            $winFormatReplace[] = \sprintf('%\' 2d', \date('h', $timestamp));
         }
-        $format = str_replace($winFormatSearch, $winFormatReplace, $format);
+        $format = \str_replace($winFormatSearch, $winFormatReplace, $format);
 
         return $format;
     }

--- a/source/Internal/Transition/Adapter/TemplateLogic/FileSizeLogic.php
+++ b/source/Internal/Transition/Adapter/TemplateLogic/FileSizeLogic.php
@@ -24,17 +24,17 @@ class FileSizeLogic
         $size = $size / 1024;
 
         if ($size < 1024) {
-            return sprintf("%.1f KB", $size);
+            return \sprintf("%.1f KB", $size);
         }
 
         $size = $size / 1024;
 
         if ($size < 1024) {
-            return sprintf("%.1f MB", $size);
+            return \sprintf("%.1f MB", $size);
         }
 
         $size = $size / 1024;
 
-        return sprintf("%.1f GB", $size);
+        return \sprintf("%.1f GB", $size);
     }
 }

--- a/source/Internal/Transition/Adapter/TemplateLogic/FormatCurrencyLogic.php
+++ b/source/Internal/Transition/Adapter/TemplateLogic/FormatCurrencyLogic.php
@@ -21,19 +21,19 @@ class FormatCurrencyLogic
     public function numberFormat($sFormat = "EUR@ 1.00@ ,@ .@ EUR@ 2", $sValue = 0)
     {
         // logic copied from \OxidEsales\Eshop\Core\Config::getCurrencyArray()
-        $sCur = explode("@", $sFormat);
+        $sCur = \explode("@", $sFormat);
         $oCur = new stdClass();
         $oCur->id = 0;
-        $oCur->name = @trim($sCur[0]);
-        $oCur->rate = @trim($sCur[1]);
-        $oCur->dec = @trim($sCur[2]);
-        $oCur->thousand = @trim($sCur[3]);
-        $oCur->sign = @trim($sCur[4]);
-        $oCur->decimal = @trim($sCur[5]);
+        $oCur->name = @\trim($sCur[0]);
+        $oCur->rate = @\trim($sCur[1]);
+        $oCur->dec = @\trim($sCur[2]);
+        $oCur->thousand = @\trim($sCur[3]);
+        $oCur->sign = @\trim($sCur[4]);
+        $oCur->decimal = @\trim($sCur[5]);
 
         // change for US version
         if (isset($sCur[6])) {
-            $oCur->side = @trim($sCur[6]);
+            $oCur->side = @\trim($sCur[6]);
         }
 
         return \OxidEsales\Eshop\Core\Registry::getLang()->formatCurrency($sValue, $oCur);

--- a/source/Internal/Transition/Adapter/TemplateLogic/FormatDateLogic.php
+++ b/source/Internal/Transition/Adapter/TemplateLogic/FormatDateLogic.php
@@ -20,7 +20,7 @@ class FormatDateLogic
     public function formdate($oConvObject, string $sFieldType = null, bool $blPassedValue = false): ?string
     {
         // creating fake bject
-        if ($blPassedValue || is_string($oConvObject)) {
+        if ($blPassedValue || \is_string($oConvObject)) {
             $sValue = $oConvObject;
             $oConvObject = new \OxidEsales\Eshop\Core\Field();
             $oConvObject->fldmax_length = "0";

--- a/source/Internal/Transition/Adapter/TemplateLogic/FormatPriceLogic.php
+++ b/source/Internal/Transition/Adapter/TemplateLogic/FormatPriceLogic.php
@@ -21,7 +21,7 @@ class FormatPriceLogic
     {
         $output = '';
         $inputPrice = $params['price'];
-        if (!is_null($inputPrice)) {
+        if (!\is_null($inputPrice)) {
             $output = $this->calculatePrice($inputPrice, $params);
         }
 
@@ -41,7 +41,7 @@ class FormatPriceLogic
         $currency = isset($params['currency']) ? (object) $params['currency'] : $config->getActShopCurrencyObject();
         $output = '';
 
-        if (is_numeric($price)) {
+        if (\is_numeric($price)) {
             $output = $this->getFormattedPrice($currency, $price);
         }
 
@@ -64,13 +64,13 @@ class FormatPriceLogic
         $decimals = isset($currency->decimal) ? (int) $currency->decimal : 2;
 
         if ((float) $price > 0 || $currencySymbol) {
-            $price = number_format($price, $decimals, $decimalSeparator, $thousandsSeparator);
+            $price = \number_format($price, $decimals, $decimalSeparator, $thousandsSeparator);
             $output = (isset($currencySymbolLocation) && $currencySymbolLocation == 'Front')
                 ? $currencySymbol . $price
                 : $price . ' ' . $currencySymbol;
         }
 
-        $output = trim($output);
+        $output = \trim($output);
 
         return $output;
     }

--- a/source/Internal/Transition/Adapter/TemplateLogic/FormatTimeLogic.php
+++ b/source/Internal/Transition/Adapter/TemplateLogic/FormatTimeLogic.php
@@ -17,10 +17,10 @@ class FormatTimeLogic
      */
     public function getFormattedTime(int $seconds): string
     {
-        $hours = floor($seconds / 3600);
-        $minutes = floor($seconds % 3600 / 60);
+        $hours = \floor($seconds / 3600);
+        $minutes = \floor($seconds % 3600 / 60);
         $seconds = $seconds % 60;
 
-        return sprintf("%02d:%02d:%02d", $hours, $minutes, $seconds);
+        return \sprintf("%02d:%02d:%02d", $hours, $minutes, $seconds);
     }
 }

--- a/source/Internal/Transition/Adapter/TemplateLogic/IncludeDynamicLogic.php
+++ b/source/Internal/Transition/Adapter/TemplateLogic/IncludeDynamicLogic.php
@@ -19,7 +19,7 @@ class IncludeDynamicLogic
         $content = "<oxid_dynamic>";
 
         foreach ($parameters as $key => $value) {
-            $content .= " $key='" . base64_encode($value) . "'";
+            $content .= " $key='" . \base64_encode($value) . "'";
         }
 
         $content .= "</oxid_dynamic>";
@@ -35,7 +35,7 @@ class IncludeDynamicLogic
     public function includeDynamicPrefix(array $parameters): array
     {
         $prefix = "_";
-        if (array_key_exists('type', $parameters)) {
+        if (\array_key_exists('type', $parameters)) {
             $prefix .= $parameters['type'] . "_";
         }
         foreach ($parameters as $key => $value) {

--- a/source/Internal/Transition/Adapter/TemplateLogic/IncludeWidgetLogic.php
+++ b/source/Internal/Transition/Adapter/TemplateLogic/IncludeWidgetLogic.php
@@ -20,13 +20,13 @@ class IncludeWidgetLogic
     {
         $class = '';
         if (isset($params['cl'])) {
-            $class = strtolower($params['cl']);
+            $class = \strtolower($params['cl']);
             unset($params['cl']);
         }
 
         $parentViews = null;
         if (!empty($params["_parent"])) {
-            $parentViews = explode("|", $params["_parent"]);
+            $parentViews = \explode("|", $params["_parent"]);
             unset($params["_parent"]);
         }
 

--- a/source/Internal/Transition/Adapter/TemplateLogic/SeoUrlLogic.php
+++ b/source/Internal/Transition/Adapter/TemplateLogic/SeoUrlLogic.php
@@ -31,7 +31,7 @@ class SeoUrlLogic
                 $sUrl = $oObject->getLink();
             } elseif ($sOxid) {
                 //minimising aricle object loading
-                if (strtolower($sType) == "oxarticle") {
+                if (\strtolower($sType) == "oxarticle") {
                     $oObject->disablePriceLoad();
                     $oObject->setNoVariantLoading(true);
                 }

--- a/source/Internal/Transition/Adapter/TemplateLogic/SmartWordwrapLogic.php
+++ b/source/Internal/Transition/Adapter/TemplateLogic/SmartWordwrapLogic.php
@@ -27,33 +27,33 @@ class SmartWordwrapLogic
         $afterWrapChars = ["-" . $wrapTag];
 
 
-        $string = trim($string);
+        $string = \trim($string);
 
-        if (strlen($string) <= $length) {
+        if (\strlen($string) <= $length) {
             return $string;
         }
 
         //trying to wrap without cut
-        $str = wordwrap($string, $length, $wrapTag, false);
-        $arr = explode($wrapTag, $str);
+        $str = \wordwrap($string, $length, $wrapTag, false);
+        $arr = \explode($wrapTag, $str);
 
         $alt = [];
 
         $ok = true;
         foreach ($arr as $row) {
-            if (strlen($row) > ($length + $tolerance)) {
-                $tmpstr = str_replace($wrapChars, $afterWrapChars, $row);
-                $tmparr = explode($wrapTag, $tmpstr);
+            if (\strlen($row) > ($length + $tolerance)) {
+                $tmpstr = \str_replace($wrapChars, $afterWrapChars, $row);
+                $tmparr = \explode($wrapTag, $tmpstr);
 
                 foreach ($tmparr as $altrow) {
-                    array_push($alt, $altrow);
+                    \array_push($alt, $altrow);
 
-                    if (strlen($altrow) > ($length + $tolerance)) {
+                    if (\strlen($altrow) > ($length + $tolerance)) {
                         $ok = false;
                     }
                 }
             } else {
-                array_push($alt, $row);
+                \array_push($alt, $row);
             }
         }
 
@@ -61,20 +61,20 @@ class SmartWordwrapLogic
 
         if (!$ok) {
             //trying to wrap with cut
-            $str = wordwrap($string, $length, $wrapTag, true);
-            $arr = explode($wrapTag, $str);
+            $str = \wordwrap($string, $length, $wrapTag, true);
+            $arr = \explode($wrapTag, $str);
         }
 
-        if ($cutRows && count($arr) > $cutRows) {
-            $arr = array_splice($arr, 0, $cutRows);
+        if ($cutRows && \count($arr) > $cutRows) {
+            $arr = \array_splice($arr, 0, $cutRows);
 
-            if (strlen($arr[$cutRows - 1] . $etc) > $length + $tolerance) {
-                $arr[$cutRows - 1] = substr($arr[$cutRows - 1], 0, $length - strlen($etc));
+            if (\strlen($arr[$cutRows - 1] . $etc) > $length + $tolerance) {
+                $arr[$cutRows - 1] = \substr($arr[$cutRows - 1], 0, $length - \strlen($etc));
             }
 
             $arr[$cutRows - 1] = $arr[$cutRows - 1] . $etc;
         }
 
-        return implode($break, $arr);
+        return \implode($break, $arr);
     }
 }

--- a/source/Internal/Transition/Adapter/TemplateLogic/StyleLogic.php
+++ b/source/Internal/Transition/Adapter/TemplateLogic/StyleLogic.php
@@ -36,7 +36,7 @@ class StyleLogic
             'if'       => null,
             'include'  => null,
         ];
-        $params = array_merge($defaults, $params);
+        $params = \array_merge($defaults, $params);
 
         return $params;
     }

--- a/source/Internal/Transition/Adapter/TemplateLogic/TranslateFilterLogic.php
+++ b/source/Internal/Transition/Adapter/TemplateLogic/TranslateFilterLogic.php
@@ -40,10 +40,10 @@ class TranslateFilterLogic
 
         if (!$blTranslationNotFound) {
             if ($args) {
-                if (is_array($args)) {
-                    $sTranslation = vsprintf($sTranslation, $args);
+                if (\is_array($args)) {
+                    $sTranslation = \vsprintf($sTranslation, $args);
                 } else {
-                    $sTranslation = sprintf($sTranslation, $args);
+                    $sTranslation = \sprintf($sTranslation, $args);
                 }
             }
         } elseif ($blShowError) {

--- a/source/Internal/Transition/Adapter/TemplateLogic/TranslateFunctionLogic.php
+++ b/source/Internal/Transition/Adapter/TemplateLogic/TranslateFunctionLogic.php
@@ -44,10 +44,10 @@ class TranslateFunctionLogic
         }
         if (!$translationNotFound) {
             if ($args !== false) {
-                if (is_array($args)) {
-                    $translation = vsprintf($translation, $args);
+                if (\is_array($args)) {
+                    $translation = \vsprintf($translation, $args);
                 } else {
-                    $translation = sprintf($translation, $args);
+                    $translation = \sprintf($translation, $args);
                 }
             }
             if ('NO_SUFFIX' != $suffix) {

--- a/source/Internal/Transition/Adapter/TemplateLogic/TruncateLogic.php
+++ b/source/Internal/Transition/Adapter/TemplateLogic/TruncateLogic.php
@@ -32,7 +32,7 @@ class TruncateLogic
         } elseif ($iLength > 0 && Str::getStr()->strlen($sString) > $iLength) {
             $iLength -= Str::getStr()->strlen($sSufix);
 
-            $sString = str_replace(['&#039;', '&quot;'], ["'", '"'], $sString);
+            $sString = \str_replace(['&#039;', '&quot;'], ["'", '"'], $sString);
 
             if (!$blBreakWords) {
                 $sString = Str::getStr()->preg_replace('/\s+?(\S+)?$/', '', Str::getStr()->substr($sString, 0, $iLength + 1));
@@ -40,7 +40,7 @@ class TruncateLogic
 
             $sString = Str::getStr()->substr($sString, 0, $iLength) . $sSufix;
 
-            return str_replace(["'", '"'], ['&#039;', '&quot;'], $sString);
+            return \str_replace(["'", '"'], ['&#039;', '&quot;'], $sString);
         }
 
         return $sString ?: '';

--- a/source/Internal/Transition/Utility/Context.php
+++ b/source/Internal/Transition/Utility/Context.php
@@ -159,7 +159,7 @@ class Context extends BasicContext implements ContextInterface
      */
     private function getFactsConfigFile(): FactsConfigFile
     {
-        if (!is_a($this->factsConfigFile, FactsConfigFile::class)) {
+        if (!\is_a($this->factsConfigFile, FactsConfigFile::class)) {
             $this->factsConfigFile = new FactsConfigFile();
         }
 

--- a/source/Internal/Utility/Authentication/Policy/PasswordPolicy.php
+++ b/source/Internal/Utility/Authentication/Policy/PasswordPolicy.php
@@ -45,6 +45,6 @@ class PasswordPolicy implements PasswordPolicyInterface
          * preg_match will return false on a invalid subject
          * Not perfect, but good enough.
          */
-        return false !== preg_match('//u', $password);
+        return false !== \preg_match('//u', $password);
     }
 }

--- a/source/Internal/Utility/Email/EmailValidatorService.php
+++ b/source/Internal/Utility/Email/EmailValidatorService.php
@@ -22,6 +22,6 @@ class EmailValidatorService implements EmailValidatorServiceInterface
      */
     public function isEmailValid($email): bool
     {
-        return filter_var($email, FILTER_VALIDATE_EMAIL) !== false;
+        return \filter_var($email, FILTER_VALIDATE_EMAIL) !== false;
     }
 }

--- a/source/Internal/Utility/Hash/Service/Argon2IPasswordHashService.php
+++ b/source/Internal/Utility/Hash/Service/Argon2IPasswordHashService.php
@@ -64,7 +64,7 @@ class Argon2IPasswordHashService implements PasswordHashServiceInterface
     {
         $this->passwordPolicy->enforcePasswordPolicy($password);
 
-        $hash = password_hash(
+        $hash = \password_hash(
             $password,
             PASSWORD_ARGON2I,
             $this->getOptions()
@@ -86,7 +86,7 @@ class Argon2IPasswordHashService implements PasswordHashServiceInterface
      */
     public function passwordNeedsRehash(string $passwordHash): bool
     {
-        return password_needs_rehash($passwordHash, PASSWORD_ARGON2I, $this->getOptions());
+        return \password_needs_rehash($passwordHash, PASSWORD_ARGON2I, $this->getOptions());
     }
 
     /**

--- a/source/Internal/Utility/Hash/Service/BcryptPasswordHashService.php
+++ b/source/Internal/Utility/Hash/Service/BcryptPasswordHashService.php
@@ -54,7 +54,7 @@ class BcryptPasswordHashService implements PasswordHashServiceInterface
     {
         $this->passwordPolicy->enforcePasswordPolicy($password);
 
-        $hash = password_hash(
+        $hash = \password_hash(
             $password,
             PASSWORD_BCRYPT,
             $this->getOptions()
@@ -76,7 +76,7 @@ class BcryptPasswordHashService implements PasswordHashServiceInterface
      */
     public function passwordNeedsRehash(string $passwordHash): bool
     {
-        return password_needs_rehash(
+        return \password_needs_rehash(
             $passwordHash,
             PASSWORD_BCRYPT,
             $this->getOptions()

--- a/source/Internal/Utility/Url/UrlParser.php
+++ b/source/Internal/Utility/Url/UrlParser.php
@@ -25,7 +25,7 @@ class UrlParser implements UrlParserInterface
      */
     private function getPath(string $url): string
     {
-        return (string)parse_url($url, PHP_URL_PATH);
+        return (string)\parse_url($url, PHP_URL_PATH);
     }
 
     /**
@@ -34,6 +34,6 @@ class UrlParser implements UrlParserInterface
      */
     private function removeTrailingSlash(string $path): string
     {
-        return rtrim($path, '/');
+        return \rtrim($path, '/');
     }
 }

--- a/source/Setup/Controller.php
+++ b/source/Setup/Controller.php
@@ -73,7 +73,7 @@ class Controller extends Core
 
         //setting admin area default language
         $adminLanguage = $session->getSessionParam('setup_lang');
-        $this->getUtilitiesInstance()->setCookie("oxidadminlanguage", $adminLanguage, time() + 31536000, "/");
+        $this->getUtilitiesInstance()->setCookie("oxidadminlanguage", $adminLanguage, \time() + 31536000, "/");
 
         $this->setViewOptions(
             'welcome.php',
@@ -380,7 +380,7 @@ class Controller extends Core
         }
 
         // check if passwords match
-        if (strlen($adminData['sPassword']) < 6) {
+        if (\strlen($adminData['sPassword']) < 6) {
             $setup->setNextStep($setup->getStep('STEP_DIRS_INFO'));
             $view->setMessage($language->getText('ERROR_PASSWORD_TOO_SHORT'));
 
@@ -405,7 +405,7 @@ class Controller extends Core
 
         // write it now
         try {
-            $parameters = array_merge((array)$session->getSessionParam('aDB'), $pathCollection);
+            $parameters = \array_merge((array)$session->getSessionParam('aDB'), $pathCollection);
 
             // updating config file
             $utils->updateConfigFile($parameters);
@@ -466,7 +466,7 @@ class Controller extends Core
                 "aPath" => $pathCollection,
                 "aSetupConfig" => $aSetupConfig,
                 "aDB" => $aDB,
-                "blWritableConfig" => is_writable($pathCollection['sShopDir'] . "/config.inc.php")
+                "blWritableConfig" => \is_writable($pathCollection['sShopDir'] . "/config.inc.php")
             ]
         );
     }
@@ -516,7 +516,7 @@ class Controller extends Core
      */
     private function formMessageIfDBCanBeOverwritten($databaseName, $view, $language)
     {
-        $view->setMessage(sprintf($language->getText('ERROR_DB_ALREADY_EXISTS'), $databaseName));
+        $view->setMessage(\sprintf($language->getText('ERROR_DB_ALREADY_EXISTS'), $databaseName));
     }
 
     /**
@@ -549,7 +549,7 @@ class Controller extends Core
             if ($demoDataRequired && $this->getUtilitiesInstance()->isDemodataPrepared()) {
                 $this->getUtilitiesInstance()->executeExternalDatabaseMigrationCommand();
 
-                exec(
+                \exec(
                     (new Facts())->getCommunityEditionRootPath() .
                     '/bin/oe-console oe:setup:demodata'
                 );
@@ -692,15 +692,15 @@ class Controller extends Core
         $commandOutput = $exception->getCommandOutput();
         $htmlCommandOutput = $this->convertCommandOutputToHtmlOutput($commandOutput);
 
-        $errorLines[] = sprintf(
+        $errorLines[] = \sprintf(
             $language->getText('EXTERNAL_COMMAND_ERROR_1'),
             $exception->getCommand(),
             $exception->getReturnCode()
         );
         $errorLines[] = $language->getText('EXTERNAL_COMMAND_ERROR_2');
 
-        $errorHeader = implode("<br />", $errorLines);
-        $errorMessage = implode("<br /><br />", [$errorHeader, $htmlCommandOutput]);
+        $errorHeader = \implode("<br />", $errorLines);
+        $errorMessage = \implode("<br /><br />", [$errorHeader, $htmlCommandOutput]);
 
         $view->setMessage($errorMessage);
     }
@@ -713,8 +713,8 @@ class Controller extends Core
     private function convertCommandOutputToHtmlOutput($commandOutput)
     {
         $commandOutput = Utilities::stripAnsiControlCodes($commandOutput);
-        $commandOutput = htmlspecialchars($commandOutput);
-        $commandOutput = str_replace("\n", "<br />", $commandOutput);
+        $commandOutput = \htmlspecialchars($commandOutput);
+        $commandOutput = \str_replace("\n", "<br />", $commandOutput);
         $commandOutput = "<span style=\"font-family: courier,serif\">$commandOutput</span>";
 
         return $commandOutput;

--- a/source/Setup/Core.php
+++ b/source/Setup/Core.php
@@ -32,7 +32,7 @@ class Core
      */
     public function getInstance($sInstanceName)
     {
-        if (strpos($sInstanceName, '\\') === false) {
+        if (\strpos($sInstanceName, '\\') === false) {
             $sInstanceName = $this->getClass($sInstanceName);
         }
         if (!isset(Core::$_aInstances[$sInstanceName])) {
@@ -55,16 +55,16 @@ class Core
      */
     public function __call($sMethod, $aArgs)
     {
-        if (defined('OXID_PHP_UNIT')) {
-            if (substr($sMethod, 0, 4) == "UNIT") {
-                $sMethod = str_replace("UNIT", "_", $sMethod);
+        if (\defined('OXID_PHP_UNIT')) {
+            if (\substr($sMethod, 0, 4) == "UNIT") {
+                $sMethod = \str_replace("UNIT", "_", $sMethod);
             }
-            if (method_exists($this, $sMethod)) {
-                return call_user_func_array([& $this, $sMethod], $aArgs);
+            if (\method_exists($this, $sMethod)) {
+                return \call_user_func_array([& $this, $sMethod], $aArgs);
             }
         }
 
-        throw new \OxidEsales\Eshop\Core\Exception\SystemComponentException("Function '$sMethod' does not exist or is not accessible! (" . get_class($this) . ")" . PHP_EOL);
+        throw new \OxidEsales\Eshop\Core\Exception\SystemComponentException("Function '$sMethod' does not exist or is not accessible! (" . \get_class($this) . ")" . PHP_EOL);
     }
 
     /**
@@ -161,7 +161,7 @@ class Core
     private function classExists($className)
     {
         try {
-            $classExists = class_exists($className);
+            $classExists = \class_exists($className);
         } catch (\Exception $e) {
             return false;
         }

--- a/source/Setup/Database.php
+++ b/source/Setup/Database.php
@@ -37,8 +37,8 @@ class Database extends Core
     {
         try {
             $pdo = $this->getConnection();
-            list($sStatement) = explode(' ', ltrim($sQ));
-            if (in_array(strtoupper($sStatement), ['SELECT', 'SHOW'])) {
+            list($sStatement) = \explode(' ', \ltrim($sQ));
+            if (\in_array(\strtoupper($sStatement), ['SELECT', 'SHOW'])) {
                 $oStatement = $pdo->query($sQ);
             } else {
                 return $pdo->exec($sQ);
@@ -98,19 +98,19 @@ class Database extends Core
      */
     public function queryFile($sFilename)
     {
-        $fp = @fopen($sFilename, "r");
+        $fp = @\fopen($sFilename, "r");
         if (!$fp) {
             /** @var Setup $oSetup */
             $oSetup = $this->getInstance("Setup");
             // problems with file
             $oSetup->setNextStep($oSetup->getStep('STEP_DB_INFO'));
-            throw new Exception(sprintf($this->translate('ERROR_OPENING_SQL_FILE'), $sFilename), Database::ERROR_OPENING_SQL_FILE);
+            throw new Exception(\sprintf($this->translate('ERROR_OPENING_SQL_FILE'), $sFilename), Database::ERROR_OPENING_SQL_FILE);
         }
 
-        $sQuery = fread($fp, filesize($sFilename));
-        fclose($fp);
+        $sQuery = \fread($fp, \filesize($sFilename));
+        \fclose($fp);
 
-        if (version_compare($this->getDatabaseVersion(), "5") > 0) {
+        if (\version_compare($this->getDatabaseVersion(), "5") > 0) {
             //disable STRICT db mode if there are set any (mysql >= 5).
             $this->execSql("SET @@session.sql_mode = ''");
         }
@@ -174,7 +174,7 @@ class Database extends Core
         } catch (Exception $e) {
             $oSetup = $this->getInstance("Setup");
             $oSetup->setNextStep($oSetup->getStep('STEP_DB_INFO'));
-            throw new Exception(sprintf($this->translate('ERROR_COULD_NOT_CREATE_DB'), $sDbName) . " - " . $e->getMessage(), $e->getCode(), $e);
+            throw new Exception(\sprintf($this->translate('ERROR_COULD_NOT_CREATE_DB'), $sDbName) . " - " . $e->getMessage(), $e->getCode(), $e);
         }
     }
 
@@ -249,13 +249,13 @@ class Database extends Core
         //set only one active language
         $oStatement = $oPdo->query("select oxvarname, oxvartype, oxvarvalue from oxconfig where oxvarname='aLanguageParams'");
         if ($oStatement && false !== ($aRow = $oStatement->fetch())) {
-            if (!is_array(unserialize($aRow['oxvarvalue']))) {
+            if (!\is_array(\unserialize($aRow['oxvarvalue']))) {
                 throw new LanguageParamsException("aLanguageParams can not be type of 
-                " . gettype($aRow['oxvarvalue']) . ", aLanguageParams must be type of array");
+                " . \gettype($aRow['oxvarvalue']) . ", aLanguageParams must be type of array");
             }
 
             if ($aRow['oxvartype'] == 'arr' || $aRow['oxvartype'] == 'aarr') {
-                $aRow['oxvarvalue'] = unserialize($aRow['oxvarvalue']);
+                $aRow['oxvarvalue'] = \unserialize($aRow['oxvarvalue']);
             }
             $aLanguageParams = $aRow['oxvarvalue'];
             foreach ($aLanguageParams as $sKey => $aLang) {
@@ -263,7 +263,7 @@ class Database extends Core
             }
             $aLanguageParams[$sShopLang]["active"] = "1";
 
-            $sValue = serialize($aLanguageParams);
+            $sValue = \serialize($aLanguageParams);
 
             $oPdo->exec("delete from oxconfig where oxvarname = 'aLanguageParams'");
             $oInsert->execute(
@@ -293,11 +293,11 @@ class Database extends Core
         $blQuote = false;
         $sThisSQL = "";
 
-        $aLines = explode("\n", $sSQL);
+        $aLines = \explode("\n", $sSQL);
 
         // parse it
         foreach ($aLines as $sLine) {
-            $iLen = strlen($sLine);
+            $iLen = \strlen($sLine);
             for ($i = 0; $i < $iLen; $i++) {
                 if (!$blQuote && ($sLine[$i] == '#' || ($sLine[0] == '-' && $sLine[1] == '-'))) {
                     $blComment = true;
@@ -316,9 +316,9 @@ class Database extends Core
                 // now test if command end is reached
                 if (!$blQuote && $sLine[$i] == ';') {
                     // add this
-                    $sThisSQL = trim($sThisSQL);
+                    $sThisSQL = \trim($sThisSQL);
                     if ($sThisSQL) {
-                        $sThisSQL = str_replace("\r", "", $sThisSQL);
+                        $sThisSQL = \str_replace("\r", "", $sThisSQL);
                         $aRet[] = $sThisSQL;
                     }
                     $sThisSQL = "";
@@ -342,7 +342,7 @@ class Database extends Core
     {
         $baseShopId = $this->getInstance("Setup")->getShopId();
         $uniqueId = $this->getInstance("Utilities")->generateUID();
-        $password = hash('sha512', $password . $uniqueId);
+        $password = \hash('sha512', $password . $uniqueId);
 
         $this->execSql(
             "insert into oxuser (oxid, oxusername, oxpassword, oxpasssalt, oxrights, oxshopid)
@@ -376,7 +376,7 @@ class Database extends Core
      */
     private function prepareConnectionParameters($parameters): array
     {
-        return (is_array($parameters) && !empty($parameters)) ?
+        return (\is_array($parameters) && !empty($parameters)) ?
             $parameters :
             $this->getInstance('Session')->getSessionParam('aDB');
     }
@@ -405,7 +405,7 @@ class Database extends Core
     /** @param array $parameters */
     private function createPdoConnection(array $parameters): void
     {
-        $dsn = sprintf('mysql:host=%s;port=%s', $parameters['dbHost'], $parameters['dbPort']);
+        $dsn = \sprintf('mysql:host=%s;port=%s', $parameters['dbHost'], $parameters['dbPort']);
         $this->_oConn = new PDO(
             $dsn,
             $parameters['dbUser'],

--- a/source/Setup/De/lang.php
+++ b/source/Setup/De/lang.php
@@ -10,7 +10,7 @@ $aLang = [
 'charset'                                       => 'UTF-8',
 'HEADER_META_MAIN_TITLE'                        => 'OXID eShop Installationsassistent',
 'HEADER_TEXT_SETUP_NOT_RUNS_AUTOMATICLY'        => 'Sollte das Setup nicht nach einigen Sekunden automatisch weiterspringen, dann klicken Sie bitte',
-'FOOTER_OXID_ESALES'                            => '&copy; OXID eSales AG 2003-' . @date("Y"),
+'FOOTER_OXID_ESALES'                            => '&copy; OXID eSales AG 2003-' . @\date("Y"),
 
 'TAB_0_TITLE'                                   => 'Voraussetzungen',
 'TAB_1_TITLE'                                   => 'Willkommen',

--- a/source/Setup/Dispatcher.php
+++ b/source/Setup/Dispatcher.php
@@ -52,8 +52,8 @@ class Dispatcher extends Core
         $sName = null;
         foreach ($oSetup->getSteps() as $sStepName => $sStepId) {
             if ($sStepId == $iCurrStep) {
-                $sActionName = str_ireplace("step_", "", $sStepName);
-                $sName = str_replace("_", "", $sActionName);
+                $sActionName = \str_ireplace("step_", "", $sStepName);
+                $sName = \str_replace("_", "", $sActionName);
                 break;
             }
         }

--- a/source/Setup/En/lang.php
+++ b/source/Setup/En/lang.php
@@ -10,7 +10,7 @@ $aLang = [
 'charset'                                       => 'UTF-8',
 'HEADER_META_MAIN_TITLE'                        => 'OXID eShop installation wizard',
 'HEADER_TEXT_SETUP_NOT_RUNS_AUTOMATICLY'        => 'If setup does not continue in a few seconds, please click ',
-'FOOTER_OXID_ESALES'                            => '&copy; OXID eSales AG 2003 - ' . @date("Y"),
+'FOOTER_OXID_ESALES'                            => '&copy; OXID eSales AG 2003 - ' . @\date("Y"),
 
 'TAB_0_TITLE'                                   => 'System Requirements',
 'TAB_1_TITLE'                                   => 'Welcome',

--- a/source/Setup/Exception/CommandExecutionFailedException.php
+++ b/source/Setup/Exception/CommandExecutionFailedException.php
@@ -31,7 +31,7 @@ class CommandExecutionFailedException extends \Exception
     {
         $this->command = $message;
 
-        $message = sprintf("There was an error while executing '%s'.", $message);
+        $message = \sprintf("There was an error while executing '%s'.", $message);
         parent::__construct($message, $code, $previous);
     }
 
@@ -82,6 +82,6 @@ class CommandExecutionFailedException extends \Exception
      */
     public function getCommandOutput()
     {
-        return $this->commandOutput ? implode("\n", $this->commandOutput) : null;
+        return $this->commandOutput ? \implode("\n", $this->commandOutput) : null;
     }
 }

--- a/source/Setup/Exception/TemplateNotFoundException.php
+++ b/source/Setup/Exception/TemplateNotFoundException.php
@@ -23,7 +23,7 @@ class TemplateNotFoundException extends \Exception
      */
     public function __construct($message = '', $code = 0, \Exception $previous = null)
     {
-        $message = sprintf("Template named '%s' was not found.", $message);
+        $message = \sprintf("Template named '%s' was not found.", $message);
 
         parent::__construct($message, $code, $previous);
     }

--- a/source/Setup/Language.php
+++ b/source/Setup/Language.php
@@ -44,8 +44,8 @@ class Language extends Core
             }
         } elseif ($oSession->getSessionParam('setup_lang') === null) {
             $aLangs = ['en', 'de'];
-            $sBrowserLang = strtolower(substr($_SERVER['HTTP_ACCEPT_LANGUAGE'], 0, 2));
-            $sBrowserLang = (in_array($sBrowserLang, $aLangs)) ? $sBrowserLang : $aLangs[0];
+            $sBrowserLang = \strtolower(\substr($_SERVER['HTTP_ACCEPT_LANGUAGE'], 0, 2));
+            $sBrowserLang = (\in_array($sBrowserLang, $aLangs)) ? $sBrowserLang : $aLangs[0];
             $oSession->setSessionParam('setup_lang', $sBrowserLang);
         }
 
@@ -63,11 +63,11 @@ class Language extends Core
     {
         if ($this->_aLangData === null) {
             $this->_aLangData = [];
-            $sLangFilePath = getShopBasePath() . EditionPathProvider::SETUP_DIRECTORY . '/' . ucfirst($this->getLanguage()) . '/lang.php';
-            if (file_exists($sLangFilePath) && is_readable($sLangFilePath)) {
+            $sLangFilePath = getShopBasePath() . EditionPathProvider::SETUP_DIRECTORY . '/' . \ucfirst($this->getLanguage()) . '/lang.php';
+            if (\file_exists($sLangFilePath) && \is_readable($sLangFilePath)) {
                 $aLang = [];
                 include $sLangFilePath;
-                $this->_aLangData = array_merge($aLang, $this->getAdditionalMessages());
+                $this->_aLangData = \array_merge($aLang, $this->getAdditionalMessages());
             }
         }
 
@@ -83,7 +83,7 @@ class Language extends Core
      */
     public function getModuleName($sModuleName)
     {
-        return $this->getText('MOD_' . strtoupper($sModuleName));
+        return $this->getText('MOD_' . \strtoupper($sModuleName));
     }
 
     /**

--- a/source/Setup/Session.php
+++ b/source/Setup/Session.php
@@ -45,7 +45,7 @@ class Session extends Core
      */
     public function __construct()
     {
-        ini_set('session.use_cookies', 0);
+        \ini_set('session.use_cookies', 0);
 
         // initialize session
         $this->_startSession();
@@ -58,7 +58,7 @@ class Session extends Core
      */
     protected function _startSession() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
-        session_name($this->_sSessionName);
+        \session_name($this->_sSessionName);
 
         /** @var Utilities $oUtils */
         $oUtils = $this->getInstance("Utilities");
@@ -69,10 +69,10 @@ class Session extends Core
         }
 
         if (!empty($sSid)) {
-            session_id($sSid);
+            \session_id($sSid);
         }
 
-        session_start();
+        \session_start();
         $sSid = $this->_validateSession();
         $this->setSid($sSid);
     }
@@ -89,14 +89,14 @@ class Session extends Core
             $this->setSessionParam('setup_session', true);
         } elseif ($this->getSessionParam('setup_session') !== true) {
             $sNewSid = $this->_getNewSessionID();
-            session_write_close();
+            \session_write_close();
 
-            session_id($sNewSid);
-            session_start();
+            \session_id($sNewSid);
+            \session_start();
             $this->setSessionParam('setup_session', true);
         }
 
-        return session_id();
+        return \session_id();
     }
 
     /**
@@ -107,10 +107,10 @@ class Session extends Core
      */
     protected function _getNewSessionID() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
-        session_regenerate_id(false);
+        \session_regenerate_id(false);
         $this->setIsNewSession(true);
 
-        return session_id();
+        return \session_id();
     }
 
     /**

--- a/source/Setup/Setup.php
+++ b/source/Setup/Setup.php
@@ -138,8 +138,8 @@ class Setup extends Core
     public function alreadySetUp()
     {
         $blSetUp = false;
-        $sConfig = join("", file(getShopBasePath() . "config.inc.php"));
-        if (strpos($sConfig, "<dbHost>") === false) {
+        $sConfig = \join("", \file(getShopBasePath() . "config.inc.php"));
+        if (\strpos($sConfig, "<dbHost>") === false) {
             $blSetUp = true;
         }
 
@@ -155,8 +155,8 @@ class Setup extends Core
     {
         $blDeleteSetupDirectory = true;
 
-        $sConfig = join("", file(getShopBasePath() . "config.inc.php"));
-        if (strpos($sConfig, "this->blDelSetupDir = false;") !== false) {
+        $sConfig = \join("", \file(getShopBasePath() . "config.inc.php"));
+        if (\strpos($sConfig, "this->blDelSetupDir = false;") !== false) {
             $blDeleteSetupDirectory = false;
         }
 

--- a/source/Setup/Utilities.php
+++ b/source/Setup/Utilities.php
@@ -67,7 +67,7 @@ class Utilities extends Core
      */
     public function generateUID()
     {
-        return md5(uniqid(rand(), true));
+        return \md5(\uniqid(\rand(), true));
     }
 
     /**
@@ -83,22 +83,22 @@ class Utilities extends Core
      */
     public function removeDir($sPath, $blDeleteSuccess, $iMode = 0, $aSkipFiles = [], $aSkipFolders = [])
     {
-        if (is_file($sPath) || is_dir($sPath)) {
+        if (\is_file($sPath) || \is_dir($sPath)) {
             // setting path to remove
-            $d = dir($sPath);
+            $d = \dir($sPath);
             $d->handle;
             while (false !== ($sEntry = $d->read())) {
                 if ($sEntry != "." && $sEntry != "..") {
                     $sFilePath = $sPath . "/" . $sEntry;
-                    if (is_file($sFilePath)) {
-                        if (!in_array(basename($sFilePath), $aSkipFiles)) {
-                            $blDeleteSuccess = $blDeleteSuccess * @unlink($sFilePath);
+                    if (\is_file($sFilePath)) {
+                        if (!\in_array(\basename($sFilePath), $aSkipFiles)) {
+                            $blDeleteSuccess = $blDeleteSuccess * @\unlink($sFilePath);
                         }
-                    } elseif (is_dir($sFilePath)) {
+                    } elseif (\is_dir($sFilePath)) {
                         // removing direcotry contents
                         $this->removeDir($sFilePath, $blDeleteSuccess, $iMode, $aSkipFiles, $aSkipFolders);
-                        if ($iMode === 0 && !in_array(basename($sFilePath), $aSkipFolders)) {
-                            $blDeleteSuccess = $blDeleteSuccess * @rmdir($sFilePath);
+                        if ($iMode === 0 && !\in_array(\basename($sFilePath), $aSkipFolders)) {
+                            $blDeleteSuccess = $blDeleteSuccess * @\rmdir($sFilePath);
                         }
                     } else {
                         // there are some other objects ?
@@ -126,12 +126,12 @@ class Utilities extends Core
     {
         $sExtPath = '';
         $blBuildPath = false;
-        for ($i = count($aPath); $i > 0; $i--) {
+        for ($i = \count($aPath); $i > 0; $i--) {
             $sDir = $aPath[$i - 1];
             if ($blBuildPath) {
                 $sExtPath = $sDir . '/' . $sExtPath;
             }
-            if (stristr($sDir, EditionPathProvider::SETUP_DIRECTORY)) {
+            if (\stristr($sDir, EditionPathProvider::SETUP_DIRECTORY)) {
                 $blBuildPath = true;
             }
         }
@@ -157,7 +157,7 @@ class Utilities extends Core
             $sFilepath = $_SERVER['SCRIPT_FILENAME'];
         }
 
-        $aParams['sShopDir'] = str_replace("\\", "/", $this->_extractPath(preg_split("/\\\|\//", $sFilepath)));
+        $aParams['sShopDir'] = \str_replace("\\", "/", $this->_extractPath(\preg_split("/\\\|\//", $sFilepath)));
         $aParams['sCompileDir'] = $aParams['sShopDir'] . "tmp/";
 
         // try referer
@@ -165,7 +165,7 @@ class Utilities extends Core
         if (!isset($sFilepath) || !$sFilepath) {
             $sFilepath = "http://" . @$_SERVER['HTTP_HOST'] . @$_SERVER['SCRIPT_NAME'];
         }
-        $aParams['sShopURL'] = ltrim($this->_extractPath(explode("/", $sFilepath)), "/");
+        $aParams['sShopURL'] = \ltrim($this->_extractPath(\explode("/", $sFilepath)), "/");
 
         return $aParams;
     }
@@ -187,26 +187,26 @@ class Utilities extends Core
         }
         $this->handleMissingConfigFileException($configFile);
 
-        clearstatcache();
+        \clearstatcache();
         // Make config file writable, as it may be write protected
-        @chmod($configFile, getDefaultFileMode());
-        if (!$configFileContent = file_get_contents($configFile)) {
-            throw new Exception(sprintf($language->getText('ERROR_COULD_NOT_OPEN_CONFIG_FILE'), $configFile));
+        @\chmod($configFile, getDefaultFileMode());
+        if (!$configFileContent = \file_get_contents($configFile)) {
+            throw new Exception(\sprintf($language->getText('ERROR_COULD_NOT_OPEN_CONFIG_FILE'), $configFile));
         }
 
         // overwriting settings
         foreach ($parameters as $configOption => $value) {
             $search = ["\'", "'" ];
             $replace = ["\\\'", "\'"];
-            $escapedValue = str_replace($search, $replace, $value);
-            $configFileContent = str_replace("<{$configOption}>", $escapedValue, $configFileContent);
+            $escapedValue = \str_replace($search, $replace, $value);
+            $configFileContent = \str_replace("<{$configOption}>", $escapedValue, $configFileContent);
         }
 
-        if (!file_put_contents($configFile, $configFileContent)) {
-            throw new Exception(sprintf($language->getText('ERROR_CONFIG_FILE_IS_NOT_WRITABLE'), $configFile));
+        if (!\file_put_contents($configFile, $configFileContent)) {
+            throw new Exception(\sprintf($language->getText('ERROR_CONFIG_FILE_IS_NOT_WRITABLE'), $configFile));
         }
         // Make config file read-only, this is our recomnedation for config.inc.php
-        @chmod($configFile, getDefaultConfigFileMode());
+        @\chmod($configFile, getDefaultConfigFileMode());
     }
 
     /**
@@ -221,10 +221,10 @@ class Utilities extends Core
      */
     private function handleMissingConfigFileException($pathToConfigFile)
     {
-        if (!file_exists($pathToConfigFile)) {
+        if (!\file_exists($pathToConfigFile)) {
             $language = $this->getLanguageInstance();
 
-            throw new Exception(sprintf($language->getText('ERROR_COULD_NOT_OPEN_CONFIG_FILE'), $pathToConfigFile));
+            throw new Exception(\sprintf($language->getText('ERROR_COULD_NOT_OPEN_CONFIG_FILE'), $pathToConfigFile));
         }
     }
 
@@ -250,32 +250,32 @@ class Utilities extends Core
             $sSubFolder = $this->preparePath("/" . $sSubFolder);
         }
 
-        $aParams["sBaseUrlPath"] = trim($aParams["sBaseUrlPath"] . $sSubFolder, "/");
+        $aParams["sBaseUrlPath"] = \trim($aParams["sBaseUrlPath"] . $sSubFolder, "/");
         $aParams["sBaseUrlPath"] = "/" . $aParams["sBaseUrlPath"];
 
         $sHtaccessPath = $this->preparePath($aParams["sShopDir"]) . $sSubFolder . "/.htaccess";
 
-        clearstatcache();
-        if (!file_exists($sHtaccessPath)) {
-            throw new Exception(sprintf($oLang->getText('ERROR_COULD_NOT_FIND_FILE'), $sHtaccessPath), Utilities::ERROR_COULD_NOT_FIND_FILE);
+        \clearstatcache();
+        if (!\file_exists($sHtaccessPath)) {
+            throw new Exception(\sprintf($oLang->getText('ERROR_COULD_NOT_FIND_FILE'), $sHtaccessPath), Utilities::ERROR_COULD_NOT_FIND_FILE);
         }
 
-        @chmod($sHtaccessPath, getDefaultFileMode());
-        if (is_readable($sHtaccessPath) && ($fp = fopen($sHtaccessPath, "r"))) {
-            $sHtaccessFile = fread($fp, filesize($sHtaccessPath));
-            fclose($fp);
+        @\chmod($sHtaccessPath, getDefaultFileMode());
+        if (\is_readable($sHtaccessPath) && ($fp = \fopen($sHtaccessPath, "r"))) {
+            $sHtaccessFile = \fread($fp, \filesize($sHtaccessPath));
+            \fclose($fp);
         } else {
-            throw new Exception(sprintf($oLang->getText('ERROR_COULD_NOT_READ_FILE'), $sHtaccessPath), Utilities::ERROR_COULD_NOT_READ_FILE);
+            throw new Exception(\sprintf($oLang->getText('ERROR_COULD_NOT_READ_FILE'), $sHtaccessPath), Utilities::ERROR_COULD_NOT_READ_FILE);
         }
 
         // overwriting settings
-        $sHtaccessFile = preg_replace("/RewriteBase.*/", "RewriteBase " . $aParams["sBaseUrlPath"], $sHtaccessFile);
-        if (is_writable($sHtaccessPath) && ($fp = fopen($sHtaccessPath, "w"))) {
-            fwrite($fp, $sHtaccessFile);
-            fclose($fp);
+        $sHtaccessFile = \preg_replace("/RewriteBase.*/", "RewriteBase " . $aParams["sBaseUrlPath"], $sHtaccessFile);
+        if (\is_writable($sHtaccessPath) && ($fp = \fopen($sHtaccessPath, "w"))) {
+            \fwrite($fp, $sHtaccessFile);
+            \fclose($fp);
         } else {
             // error ? strange !?
-            throw new Exception(sprintf($oLang->getText('ERROR_COULD_NOT_WRITE_TO_FILE'), $sHtaccessPath), Utilities::ERROR_COULD_NOT_WRITE_TO_FILE);
+            throw new Exception(\sprintf($oLang->getText('ERROR_COULD_NOT_WRITE_TO_FILE'), $sHtaccessPath), Utilities::ERROR_COULD_NOT_WRITE_TO_FILE);
         }
     }
 
@@ -309,7 +309,7 @@ class Utilities extends Core
      */
     public function getEnvVar($sVarName)
     {
-        if (($sVarVal = getenv($sVarName)) !== false) {
+        if (($sVarVal = \getenv($sVarName)) !== false) {
             return $sVarVal;
         }
     }
@@ -369,7 +369,7 @@ class Utilities extends Core
      */
     public function setCookie($sName, $sValue, $iExpireDate, $sPath)
     {
-        setcookie($sName, $sValue, $iExpireDate, $sPath);
+        \setcookie($sName, $sValue, $iExpireDate, $sPath);
     }
 
     /**
@@ -382,8 +382,8 @@ class Utilities extends Core
     public function getFileContents($sFile)
     {
         $sContents = null;
-        if (file_exists($sFile) && is_readable($sFile)) {
-            $sContents = file_get_contents($sFile);
+        if (\file_exists($sFile) && \is_readable($sFile)) {
+            $sContents = \file_get_contents($sFile);
         }
 
         return $sContents;
@@ -398,7 +398,7 @@ class Utilities extends Core
      */
     public function preparePath($sPath)
     {
-        return rtrim(str_replace("\\", "/", $sPath), "/");
+        return \rtrim(\str_replace("\\", "/", $sPath), "/");
     }
 
     /**
@@ -411,7 +411,7 @@ class Utilities extends Core
     public function extractRewriteBase($sUrl)
     {
         $sPath = "/";
-        if (($aPathInfo = @parse_url($sUrl)) !== false) {
+        if (($aPathInfo = @\parse_url($sUrl)) !== false) {
             if (isset($aPathInfo["path"])) {
                 $sPath = $this->preparePath($aPathInfo["path"]);
             }
@@ -430,7 +430,7 @@ class Utilities extends Core
      */
     public function isValidEmail($sEmail)
     {
-        return preg_match($this->_sEmailTpl, $sEmail) != 0;
+        return \preg_match($this->_sEmailTpl, $sEmail) != 0;
     }
 
     /**
@@ -551,7 +551,7 @@ class Utilities extends Core
     public function isDemodataPrepared()
     {
         $demodataSqlFile = $this->getActiveEditionDemodataPackageSqlFilePath();
-        return file_exists($demodataSqlFile) ? true : false;
+        return \file_exists($demodataSqlFile) ? true : false;
     }
 
     /**
@@ -561,7 +561,7 @@ class Utilities extends Core
      */
     public function getActiveEditionDemodataPackageSqlFilePath()
     {
-        return implode(
+        return \implode(
             DIRECTORY_SEPARATOR,
             [
                 $this->getActiveEditionDemodataPackagePath(),
@@ -583,7 +583,7 @@ class Utilities extends Core
         return $this->getVendorDirectory()
             . EditionRootPathProvider::EDITIONS_DIRECTORY
             . DIRECTORY_SEPARATOR
-            . sprintf(self::DEMODATA_PACKAGE_NAME, strtolower($facts->getEdition()));
+            . \sprintf(self::DEMODATA_PACKAGE_NAME, \strtolower($facts->getEdition()));
     }
 
     /**
@@ -606,7 +606,7 @@ class Utilities extends Core
      */
     public static function stripAnsiControlCodes($outputWithAnsiControlCodes)
     {
-        return preg_replace('/\x1b(\[|\(|\))[;?0-9]*[0-9A-Za-z]/', "", $outputWithAnsiControlCodes);
+        return \preg_replace('/\x1b(\[|\(|\))[;?0-9]*[0-9A-Za-z]/', "", $outputWithAnsiControlCodes);
     }
 
     /**

--- a/source/Setup/View.php
+++ b/source/Setup/View.php
@@ -47,7 +47,7 @@ class View extends Core
      */
     public function setTemplateFileName($templateFileName)
     {
-        if (!file_exists($this->getPathToTemplateFileName($templateFileName))) {
+        if (!\file_exists($this->getPathToTemplateFileName($templateFileName))) {
             throw new TemplateNotFoundException($templateFileName);
         }
 
@@ -59,10 +59,10 @@ class View extends Core
      */
     public function display()
     {
-        ob_start();
+        \ob_start();
         $templateFilePath = $this->getPathToActiveTemplateFileName();
         include $templateFilePath;
-        ob_end_flush();
+        \ob_end_flush();
     }
 
     /**
@@ -80,7 +80,7 @@ class View extends Core
      */
     private function getPathToTemplateFileName($templateFileName)
     {
-        return implode(DIRECTORY_SEPARATOR, [__DIR__, "tpl", $templateFileName]);
+        return \implode(DIRECTORY_SEPARATOR, [__DIR__, "tpl", $templateFileName]);
     }
 
     /**
@@ -285,6 +285,6 @@ class View extends Core
      */
     public function sendHeaders()
     {
-        header('Content-Type: text/html; charset=utf-8');
+        \header('Content-Type: text/html; charset=utf-8');
     }
 }

--- a/source/Setup/functions.php
+++ b/source/Setup/functions.php
@@ -8,7 +8,7 @@
 use OxidEsales\Facts\Facts;
 use OxidEsales\EshopProfessional\Core\Serial;
 
-if (!function_exists('getInstallPath')) {
+if (!\function_exists('getInstallPath')) {
     /**
      * Returns shop installation directory
      *
@@ -20,7 +20,7 @@ if (!function_exists('getInstallPath')) {
     }
 }
 
-if (!function_exists('getSystemReqCheck')) {
+if (!\function_exists('getSystemReqCheck')) {
     /**
      * Returns class responsible for system requirements check
      *
@@ -41,7 +41,7 @@ if (!function_exists('getSystemReqCheck')) {
     }
 }
 
-if (!function_exists('getCountryList')) {
+if (!\function_exists('getCountryList')) {
     /**
      * Includes country list for setup
      *
@@ -59,7 +59,7 @@ if (!function_exists('getCountryList')) {
     }
 }
 
-if (!function_exists('getLocation')) {
+if (!\function_exists('getLocation')) {
     /**
      * Includes country list for setup
      *
@@ -77,7 +77,7 @@ if (!function_exists('getLocation')) {
     }
 }
 
-if (!function_exists('getLanguages')) {
+if (!\function_exists('getLanguages')) {
     /**
      * Includes country list for setup
      *
@@ -95,7 +95,7 @@ if (!function_exists('getLanguages')) {
     }
 }
 
-if (!function_exists('getDefaultFileMode')) {
+if (!\function_exists('getDefaultFileMode')) {
     /**
      * Returns mode which must be set for files or folders
      *
@@ -107,7 +107,7 @@ if (!function_exists('getDefaultFileMode')) {
     }
 }
 
-if (!function_exists('getDefaultConfigFileMode')) {
+if (!\function_exists('getDefaultConfigFileMode')) {
     /**
      * Returns mode which must be set for config file
      *
@@ -119,7 +119,7 @@ if (!function_exists('getDefaultConfigFileMode')) {
     }
 }
 
-if (!function_exists('getSerial') && class_exists(Serial::class)) {
+if (!\function_exists('getSerial') && \class_exists(Serial::class)) {
     /**
      * Creates and returns oxSerial object
      *
@@ -131,7 +131,7 @@ if (!function_exists('getSerial') && class_exists(Serial::class)) {
     }
 }
 
-if (!function_exists('getVendorDirectory')) {
+if (!\function_exists('getVendorDirectory')) {
     /**
      * Returns vendors directory
      *

--- a/source/Setup/index.php
+++ b/source/Setup/index.php
@@ -11,9 +11,9 @@ require_once '../bootstrap.php';
 
 /** moduleAutoload must be unregistered, as it would trigger a database connection, which is not yet available */
 $moduleAutoload = \OxidEsales\EshopCommunity\Core\Autoload\ModuleAutoload::class ;
-spl_autoload_unregister([$moduleAutoload, 'autoload']);
+\spl_autoload_unregister([$moduleAutoload, 'autoload']);
 
-error_reporting((E_ALL ^ E_NOTICE) | E_STRICT);
+\error_reporting((E_ALL ^ E_NOTICE) | E_STRICT);
 
 require_once 'functions.php';
 

--- a/source/Setup/tpl/_header.php
+++ b/source/Setup/tpl/_header.php
@@ -52,15 +52,15 @@ $facts = new \OxidEsales\Facts\Facts();
     </script>
     <style type="text/css">
         <?php
-            $cssPath = str_replace('/', DIRECTORY_SEPARATOR, __DIR__ . '/../out/src/');
-            $imgPath = str_replace('/', DIRECTORY_SEPARATOR, __DIR__ . '/../out/src/img/');
-            $imgLogo = 'data:image/svg+xml;base64,' . base64_encode(file_get_contents($imgPath . 'logo_dark.svg'));
-            $cssData = file_get_contents($cssPath . 'main.css');
-            preg_match_all("/url\('img\/([^']+)'\);/", $cssData, $matches);
-            $images = array_unique($matches[1]);
+            $cssPath = \str_replace('/', DIRECTORY_SEPARATOR, __DIR__ . '/../out/src/');
+            $imgPath = \str_replace('/', DIRECTORY_SEPARATOR, __DIR__ . '/../out/src/img/');
+            $imgLogo = 'data:image/svg+xml;base64,' . \base64_encode(\file_get_contents($imgPath . 'logo_dark.svg'));
+            $cssData = \file_get_contents($cssPath . 'main.css');
+            \preg_match_all("/url\('img\/([^']+)'\);/", $cssData, $matches);
+            $images = \array_unique($matches[1]);
         foreach ($images as $image) {
-            $imgData = 'data:image/png;base64,' . base64_encode(file_get_contents($imgPath . $image));
-            $cssData = str_replace('img/' . $image, $imgData, $cssData);
+            $imgData = 'data:image/png;base64,' . \base64_encode(\file_get_contents($imgPath . $image));
+            $cssData = \str_replace('img/' . $image, $imgData, $cssData);
         }
             echo $cssData;
         ?>
@@ -99,12 +99,12 @@ $facts = new \OxidEsales\Facts\Facts();
         $iCntr = 0;
         foreach ($this->getSetupSteps() as $iTab) :
             // only "real" steps
-            if (fmod($iTab, 100)) {
+            if (\fmod($iTab, 100)) {
                 continue;
             }
 
-            $blAct = (floor($this->getCurrentSetupStep() / 100) == ($iTab / 100));
-            $iStepId = floor($iTab / 100) - 1;
+            $blAct = (\floor($this->getCurrentSetupStep() / 100) == ($iTab / 100));
+            $iStepId = \floor($iTab / 100) - 1;
             $iCntr++;
 
             $sTabClass = $sTabLinkOpen = $sTabLinkClose = '';
@@ -129,7 +129,7 @@ $facts = new \OxidEsales\Facts\Facts();
     foreach ($this->getMessages() as $sMessage) {
         ?><br><b><?php echo $sMessage; ?></b><?php
     }
-    if (count($aMessages)) {
+    if (\count($aMessages)) {
         ?><br><br><?php
     }
 

--- a/source/Setup/tpl/dbconnect.php
+++ b/source/Setup/tpl/dbconnect.php
@@ -9,7 +9,7 @@ require "_header.php"; ?>
 <b><?php $this->getText('STEP_3_1_DB_CONNECT_IS_OK'); ?></b><br>
 <?php
 if ($this->getViewParam("blCreated") === 1) {
-    $aDB = $this->getViewParam("aDB"); ?><b><?php printf($this->getText('STEP_3_1_DB_CREATE_IS_OK', false), $aDB['dbName']); ?></b><br><?php
+    $aDB = $this->getViewParam("aDB"); ?><b><?php \printf($this->getText('STEP_3_1_DB_CREATE_IS_OK', false), $aDB['dbName']); ?></b><br><?php
 }
 ?>
 <?php require "_footer.php";

--- a/source/Setup/tpl/finish.php
+++ b/source/Setup/tpl/finish.php
@@ -8,10 +8,10 @@
 require "_header.php";
 
 // caching output
-ob_flush();
+\ob_flush();
 require "_footer.php";
-$sFooter = ob_get_contents();
-ob_clean();
+$sFooter = \ob_get_contents();
+\ob_clean();
 
 $this->getText('STEP_6_DESC');
 $aPath = $this->getViewParam("aPath");
@@ -45,5 +45,5 @@ if (!$blRemoved) {
 if ($blWritableConfig) {
     ?><strong class="attention-item"><?php $this->getText('SETUP_CONFIG_PERMISSIONS'); ?></strong><br><?php
 }
-ob_flush();
+\ob_flush();
 echo $sFooter;

--- a/source/Setup/tpl/systemreq.php
+++ b/source/Setup/tpl/systemreq.php
@@ -50,7 +50,7 @@ require "_header.php"; ?>
         print '<li class="group">' . $sGroupName . '<ul>';
         foreach ($aGroupInfo as $aModuleInfo) {
             print '<li id="' . $aModuleInfo['module'] . '" class="' . $aModuleInfo['class'] . '">';
-            if (in_array($aModuleInfo['class'], ['fail', 'pmin', 'null'])) {
+            if (\in_array($aModuleInfo['class'], ['fail', 'pmin', 'null'])) {
                 print "<a href='" . $this->getReqInfoUrl($aModuleInfo['module'], false) . "' target='_blank'>"
                     . $aModuleInfo['modulename']
                     . '</a>';
@@ -60,18 +60,18 @@ require "_header.php"; ?>
             print '</li>';
 
             if ($aModuleInfo['module'] === 'server_permissions') {
-                if (count($permissionIssues['missing']) > 0) {
+                if (\count($permissionIssues['missing']) > 0) {
                     echo '<li><b>'
                         . $this->getText('MOD_SERVER_PERMISSIONS_MISSING', false)
                         . '</b></li><li>&nbsp;'
-                        . implode('</li><li>&nbsp;', $permissionIssues['missing'])
+                        . \implode('</li><li>&nbsp;', $permissionIssues['missing'])
                         . '</li>';
                 }
-                if (count($permissionIssues['not_writable']) > 0) {
+                if (\count($permissionIssues['not_writable']) > 0) {
                     echo '<li><b>'
                         . $this->getText('MOD_SERVER_PERMISSIONS_NOTWRITABLE', false)
                         . '</b></li><li>&nbsp;'
-                        . implode('</li><li>&nbsp;', $permissionIssues['not_writable'])
+                        . \implode('</li><li>&nbsp;', $permissionIssues['not_writable'])
                         . '</li>';
                 }
             }

--- a/source/admin/index.php
+++ b/source/admin/index.php
@@ -5,8 +5,8 @@
  * See LICENSE file for license details.
  */
 
-define('OX_IS_ADMIN', true);
-define('OX_ADMIN_DIR', basename(dirname(__FILE__)));
+\define('OX_IS_ADMIN', true);
+\define('OX_ADMIN_DIR', \basename(\dirname(__FILE__)));
 
 // Includes main index.php file
-require_once dirname(__FILE__) . "/../index.php";
+require_once \dirname(__FILE__) . "/../index.php";

--- a/source/admin/oxajax.php
+++ b/source/admin/oxajax.php
@@ -10,27 +10,27 @@ use OxidEsales\Eshop\Core\Exception\SystemComponentException;
 use OxidEsales\Eshop\Core\Registry;
 use OxidEsales\Eshop\Core\Request;
 
-if (!defined('OX_IS_ADMIN')) {
-    define('OX_IS_ADMIN', true);
+if (!\defined('OX_IS_ADMIN')) {
+    \define('OX_IS_ADMIN', true);
 }
 
-if (!defined('OX_ADMIN_DIR')) {
-    define('OX_ADMIN_DIR', dirname(__FILE__));
+if (!\defined('OX_ADMIN_DIR')) {
+    \define('OX_ADMIN_DIR', \dirname(__FILE__));
 }
 
-require_once dirname(__FILE__) . "/../bootstrap.php";
+require_once \dirname(__FILE__) . "/../bootstrap.php";
 
 // processing ..
 $blAjaxCall = (isset($_SERVER['HTTP_X_REQUESTED_WITH']) && $_SERVER['HTTP_X_REQUESTED_WITH'] == 'XMLHttpRequest');
 if ($blAjaxCall) {
     // Setting error reporting mode
-    error_reporting(E_ALL ^ E_NOTICE);
+    \error_reporting(E_ALL ^ E_NOTICE);
 
     $myConfig = Registry::getConfig();
 
     // Includes Utility module.
     $sUtilModule = $myConfig->getConfigParam('sUtilModule');
-    if ($sUtilModule && file_exists(getShopBasePath() . "modules/" . $sUtilModule)) {
+    if ($sUtilModule && \file_exists(getShopBasePath() . "modules/" . $sUtilModule)) {
         include_once getShopBasePath() . "modules/" . $sUtilModule;
     }
 
@@ -40,16 +40,16 @@ if ($blAjaxCall) {
     if (
         !(
         Registry::getSession()->checkSessionChallenge()
-        && count(Registry::getUtilsServer()->getOxCookie())
+        && \count(Registry::getUtilsServer()->getOxCookie())
         && Registry::getUtils()->checkAccessRights()
         )
     ) {
-        header("location:index.php");
+        \header("location:index.php");
         Registry::getUtils()->showMessageAndExit("");
     }
 
     if ($sContainer = Registry::get(Request::class)->getRequestParameter('container')) {
-        $sContainer = trim(strtolower(basename($sContainer)));
+        $sContainer = \trim(\strtolower(\basename($sContainer)));
 
         try {
             // Controller name for ajax class is automatically done from the request.
@@ -59,7 +59,7 @@ if ($blAjaxCall) {
             $containerClass = Registry::getControllerClassNameResolver()->getClassNameById($ajaxContainerClassName);
 
             // Fallback in case controller could not be resolved (modules using metadata version 1).
-            if (!class_exists($containerClass)) {
+            if (!\class_exists($containerClass)) {
                 $containerClass = $ajaxContainerClassName;
             }
             $oAjaxComponent = oxNew($containerClass);

--- a/source/bin/cron.php
+++ b/source/bin/cron.php
@@ -5,7 +5,7 @@
  * See LICENSE file for license details.
  */
 
-require_once dirname(__FILE__) . "/../bootstrap.php";
+require_once \dirname(__FILE__) . "/../bootstrap.php";
 
 // initializes singleton config class
 $myConfig = \OxidEsales\Eshop\Core\Registry::getConfig();

--- a/source/bootstrap.php
+++ b/source/bootstrap.php
@@ -5,14 +5,14 @@
  * See LICENSE file for license details.
  */
 
-error_reporting(E_ALL & ~E_DEPRECATED & ~E_NOTICE);
-ini_set('display_errors', '0');
+\error_reporting(E_ALL & ~E_DEPRECATED & ~E_NOTICE);
+\ini_set('display_errors', '0');
 
-define('INSTALLATION_ROOT_PATH', dirname(__DIR__));
-define('OX_BASE_PATH', INSTALLATION_ROOT_PATH . DIRECTORY_SEPARATOR . 'source' . DIRECTORY_SEPARATOR);
-define('OX_LOG_FILE', OX_BASE_PATH . 'log' . DIRECTORY_SEPARATOR . 'oxideshop.log');
-define('OX_OFFLINE_FILE', OX_BASE_PATH . 'offline.html');
-define('VENDOR_PATH', INSTALLATION_ROOT_PATH . DIRECTORY_SEPARATOR . 'vendor' . DIRECTORY_SEPARATOR);
+\define('INSTALLATION_ROOT_PATH', \dirname(__DIR__));
+\define('OX_BASE_PATH', INSTALLATION_ROOT_PATH . DIRECTORY_SEPARATOR . 'source' . DIRECTORY_SEPARATOR);
+\define('OX_LOG_FILE', OX_BASE_PATH . 'log' . DIRECTORY_SEPARATOR . 'oxideshop.log');
+\define('OX_OFFLINE_FILE', OX_BASE_PATH . 'offline.html');
+\define('VENDOR_PATH', INSTALLATION_ROOT_PATH . DIRECTORY_SEPARATOR . 'vendor' . DIRECTORY_SEPARATOR);
 
 /**
  * Provide a handler for catchable fatal errors, like failed requirement of files.
@@ -22,17 +22,17 @@ define('VENDOR_PATH', INSTALLATION_ROOT_PATH . DIRECTORY_SEPARATOR . 'vendor' . 
  *
  * As this is the last resort no further errors must happen.
  */
-register_shutdown_function(
+\register_shutdown_function(
     function () {
         $handledErrorTypes = [E_ERROR, E_PARSE, E_CORE_ERROR, E_COMPILE_ERROR, E_RECOVERABLE_ERROR, E_USER_ERROR];
         $sessionResetErrorTypes = [E_ERROR];
 
-        $error = error_get_last();
-        if ($error !== null && in_array($error['type'], $handledErrorTypes)) {
-            $errorType = array_flip(array_slice(get_defined_constants(true)['Core'], 0, 16, true))[$error['type']];
+        $error = \error_get_last();
+        if ($error !== null && \in_array($error['type'], $handledErrorTypes)) {
+            $errorType = \array_flip(\array_slice(\get_defined_constants(true)['Core'], 0, 16, true))[$error['type']];
 
             $errorMessage = $error['message'];
-            $unifiedNamespaceClassNotFound = preg_match(
+            $unifiedNamespaceClassNotFound = \preg_match(
                 '/^Class \'OxidEsales\\\\Eshop\\\\.*\' not found/',
                 $errorMessage,
                 $matches
@@ -47,12 +47,12 @@ register_shutdown_function(
                           " [message {$errorMessage}]";
 
             /** write to log */
-            $time = microtime(true);
-            $micro = sprintf("%06d", ($time - floor($time)) * 1000000);
-            $date = new \DateTime(date('Y-m-d H:i:s.' . $micro, $time));
+            $time = \microtime(true);
+            $micro = \sprintf("%06d", ($time - \floor($time)) * 1000000);
+            $date = new \DateTime(\date('Y-m-d H:i:s.' . $micro, $time));
             $timestamp = $date->format('d M H:i:s.u Y');
             $message = "[$timestamp] " . $logMessage . PHP_EOL;
-            file_put_contents(OX_LOG_FILE, $message, FILE_APPEND);
+            \file_put_contents(OX_LOG_FILE, $message, FILE_APPEND);
 
 
             $bootstrapConfigFileReader = new \BootstrapConfigFileReader();
@@ -60,9 +60,9 @@ register_shutdown_function(
                 \oxTriggerOfflinePageDisplay();
             }
 
-            if (in_array($error['type'], $sessionResetErrorTypes)) {
-                setcookie('sid', null, null, '/');
-                setcookie('admin_sid', null, null, '/');
+            if (\in_array($error['type'], $sessionResetErrorTypes)) {
+                \setcookie('sid', null, null, '/');
+                \setcookie('admin_sid', null, null, '/');
             }
         }
     }
@@ -97,10 +97,10 @@ class BootstrapConfigFileReader
 /**
  * Ensure shop config and autoload files are available.
  */
-$configMissing = !is_readable(OX_BASE_PATH . "config.inc.php");
-if ($configMissing || !is_readable(VENDOR_PATH . 'autoload.php')) {
+$configMissing = !\is_readable(OX_BASE_PATH . "config.inc.php");
+if ($configMissing || !\is_readable(VENDOR_PATH . 'autoload.php')) {
     if ($configMissing) {
-        $message = sprintf(
+        $message = \sprintf(
             "Error: Config file '%s' could not be found! Please use '%s.dist' to make a copy.",
             OX_BASE_PATH . "config.inc.php",
             OX_BASE_PATH . "config.inc.php"
@@ -109,7 +109,7 @@ if ($configMissing || !is_readable(VENDOR_PATH . 'autoload.php')) {
         $message = "Error: Autoload file missing. Make sure you have ran the 'composer install' command.";
     }
 
-    trigger_error($message, E_USER_ERROR);
+    \trigger_error($message, E_USER_ERROR);
 }
 unset($configMissing);
 
@@ -118,8 +118,8 @@ unset($configMissing);
  */
 $bootstrapConfigFileReader = new \BootstrapConfigFileReader();
 if ($bootstrapConfigFileReader->isDebugMode()) {
-    ini_set('display_errors', '1');
-    error_reporting(E_ALL & ~E_DEPRECATED);
+    \ini_set('display_errors', '1');
+    \error_reporting(E_ALL & ~E_DEPRECATED);
 }
 unset($bootstrapConfigFileReader);
 
@@ -140,13 +140,13 @@ require_once VENDOR_PATH . 'autoload.php';
  * compilation, the directory 'Core', where the auto load classes are located, does not reside inside OX_BASE_PATH,
  * but inside VENDOR_PATH.
  */
-if (!is_dir(OX_BASE_PATH . 'Core')) {
-    define('CORE_AUTOLOADER_PATH', (new \OxidEsales\Facts\Facts())->getCommunityEditionSourcePath() .
+if (!\is_dir(OX_BASE_PATH . 'Core')) {
+    \define('CORE_AUTOLOADER_PATH', (new \OxidEsales\Facts\Facts())->getCommunityEditionSourcePath() .
             DIRECTORY_SEPARATOR .
             'Core' . DIRECTORY_SEPARATOR .
             'Autoload' . DIRECTORY_SEPARATOR);
 } else {
-    define('CORE_AUTOLOADER_PATH', OX_BASE_PATH . 'Core' . DIRECTORY_SEPARATOR . 'Autoload' . DIRECTORY_SEPARATOR);
+    \define('CORE_AUTOLOADER_PATH', OX_BASE_PATH . 'Core' . DIRECTORY_SEPARATOR . 'Autoload' . DIRECTORY_SEPARATOR);
 }
 
 /*
@@ -154,7 +154,7 @@ if (!is_dir(OX_BASE_PATH . 'Core')) {
  * This autoloader will load classes for reasons of backwards compatibility like 'oxArticle'.
  */
 require_once CORE_AUTOLOADER_PATH . 'BackwardsCompatibilityAutoload.php';
-spl_autoload_register([OxidEsales\EshopCommunity\Core\Autoload\BackwardsCompatibilityAutoload::class, 'autoload']);
+\spl_autoload_register([OxidEsales\EshopCommunity\Core\Autoload\BackwardsCompatibilityAutoload::class, 'autoload']);
 
 /**
  * Register the module autoloader.
@@ -162,7 +162,7 @@ spl_autoload_register([OxidEsales\EshopCommunity\Core\Autoload\BackwardsCompatib
  * When this autoloader is called a database connection will be triggered
  */
 require_once CORE_AUTOLOADER_PATH . 'ModuleAutoload.php';
-spl_autoload_register([\OxidEsales\EshopCommunity\Core\Autoload\ModuleAutoload::class, 'autoload']);
+\spl_autoload_register([\OxidEsales\EshopCommunity\Core\Autoload\ModuleAutoload::class, 'autoload']);
 
 
 /**
@@ -177,7 +177,7 @@ unset($configFile);
  * Set exception handler before including modules/functions.php so it can be overwritten easiliy by shop operators.
  */
 $debugMode = (bool) \OxidEsales\Eshop\Core\Registry::get(\OxidEsales\Eshop\Core\ConfigFile::class)->getVar('iDebug');
-set_exception_handler(
+\set_exception_handler(
     [
         new \OxidEsales\Eshop\Core\Exception\ExceptionHandler($debugMode),
         'handleUncaughtException'
@@ -194,7 +194,7 @@ require_once OX_BASE_PATH . 'oxfunctions.php';
 /**
  * Custom bootstrap functionality.
  */
-if (@is_readable(OX_BASE_PATH . 'modules/functions.php')) {
+if (@\is_readable(OX_BASE_PATH . 'modules/functions.php')) {
     include OX_BASE_PATH . 'modules/functions.php';
 }
 
@@ -205,29 +205,29 @@ if (@is_readable(OX_BASE_PATH . 'modules/functions.php')) {
 require_once OX_BASE_PATH . 'overridablefunctions.php';
 
 //sets default PHP ini params
-ini_set('session.name', 'sid');
-ini_set('session.use_cookies', 0);
-ini_set('session.use_trans_sid', 0);
-ini_set('url_rewriter.tags', '');
+\ini_set('session.name', 'sid');
+\ini_set('session.use_cookies', 0);
+\ini_set('session.use_trans_sid', 0);
+\ini_set('url_rewriter.tags', '');
 
-if (!function_exists('oxTriggerOfflinePageDisplay')) {
+if (!\function_exists('oxTriggerOfflinePageDisplay')) {
     /**
      * Bulletproof offline page loader
      */
     function oxTriggerOfflinePageDisplay()
     {
         // Do not display the offline page, if this running in CLI mode
-        if ('cli' !== strtolower(php_sapi_name())) {
-            header("HTTP/1.1 500 Internal Server Error");
-            header("Connection: close");
+        if ('cli' !== \strtolower(\php_sapi_name())) {
+            \header("HTTP/1.1 500 Internal Server Error");
+            \header("Connection: close");
 
             /**
              * Render an error message.
              * If offline.php exists its content is displayed.
              * Like this the error message is overridable within that file.
              */
-            if (is_readable(OX_OFFLINE_FILE)) {
-                echo file_get_contents(OX_OFFLINE_FILE);
+            if (\is_readable(OX_OFFLINE_FILE)) {
+                echo \file_get_contents(OX_OFFLINE_FILE);
             };
         }
     }

--- a/source/index.php
+++ b/source/index.php
@@ -5,7 +5,7 @@
  * See LICENSE file for license details.
  */
 
-require_once dirname(__FILE__) . "/bootstrap.php";
+require_once \dirname(__FILE__) . "/bootstrap.php";
 
 /**
  * Redirect to Setup, if shop is not configured

--- a/source/migration/data/Version20180703135728.php
+++ b/source/migration/data/Version20180703135728.php
@@ -25,7 +25,7 @@ class Version20180703135728 extends AbstractMigration
     {
         $varName = 'contactFormRequiredFields';
         $varType = 'arr';
-        $rawValue = serialize(['email']);
+        $rawValue = \serialize(['email']);
 
         $query = "INSERT INTO `oxconfig` 
                   (

--- a/source/overridablefunctions.php
+++ b/source/overridablefunctions.php
@@ -8,11 +8,11 @@
 use OxidEsales\Eshop\Core\Registry;
 use OxidEsales\Eshop\Core\Request;
 
-if (!defined('ESHOP_CONFIG_FILE')) {
-    define('ESHOP_CONFIG_FILE', 'config.inc.php');
+if (!\defined('ESHOP_CONFIG_FILE')) {
+    \define('ESHOP_CONFIG_FILE', 'config.inc.php');
 }
 
-if (!function_exists('redirectIfShopNotConfigured')) {
+if (!\function_exists('redirectIfShopNotConfigured')) {
     /**
      * @return null
      */
@@ -20,25 +20,25 @@ if (!function_exists('redirectIfShopNotConfigured')) {
     {
         $configFileName = __DIR__ . DIRECTORY_SEPARATOR . ESHOP_CONFIG_FILE;
 
-        if (file_exists($configFileName) && strpos(file_get_contents($configFileName), '<dbHost') === false) {
+        if (\file_exists($configFileName) && \strpos(\file_get_contents($configFileName), '<dbHost') === false) {
             return;
         }
 
-        $message = sprintf(
+        $message = \sprintf(
             "Config file '%s' is not updated! Please navigate to '/Setup' or update '%s' manually.",
             ESHOP_CONFIG_FILE,
             ESHOP_CONFIG_FILE
         );
 
-        header("HTTP/1.1 302 Found");
-        header("Location: Setup/index.php");
-        header("Connection: close");
+        \header("HTTP/1.1 302 Found");
+        \header("Location: Setup/index.php");
+        \header("Connection: close");
 
         die($message);
     }
 }
 
-if (!function_exists('getShopBasePath')) {
+if (!\function_exists('getShopBasePath')) {
     /**
      * Returns framework base path.
      *
@@ -50,7 +50,7 @@ if (!function_exists('getShopBasePath')) {
     }
 }
 
-if (!function_exists('error_404_handler')) {
+if (!\function_exists('error_404_handler')) {
     /**
      * error_404_handler handler for 404 (page not found) error
      *
@@ -62,7 +62,7 @@ if (!function_exists('error_404_handler')) {
     }
 }
 
-if (!function_exists('isSearchEngineUrl')) {
+if (!\function_exists('isSearchEngineUrl')) {
 
     /**
      * Returns search engine url status
@@ -75,7 +75,7 @@ if (!function_exists('isSearchEngineUrl')) {
     }
 }
 
-if (!function_exists('startProfile')) {
+if (!\function_exists('startProfile')) {
     /**
      * Start profiling
      *
@@ -92,11 +92,11 @@ if (!function_exists('startProfile')) {
             $aStartTimes[$sProfileName] = 0;
         }
         $executionCounts[$sProfileName]++;
-        $aStartTimes[$sProfileName] = microtime(true);
+        $aStartTimes[$sProfileName] = \microtime(true);
     }
 }
 
-if (!function_exists('stopProfile')) {
+if (!\function_exists('stopProfile')) {
     /**
      * Stop profiling
      *
@@ -109,11 +109,11 @@ if (!function_exists('stopProfile')) {
         if (!isset($aProfileTimes[$sProfileName])) {
             $aProfileTimes[$sProfileName] = 0;
         }
-        $aProfileTimes[$sProfileName] += microtime(true) - $aStartTimes[$sProfileName];
+        $aProfileTimes[$sProfileName] += \microtime(true) - $aStartTimes[$sProfileName];
     }
 }
 
-if (!function_exists('getLangTableIdx')) {
+if (!\function_exists('getLangTableIdx')) {
 
     /**
      * Returns language table index
@@ -134,7 +134,7 @@ if (!function_exists('getLangTableIdx')) {
     }
 }
 
-if (!function_exists('getLangTableName')) {
+if (!\function_exists('getLangTableName')) {
 
     /**
      * Returns language table name
@@ -147,7 +147,7 @@ if (!function_exists('getLangTableName')) {
     function getLangTableName($sTable, $iLangId)
     {
         $iTableIdx = getLangTableIdx($iLangId);
-        if ($iTableIdx && in_array($sTable, Registry::getLang()->getMultiLangTables())) {
+        if ($iTableIdx && \in_array($sTable, Registry::getLang()->getMultiLangTables())) {
             $sLangTableSuffix = Registry::getConfig()->getConfigParam("sLangTableSuffix");
             $sLangTableSuffix = $sLangTableSuffix ? $sLangTableSuffix : "_set";
 
@@ -158,7 +158,7 @@ if (!function_exists('getLangTableName')) {
     }
 }
 
-if (!function_exists('getViewName')) {
+if (!\function_exists('getViewName')) {
 
     /**
      * Return the view name of the given table if a view exists, otherwise the table name itself
@@ -179,7 +179,7 @@ if (!function_exists('getViewName')) {
     }
 }
 
-if (!function_exists('getRequestUrl')) {
+if (!\function_exists('getRequestUrl')) {
     /**
      * Returns request url, which was executed to render current page view
      *
@@ -196,7 +196,7 @@ if (!function_exists('getRequestUrl')) {
     }
 }
 
-if (!function_exists('getLogger')) {
+if (!\function_exists('getLogger')) {
     /**
      * Returns the Logger
      *

--- a/source/oxfunctions.php
+++ b/source/oxfunctions.php
@@ -16,7 +16,7 @@ use OxidEsales\Eshop\Core\UtilsObject;
  */
 function isAdmin()
 {
-    return defined('OX_IS_ADMIN') ? OX_IS_ADMIN : false;
+    return \defined('OX_IS_ADMIN') ? OX_IS_ADMIN : false;
 }
 
 /**
@@ -44,13 +44,13 @@ function dumpVar($mVar, $blToFile = false)
 {
     $myConfig = Registry::getConfig();
     if ($blToFile) {
-        $out = var_export($mVar, true);
-        $f = fopen($myConfig->getConfigParam('sCompileDir') . "/vardump.txt", "a");
-        fwrite($f, $out);
-        fclose($f);
+        $out = \var_export($mVar, true);
+        $f = \fopen($myConfig->getConfigParam('sCompileDir') . "/vardump.txt", "a");
+        \fwrite($f, $out);
+        \fclose($f);
     } else {
         echo '<pre>';
-        var_export($mVar);
+        \var_export($mVar);
         echo '</pre>';
     }
 }
@@ -62,10 +62,10 @@ function dumpVar($mVar, $blToFile = false)
  */
 function debug($mVar)
 {
-    $f = fopen('out.txt', 'a');
-    $sString = var_export($mVar, true);
-    fputs($f, $sString . "\n---------------------------------------------\n");
-    fclose($f);
+    $f = \fopen('out.txt', 'a');
+    $sString = \var_export($mVar, true);
+    \fputs($f, $sString . "\n---------------------------------------------\n");
+    \fclose($f);
 }
 
 /**
@@ -100,7 +100,7 @@ function cmpart($a, $b)
 function oxNew($className, ...$args)
 {
     startProfile('oxNew');
-    $object = call_user_func_array([UtilsObject::getInstance(), "oxNew"], array_merge([$className], $args));
+    $object = \call_user_func_array([UtilsObject::getInstance(), "oxNew"], \array_merge([$className], $args));
     stopProfile('oxNew');
 
     return $object;
@@ -171,7 +171,7 @@ function ox_get_template($sTplName, &$sTplSource, $oSmarty)
  */
 function ox_get_timestamp($sTplName, &$iTplTimestamp, $oSmarty)
 {
-    $iTplTimestamp = isset($oSmarty->oxidtimecache->value) ? $oSmarty->oxidtimecache->value : time();
+    $iTplTimestamp = isset($oSmarty->oxidtimecache->value) ? $oSmarty->oxidtimecache->value : \time();
 
     return true;
 }

--- a/source/widget.php
+++ b/source/widget.php
@@ -5,7 +5,7 @@
  * See LICENSE file for license details.
  */
 
-require_once dirname(__FILE__) . "/bootstrap.php";
+require_once \dirname(__FILE__) . "/bootstrap.php";
 
 //Starts the shop
 OxidEsales\EshopCommunity\Core\Oxid::runWidget();


### PR DESCRIPTION
Fist of all, if you're not familiar with opcode, [here's](https://en.wikipedia.org/wiki/Opcode) a definition.

**Purpose of this PR:**
Optimizing the performance by invoking the native PHP functions correctly.  
Without using the incorrect invocation, native functions will be less performant because the initialization and parameter passing is split in separate operations.  

I posted a benchmark and references below.  

**Benchmarks:**
````
<?php //demo.php

namespace Foo;

in_array('foo', ['bar']);
````

produces  

```
/Users/Shared/dev/oxideshop_ce(master*) » php -d vld.active=1 -d vld.execute=0 demo.php                                                                                                                                                                                                         administrator@administorsiMac
Finding entry points
Branch analysis from position: 0
1 jumps found. (Code = 62) Position 1 = -2
filename:       /Users/Shared/dev/oxideshop_ce/demo.php
function name:  (null)
number of ops:  7
compiled vars:  none
line     #* E I O op                           fetch          ext  return  operands
-------------------------------------------------------------------------------------
   3     0  E >   NOP
   5     1        EXT_STMT
         2        INIT_NS_FCALL_BY_NAME                                    'Foo%5Cin_array'
         3        SEND_VAL_EX                                              'foo'
         4        SEND_VAL_EX                                              <array>
         5        DO_FCALL                                      0
   6     6      > RETURN                                                   1

branch: #  0; line:     3-    6; sop:     0; eop:     6; out0:  -2
path #1: 0,
```

and  

```
<?php  //demo.php

namespace Foo;

\in_array('foo', ['bar']);
```

produces 

```
/Users/Shared/dev/oxideshop_ce(master*) » php -d vld.active=1 -d vld.execute=0 demo.php                                                                                                                                                                                                         administrator@administorsiMac
Finding entry points
Branch analysis from position: 0
1 jumps found. (Code = 62) Position 1 = -2
filename:       /Users/Shared/dev/oxideshop_ce/demo.php
function name:  (null)
number of ops:  5
compiled vars:  none
line     #* E I O op                           fetch          ext  return  operands
-------------------------------------------------------------------------------------
   3     0  E >   NOP
   5     1        EXT_STMT
         2        IN_ARRAY                                         ~0      'foo', <array>
         3        FREE                                                     ~0
   6     4      > RETURN                                                   1

branch: #  0; line:     3-    6; sop:     0; eop:     4; out0:  -2
path #1: 0,
```

**References:**
https://www.php.net/manual/de/internals2.opcodes.list.php
https://github.com/php/php-src/blob/f2db305fa4e9bd7d04d567822687ec714aedcdb5/Zend/zend_compile.c#L3872
https://github.com/Roave/FunctionFQNReplacer#rationale
https://veewee.github.io/blog/optimizing-php-performance-by-fq-function-calls/