### PR TITLE
Fixed PHP-warning if varselid is not an array

### DIFF
--- a/source/Application/Controller/ArticleDetailsController.php
+++ b/source/Application/Controller/ArticleDetailsController.php
@@ -208,13 +208,13 @@ class ArticleDetailsController extends \OxidEsales\Eshop\Application\Controller\
             return $parameters;
         }
 
-        if ($variantSelectionListId) {
+        if (is_array($variantSelectionListId)) {
             foreach ($variantSelectionListId as $key => $value) {
                 $parameters["varselid[$key]"] = $value;
             }
         }
 
-        if ($selectListParameters) {
+        if (is_array($selectListParameters)) {
             foreach ($selectListParameters as $key => $value) {
                 $parameters["sel[$key]"] = $value;
             }


### PR DESCRIPTION
Search-robots like to add this param to detail-pages they crawl: ...?varselid=Array ("Array" is a string here)
And this will cause a PHP warning, if we don't check the param with is_array()