### PR TITLE
Fixed rare exception if getPrice() is null

### DIFF
--- a/source/Application/Model/Delivery.php
+++ b/source/Application/Model/Delivery.php
@@ -230,8 +230,8 @@ class Delivery extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel
                 case self::CONDITION_TYPE_PRICE: // price
                     if ($this->getCalculationRule() == self::CALCULATION_RULE_FOR_EACH_PRODUCT) {
                         $dAmount += $oProduct->getPrice()->getPrice();
-                    } else {
-                        $dAmount += $oBasketItem->getPrice()->getPrice(); // price// currency conversion must allready be done in price class / $oCur->rate; // $oBasketItem->oPrice->getPrice() / $oCur->rate;
+                    } elseif ($oBasketItem->getPrice()) {
+                        $dAmount += $oBasketItem->getPrice()->getPrice(); // price// currency conversion must already be done in price class / $oCur->rate; // $oBasketItem->oPrice->getPrice() / $oCur->rate;
                     }
                     break;
                 case self::CONDITION_TYPE_WEIGHT: // weight


### PR DESCRIPTION
In some extremely rare circumstances, $oBasketItem->getPrice() can return null. Then, line 234 will throw a PHP exception because getPrice() cannot be called on a null-object. (I could not really reproduce the null-object by myself - but somehow one customer produced this.)
There is already same check in line 255, which I added to line 233 as well.