### PR TITLE
Autoselect single variants

### DIFF
--- a/source/Application/Model/Article.php
+++ b/source/Application/Model/Article.php
@@ -1710,6 +1710,19 @@ class Article extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
         return $oVariants;
     }
 
+    public function getSingleVariant()
+    {
+        $variant_selection = $this->getVariantSelections();
+        if (!is_array($variant_selection) || count($variant_selection['rawselections']) != 1) {
+            return false;
+        }
+        $article_ids = array_keys($variant_selection['rawselections']);
+        $article = oxNew(Article::class);
+        $article->load($article_ids[0]);
+
+        return $article;
+    }
+
     /**
      * Loads and returns article category object. First tries to load
      * assigned category and is such category does not exist, tries to

--- a/source/Application/Model/VariantSelectList.php
+++ b/source/Application/Model/VariantSelectList.php
@@ -107,6 +107,9 @@ class VariantSelectList implements \OxidEsales\Eshop\Core\Contract\ISelectList
      */
     public function getActiveSelection()
     {
+        if (count($this->_aList) === 1) {
+            $this->_oActiveSelection = array_values($this->_aList)[0];
+        }
         return $this->_oActiveSelection;
     }
 

--- a/tests/Unit/Application/Model/VariantselectlistTest.php
+++ b/tests/Unit/Application/Model/VariantselectlistTest.php
@@ -72,4 +72,19 @@ class VariantselectlistTest extends \OxidTestCase
         $this->assertNotInstanceOf('oxSelection', $aSelections["test4"]);
         $this->assertNotInstanceOf('oxSelection', $aSelections["test5"]);
     }
+
+    public function testGetActiveSelectionSingleSelection()
+    {
+        $list = new VariantSelectList('test', 1);
+        $list->addVariant('testName', 'testValue', false, false);
+        $this->assertInstanceOf(Selection::class, $list->getActiveSelection());
+    }
+
+    public function testGetActiveSelectionMultipleSelections()
+    {
+        $list = new VariantSelectList('test', 1);
+        $list->addVariant('testName', 'testValue', false, false);
+        $list->addVariant('otherTestName', 'otherTestValue', false, false);
+        $this->assertNull($list->getActiveSelection());
+    }
 }


### PR DESCRIPTION
This is the code I could find for the code/core part of autoselecting variant dimensions that have no possible choice left.

Not intended to be merged into the product as is. There are also other modules within OXID Professional Services that try to achieve similar things. 