### PR TITLE
fix: PasswordHandling in Admin Tpls

### DIFF
--- a/source/Application/views/admin/tpl/module_config.tpl
+++ b/source/Application/views/admin/tpl/module_config.tpl
@@ -50,7 +50,7 @@ function _groupExp(el) {
                     <dl>
                         <dt>
                             [{block name="admin_module_config_var_types"}]
-                            
+
                             [{if $var_type == 'bool'}]
                                 [{block name="admin_module_config_var_type_bool"}]
                                 <input type=hidden name="confbools[[{$module_var}]]" value=false>
@@ -82,10 +82,10 @@ function _groupExp(el) {
                                 [{/block}]
                             [{elseif $var_type == 'password'}]
                                 [{block name="admin_module_config_var_type_password"}]
-                                <input class="password_input" type="password" style="width: 250px;" name="confpassword[[{$module_var}]]" data-empty="[{if $confpassword.$module_var}]false[{else}]true[{/if}]" data-errorMessage="[{oxmultilang ident="MODULE_PASSWORDS_DO_NOT_MATCH"}]" [{$readonly}] title="[{oxmultilang ident="MODULE_REPEAT_PASSWORD"}]">
+                                <input class="password_input" type="password" style="width: 250px;" name="confpassword[[{$module_var}]]" data-empty="[{if $confpassword.$module_var}]false[{else}]true[{/if}]" data-errormessage="[{oxmultilang ident="MODULE_PASSWORDS_DO_NOT_MATCH"}]" [{$readonly}] title="[{oxmultilang ident="MODULE_REPEAT_PASSWORD"}]">
                                 [{/block}]
                             [{/if}]
-                            
+
                             [{/block}]
                             [{oxinputhelp ident="HELP_SHOP_MODULE_`$module_var`"}]
                         </dt>

--- a/source/out/admin/src/js/widgets/oxmoduleconfiguration.js
+++ b/source/out/admin/src/js/widgets/oxmoduleconfiguration.js
@@ -50,7 +50,7 @@
         function handlePassword(position, password)
         {
             password = $(password);
-            var passwordConfirm = password.clone().attr('name', '');
+            var passwordConfirm = password.clone().prop('name', '');
 
             passwordFields.push({original: password, confirmation: passwordConfirm});
 
@@ -61,7 +61,7 @@
             }
 
             password.add(passwordConfirm).change(function () {
-                if (password.attr('value') != '' || passwordConfirm.attr('value') == '') {
+                if (password.prop('value') != '' || passwordConfirm.prop('value') == '') {
                     checkPassword(password, passwordConfirm);
                 }
             });
@@ -95,12 +95,12 @@
          */
         function hidePassword(password, passwordConfirm)
         {
-            passwordConfirm.attr('value', '*****');
-            password.hide().attr('disabled', true);
+            passwordConfirm.prop('value', '*****');
+            password.hide().prop('disabled', true);
 
             passwordConfirm.bind("change paste keyup", function () {
                 if (!password.is(":visible")) {
-                    password.show().attr('disabled', false);
+                    password.show().prop('disabled', false);
                 }
             })
         }
@@ -114,9 +114,9 @@
         function checkPassword(original, confirm)
         {
             var result = true;
-            if (original.attr('disabled') == false && original.attr('value') != confirm.attr('value')) {
+            if (original.prop('disabled') == false && original.prop('value') != confirm.prop('value')) {
                 if (original.errorBox == undefined) {
-                    original.errorBox = $('<div class="errorbox"></div>').text(original.data('errorMessage'));
+                    original.errorBox = $('<div class="errorbox"></div>').text(original.data('errormessage'));
                     original.after(original.errorBox);
                 } else {
                     original.errorBox.show();


### PR DESCRIPTION
since Update of backend jquery (from v1.5.1 to v3.4.1 :
OXDEV-2401 OXDEV-2501 Update to latest jquery lib)
the password-validation is broken because of using "attr"
instead of "prop" (introduced in jquery v1.6)

also the data-attributes should written in lowercase letters