### PR TITLE
Add check if moduleSettings is defined in environment file

### DIFF
--- a/source/Internal/Framework/Module/Configuration/Dao/ShopEnvironmentConfigurationExtender.php
+++ b/source/Internal/Framework/Module/Configuration/Dao/ShopEnvironmentConfigurationExtender.php
@@ -48,10 +48,12 @@ class ShopEnvironmentConfigurationExtender implements ShopConfigurationExtenderI
                 unset($environmentData['modules'][$moduleId]);
                 continue;
             }
-            foreach (\array_keys($moduleConfiguration['moduleSettings']) as $settingId) {
-                if (!isset($shopConfiguration['modules'][$moduleId]['moduleSettings'][$settingId])) {
-                    unset($environmentData['modules'][$moduleId]['moduleSettings'][$settingId]);
-                    $this->processOrphanSetting($moduleId, $settingId);
+            if (isset($moduleConfiguration['moduleSettings'])) {
+                foreach (\array_keys($moduleConfiguration['moduleSettings']) as $settingId) {
+                    if (!isset($shopConfiguration['modules'][$moduleId]['moduleSettings'][$settingId])) {
+                        unset($environmentData['modules'][$moduleId]['moduleSettings'][$settingId]);
+                        $this->processOrphanSetting($moduleId, $settingId);
+                    }
                 }
             }
         }


### PR DESCRIPTION

Whenever you have an module entry in **environment/1.yaml** without the key `moduleSettings` the error "_array_keys() expects parameter 1 to be array, null given_" is caused.

The [documentation](https://docs.oxid-esales.com/developer/en/6.3/development/modules_components_themes/project/module_configuration/modules_configuration_deployment.html) doesn't state clearly if the key `moduleSettings` must be part of the entry in the environment YAML file for a module. Although the documentation is completely about the module configuration, the following example works completely fine and is only about to change meta information about the module - not its configuration:


```yaml
modules:
    oxsnosettings:
        title:
            en: NoSettingsTM22
        moduleSettings:
```
        
Since this entry only changes the title, one could think to remove the last and empty line `moduleSettings:` since it seems not to be necessary:

```yaml
modules:
    oxsnosettings:
        title:
            en: NoSettingsTM22
```
            
This leads to such an error message in the shop log:

```
[2021-05-20 13:58:44] OXID Logger.ERROR: array_keys() expects parameter 1 to be array, null given ["[object] (TypeError(code: 0): array_keys() expects parameter 1 to be array, null given at /var/www/html/vendor/oxid-esales/oxideshop-ce/source/Internal/Framework/Module/Configuration/Dao/ShopEnvironmentConfigurationExtender.php:55)\n[stacktrace]\n#0 /var/www/html/vendor/oxid-esales/oxideshop-ce/source/Internal/Framework/Module/Configuration/Dao/ShopEnvironmentConfigurationExtender.php(55): array_keys(NULL)\n#1 /var/www/html/vendor/oxid-esales/oxideshop-ce/source/Internal/Framework/Module/Configuration/Dao/ShopEnvironmentConfigurationExtender.php(38): OxidEsales\\EshopCommunity\\Internal\\Framework\\Module\\Configuration\\Dao\\ShopEnvironmentConfigurationExtender->filterEnvironmentData(Array, Array)\n#2 /var/www/html/vendor/oxid-esales/oxideshop-ce/source/Internal/Framework/Module/Configuration/Dao/ShopConfigurationDao.php(203): OxidEsales\\EshopCommunity\\Internal\\Framework\\Module\\Configuration\\Dao\\ShopEnvironmentConfigurationExtender->getExtendedConfiguration(1, Array)\n#3 /var/www/html/vendor/oxid-esales/oxideshop-ce/source/Internal/Framework/Module/Configuration/Dao/ShopConfigurationDao.php(95): OxidEsales\\EshopCommunity\\Internal\\Framework\\Module\\Configuration\\Dao\\ShopConfigurationDao->getConfigurationFromStorage(1)\n#4 /var/www/html/vendor/oxid-esales/oxideshop-ce/source/Internal/Framework/Module/Configuration/Bridge/ShopConfigurationDaoBridge.php(57): OxidEsales\\EshopCommunity\\Internal\\Framework\\Module\\Configuration\\Dao\\ShopConfigurationDao->get(1)\n#5 /var/www/html/vendor/oxid-esales/oxideshop-ce/source/Application/Controller/Admin/ModuleSortList.php(131): OxidEsales\\EshopCommunity\\Internal\\Framework\\Module\\Configuration\\Bridge\\ShopConfigurationDaoBridge->get()\n#6 /var/www/html/vendor/oxid-esales/oxideshop-ce/source/Application/Controller/Admin/ModuleSortList.php(40): OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\ModuleSortList->getShopConfiguration()\n#7 /var/www/html/vendor/oxid-esales/oxideshop-ce/source/Core/ShopControl.php(471): OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\ModuleSortList->render()\n#8 /var/www/html/vendor/oxid-esales/oxideshop-ee/Core/ShopControl.php(209): OxidEsales\\EshopCommunity\\Core\\ShopControl->_render(Object(OxidEsales\\Eshop\\Application\\Controller\\Admin\\ModuleSortList))\n#9 /var/www/html/vendor/oxid-esales/oxideshop-ce/source/Core/ShopControl.php(359): OxidEsales\\EshopEnterprise\\Core\\ShopControl->_render(Object(OxidEsales\\Eshop\\Application\\Controller\\Admin\\ModuleSortList))\n#10 /var/www/html/vendor/oxid-esales/oxideshop-ee/Core/ShopControl.php(98): OxidEsales\\EshopCommunity\\Core\\ShopControl->formOutput(Object(OxidEsales\\Eshop\\Application\\Controller\\Admin\\ModuleSortList))\n#11 /var/www/html/vendor/oxid-esales/oxideshop-ce/source/Core/ShopControl.php(282): OxidEsales\\EshopEnterprise\\Core\\ShopControl->formOutput(Object(OxidEsales\\Eshop\\Application\\Controller\\Admin\\ModuleSortList))\n#12 /var/www/html/vendor/oxid-esales/oxideshop-ce/source/Core/ShopControl.php(142): OxidEsales\\EshopCommunity\\Core\\ShopControl->_process('OxidEsales\\\\Esho...', NULL, NULL, NULL)\n#13 /var/www/html/vendor/oxid-esales/oxideshop-ce/source/Core/Oxid.php(27): OxidEsales\\EshopCommunity\\Core\\ShopControl->start()\n#14 /var/www/html/source/index.php(16): OxidEsales\\EshopCommunity\\Core\\Oxid::run()\n#15 /var/www/html/source/admin/index.php(12): require_once('/var/www/html/s...')\n#16 {main}\n"] []
```


If it is expected that `moduleSettings` is set all the time, feel free to close this PR, since I'm not sure which solution is the correct one here. But in this case I recommend to adapt the corresponding documentation accordingly.

This PR is based on the bug reporting [#7241](https://bugs.oxid-esales.com/view.php?id=7241)