### PR TITLE
Remove dynamically included Google Webfonts (GDPR) from offline.html

### DIFF
--- a/source/offline.html
+++ b/source/offline.html
@@ -5,10 +5,9 @@
     <meta name="robots" content="noindex, nofollow">
     <meta http-equiv="refresh" content="10; URL=/index.php">
     <title>Maintenance mode / Wartungsarbeiten</title>
-    <link href="https://fonts.googleapis.com/css?family=Source+Sans+Pro:400" rel="stylesheet" type="text/css">
     <style>
         body {
-            font-family: "Source Sans Pro", sans-serif;
+            font-family: "Source Sans Pro", "DIN Next LT Pro", Helvetica, Arial, sans-serif;
             line-height: 1.8;
             color: #333;
         }


### PR DESCRIPTION
Removed inclusion of Google Webfonts directly from Google and replaced it by multiple alternatives: 1) still Source Sans Pro in case the browser has it from any other source 2) OXID font in case anyone uses it
3) Helvetica and Arial for 2 of the most widely used fonts installed on most devices 4) generic sans-serif (as before)