### PR TITLE
Fix issue#6247

### DIFF
--- a/source/Application/Model/DeliverySetList.php
+++ b/source/Application/Model/DeliverySetList.php
@@ -159,7 +159,6 @@ class DeliverySetList extends \OxidEsales\Eshop\Core\Model\ListModel
         $sGroupSql = count($aIds) ? "EXISTS(select oxobject2delivery.oxid from oxobject2delivery where oxobject2delivery.oxdeliveryid=$sTable.OXID and oxobject2delivery.oxtype='oxdelsetg' and oxobject2delivery.OXOBJECTID in (" . implode(', ', \OxidEsales\Eshop\Core\DatabaseProvider::getDb()->quoteArray($aIds)) . ") )" : '0';
 
         $sQ .= "and (
-            select
                 if(EXISTS(select 1 from oxobject2delivery, $sCountryTable where $sCountryTable.oxid=oxobject2delivery.oxobjectid and oxobject2delivery.oxdeliveryid=$sTable.OXID and oxobject2delivery.oxtype='oxdelset' LIMIT 1),
                     $sCountrySql,
                     1) &&


### PR DESCRIPTION
This change is a fix for issue#6247.
See: https://bugs.oxid-esales.com/view.php?id=6247

The issue is related to a MySQL 5.6 bug and an update to MySQL 5.7 was mentioned as a solution back in the days. While several users were able to "fix" the issue with the update, others still complain about the problems. Currently it is not 100% known what causes the issue, since not everyone experiences it.

There are several workarounds mentioned in MySQL- as well as OXID Bugtracker, but changes on the database optimizer_switch parameters are affecting the performance. Therefore these are not acceptable fixes. However, removing the SELECT also resulted in a working eShop instance - several developers agreed with that. Since this is a super simple modification and does not affect performance, I highly suggest to implement the change in future shop versions.

No new challenges were noticed with this change, but need to be tested carefully with the CI etc.

Additional information can be found in OXID Bugtracker (linked notes are private):
https://bugs.oxid-esales.com/view.php?id=6247#c13436
https://bugs.oxid-esales.com/view.php?id=6247#c13437