### PR TITLE
Remove redirects to directory

### DIFF
--- a/source/.htaccess
+++ b/source/.htaccess
@@ -21,11 +21,6 @@
     RewriteCond %{REQUEST_URI} !(\/admin\/|\/Core\/|\/Application\/|\/export\/|\/modules\/|\/out\/|\/Setup\/|\/tmp\/|\/views\/)
     RewriteCond %{REQUEST_FILENAME} !-f
     RewriteCond %{REQUEST_FILENAME} !-d
-    RewriteRule !(\.html|\/|\.jpe?g|\.css|\.pdf|\.doc|\.gif|\.png|\.js|\.htc|\.svg)$ %{REQUEST_URI}/ [NC,R=301,L]
-
-    RewriteCond %{REQUEST_URI} !(\/admin\/|\/Core\/|\/Application\/|\/export\/|\/modules\/|\/out\/|\/Setup\/|\/tmp\/|\/views\/)
-    RewriteCond %{REQUEST_FILENAME} !-f
-    RewriteCond %{REQUEST_FILENAME} !-d
     RewriteRule (\.html|\/)$ oxseo.php
 
 


### PR DESCRIPTION
why:
It can make trouble if apache adds internal ports to the redirect, it makes oxid not flexible to configure seo url by modules (e.g. you may not like to have the slash or .html extension and it does not add value because seo.php can also handle the redirect so it is useless code.

bc break: no

performance:
Some redirects will get slower because they will now be handled by php, normal performance of a shoul should stay the same as this redirects are not used when normally using the page, but only when typing urls manually.
