### PR TITLE
Change type of default value for parameter (probably missed before)

### DIFF
--- a/source/Application/Model/Article.php
+++ b/source/Application/Model/Article.php
@@ -3160,9 +3160,8 @@ class Article extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
      *
      * @return string
      */
-    public function getZoomPictureUrl($iIndex = '')
+    public function getZoomPictureUrl($iIndex = 0)
     {
-        $iIndex = (int) $iIndex;
         if ($iIndex > 0 && !$this->isFieldEmpty("oxarticles__oxpic" . $iIndex)) {
             $sImgName = basename($this->{"oxarticles__oxpic" . $iIndex}->value);
             $sSize = Registry::getConfig()->getConfigParam("sZoomImageSize");


### PR DESCRIPTION
ERROR: InvalidParamDefault - project-modules/bergspezl/Model/Article.php:275:15 - Default value type string() for argument 1 of method OxidProfessionalServices\Bergspezl\Model\Article::getZoomPictureUrl does not match the given type int (see https://psalm.dev/062)