### PR TITLE
feature: get pictures from first variant in MdVariants without images in masters

### DIFF
--- a/source/Application/Component/Widget/ArticleBox.php
+++ b/source/Application/Component/Widget/ArticleBox.php
@@ -113,6 +113,26 @@ class ArticleBox extends \OxidEsales\Eshop\Application\Component\Widget\WidgetCo
     }
 
     /**
+     * Returns pictures product object
+     *
+     * @return Article
+     */
+    public function getPicturesProduct()
+    {
+        /** @var Article $oProduct */
+        $oProduct = $this->getProduct();
+        if ($oProduct->isParentNotBuyable()) {
+            /** @var ArticleList $aVariantList */
+            $aVariantList = $oProduct->getVariants(true);
+            if (!empty($aVariantList)) {
+                return $aVariantList->current();
+            }
+        }
+
+        return $oProduct;
+    }
+
+    /**
      * get link of current top view
      *
      * @param int $iLang requested language

--- a/source/Application/Component/Widget/ArticleDetails.php
+++ b/source/Application/Component/Widget/ArticleDetails.php
@@ -850,12 +850,22 @@ class ArticleDetails extends \OxidEsales\Eshop\Application\Component\Widget\Widg
      */
     public function getPicturesProduct()
     {
+        $oProduct = $this->getProduct();
+
         $aVariantSelections = $this->getVariantSelections();
         if ($aVariantSelections && $aVariantSelections['oActiveVariant'] && !$aVariantSelections['blPerfectFit']) {
-            return $aVariantSelections['oActiveVariant'];
+            $oProduct = $aVariantSelections['oActiveVariant'];
         }
 
-        return $this->getProduct();
+        if ($oProduct->isParentNotBuyable() && $oProduct->hasMdVariants()) {
+            /** @var ArticleList $aVariantList */
+            $aVariantList = $oProduct->getVariants(true);
+            if (!empty($aVariantList)) {
+                return $aVariantList->current();
+            }
+        }
+
+        return $oProduct;
     }
 
     /**

--- a/source/Application/Controller/ArticleDetailsController.php
+++ b/source/Application/Controller/ArticleDetailsController.php
@@ -972,12 +972,22 @@ class ArticleDetailsController extends \OxidEsales\Eshop\Application\Controller\
      */
     public function getPicturesProduct()
     {
+        $product = $this->getProduct();
+
         $variantSelections = $this->getVariantSelections();
         if ($variantSelections && $variantSelections['oActiveVariant'] && !$variantSelections['blPerfectFit']) {
             return $variantSelections['oActiveVariant'];
         }
 
-        return $this->getProduct();
+        if ($product->isParentNotBuyable()) {
+            /** @var ArticleList $variantList */
+            $variantList = $product->getVariants(true);
+            if (!empty($variantList)) {
+                return $variantList->current();
+            }
+        }
+
+        return $product;
     }
 
     /**


### PR DESCRIPTION
This is used in one of our OXID cloud projects to get the pictures of master products in product overview pages from the first active variant instead.
In this case the ERP system does not have real products and also no images assigned to them for master products.
With these modifications it can be used e.g. in listitem_grid.tpl by adding [{assign var="oPictureProduct" value=$oView->getPicturesProduct()}] and replacing $product->getThumbnailUrl() with $oPictureProduct->getThumbnailUrl()