### PR TITLE
Missing Event SettingChanged

### DIFF
--- a/source/Internal/Framework/Module/Setting/SettingDao.php
+++ b/source/Internal/Framework/Module/Setting/SettingDao.php
@@ -10,11 +10,13 @@ declare(strict_types=1);
 namespace OxidEsales\EshopCommunity\Internal\Framework\Module\Setting;
 
 use OxidEsales\EshopCommunity\Internal\Framework\Config\Utility\ShopSettingEncoderInterface;
+use OxidEsales\EshopCommunity\Internal\Framework\Module\Setting\Event\SettingChangedEvent;
 use OxidEsales\EshopCommunity\Internal\Transition\Adapter\ShopAdapterInterface;
 use OxidEsales\EshopCommunity\Internal\Framework\Database\QueryBuilderFactoryInterface;
 use OxidEsales\EshopCommunity\Internal\Framework\Database\TransactionServiceInterface;
 use OxidEsales\EshopCommunity\Internal\Framework\Dao\EntryDoesNotExistDaoException;
 use OxidEsales\EshopCommunity\Internal\Transition\Utility\ContextInterface;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
 use function is_string;
 
@@ -46,24 +48,32 @@ class SettingDao implements SettingDaoInterface
     private $transactionService;
 
     /**
+     * @var EventDispatcherInterface
+     */
+    private $eventDispatcher;
+
+    /**
      * @param QueryBuilderFactoryInterface $queryBuilderFactory
      * @param ContextInterface             $context
      * @param ShopSettingEncoderInterface  $shopSettingEncoder
      * @param ShopAdapterInterface         $shopAdapter
      * @param TransactionServiceInterface  $transactionService
+     * @param EventDispatcherInterface     $eventDispatcher
      */
     public function __construct(
         QueryBuilderFactoryInterface $queryBuilderFactory,
         ContextInterface $context,
         ShopSettingEncoderInterface $shopSettingEncoder,
         ShopAdapterInterface $shopAdapter,
-        TransactionServiceInterface $transactionService
+        TransactionServiceInterface $transactionService,
+        EventDispatcherInterface $eventDispatcher
     ) {
         $this->queryBuilderFactory = $queryBuilderFactory;
         $this->context = $context;
         $this->shopSettingEncoder = $shopSettingEncoder;
         $this->shopAdapter = $shopAdapter;
         $this->transactionService = $transactionService;
+        $this->eventDispatcher = $eventDispatcher;
     }
 
     /**
@@ -88,6 +98,8 @@ class SettingDao implements SettingDaoInterface
             $this->saveDataToOxConfigDisplayTable($moduleSetting, $moduleId);
 
             $this->transactionService->commit();
+
+            $this->dispatchEvent($moduleSetting, $moduleId, $shopId);
         } catch (\Throwable $throwable) {
             $this->transactionService->rollback();
             throw $throwable;
@@ -321,5 +333,22 @@ class SettingDao implements SettingDaoInterface
     private function getPrefixedModuleId(string $moduleId): string
     {
         return 'module:' . $moduleId;
+    }
+
+    /**
+     * @param Setting $shopModuleSetting
+     * @param string  $moduleId
+     * @param int     $shopId
+     */
+    private function dispatchEvent(Setting $shopModuleSetting, string $moduleId, int $shopId)
+    {
+        $this->eventDispatcher->dispatch(
+            SettingChangedEvent::NAME,
+            new SettingChangedEvent(
+                $shopModuleSetting->getName(),
+                $shopId,
+                $moduleId
+            )
+        );
     }
 }

--- a/tests/Unit/Internal/Framework/Module/ShopModuleSetting/SettingDaoTest.php
+++ b/tests/Unit/Internal/Framework/Module/ShopModuleSetting/SettingDaoTest.php
@@ -6,6 +6,7 @@
 
 namespace OxidEsales\EshopCommunity\Tests\Unit\Internal\Framework\Module\Setting;
 
+use OxidEsales\EshopCommunity\Internal\Framework\Module\Setting\Event\SettingChangedEvent;
 use OxidEsales\EshopCommunity\Internal\Framework\Module\Setting\Helper\ModuleIdPreparator;
 use OxidEsales\EshopCommunity\Internal\Framework\Config\Utility\ShopSettingEncoderInterface;
 use OxidEsales\EshopCommunity\Internal\Transition\Adapter\ShopAdapterInterface;
@@ -14,13 +15,17 @@ use OxidEsales\EshopCommunity\Internal\Framework\Database\TransactionServiceInte
 use OxidEsales\EshopCommunity\Internal\Framework\Module\Setting\Setting;
 use OxidEsales\EshopCommunity\Internal\Framework\Module\Setting\SettingDao;
 use OxidEsales\EshopCommunity\Internal\Transition\Utility\ContextInterface;
+use OxidEsales\EshopCommunity\Tests\Integration\Internal\ContainerTrait;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
 /**
  * @internal
  */
 class SettingDaoTest extends TestCase
 {
+    use ContainerTrait;
+
     /**
      * @expectedException \Exception
      */
@@ -36,14 +41,47 @@ class SettingDaoTest extends TestCase
             ->expects($this->once())
             ->method('rollback');
 
+        $eventDispatcher = $this->getMockBuilder(EventDispatcherInterface::class)->getMock();
+        $eventDispatcher
+            ->expects($this->never())
+            ->method('dispatch');
+
         $shopModuleSettingDao = new SettingDao(
             $queryBuilderFactory,
             $this->getMockBuilder(ContextInterface::class)->getMock(),
             $this->getMockBuilder(ShopSettingEncoderInterface::class)->getMock(),
             $this->getMockBuilder(ShopAdapterInterface::class)->getMock(),
-            $transactionService
+            $transactionService,
+            $eventDispatcher
         );
 
         $shopModuleSettingDao->save(new Setting(), '', 0);
+    }
+
+    public function testDispatchEventOnSave()
+    {
+        $eventDispatcher = $this->getMockBuilder(EventDispatcherInterface::class)->getMock();
+        $eventDispatcher
+            ->expects($this->once())
+            ->method('dispatch')
+            ->with(
+                //In the new version of EventDispatcher the entries have to be flipped.
+                $this->stringContains(SettingChangedEvent::NAME),
+                $this->isInstanceOf(SettingChangedEvent::class)
+            );
+
+        $shopModuleSettingDao = new SettingDao(
+            $this->get(QueryBuilderFactoryInterface::class),
+            $this->get(ContextInterface::class),
+            $this->get(ShopSettingEncoderInterface::class),
+            $this->get(ShopAdapterInterface::class),
+            $this->getMockBuilder(TransactionServiceInterface::class)->getMock(),
+            $eventDispatcher
+        );
+
+        $moduleSetting = new Setting();
+        $moduleSetting->setName('module_param')->setType('str')->setValue('module_value');
+
+        $shopModuleSettingDao->save($moduleSetting, 'phpunit_module_id', 0);
     }
 }


### PR DESCRIPTION
As the [documentation](https://docs.oxid-esales.com/developer/en/6.2/development/tell_me_about/event/ModuleEvents/SettingChangedEvent.html) says, the event should be triggered when the module settings change. Therefore I expect the event also when I change module settings in admin.