### PR TITLE
remove display errors 0

### DIFF
--- a/source/bootstrap.php
+++ b/source/bootstrap.php
@@ -6,7 +6,6 @@
  */
 
 error_reporting(E_ALL & ~E_DEPRECATED & ~E_NOTICE);
-ini_set('display_errors', '0');
 
 define('INSTALLATION_ROOT_PATH', dirname(__DIR__));
 define('OX_BASE_PATH', INSTALLATION_ROOT_PATH . DIRECTORY_SEPARATOR . 'source' . DIRECTORY_SEPARATOR);


### PR DESCRIPTION
ini_set('display_errors', '0') does hide errors from developers so it should not be done in the bootstrap.
I know it is important security setting and should be set to 0 in production for web requests, but this is a setting the hoster is responsible to do, and the application should not change it from my point of view.
If this setting is overwritten here it must be configurable and distinguish at least between CLI and web request, wich would be a overklill here and that is what php.ini is good for.