### PR TITLE
Provide getConfigParam() in $oViewConf/Smarty

### DIFF
--- a/source/Core/ViewConfig.php
+++ b/source/Core/ViewConfig.php
@@ -1258,6 +1258,19 @@ class ViewConfig extends \OxidEsales\Eshop\Core\Base
 
 
     /**
+     * return config-param value
+     *
+     * @param string $sName param name
+     *
+     * @return mixed
+     */
+    public function getConfigParam($sName)
+    {
+        return Registry::getConfig()->getConfigParam($sName);
+    }
+
+
+    /**
      * Returns true if selection lists must be displayed in details page
      *
      * @return bool


### PR DESCRIPTION
Currently you have to assign oConfig separately to get a config-param in templates:
[{assign var="oConfig" value=$oViewConf->getConfig()}]
[{$oConfig->getConfigParam('sDefaultLang')}]

Smarter way would be:
[{$oViewConf->getConfigParam('sDefaultLang')}]

Alternative way:
Make $oConfig-var global in templates like $oView or $oViewConf vars