### PR TITLE
Fix for sortLanguagesCallback() return value

### DIFF
--- a/source/Core/Language.php
+++ b/source/Core/Language.php
@@ -1082,11 +1082,11 @@ class Language extends \OxidEsales\Eshop\Core\Base
      * @param object $a1 first value to check
      * @param object $a2 second value to check
      *
-     * @return bool
+     * @return int
      */
     protected function sortLanguagesCallback($a1, $a2)
     {
-        return ($a1->sort > $a2->sort);
+        return ($a1->sort - $a2->sort);
     }
 
     /**


### PR DESCRIPTION
php expects the callback for uasort() to return an integer, currently returns bool. Generates a deprecation warning in newer php-versions.

For comparison:
https://onlinephp.io?s=lZDfCoIwFMbvA99hF4MZKKi3pVF22RtExHEzi2yJ2-oievc8bUmBUB3Yn3P2_c63bTpr9o038kYUUlleidIir0EpfzzBWpjpg67LlM2Zy9W51WkcRROEulIxgBU9tmAuf2KJwygfgHgP5czln5AYgEQPLZnLPy5IYQWyMlCVKl1TCGgREMq7ITbuAaSLnZFcH86SINsDOdR1AfzoU4g7ApKxVd_sgtGW2rSSoMIakwyFdo8XRNHdLr9YJX95hV-87GwABf7bTwSEDbqzV5cLtFthTs079Dr7t2nypesD&v=8.1.11%2C8.0.24%2C7.4.32