### PR TITLE
The bug occurs when having the B2B modules activated.

### DIFF
--- a/source/Application/Model/DeliveryList.php
+++ b/source/Application/Model/DeliveryList.php
@@ -233,6 +233,8 @@ class DeliveryList extends \OxidEsales\Eshop\Core\Model\ListModel
         $aFittingDelSets = [];
         $aDelSetList = \OxidEsales\Eshop\Core\Registry::get(\OxidEsales\Eshop\Application\Model\DeliverySetList::class)->getDeliverySetList($oUser, $sDelCountry, $sDelSet);
 
+	$this->_aDeliveries = [];
+
         // must choose right delivery set to use its delivery list
         foreach ($aDelSetList as $sDeliverySetId => $oDeliverySet) {
             // loading delivery list to check if some of them fits


### PR DESCRIPTION
When increasing the amount of a basket position in the basket overview so that a delivery rule which has zero cost
should be pulled, the old cost is still visible and only updated when pushing the update button a second time.
Initializing the member variable _aDeliveries to an emty array fixes this behaviour.