### PR TITLE
Updated PHP requirements check.

### DIFF
--- a/source/Application/views/admin/de/lang.php
+++ b/source/Application/views/admin/de/lang.php
@@ -1258,7 +1258,7 @@ $aLang = [
     'SYSREQ_ALLOW_URL_FOPEN'                  => 'allow_url_fopen oder fsockopen auf Port 80',
     'SYSREQ_PHP4_COMPAT'                      => 'Zend Kompatibilitätsmodus muss ausgeschaltet sein',
     // @deprecated since v.6.5.1 (2020-02-12);
-    'SYSREQ_PHP_VERSION'                      => 'PHP Version 7.4 and 8.0',
+    'SYSREQ_PHP_VERSION'                      => 'PHP Version 7.4 bis 8.1',
     // END deprecated
     'SYSREQ_REQUEST_URI'                      => 'REQUEST_URI vorhanden',
     'SYSREQ_LIB_XML2'                         => 'LIB XML2',

--- a/source/Application/views/admin/en/lang.php
+++ b/source/Application/views/admin/en/lang.php
@@ -1258,7 +1258,7 @@ $aLang = [
     'SYSREQ_ALLOW_URL_FOPEN'                  => 'allow_url_fopen or fsockopen to port 80',
     'SYSREQ_PHP4_COMPAT'                      => 'Zend compatibility mode must be off',
     // @deprecated since v.6.5.1 (2020-02-12);
-    'SYSREQ_PHP_VERSION'                      => 'PHP version from 7.4 to 8.0',
+    'SYSREQ_PHP_VERSION'                      => 'PHP version from 7.4 to 8.1',
     // END deprecated
     'SYSREQ_REQUEST_URI'                      => 'REQUEST_URI set',
     'SYSREQ_LIB_XML2'                         => 'LIB XML2',

--- a/source/Core/SystemRequirements.php
+++ b/source/Core/SystemRequirements.php
@@ -586,7 +586,7 @@ class SystemRequirements
 
         $minimalRequiredVersion = '7.4.0';
         $minimalRecommendedVersion = $minimalRequiredVersion;
-        $maximalRecommendedVersion = '8.0.9999';
+        $maximalRecommendedVersion = '8.1.9999';
 
         $installedPhpVersion = $this->getPhpVersion();
 


### PR DESCRIPTION
Shop 6.5.0 is compatible with PHP 7.4, 8.0 and 8.1.
https://github.com/OXID-eSales/oxideshop-user-documentation/blob/b-6.5-de-650/installation/neu-installation/server-und-systemvoraussetzungen.rst#php

The system requirements check need to be adapted for these needs.

