### PR TITLE
404 Page at a SEO Url where the oxarticels__oxid is no longer present.

### DIFF
--- a/source/Application/Controller/ArticleDetailsController.php
+++ b/source/Application/Controller/ArticleDetailsController.php
@@ -460,7 +460,6 @@ class ArticleDetailsController extends \OxidEsales\Eshop\Application\Controller\
     public function getProduct()
     {
         $config = \OxidEsales\Eshop\Core\Registry::getConfig();
-        $utils = \OxidEsales\Eshop\Core\Registry::getUtils();
 
         if ($this->_oProduct === null) {
             //this option is only for lists and we must reset value
@@ -473,8 +472,9 @@ class ArticleDetailsController extends \OxidEsales\Eshop\Application\Controller\
             $this->_oProduct = oxNew(\OxidEsales\Eshop\Application\Model\Article::class);
 
             if (!$this->_oProduct->load($articleId)) {
-                $utils->redirect($config->getShopHomeUrl());
-                $utils->showMessageAndExit('');
+                unset($_GET, $_POST);
+                $config->dropLastActiveView();
+                error_404_handler($_SERVER['REQUEST_URI']);
             }
 
             $variantSelectionId = Registry::getRequest()->getRequestEscapedParameter("varselid");

--- a/tests/Unit/Application/Controller/DetailsTest.php
+++ b/tests/Unit/Application/Controller/DetailsTest.php
@@ -236,14 +236,15 @@ class DetailsTest extends \OxidTestCase
      */
     public function testGetProductNotExistingProduct()
     {
+        $_SERVER['REQUEST_URI'] = "index.php?cl=details&amp;anid=notexistingproductid";
         $this->setRequestParameter('anid', 'notexistingproductid');
-        oxTestModules::addFunction("oxUtils", "redirect", "{ throw new Exception( \$aA[0] ); }");
+        oxTestModules::addFunction("oxUtils", "handlePageNotFoundError", "{ throw new Exception( \$aA[0] ); }");
 
         try {
             $oDetailsView = oxNew('Details');
             $oDetailsView->getProduct();
         } catch (Exception $oExcp) {
-            $this->assertEquals($this->getConfig()->getShopHomeURL(), $oExcp->getMessage(), 'result does not match');
+            $this->assertEquals($_SERVER['REQUEST_URI'], $oExcp->getMessage(), 'result does not match');
 
             return;
         }


### PR DESCRIPTION
To date, status 200 was output when an SEO existed for an article. But the article is no longer present in the DB.

With this SQL a URL is created for a non exits article OXID.

```sql
INSERT INTO `oxseo` (`OXOBJECTID`, `OXIDENT`, `OXSHOPID`, `OXLANG`, `OXSTDURL`, `OXSEOURL`, `OXTYPE`, `OXFIXED`, `OXEXPIRED`, `OXPARAMS`, `OXTIMESTAMP`)
VALUES
	('b56369b1fc9d7b97f9c5fc343b349ece', 'b2e64c19290bff182ed2947ec51f0349', 1, 0, 'index.php?cl=details&amp;anid=ANY_OXID_FOR_ARTICLE', 'Kiteboarding/Kites/Kite-CORE-GTS-OXID-IS-WRONG.html', 'oxarticle', 0, 0, '0f4fb00809cec9aa0910aa9c8fe36751', '2021-06-14 12:48:48');

```

with `http://oxiddemo.local/Kiteboarding/Kites/Kite-CORE-GTS-OXID-IS-WRONG.html` should come status 404 not 200.

or simple

http://oxiddemo.local/index.php?cl=details&anid=notexistingproductid

---

Error can occur when sitemaps are generated incorrectly or a self-built article importer makes errors.