### PR TITLE
resizes the admin login box

### DIFF
--- a/source/out/admin/src/login_facelift.css
+++ b/source/out/admin/src/login_facelift.css
@@ -10,11 +10,9 @@ div.admin-login-box {
     background: #fff;
     box-shadow: 0 20px 40px rgba(0,0,0,0.1);
     width: 340px;
-    height: 400px;
-    left: 0;
-    right: 0;
-    top: 0;
-    bottom: 0;
+    top: 50%;
+    -ms-transform: translate(-50%, -50%);
+    transform: translate(-50%, -50%);
     margin: auto;
 }
 


### PR DESCRIPTION
### why
In case new functionality or longer error messages when logging in are added to the admin login, the box needs to be bigger.
Now the box automatically resizes when there are longer error messages so the login button doesn't go out of the box.