### PR TITLE
using OXUSERNAME in addRegister() instead of OXID

### DIFF
--- a/source/Core/Smarty/Plugin/EmosAdapter.php
+++ b/source/Core/Smarty/Plugin/EmosAdapter.php
@@ -584,11 +584,11 @@ class EmosAdapter extends \OxidEsales\Eshop\Core\Base
         $iSuccess = Registry::getRequest()->getRequestEscapedParameter('success');
 
         if ($iError && $iError < 0) {
-            $oEmos->addRegister($oUser ? $oUser->getId() : 'NULL', abs($iError));
+            $oEmos->addRegister($oUser ? $oUser->oxuser__oxusername->value : 'NULL', abs($iError));
         }
 
         if ($iSuccess && $iSuccess > 0 && $oUser) {
-            $oEmos->addRegister($oUser->getId(), 0);
+            $oEmos->addRegister($oUser->oxuser__oxusername->value, 0);
         }
     }
 


### PR DESCRIPTION
The problem is: The register event fires the user's OXID via addRegister(). In the Emos.php within the addRegister() method the user's OXID is hashed again: $this->_registerUser = md5($sUserId);
So econda would receive a md5(OXUSERNAME) from the addLogin(), but unfortunately a different hash, a md5(OXID), which would be a md5(md5(OXUSERNAME)).

You can easily see check that within the browser's dev tools (console) by analysing the emospro object and look after the register or login event hash.
Different hashes could create misconduct in econda or rather econda ARP (profile matching).

So the (bug?) fix could be this one, so that both methods the addRegister() and the addLogin() receive the OXUSERNAME. but return the hashed OXUSERNAME: md5(OXUSERNAME).

Or (second approach): You could modify the Emos.php and remove the md5() within the addRegister() method.

With both suggestions econda would receive the same hash for both the register and the login event.