### PR TITLE
Various changes to decrease amount of PHP8 warnings

### DIFF
--- a/source/Application/Component/BasketComponent.php
+++ b/source/Application/Component/BasketComponent.php
@@ -272,19 +272,19 @@ class BasketComponent extends \OxidEsales\Eshop\Core\Controller\BaseController
     {
 
         // active controller id
-        $controllerId = Registry::getConfig()->getRequestControllerId();
+        $controllerId = (string)Registry::getConfig()->getRequestControllerId();
         $controllerId = $controllerId ? $controllerId . '?' : 'start?';
         $sPosition = '';
 
         // setting redirect parameters
         foreach ($this->aRedirectParams as $sParamName) {
-            $sParamVal = Registry::getRequest()->getRequestEscapedParameter($sParamName);
+            $sParamVal = (string)Registry::getRequest()->getRequestEscapedParameter($sParamName);
             $sPosition .= $sParamVal ? $sParamName . '=' . $sParamVal . '&' : '';
         }
 
         // special treatment
         // search param
-        $sParam = rawurlencode(Registry::getRequest()->getRequestParameter('searchparam'));
+        $sParam = rawurlencode((string)Registry::getRequest()->getRequestParameter('searchparam'));
         $sPosition .= $sParam ? 'searchparam=' . $sParam . '&' : '';
 
         // current page number
@@ -292,7 +292,8 @@ class BasketComponent extends \OxidEsales\Eshop\Core\Controller\BaseController
         $sPosition .= ($iPageNr > 0) ? 'pgNr=' . $iPageNr . '&' : '';
 
         // reload and backbutton blocker
-        if (\OxidEsales\Eshop\Core\Registry::getConfig()->getConfigParam('iNewBasketItemMessage') == 3) {
+        $iNewBasketItemMessage=(int)\OxidEsales\Eshop\Core\Registry::getConfig()->getConfigParam('iNewBasketItemMessage');
+        if ($iNewBasketItemMessage == 3) {
             // saving return to shop link to session
             Registry::getSession()->setVariable('_backtoshop', $controllerId . $sPosition);
 

--- a/source/Application/Component/CategoriesComponent.php
+++ b/source/Application/Component/CategoriesComponent.php
@@ -109,29 +109,29 @@ class CategoriesComponent extends \OxidEsales\Eshop\Core\Controller\BaseControll
      */
     protected function getActCat()
     {
-        $sActManufacturer = Registry::getRequest()->getRequestEscapedParameter('mnid');
+        $sActManufacturer = (string)Registry::getRequest()->getRequestEscapedParameter('mnid');
 
-        $sActCat = $sActManufacturer ? null : Registry::getRequest()->getRequestEscapedParameter('cnid');
+        $sActCat = $sActManufacturer ? '' : (string)Registry::getRequest()->getRequestEscapedParameter('cnid');
 
         // loaded article - then checking additional parameters
         $oProduct = $this->getProduct();
         if ($oProduct) {
             $myConfig = \OxidEsales\Eshop\Core\Registry::getConfig();
 
-            $sActManufacturer = $myConfig->getConfigParam('bl_perfLoadManufacturerTree') ? $sActManufacturer : null;
+            $sActManufacturer = $myConfig->getConfigParam('bl_perfLoadManufacturerTree') ? $sActManufacturer : '';
 
-            $sActVendor = (Str::getStr()->preg_match('/^v_.?/i', $sActCat)) ? $sActCat : null;
+            $sActVendor = (Str::getStr()->preg_match('/^v_.?/i', $sActCat)) ? $sActCat : '';
 
             $sActCat = $this->addAdditionalParams($oProduct, $sActCat, $sActManufacturer, $sActVendor);
         }
 
         // Checking for the default category
-        if ($sActCat === null && !$oProduct && !$sActManufacturer) {
+        if (!$sActCat && !$oProduct && !$sActManufacturer) {
             // set remote cat
             $sActCat = \OxidEsales\Eshop\Core\Registry::getConfig()->getActiveShop()->oxshops__oxdefcat->value;
             if ($sActCat == 'oxrootid') {
                 // means none selected
-                $sActCat = null;
+                $sActCat = '';
             }
         }
 

--- a/source/Application/Controller/Admin/AdminController.php
+++ b/source/Application/Controller/Admin/AdminController.php
@@ -234,7 +234,7 @@ class AdminController extends \OxidEsales\Eshop\Core\Controller\BaseController
         $myUtilsServer = \OxidEsales\Eshop\Core\Registry::getUtilsServer();
 
         // store navigation history
-        $aHistory = explode('|', $myUtilsServer->getOxCookie('oxidadminhistory'));
+        $aHistory = explode('|', (string)$myUtilsServer->getOxCookie('oxidadminhistory'));
         if (!is_array($aHistory)) {
             $aHistory = [];
         }

--- a/source/Application/Controller/Admin/LoginController.php
+++ b/source/Application/Controller/Admin/LoginController.php
@@ -42,8 +42,8 @@ class LoginController extends \OxidEsales\Eshop\Application\Controller\Admin\Adm
         $myConfig = \OxidEsales\Eshop\Core\Registry::getConfig();
 
         // automatically redirect to SSL login
-        if (!$myConfig->isSsl() && strpos($myConfig->getConfigParam('sAdminSSLURL'), 'https://') === 0) {
-            \OxidEsales\Eshop\Core\Registry::getUtils()->redirect($myConfig->getConfigParam('sAdminSSLURL'), false, 302);
+        if (!$myConfig->isSsl() && strpos((string)$myConfig->getConfigParam('sAdminSSLURL'), 'https://') === 0) {
+            \OxidEsales\Eshop\Core\Registry::getUtils()->redirect((string)$myConfig->getConfigParam('sAdminSSLURL'), false, 302);
         }
 
         //resets user once on this screen.

--- a/source/Application/Controller/Admin/NavigationController.php
+++ b/source/Application/Controller/Admin/NavigationController.php
@@ -58,7 +58,7 @@ class NavigationController extends \OxidEsales\Eshop\Application\Controller\Admi
             }
 
             // favorite navigation
-            $aFavorites = explode('|', $myUtilsServer->getOxCookie('oxidadminfavorites'));
+            $aFavorites = explode('|', (string)$myUtilsServer->getOxCookie('oxidadminfavorites'));
 
             if (is_array($aFavorites) && count($aFavorites)) {
                 $this->_aViewData["menufavorites"] = $oNavTree->getListNodes($aFavorites);

--- a/source/Application/Controller/Admin/OrderList.php
+++ b/source/Application/Controller/Admin/OrderList.php
@@ -137,9 +137,9 @@ class OrderList extends \OxidEsales\Eshop\Application\Controller\Admin\AdminList
         $query = parent::buildSelectString($listObject);
         $database = \OxidEsales\Eshop\Core\DatabaseProvider::getDb();
 
-        $searchQuery = Registry::getRequest()->getRequestEscapedParameter('addsearch');
+        $searchQuery = (string)Registry::getRequest()->getRequestEscapedParameter('addsearch');
         $searchQuery = trim($searchQuery);
-        $searchField = Registry::getRequest()->getRequestEscapedParameter('addsearchfld');
+        $searchField = (string)Registry::getRequest()->getRequestEscapedParameter('addsearchfld');
 
         if ($searchQuery) {
             switch ($searchField) {

--- a/source/Application/Controller/Admin/OrderMain.php
+++ b/source/Application/Controller/Admin/OrderMain.php
@@ -49,6 +49,9 @@ class OrderMain extends \OxidEsales\Eshop\Application\Controller\Admin\AdminDeta
                 $oUtilsDate = \OxidEsales\Eshop\Core\Registry::getUtilsDate();
                 $oOrder->$sOxPaidField = new \OxidEsales\Eshop\Core\Field($oUtilsDate->formatDBDate($oOrder->$sOxPaidField->value));
             }
+            else{
+                $oOrder->blIsPaid = false;
+            }
 
             $this->_aViewData["edit"] = $oOrder;
             $this->_aViewData["paymentType"] = $oOrder->getPaymentType();

--- a/source/Application/Controller/Admin/ShopConfiguration.php
+++ b/source/Application/Controller/Admin/ShopConfiguration.php
@@ -224,6 +224,9 @@ class ShopConfiguration extends \OxidEsales\Eshop\Application\Controller\Admin\A
         if ($rs != false && $rs->count() > 0) {
             while (!$rs->EOF) {
                 list($name, $type, $value, $constraint, $grouping) = $rs->fields;
+                if(!$constraint){
+                    $constraint='';
+                }
                 $configurationVariables[$type][$name] = $this->unserializeConfVar($type, $name, $value);
                 $constraints[$name] = $this->parseConstraint($type, $constraint);
                 if ($grouping) {
@@ -268,7 +271,7 @@ class ShopConfiguration extends \OxidEsales\Eshop\Application\Controller\Admin\A
      *
      * @return mixed
      */
-    protected function parseConstraint($type, $constraint)
+    protected function parseConstraint(string $type, string $constraint)
     {
         switch ($type) {
             case "select":
@@ -286,7 +289,7 @@ class ShopConfiguration extends \OxidEsales\Eshop\Application\Controller\Admin\A
      *
      * @return string
      */
-    protected function serializeConstraint($type, $constraint)
+    protected function serializeConstraint(string $type, mixed $constraint)
     {
         switch ($type) {
             case "select":
@@ -434,7 +437,9 @@ class ShopConfiguration extends \OxidEsales\Eshop\Application\Controller\Admin\A
                 if ($multiline) {
                     $multiline .= "\n";
                 }
-                $multiline .= $key . " => " . $value;
+
+                // Using print_r() as $value could be a non scalar data type (eg array)
+                $multiline .= $key . " => " .print_r($value,true);
             }
 
             return $multiline;

--- a/source/Application/Controller/ArticleListController.php
+++ b/source/Application/Controller/ArticleListController.php
@@ -693,7 +693,7 @@ class ArticleListController extends \OxidEsales\Eshop\Application\Controller\Fro
     public function getTemplateName()
     {
         // assign template name
-        if (($templateName = basename(Registry::getRequest()->getRequestEscapedParameter('tpl')))) {
+        if (($templateName = basename((string)Registry::getRequest()->getRequestEscapedParameter('tpl')))) {
             $this->_sThisTemplate = 'custom/' . $templateName;
         } elseif (($category = $this->getActiveCategory()) && $category->getFieldData('oxtemplate')) {
             $this->_sThisTemplate = $category->oxcategories__oxtemplate->value;

--- a/source/Application/Controller/BasketController.php
+++ b/source/Application/Controller/BasketController.php
@@ -79,6 +79,8 @@ class BasketController extends \OxidEsales\Eshop\Application\Controller\Frontend
      */
     protected $_oWrappings = null;
 
+    protected $_iWrapCnt=null;
+
     /**
      * Card objects list
      *

--- a/source/Application/Controller/FrontendController.php
+++ b/source/Application/Controller/FrontendController.php
@@ -165,7 +165,7 @@ class FrontendController extends \OxidEsales\Eshop\Core\Controller\BaseControlle
      *
      * @var string
      */
-    protected $_sListOrderBy = null;
+    protected $_sListOrderBy = '';
 
     /**
      * Order direction of list
@@ -1314,6 +1314,11 @@ class FrontendController extends \OxidEsales\Eshop\Core\Controller\BaseControlle
         if (is_array($input)) {
             $input = implode(" ", $input);
         }
+        if (!$input)
+        {
+            // nothing to do
+            return '';
+        }
 
         // removing some usually met characters..
         $input = $stringModifier->preg_replace("/[" . preg_quote($this->_sRemoveMetaChars, "/") . "]/", " ", $input);
@@ -1633,25 +1638,25 @@ class FrontendController extends \OxidEsales\Eshop\Core\Controller\BaseControlle
         if ($function) {
             $url .= "&amp;fnc={$function}";
         }
-        if ($value = Registry::getRequest()->getRequestEscapedParameter('cnid')) {
+        if ($value = (string)Registry::getRequest()->getRequestEscapedParameter('cnid')) {
             $url .= "&amp;cnid={$value}";
         }
-        if ($value = Registry::getRequest()->getRequestEscapedParameter('mnid')) {
+        if ($value = (string)Registry::getRequest()->getRequestEscapedParameter('mnid')) {
             $url .= "&amp;mnid={$value}";
         }
-        if ($value = Registry::getRequest()->getRequestEscapedParameter('anid')) {
+        if ($value = (string)Registry::getRequest()->getRequestEscapedParameter('anid')) {
             $url .= "&amp;anid={$value}";
         }
 
-        if ($value = basename(Registry::getRequest()->getRequestEscapedParameter('page'))) {
+        if ($value = basename((string)Registry::getRequest()->getRequestEscapedParameter('page'))) {
             $url .= "&amp;page={$value}";
         }
 
-        if ($value = basename(Registry::getRequest()->getRequestEscapedParameter('tpl'))) {
+        if ($value = basename((string)Registry::getRequest()->getRequestEscapedParameter('tpl'))) {
             $url .= "&amp;tpl={$value}";
         }
 
-        if ($value = Registry::getRequest()->getRequestEscapedParameter('oxloadid')) {
+        if ($value = (string)Registry::getRequest()->getRequestEscapedParameter('oxloadid')) {
             $url .= "&amp;oxloadid={$value}";
         }
 
@@ -1663,28 +1668,28 @@ class FrontendController extends \OxidEsales\Eshop\Core\Controller\BaseControlle
         }
 
         // #1184M - specialchar search
-        if ($value = rawurlencode(Registry::getRequest()->getRequestParameter('searchparam'))) {
+        if ($value = rawurlencode((string)Registry::getRequest()->getRequestParameter('searchparam'))) {
             $url .= "&amp;searchparam={$value}";
         }
 
-        if ($value = Registry::getRequest()->getRequestEscapedParameter('searchcnid')) {
+        if ($value = (string)Registry::getRequest()->getRequestEscapedParameter('searchcnid')) {
             $url .= "&amp;searchcnid={$value}";
         }
 
-        if ($value = Registry::getRequest()->getRequestEscapedParameter('searchvendor')) {
+        if ($value = (string)Registry::getRequest()->getRequestEscapedParameter('searchvendor')) {
             $url .= "&amp;searchvendor={$value}";
         }
 
-        if ($value = Registry::getRequest()->getRequestEscapedParameter('searchmanufacturer')) {
+        if ($value = (string)Registry::getRequest()->getRequestEscapedParameter('searchmanufacturer')) {
             $url .= "&amp;searchmanufacturer={$value}";
         }
 
-        if ($value = Registry::getRequest()->getRequestEscapedParameter('searchrecomm')) {
+        if ($value = (string)Registry::getRequest()->getRequestEscapedParameter('searchrecomm')) {
             $url .= "&amp;searchrecomm={$value}";
         }
 
         // @deprecated since v5.3 (2016-06-17); Listmania will be moved to an own module.
-        if ($value = Registry::getRequest()->getRequestEscapedParameter('recommid')) {
+        if ($value = (string)Registry::getRequest()->getRequestEscapedParameter('recommid')) {
             $url .= "&amp;recommid={$value}";
         }
         // END deprecated
@@ -1715,15 +1720,15 @@ class FrontendController extends \OxidEsales\Eshop\Core\Controller\BaseControlle
         if ($function) {
             $url .= "&amp;fnc={$function}";
         }
-        if ($value = basename(Registry::getRequest()->getRequestEscapedParameter('page'))) {
+        if ($value = basename((string)Registry::getRequest()->getRequestEscapedParameter('page'))) {
             $url .= "&amp;page={$value}";
         }
 
-        if ($value = basename(Registry::getRequest()->getRequestEscapedParameter('tpl'))) {
+        if ($value = basename((string)Registry::getRequest()->getRequestEscapedParameter('tpl'))) {
             $url .= "&amp;tpl={$value}";
         }
 
-        if ($value = Registry::getRequest()->getRequestEscapedParameter('oxloadid')) {
+        if ($value = (string)Registry::getRequest()->getRequestEscapedParameter('oxloadid')) {
             $url .= "&amp;oxloadid={$value}";
         }
 
@@ -1923,23 +1928,23 @@ class FrontendController extends \OxidEsales\Eshop\Core\Controller\BaseControlle
             $this->_sAdditionalParams .= 'cl=' . Registry::getConfig()->getTopActiveView()->getClassKey();
 
             // #1834M - special char search
-            $searchParamForLink = rawurlencode(Registry::getRequest()->getRequestParameter('searchparam'));
+            $searchParamForLink = rawurlencode((string)Registry::getRequest()->getRequestParameter('searchparam'));
             if (isset($searchParamForLink)) {
                 $this->_sAdditionalParams .= "&amp;searchparam={$searchParamForLink}";
             }
-            if (($value = Registry::getRequest()->getRequestEscapedParameter('searchcnid'))) {
+            if (($value = (string)Registry::getRequest()->getRequestEscapedParameter('searchcnid'))) {
                 $this->_sAdditionalParams .= '&amp;searchcnid=' . rawurlencode(rawurldecode($value));
             }
-            if (($value = Registry::getRequest()->getRequestEscapedParameter('searchvendor'))) {
+            if (($value = (string)Registry::getRequest()->getRequestEscapedParameter('searchvendor'))) {
                 $this->_sAdditionalParams .= '&amp;searchvendor=' . rawurlencode(rawurldecode($value));
             }
-            if (($value = Registry::getRequest()->getRequestEscapedParameter('searchmanufacturer'))) {
+            if (($value = (string)Registry::getRequest()->getRequestEscapedParameter('searchmanufacturer'))) {
                 $this->_sAdditionalParams .= '&amp;searchmanufacturer=' . rawurlencode(rawurldecode($value));
             }
-            if (($value = Registry::getRequest()->getRequestEscapedParameter('cnid'))) {
+            if (($value = (string)Registry::getRequest()->getRequestEscapedParameter('cnid'))) {
                 $this->_sAdditionalParams .= '&amp;cnid=' . rawurlencode(rawurldecode($value));
             }
-            if (($value = Registry::getRequest()->getRequestEscapedParameter('mnid'))) {
+            if (($value = (string)Registry::getRequest()->getRequestEscapedParameter('mnid'))) {
                 $this->_sAdditionalParams .= '&amp;mnid=' . rawurlencode(rawurldecode($value));
             }
 

--- a/source/Application/Controller/ManufacturerListController.php
+++ b/source/Application/Controller/ManufacturerListController.php
@@ -337,9 +337,12 @@ class ManufacturerListController extends \OxidEsales\Eshop\Application\Controlle
      */
     public function getTitleSuffix()
     {
-        if ($this->getActManufacturer()->oxmanufacturers__oxshowsuffix->value) {
-            return \OxidEsales\Eshop\Core\Registry::getConfig()->getActiveShop()->oxshops__oxtitlesuffix->value;
-        }
+        $actManufacturer=$this->getActManufacturer();
+        if ($actManufacturer) {
+                if ($actManufacturer->oxmanufacturers__oxshowsuffix->value) {
+                    return \OxidEsales\Eshop\Core\Registry::getConfig()->getActiveShop()->oxshops__oxtitlesuffix->value;
+                }
+            }
     }
 
     /**

--- a/source/Application/Controller/PaymentController.php
+++ b/source/Application/Controller/PaymentController.php
@@ -508,6 +508,7 @@ class PaymentController extends \OxidEsales\Eshop\Application\Controller\Fronten
     public function getCheckedPaymentId()
     {
         if ($this->_sCheckedPaymentId === null) {
+            $sCheckedId='';
             if (!($sPaymentID = Registry::getRequest()->getRequestEscapedParameter('paymentid'))) {
                 $sPaymentID = Registry::getSession()->getVariable('paymentid');
             }

--- a/source/Application/Model/Article.php
+++ b/source/Application/Model/Article.php
@@ -3434,9 +3434,7 @@ class Article extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
     public function getPictureFieldValue($sFieldName, $iIndex = null)
     {
         if ($sFieldName) {
-            $sFieldName = "oxarticles__" . $sFieldName . $iIndex;
-
-            return $this->$sFieldName->value;
+            return $this->getFieldData($sFieldName.$iIndex);
         }
     }
 

--- a/source/Application/Model/CategoryList.php
+++ b/source/Application/Model/CategoryList.php
@@ -9,6 +9,7 @@ namespace OxidEsales\EshopCommunity\Application\Model;
 
 use oxDb;
 use Exception;
+use OxidEsales\Eshop\Core\Exception\StandardException;
 
 /**
  * Category list manager.
@@ -453,13 +454,21 @@ class CategoryList extends \OxidEsales\Eshop\Core\Model\ListModel
         }
 
         $aPath = [];
-        $sCurrentCat = $this->_sActCat;
+        $sInitialCat= $sCurrentCat = $this->_sActCat;
+        $aPathIds=[];
 
-        while ($sCurrentCat != 'oxrootid' && isset($this[$sCurrentCat])) {
+        while ($sCurrentCat !== 'oxrootid' && isset($this[$sCurrentCat])) {
+            $aPathIds[]=$sCurrentCat;
             $oCat = $this[$sCurrentCat];
             $oCat->setExpanded(true);
             $aPath[$sCurrentCat] = $oCat;
             $sCurrentCat = $oCat->oxcategories__oxparentid->value;
+
+            if (in_array($sCurrentCat, $aPathIds, true))
+            {
+                $msg="Path to category '".$sInitialCat."' seems to be broken/looping. Path: ".implode(", ",$aPathIds);
+                throw new StandardException($msg);
+            }
         }
 
         $this->_aPath = array_reverse($aPath);

--- a/source/Application/Model/Order.php
+++ b/source/Application/Model/Order.php
@@ -1936,7 +1936,7 @@ class Order extends \OxidEsales\Eshop\Core\Model\BaseModel
      */
     public function getBillCountry()
     {
-        if (!$this->oxorder__oxbillcountry->value) {
+        if (!isset($this->oxorder__oxbillcountry)) {
             $this->oxorder__oxbillcountry = new \OxidEsales\Eshop\Core\Field($this->getCountryTitle($this->oxorder__oxbillcountryid->value));
         }
 

--- a/source/Application/Model/UserPayment.php
+++ b/source/Application/Model/UserPayment.php
@@ -114,7 +114,7 @@ class UserPayment extends \OxidEsales\Eshop\Core\Model\BaseModel
     public function getDynValues()
     {
         if (!$this->_aDynValues) {
-            $sRawDynValue = null;
+            $sRawDynValue = '';
             if (is_object($this->oxuserpayments__oxvalue)) {
                 $sRawDynValue = $this->oxuserpayments__oxvalue->getRawValue();
             }

--- a/source/Core/Autoload/BackwardsCompatibilityClassMap.php
+++ b/source/Core/Autoload/BackwardsCompatibilityClassMap.php
@@ -95,7 +95,8 @@ return [
     'article_variant' => 'OxidEsales\\Eshop\\Application\\Controller\\Admin\\ArticleVariant',
     'attribute_category' => 'OxidEsales\\Eshop\\Application\\Controller\\Admin\\AttributeCategory',
     'attribute_category_ajax' => 'OxidEsales\\Eshop\\Application\\Controller\\Admin\\AttributeCategoryAjax',
-    'attribute' => 'OxidEsales\\Eshop\\Application\\Controller\\Admin\\AttributeController',
+    // PHP8.x introduces an attribute class itself which causes 'cannot declare class attribute' errors:
+    //'attribute' => 'OxidEsales\\Eshop\\Application\\Controller\\Admin\\AttributeController',
     'attribute_list' => 'OxidEsales\\Eshop\\Application\\Controller\\Admin\\AttributeList',
     'attribute_main' => 'OxidEsales\\Eshop\\Application\\Controller\\Admin\\AttributeMain',
     'attribute_main_ajax' => 'OxidEsales\\Eshop\\Application\\Controller\\Admin\\AttributeMainAjax',

--- a/source/Core/Contract/IDisplayError.php
+++ b/source/Core/Contract/IDisplayError.php
@@ -36,4 +36,11 @@ interface IDisplayError
      * @return string An additional value (string) by its name
      */
     public function getValue($sName);
+
+    /**
+     * Returns the stacktrace as string
+     * (Can get called in message/exception.html)
+     * @return string
+     */
+    public function getStackTrace() : string;
 }

--- a/source/Core/Controller/BaseController.php
+++ b/source/Core/Controller/BaseController.php
@@ -87,14 +87,14 @@ class BaseController extends \OxidEsales\Eshop\Core\Base
      *
      * @var string
      */
-    protected $classKey = null;
+    protected $classKey = '';
 
     /**
      * Action function name
      *
      * @var string
      */
-    protected $_sFnc = null;
+    protected $_sFnc = '';
 
     /**
      * Marker if user defined function was executed
@@ -364,7 +364,7 @@ class BaseController extends \OxidEsales\Eshop\Core\Base
      *
      * @param string $sFncName action function name
      */
-    public function setFncName($sFncName)
+    public function setFncName(string $sFncName) : void
     {
         $this->_sFnc = $sFncName;
     }
@@ -374,7 +374,7 @@ class BaseController extends \OxidEsales\Eshop\Core\Base
      *
      * @return string
      */
-    public function getFncName()
+    public function getFncName() : string
     {
         return $this->_sFnc;
     }

--- a/source/Core/Database/Adapter/Doctrine/ResultSet.php
+++ b/source/Core/Database/Adapter/Doctrine/ResultSet.php
@@ -112,7 +112,7 @@ class ResultSet implements \IteratorAggregate, ResultSetInterface
      *
      * @return Statement The Statment class implements Traversable
      */
-    public function getIterator()
+    public function getIterator() : \Traversable
     {
         $this->close();
         $this->getStatement()->execute();
@@ -165,7 +165,7 @@ class ResultSet implements \IteratorAggregate, ResultSetInterface
      *
      *  @return int The number of rows retrieved by the current statement.
      */
-    public function count()
+    public function count() : int
     {
         return $this->getStatement()->rowCount();
     }

--- a/source/Core/DisplayError.php
+++ b/source/Core/DisplayError.php
@@ -12,6 +12,14 @@ namespace OxidEsales\EshopCommunity\Core;
  */
 class DisplayError implements \OxidEsales\Eshop\Core\Contract\IDisplayError
 {
+    private $stackTrace;
+
+    public function __construct()
+    {
+        $tmpEx=new \Exception();
+        $this->stackTrace=$tmpEx->getTraceAsString();
+    }
+
     /**
      * Error message
      *
@@ -77,5 +85,11 @@ class DisplayError implements \OxidEsales\Eshop\Core\Contract\IDisplayError
     public function getValue($name)
     {
         return '';
+    }
+
+	// Can get called from message/exception.tpl
+    public function getStackTrace(): string
+    {
+        return $this->stackTrace;
     }
 }

--- a/source/Core/Exception/ExceptionToDisplay.php
+++ b/source/Core/Exception/ExceptionToDisplay.php
@@ -63,7 +63,7 @@ class ExceptionToDisplay implements \OxidEsales\Eshop\Core\Contract\IDisplayErro
      *
      * @return string
      */
-    public function getStackTrace()
+    public function getStackTrace() : string
     {
         return $this->_sStackTrace;
     }

--- a/source/Core/Language.php
+++ b/source/Core/Language.php
@@ -1082,11 +1082,11 @@ class Language extends \OxidEsales\Eshop\Core\Base
      * @param object $a1 first value to check
      * @param object $a2 second value to check
      *
-     * @return bool
+     * @return int
      */
     protected function sortLanguagesCallback($a1, $a2)
     {
-        return ($a1->sort > $a2->sort);
+        return ($a1->sort - $a2->sort);
     }
 
     /**

--- a/source/Core/Model/BaseModel.php
+++ b/source/Core/Model/BaseModel.php
@@ -38,7 +38,7 @@ class BaseModel extends \OxidEsales\Eshop\Core\Base
      *
      * @var string
      */
-    protected $_sOXID = null;
+    protected $_sOXID = '';
 
     /**
      * ID of running shop session (default null).

--- a/source/Core/Model/ListModel.php
+++ b/source/Core/Model/ListModel.php
@@ -60,7 +60,7 @@ class ListModel extends \OxidEsales\Eshop\Core\Base implements \ArrayAccess, \It
      *
      * @return boolean
      */
-    public function offsetExists($offset)
+    public function offsetExists($offset) : bool
     {
         return isset($this->_aArray[$offset]);
     }
@@ -72,7 +72,7 @@ class ListModel extends \OxidEsales\Eshop\Core\Base implements \ArrayAccess, \It
      *
      * @return BaseModel
      */
-    public function offsetGet($offset)
+    public function offsetGet($offset) : mixed
     {
         if ($this->offsetExists($offset)) {
             return $this->_aArray[$offset];
@@ -87,7 +87,7 @@ class ListModel extends \OxidEsales\Eshop\Core\Base implements \ArrayAccess, \It
      * @param mixed     $offset SPL array offset
      * @param BaseModel $oBase  Array element
      */
-    public function offsetSet($offset, $oBase)
+    public function offsetSet($offset, $oBase) : void
     {
         if (isset($offset)) {
             $this->_aArray[$offset] = & $oBase;
@@ -107,7 +107,7 @@ class ListModel extends \OxidEsales\Eshop\Core\Base implements \ArrayAccess, \It
      *
      * @param mixed $offset SPL array offset
      */
-    public function offsetUnset($offset)
+    public function offsetUnset($offset) : void
     {
         if (strcmp($offset, $this->key()) === 0) {
             // #0002184: active element removed, next element will be prev / first
@@ -130,7 +130,7 @@ class ListModel extends \OxidEsales\Eshop\Core\Base implements \ArrayAccess, \It
     /**
      * rewind for SPL
      */
-    public function rewind()
+    public function rewind() : void
     {
         $this->_blRemovedActive = false;
         $this->_blValid = (false !== reset($this->_aArray));
@@ -141,7 +141,7 @@ class ListModel extends \OxidEsales\Eshop\Core\Base implements \ArrayAccess, \It
      *
      * @return null
      */
-    public function current()
+    public function current() : mixed
     {
         return current($this->_aArray);
     }
@@ -151,7 +151,7 @@ class ListModel extends \OxidEsales\Eshop\Core\Base implements \ArrayAccess, \It
      *
      * @return mixed
      */
-    public function key()
+    public function key() : mixed
     {
         return key($this->_aArray);
     }
@@ -176,7 +176,7 @@ class ListModel extends \OxidEsales\Eshop\Core\Base implements \ArrayAccess, \It
     /**
      * next for SPL
      */
-    public function next()
+    public function next() : void
     {
         if ($this->_blRemovedActive === true && current($this->_aArray)) {
             $oVar = $this->prev();
@@ -192,7 +192,7 @@ class ListModel extends \OxidEsales\Eshop\Core\Base implements \ArrayAccess, \It
      *
      * @return boolean
      */
-    public function valid()
+    public function valid() : bool
     {
         return $this->_blValid;
     }
@@ -202,7 +202,7 @@ class ListModel extends \OxidEsales\Eshop\Core\Base implements \ArrayAccess, \It
      *
      * @return integer
      */
-    public function count()
+    public function count() : int
     {
         return count($this->_aArray);
     }

--- a/source/Core/Session.php
+++ b/source/Core/Session.php
@@ -279,7 +279,7 @@ class Session extends \OxidEsales\Eshop\Core\Base
      */
     public function getSessionChallengeToken()
     {
-        $sRet = preg_replace('/[^a-z0-9]/i', '', $this->getVariable('sess_stoken'));
+        $sRet = preg_replace('/[^a-z0-9]/i', '', (string)$this->getVariable('sess_stoken'));
         if (!$sRet) {
             $this->initNewSessionChallenge();
             $sRet = $this->getVariable('sess_stoken');

--- a/source/Core/ShopControl.php
+++ b/source/Core/ShopControl.php
@@ -116,7 +116,7 @@ class ShopControl extends \OxidEsales\Eshop\Core\Base
         try {
             $this->runOnce();
 
-            $function = !is_null($function) ? $function : Registry::getRequest()->getRequestEscapedParameter('fnc');
+            $function = !is_null($function) ? $function : (string)Registry::getRequest()->getRequestEscapedParameter('fnc');
             $controllerKey = !is_null($controllerKey) ? $controllerKey : $this->getStartControllerKey();
             $controllerClass = $this->getControllerClass($controllerKey);
 
@@ -221,7 +221,7 @@ class ShopControl extends \OxidEsales\Eshop\Core\Base
      * @param array  $parameters Parameters array
      * @param array  $viewsChain Array of views names that should be initialized also
      */
-    protected function process($class, $function, $parameters = null, $viewsChain = null)
+    protected function process(string $class, string $function, $parameters = null, $viewsChain = null)
     {
         startProfile('process');
         $config = Registry::getConfig();
@@ -290,10 +290,10 @@ class ShopControl extends \OxidEsales\Eshop\Core\Base
      * Executes provided function on view object.
      * If this function can not be executed (is protected or so), a RoutingException is thrown
      *
-     * @param FrontendController $view
-     * @param string             $functionName
+     * @param BaseController $view
+     * @param string         $functionName
      */
-    protected function executeAction($view, $functionName)
+    protected function executeAction(BaseController $view, string $functionName)
     {
         if (!$this->canExecuteFunction($view, $functionName)) {
             throw new \OxidEsales\Eshop\Core\Exception\RoutingException(
@@ -335,7 +335,7 @@ class ShopControl extends \OxidEsales\Eshop\Core\Base
      *
      * @return FrontendController
      */
-    protected function initializeViewObject($class, $function, $parameters = null, $viewsChain = null)
+    protected function initializeViewObject(string $class, string $function, $parameters = null, $viewsChain = null)
     {
         $classKey = Registry::getControllerClassNameResolver()->getIdByClassName($class);
         $classKey = !is_null($classKey) ? $classKey : $class; //fallback
@@ -368,12 +368,12 @@ class ShopControl extends \OxidEsales\Eshop\Core\Base
     /**
      * Check if method can be executed.
      *
-     * @param FrontendController $view     View object to check if its method can be executed.
-     * @param string             $function Method to check if it can be executed.
+     * @param BaseController  $view     View object to check if its method can be executed.
+     * @param string          $function Method to check if it can be executed.
      *
      * @return bool
      */
-    protected function canExecuteFunction($view, $function)
+    protected function canExecuteFunction(BaseController $view, string $function) : bool
     {
         $canExecute = true;
         if (method_exists($view, $function)) {

--- a/source/Core/StrMb.php
+++ b/source/Core/StrMb.php
@@ -47,7 +47,7 @@ class StrMb
      *
      * @return int
      */
-    public function strlen($sStr)
+    public function strlen(string $sStr) : int
     {
         return mb_strlen($sStr, $this->_sEncoding);
     }
@@ -196,7 +196,7 @@ class StrMb
      *
      * @return string
      */
-    public function preg_replace($aPattern, $sString, $sSubject, $iLimit = -1, $iCount = null)
+    public function preg_replace(mixed $aPattern, mixed $sString, string $sSubject, int $iLimit = -1, $iCount = null)
     {
         if (is_array($aPattern)) {
             foreach ($aPattern as &$sPattern) {
@@ -244,7 +244,7 @@ class StrMb
      *
      * @return string
      */
-    public function preg_match($sPattern, $sSubject, &$aMatches = null, $iFlags = null, $iOffset = null)
+    public function preg_match(string $sPattern, string $sSubject, &$aMatches = null, $iFlags = 0, $iOffset = 0)
     {
         return preg_match($sPattern . 'u', $sSubject, $aMatches, $iFlags, $iOffset);
     }

--- a/source/Core/SystemRequirements.php
+++ b/source/Core/SystemRequirements.php
@@ -404,7 +404,7 @@ class SystemRequirements
      */
     protected function getShopSSLHostInfoFromConfig()
     {
-        $sSSLShopURL = Registry::getConfig()->getConfigParam('sSSLShopURL');
+        $sSSLShopURL = (string)Registry::getConfig()->getConfigParam('sSSLShopURL');
         if (preg_match('#^(https?://)?([^/:]+)(:([0-9]+))?(/.*)?$#i', $sSSLShopURL, $m)) {
             $sHost = $m[2];
             $iPort = (int) $m[4];

--- a/source/Core/Utils.php
+++ b/source/Core/Utils.php
@@ -102,7 +102,7 @@ class Utils extends \OxidEsales\Eshop\Core\Base
      *
      * @return array
      */
-    public function assignValuesFromText($sIn, $dVat = null)
+    public function assignValuesFromText(string $sIn, $dVat = null)
     {
         $aRet = [];
         $aPieces = explode('@@', $sIn);

--- a/source/Core/UtilsUrl.php
+++ b/source/Core/UtilsUrl.php
@@ -165,7 +165,7 @@ class UtilsUrl extends \OxidEsales\Eshop\Core\Base
             }
 
             $sUrl = $this->appendParamSeparator($urlWithoutQuery);
-            $sUrl .= http_build_query($finalParameters, null, $paramSeparator);
+            $sUrl .= http_build_query($finalParameters, '', $paramSeparator);
         }
 
         if ($sUrl && !$blFinalUrl) {

--- a/source/Internal/Framework/Templating/TemplateEngine.php
+++ b/source/Internal/Framework/Templating/TemplateEngine.php
@@ -42,7 +42,7 @@ class TemplateEngine implements TemplateEngineInterface
      */
     public function render(string $name, array $context = []): string
     {
-        return $name;
+        return 'no template engine active ("'.$name.'")';
     }
 
     /**
@@ -56,7 +56,7 @@ class TemplateEngine implements TemplateEngineInterface
      */
     public function renderFragment(string $fragment, string $fragmentId, array $context = []): string
     {
-        return $fragment;
+        return 'no template engine active ("'.$fragment.'")';
     }
 
     /**

--- a/source/Internal/Transition/Adapter/TemplateLogic/AbstractInsertNewBasketItemLogic.php
+++ b/source/Internal/Transition/Adapter/TemplateLogic/AbstractInsertNewBasketItemLogic.php
@@ -24,7 +24,7 @@ abstract class AbstractInsertNewBasketItemLogic
         $config = \OxidEsales\Eshop\Core\Registry::getConfig();
 
         $types = ['0' => 'none', '1' => 'message', '2' => 'popup', '3' => 'basket'];
-        $newBasketItemMessage = $config->getConfigParam('iNewBasketItemMessage');
+        $newBasketItemMessage = (int)$config->getConfigParam('iNewBasketItemMessage');
 
         // If correct type of message is expected
         if ($newBasketItemMessage && $params['type'] && ($params['type'] != $types[$newBasketItemMessage])) {
@@ -37,7 +37,7 @@ abstract class AbstractInsertNewBasketItemLogic
         $templateName = $params['tpl'] ? $params['tpl'] : 'inc_newbasketitem.snippet.html.twig';
 
         // always render for ajaxstyle popup
-        $render = $params['ajax'] && ($newBasketItemMessage == 2);
+        $render = !empty($params['ajax']) && ($newBasketItemMessage == 2);
 
         // fetching article data
         $newItem = \OxidEsales\Eshop\Core\Registry::getSession()->getVariable('_newitem');

--- a/source/Internal/Transition/Adapter/TemplateLogic/FormatDateLogic.php
+++ b/source/Internal/Transition/Adapter/TemplateLogic/FormatDateLogic.php
@@ -18,9 +18,9 @@ class FormatDateLogic
      */
     public function formdate($oConvObject, string $sFieldType = null, bool $blPassedValue = false): ?string
     {
-        // creating fake bject
-        if ($blPassedValue || is_string($oConvObject)) {
-            $sValue = $oConvObject;
+        // creating fake object
+        if ($blPassedValue || !is_object($oConvObject)) {
+            $sValue = print_r($oConvObject,true);
             $oConvObject = new \OxidEsales\Eshop\Core\Field();
             $oConvObject->fldmax_length = "0";
             $oConvObject->fldtype = $sFieldType;

--- a/source/bootstrap.php
+++ b/source/bootstrap.php
@@ -46,7 +46,7 @@ register_shutdown_function(
             /** write to log */
             $time = microtime(true);
             $micro = sprintf("%06d", ($time - floor($time)) * 1000000);
-            $date = new \DateTime(date('Y-m-d H:i:s.' . $micro, $time));
+            $date = new \DateTime(date('Y-m-d H:i:s.' . $micro));
             $timestamp = $date->format('d M H:i:s.u Y');
             $message = "[$timestamp] " . $logMessage . PHP_EOL;
             file_put_contents(OX_LOG_FILE, $message, FILE_APPEND);
@@ -55,11 +55,12 @@ register_shutdown_function(
             $bootstrapConfigFileReader = new \BootstrapConfigFileReader();
             if (!$bootstrapConfigFileReader->isDebugMode()) {
                 \oxTriggerOfflinePageDisplay();
-            }
 
-            if (in_array($error['type'], $sessionResetErrorTypes)) {
-                setcookie('sid', null, null, '/');
-                setcookie('admin_sid', null, null, '/');
+				// Logout user if not in debug mode:
+                if (in_array($error['type'], $sessionResetErrorTypes)) {
+                    setcookie('sid', '', strtotime("-1 day"), '/');
+                    setcookie('admin_sid', '', strtotime("-1 day"), '/');
+                }
             }
         }
     }


### PR DESCRIPTION
This adds various casts and types in function signatures to lower the amount of php8 specific warnings.
Also changes some instances of null default values to using an empty string instead.
Removed "attribute"-mapping from BackwardsCompatibilityClassMap.php, as php8 itself introduced an attribute-class.
Changes also that users are only logged out when an error occurs (in bootstrap.php) if the shop is not running in debug mode