### PR TITLE
Resetting voucher reservations after logout

### DIFF
--- a/source/Application/Component/UserComponent.php
+++ b/source/Application/Component/UserComponent.php
@@ -305,9 +305,16 @@ class UserComponent extends \OxidEsales\Eshop\Core\Controller\BaseController
         $session->deleteVariable('dynvalue');
 
         // resetting & recalc basket
-        if (($oBasket = $session->getBasket())) {
+        if ($oBasket = $session->getBasket()) {
             $oBasket->resetUserInfo();
             $oBasket->onUpdate();
+            
+            // resetting voucher reservations
+            if ($aVouchers = $oBasket->getVouchers()) {
+                foreach ($aVouchers as $sVoucherId => $oVoucher) {
+                    $oBasket->removeVoucher($sVoucherId);
+                }
+            }
         }
 
         $session->delBasket();


### PR DESCRIPTION
The reservation of a voucher is not automatically resetted after logout.
If not resetted, the voucher is not redeemable again for some time.

Vouchers are not saved in user-accounts, so they are not really "reserved" after logout. Therefore we have to reset the reservation.