### PR TITLE
translations are now working for both, frontend and backend

### DIFF
--- a/source/Core/Language.php
+++ b/source/Core/Language.php
@@ -725,7 +725,7 @@ class Language extends \OxidEsales\Eshop\Core\Base
      * @return array
      * @deprecated underscore prefix violates PSR12, will be renamed to "getLangFilesPathArray" in next major
      */
-    protected function _getLangFilesPathArray($iLang) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function _getLangFilesPathArray($iLang)// phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $oConfig = $this->getConfig();
         $aLangFiles = [];
@@ -810,7 +810,7 @@ class Language extends \OxidEsales\Eshop\Core\Base
             'views' . DIRECTORY_SEPARATOR .
             $adminThemeName . DIRECTORY_SEPARATOR .
             $language;
-
+        $langFiles[] = $this->_getLangFilesPathArray($activeLanguage);
         $langFiles[] = $adminPath . DIRECTORY_SEPARATOR . 'lang.php';
         $langFiles[] = $appDirectory .
             'translations' . DIRECTORY_SEPARATOR .

--- a/source/Core/Language.php
+++ b/source/Core/Language.php
@@ -725,7 +725,7 @@ class Language extends \OxidEsales\Eshop\Core\Base
      * @return array
      * @deprecated underscore prefix violates PSR12, will be renamed to "getLangFilesPathArray" in next major
      */
-    protected function _getLangFilesPathArray($iLang)// phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    protected function _getLangFilesPathArray($iLang) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $oConfig = $this->getConfig();
         $aLangFiles = [];

--- a/source/Core/Language.php
+++ b/source/Core/Language.php
@@ -795,7 +795,7 @@ class Language extends \OxidEsales\Eshop\Core\Base
     protected function _getAdminLangFilesPathArray($activeLanguage) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $config = $this->getConfig();
-        $langFiles = [];
+        $langFiles = $this->_getLangFilesPathArray($activeLanguage);;
 
         $appDirectory = $config->getAppDir();
         $language = Registry::getLang()->getLanguageAbbr($activeLanguage);
@@ -810,7 +810,6 @@ class Language extends \OxidEsales\Eshop\Core\Base
             'views' . DIRECTORY_SEPARATOR .
             $adminThemeName . DIRECTORY_SEPARATOR .
             $language;
-        $langFiles[] = $this->_getLangFilesPathArray($activeLanguage);
         $langFiles[] = $adminPath . DIRECTORY_SEPARATOR . 'lang.php';
         $langFiles[] = $appDirectory .
             'translations' . DIRECTORY_SEPARATOR .


### PR DESCRIPTION
### why
When also using the frontend translations for the backend, no extra backend translation files are needed for modules which makes it less error-prone. It's also possible to use standard Oxid Frontend translations in the backend without copying the keys.