### PR TITLE
extend handling for service response errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [6.10.2] - Unreleased
+
+### Fixed
+- Error in coupon series during missconfiguration of value [PR-887](https://github.com/OXID-eSales/oxideshop_ce/pull/887)
+
 ## [6.10.1] - 2022-02-02
 
 ### Fixed
@@ -1122,6 +1127,7 @@ See
 - [OXID eShop v6.0.0 Beta1: Overview of Changes](https://oxidforge.org/en/oxid-eshop-v6-0-0-beta1-overview-of-changes.html)
 - [OXID eShop v6.0.0 Beta1: Detailed Code Changelog](https://oxidforge.org/en/oxid-eshop-v6-0-0-beta1-detailed-code-changelog.html)
 
+[6.10.2]: https://github.com/OXID-eSales/oxideshop_ce/compare/v6.10.1...v6.10.2
 [6.10.1]: https://github.com/OXID-eSales/oxideshop_ce/compare/v6.10.0...v6.10.1
 [6.10.0]: https://github.com/OXID-eSales/oxideshop_ce/compare/v6.9.0...v6.10.0
 [6.9.0]: https://github.com/OXID-eSales/oxideshop_ce/compare/v6.8.0...v6.9.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 - Error in coupon series during missconfiguration of value [PR-887](https://github.com/OXID-eSales/oxideshop_ce/pull/887)
+- Extend default VAT check service response errors list [PR-889](https://github.com/OXID-eSales/oxideshop_ce/pull/889)
 
 ## [6.10.1] - 2022-02-02
 

--- a/source/Application/Controller/Admin/VoucherSerieMain.php
+++ b/source/Application/Controller/Admin/VoucherSerieMain.php
@@ -99,7 +99,7 @@ class VoucherSerieMain extends \OxidEsales\Eshop\Application\Controller\Admin\Dy
             return;
         }
 
-        $aSerieParams["oxvoucherseries__oxdiscount"] = abs($aSerieParams["oxvoucherseries__oxdiscount"]);
+        $aSerieParams["oxvoucherseries__oxdiscount"] = abs((float) $aSerieParams["oxvoucherseries__oxdiscount"]);
 
         $oVoucherSerie->assign($aSerieParams);
         $oVoucherSerie->save();

--- a/source/Core/OnlineVatIdCheck.php
+++ b/source/Core/OnlineVatIdCheck.php
@@ -152,6 +152,33 @@ class OnlineVatIdCheck extends \OxidEsales\Eshop\Core\CompanyVatInChecker
      */
     protected function _checkOnline($oCheckVat) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
+        
+        //D3 Source: https://ec.europa.eu/taxation_customs/vies/checkVatService.wsdl     
+        $aRetryErrors = [
+            'SERVER_BUSY',
+            'GLOBAL_MAX_CONCURRENT_REQ',
+                //'Your Request for VAT validation has not been processed; 
+                //the maximum number of concurrent requests has been reached. 
+                //Please re-submit your request later or contact                       
+                //TAXUD-VIESWEB@ec.europa.eu for further information": 
+                //Your request cannot be processed due to high traffic on the web application. Please try again later;'
+                                        
+            'MS_MAX_CONCURRENT_REQ',    
+                //'Your Request for VAT validation has not been processed; 
+                //the maximum number of concurrent requests for this Member State has been reached. 
+                //Please re-submit your request later or contact TAXUD-VIESWEB@ec.europa.eu for further information": 
+                //Your request cannot be processed due to high traffic towards the Member State you are trying to reach. 
+                //Please try again later.',
+                                        
+            'SERVICE_UNAVAILABLE',      
+                //'an error was encountered either at the network level or the Web application level, try again later; ',
+            'MS_UNAVAILABLE',           
+                //'The application at the Member State is not replying or not available. 
+                //Please refer to the Technical Information page to check the status of the requested Member State, try again later;',
+            'TIMEOUT',                  
+                //'The application did not receive a reply within the allocated time period, try again later. ',
+        ];
+        
         if ($this->_isServiceAvailable()) {
             $iTryMoreCnt = self::BUSY_RETRY_CNT;
 
@@ -171,7 +198,7 @@ class OnlineVatIdCheck extends \OxidEsales\Eshop\Core\CompanyVatInChecker
                     $iTryMoreCnt = 0;
                 } catch (SoapFault $e) {
                     $this->setError($e->faultstring);
-                    if ($this->getError() == "SERVER_BUSY") {
+                    if (in_array($this->getError(), $aRetryErrors)) {
                         usleep(self::BUSY_RETRY_WAITUSEC);
                     } else {
                         $iTryMoreCnt = 0;

--- a/source/Core/OnlineVatIdCheck.php
+++ b/source/Core/OnlineVatIdCheck.php
@@ -152,31 +152,14 @@ class OnlineVatIdCheck extends \OxidEsales\Eshop\Core\CompanyVatInChecker
      */
     protected function _checkOnline($oCheckVat) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
-        
-        //D3 Source: https://ec.europa.eu/taxation_customs/vies/checkVatService.wsdl     
+        //Default D3 Source: https://ec.europa.eu/taxation_customs/vies/checkVatService.wsdl
         $aRetryErrors = [
             'SERVER_BUSY',
             'GLOBAL_MAX_CONCURRENT_REQ',
-                //'Your Request for VAT validation has not been processed; 
-                //the maximum number of concurrent requests has been reached. 
-                //Please re-submit your request later or contact                       
-                //TAXUD-VIESWEB@ec.europa.eu for further information": 
-                //Your request cannot be processed due to high traffic on the web application. Please try again later;'
-                                        
-            'MS_MAX_CONCURRENT_REQ',    
-                //'Your Request for VAT validation has not been processed; 
-                //the maximum number of concurrent requests for this Member State has been reached. 
-                //Please re-submit your request later or contact TAXUD-VIESWEB@ec.europa.eu for further information": 
-                //Your request cannot be processed due to high traffic towards the Member State you are trying to reach. 
-                //Please try again later.',
-                                        
-            'SERVICE_UNAVAILABLE',      
-                //'an error was encountered either at the network level or the Web application level, try again later; ',
-            'MS_UNAVAILABLE',           
-                //'The application at the Member State is not replying or not available. 
-                //Please refer to the Technical Information page to check the status of the requested Member State, try again later;',
-            'TIMEOUT',                  
-                //'The application did not receive a reply within the allocated time period, try again later. ',
+            'MS_MAX_CONCURRENT_REQ',
+            'SERVICE_UNAVAILABLE',
+            'MS_UNAVAILABLE',
+            'TIMEOUT',
         ];
         
         if ($this->_isServiceAvailable()) {


### PR DESCRIPTION
Why?
- missing handling for service response errors

What did we do?
- add error cases that lead to a new request
