### PR TITLE
OXDEV-4888 Add method BaseModel::getRawFieldData to get unencoded values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Text message on `Payment Methods > RDFa` tab
 - Docblock and other coding style fixes:
     - [PR-876](https://github.com/OXID-eSales/oxideshop_ce/pull/876)
+- Method `OxidEsales\EshopCommunity\Core\Model \BaseModel::getRawFieldData()` 
 
 ## [6.9.0] - 2021-07-27
 

--- a/source/Core/Model/BaseModel.php
+++ b/source/Core/Model/BaseModel.php
@@ -749,14 +749,29 @@ class BaseModel extends \OxidEsales\Eshop\Core\Base
      * Gets field data
      *
      * @param string $fieldName name (eg. 'oxtitle') of a data field to get
+     * @param bool   $raw       get unencoded value
      *
      * @return mixed value of a data field
      */
-    public function getFieldData($fieldName)
+    public function getFieldData($fieldName, $raw = false)
     {
         $longFieldName = $this->_getFieldLongName($fieldName);
+        $method = $raw ? 'rawValue' : 'value';
 
-        return ($this->$longFieldName instanceof Field) ? $this->$longFieldName->value : null;
+        return ($this->$longFieldName instanceof Field) ? $this->$longFieldName->$method : null;
+    }
+
+    /**
+     * Gets field data
+     *
+     * @param string $fieldName name (eg. 'oxtitle') of a data field to get
+     *
+     * @return mixed value of a data field
+     *
+     */
+    public function getRawFieldData($fieldName)
+    {
+        return $this->getFieldData($fieldName,true);
     }
 
     /**


### PR DESCRIPTION
We need something like that for GraphQL to get unencoded data,
otherwise we will end up with html encoded titles, descriptions etc. which will cause trouble with frontends.
Decision for GraphQL was to use getFieldData instead of old magic getters to have one clear central point to fetch data from. So if we introduce a solution like getRawFieldData method directly in shop (6.3.x if we have another release, otherwise 6.4.x) we have all we need in one method.

