### PR TITLE
fix endless loop on module error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [6.8.1] - Unreleased
+
+### Fixed
+- Use not extended OxidEsales\Eshop\Core\Module\Module in module chain generator error case. [PR-863](https://github.com/OXID-eSales/oxideshop_ce/pull/863)
+
 ## [6.8.0] - 2021-04-13
 
 ### Added
@@ -1027,6 +1032,7 @@ See
 - [OXID eShop v6.0.0 Beta1: Overview of Changes](https://oxidforge.org/en/oxid-eshop-v6-0-0-beta1-overview-of-changes.html)
 - [OXID eShop v6.0.0 Beta1: Detailed Code Changelog](https://oxidforge.org/en/oxid-eshop-v6-0-0-beta1-detailed-code-changelog.html)
 
+[6.8.1]: https://github.com/OXID-eSales/oxideshop_ce/compare/v6.8.0...b-6.3.x
 [6.8.0]: https://github.com/OXID-eSales/oxideshop_ce/compare/v6.7.1...v6.8.0
 [6.7.1]: https://github.com/OXID-eSales/oxideshop_ce/compare/v6.7.0...v6.7.1
 [6.7.0]: https://github.com/OXID-eSales/oxideshop_ce/compare/v6.6.0...v6.7.0

--- a/source/Core/Module/ModuleChainsGenerator.php
+++ b/source/Core/Module/ModuleChainsGenerator.php
@@ -412,7 +412,7 @@ class ModuleChainsGenerator
     {
         $moduleId = "(module id not availible)";
         if (class_exists("\OxidEsales\Eshop\Core\Module\Module", false)) {
-            $module = oxNew(\OxidEsales\Eshop\Core\Module\Module::class);
+            $module = new \OxidEsales\Eshop\Core\Module\Module();
             $moduleId = $module->getIdByPath($moduleClass);
         }
         $message = sprintf('Module class %s not found. Module ID %s', $moduleClass, $moduleId);


### PR DESCRIPTION
in rare case a module overloads \OxidEsales\Eshop\Core\Module\Module and gets for example deleted 
then the shops must not try to call oxNew for \OxidEsales\Eshop\Core\Module\Module because that would create a endless loop.

this kind of loops can result very hard to debug segmentation fault (because out of memory errors in combination with xdebug)

My first try to fix this was not sufficient, anyway it looks like this regression is only in oxid eShop 6.2 but not before, at least I did not hit it in oxid 6.1