### PR TITLE
The security has nothing to do with the domain, but with connection type.

### DIFF
--- a/source/Core/UtilsServer.php
+++ b/source/Core/UtilsServer.php
@@ -60,9 +60,9 @@ class UtilsServer extends \OxidEsales\Eshop\Core\Base
             // do NOT set cookies in php unit or in cli because it would issue warnings
             return;
         }
-        $config = $this->getConfig();
+
         //if shop runs in https only mode we can set secure flag to all cookies
-        $blSecure = $blSecure || ($config->isSsl() && $config->getSslShopUrl() == $config->getShopUrl());
+        $blSecure = $blSecure || Registry::getConfig()->isSsl();
         return setcookie(
             $sName,
             $sValue,


### PR DESCRIPTION
The bug is especially a problem in the EE version.
In the admin backend, no session is saved when you are in https mode and make a shop change where mall URLs are stored.
Moreover, it is illogical the security does not depend on the domain but on the connection. In http mode everything works fine and https mode does not. The cookie is issued anyway. It is just not returned at a https connection.
If no session is saved in https there are many language problems in the admin-backend. See https://bugs.oxid-esales.com/view.php?id=7306

