### PR TITLE
Fix typo in ActionList.php

### DIFF
--- a/source/Application/Model/ActionList.php
+++ b/source/Application/Model/ActionList.php
@@ -155,7 +155,7 @@ class ActionList extends \OxidEsales\Eshop\Core\Model\ListModel
     protected function fetchExistsActivePromotion()
     {
         $query = "select 1 from " . getViewName('oxactions') . " 
-            where oxtypex = :oxtype and oxactive = :oxactive and oxshopid = :oxshopid 
+            where oxtype = :oxtype and oxactive = :oxactive and oxshopid = :oxshopid 
             limit 1";
 
         return \OxidEsales\Eshop\Core\DatabaseProvider::getDb()->getOne($query, [


### PR DESCRIPTION
Fixed typo in SQL statement in ActionList.php. 

Previously this SQL query would throw fatal error:
`Uncaught PDOException: SQLSTATE[42S22]: Column not found: 1054 Unknown column 'oxtypex' in 'where clause' `