### PR TITLE
Cast the discount value to float to prevent an exception

### DIFF
--- a/source/Application/Controller/Admin/VoucherSerieMain.php
+++ b/source/Application/Controller/Admin/VoucherSerieMain.php
@@ -99,7 +99,7 @@ class VoucherSerieMain extends \OxidEsales\Eshop\Application\Controller\Admin\Dy
             return;
         }
 
-        $aSerieParams["oxvoucherseries__oxdiscount"] = abs($aSerieParams["oxvoucherseries__oxdiscount"]);
+        $aSerieParams["oxvoucherseries__oxdiscount"] = abs((float) $aSerieParams["oxvoucherseries__oxdiscount"]);
 
         $oVoucherSerie->assign($aSerieParams);
         $oVoucherSerie->save();


### PR DESCRIPTION
If nothing or something different than an integer or a float was provided, the shop will throw an exception:
```
OXID Logger.ERROR: abs(): Argument #1 ($num) must be of type int|float, string given ["[object] (TypeError(code: 0): abs(): Argument #1 ($num) must be of type int|float, string given at /var/www/oxideshop/vendor/oxid-esales/oxideshop-ce/source/Application/Controller/Admin/VoucherSerieMain.php:102)\n[stacktrace]\n#0 /var/www/oxideshop/vendor/oxid-esales/oxideshop-ce/source/Application/Controller/Admin/VoucherSerieMain.php(102): abs('')\n#1 /var/www/oxideshop/vendor/oxid-esales/oxideshop-ce/source/Core/Controller/BaseController.php(534): OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\VoucherSerieMain->save()\n#2 /var/www/oxideshop/vendor/oxid-esales/oxideshop-ee/Core/Controller/BaseController.php(64): OxidEsales\\EshopCommunity\\Core\\Controller\\BaseController->executeFunction('save')\n#3 /var/www/oxideshop/vendor/oxid-esales/oxideshop-ce/source/Core/ShopControl.php(347): OxidEsales\\EshopEnterprise\\Core\\Controller\\BaseController->executeFunction('save')\n#4 /var/www/oxideshop/vendor/oxid-esales/oxideshop-ce/source/Core/ShopControl.php(280): OxidEsales\\EshopCommunity\\Core\\ShopControl->executeAction(Object(OxidEsales\\Eshop\\Application\\Controller\\Admin\\VoucherSerieMain), 'save')\n#5 /var/www/oxideshop/vendor/oxid-esales/oxideshop-ce/source/Core/ShopControl.php(142): OxidEsales\\EshopCommunity\\Core\\ShopControl->_process('OxidEsales\\\\Esho...', 'save', NULL, NULL)\n#6 /var/www/oxideshop/vendor/oxid-esales/oxideshop-ce/source/Core/Oxid.php(27): OxidEsales\\EshopCommunity\\Core\\ShopControl->start()\n#7 /var/www/oxideshop/source/index.php(18): OxidEsales\\EshopCommunity\\Core\\Oxid::run()\n#8 /var/www/oxideshop/source/admin/index.php(12): require_once('/var/www/oxides...')\n#9 {main}\n"] []
```

Since the discount number is always casted to a float, this fix will not break the behaviour the customers are used to.