### PR TITLE
prevent password autofill

### DIFF
--- a/source/Application/views/admin/tpl/user_main.tpl
+++ b/source/Application/views/admin/tpl/user_main.tpl
@@ -221,7 +221,7 @@ function chkInsert()
                 [{oxmultilang ident="USER_MAIN_NEWPASSWORD"}]
                 </td>
                 <td class="edittext"><br>
-                <input type="password" class="editinput" size="15" name="newPassword" value="" [{$readonly}]>
+                <input type="password" class="editinput" size="15" name="newPassword" value="" autocomplete="new-password" [{$readonly}]>
                 [{oxinputhelp ident="HELP_USER_MAIN_NEWPASSWORD"}]
                 </td>
             </tr>


### PR DESCRIPTION
the "new password" field in user management triggers browser autofill function and might overwrite the password of selected user if you do not clean this field manually.
Adding `autocomplete="new-password"` to this field will prevent browser's autofill function