### PR TITLE
Basket position amount must be considered in voucher discount

### DIFF
--- a/source/Application/Model/Voucher.php
+++ b/source/Application/Model/Voucher.php
@@ -756,8 +756,8 @@ class Voucher extends \OxidEsales\Eshop\Core\Model\BaseModel
             // Individual voucher is not multiplied by article amount
             if (!$oSeries->oxvoucherseries__oxcalculateonce->value) {
                 $oDiscountPrice->multiply($aBasketItem['amount']);
-                $oProductPrice->multiply($aBasketItem['amount']);
             }
+            $oProductPrice->multiply($aBasketItem['amount']);
 
             $oVoucherPrice->add($oDiscountPrice->getBruttoPrice());
             $oProductTotal->add($oProductPrice->getBruttoPrice());


### PR DESCRIPTION
The problem here is:
if you have a voucher-series with 10 € product-specific discount + oxcalculateonce, and you have a 6.99 € (assigned) product with amount of 10 in you basket (= 69.90 € in total), then a discount of only 6.99 € (instead of 10 €) is granted because the position-amount is ignored.