### PR TITLE
Fix mvc pattern add voucher

### DIFF
--- a/source/Application/Controller/BasketController.php
+++ b/source/Application/Controller/BasketController.php
@@ -224,7 +224,12 @@ class BasketController extends \OxidEsales\Eshop\Application\Controller\Frontend
         }
 
         $oBasket = $session->getBasket();
-        $oBasket->addVoucher(Registry::getConfig()->getRequestParameter('voucherNr'));
+        try {
+            $oBasket->addVoucher(Registry::getConfig()->getRequestParameter('voucherNr'));
+        } catch (\OxidEsales\Eshop\Core\Exception\VoucherException $oEx) {
+            // problems adding voucher
+            \OxidEsales\Eshop\Core\Registry::getUtilsView()->addErrorToDisplay($oEx, false, true);
+        }
     }
 
     /**

--- a/source/Application/Model/Basket.php
+++ b/source/Application/Model/Basket.php
@@ -1568,8 +1568,7 @@ class Basket extends \OxidEsales\Eshop\Core\Base
     /**
      * Checks and sets voucher information. Checks it's availability according
      * to few conditions: oxvoucher::checkVoucherAvailability(),
-     * oxvoucher::checkUserAvailability(). Errors are stored in
-     * \OxidEsales\Eshop\Application\Model\Basket::voucherErrors array. After all voucher is marked as reserved
+     * oxvoucher::checkUserAvailability(). After all voucher is marked as reserved
      * (oxvoucher::MarkAsReserved())
      *
      * @param string $sVoucherId voucher ID

--- a/tests/Integration/Price/VouchersForSpecificCategoriesAndProductsAndUserGroupsTest.php
+++ b/tests/Integration/Price/VouchersForSpecificCategoriesAndProductsAndUserGroupsTest.php
@@ -153,7 +153,7 @@ final class VouchersForSpecificCategoriesAndProductsAndUserGroupsTest extends Un
         $basket->addToBasket(self::FIRST_ARTICLE_ID, 1);
         $basket->calculateBasket(true);
         $this->assertSame(11.76, $basket->getNettoSum());
-
+        $this->expectException(\OxidEsales\EshopCommunity\Core\Exception\VoucherException::class);
         $basket->addVoucher(self::FIRST_VOUCHER_NUMBER);
         $basket->calculateBasket(true);
         $this->assertSame(11.76, $basket->getNettoSum());

--- a/tests/Unit/Application/Model/BasketTest.php
+++ b/tests/Unit/Application/Model/BasketTest.php
@@ -1999,8 +1999,13 @@ class BasketTest extends \OxidTestCase
         $oBasket->addToBasket($this->oArticle->getId(), 10);
         $oBasket->addToBasket($this->oVariant->getId(), 10);
         $oBasket->calculateBasket(false);
-        $oBasket->addVoucher('_xxx');
-        $this->assertEquals(0, count($oBasket->getVouchers()));
+        try {
+            $oBasket->addVoucher('_xxx');
+        } catch (\OxidEsales\EshopCommunity\Core\Exception\VoucherException $oEx) {
+
+        } finally {
+            $this->assertEquals(0, count($oBasket->getVouchers()));
+        }
     }
 
     /**

--- a/tests/Unit/Application/Model/BasketTest.php
+++ b/tests/Unit/Application/Model/BasketTest.php
@@ -1999,13 +1999,9 @@ class BasketTest extends \OxidTestCase
         $oBasket->addToBasket($this->oArticle->getId(), 10);
         $oBasket->addToBasket($this->oVariant->getId(), 10);
         $oBasket->calculateBasket(false);
-        try {
-            $oBasket->addVoucher('_xxx');
-        } catch (\OxidEsales\EshopCommunity\Core\Exception\VoucherException $oEx) {
-
-        } finally {
-            $this->assertEquals(0, count($oBasket->getVouchers()));
-        }
+        $this->expectException(\OxidEsales\EshopCommunity\Core\Exception\VoucherException::class);
+        $oBasket->addVoucher('_xxx');
+        $this->assertEquals(0, count($oBasket->getVouchers()));
     }
 
     /**


### PR DESCRIPTION
Currently the addVoucher method in the basket model is passing errors directly to the display. This contradicts the MVC pattern and should be handled by the basket controller. This PR fixes that issue. 