### PR TITLE
Optimize accessing 'oxorder__oxbillcountry'

### DIFF
--- a/source/Application/Model/Order.php
+++ b/source/Application/Model/Order.php
@@ -235,21 +235,7 @@ class Order extends \OxidEsales\Eshop\Core\Model\BaseModel
      * @var \OxidEsales\Eshop\Application\Model\Basket
      */
     protected $_oOrderBasket = null;
-
-    /**
-     * Billing country name from billing country id
-     * (Call getBillCountry())
-     * @var null|string
-     */
-    protected $_sBillCountryTitle=null;
-
-    /**
-     * Delivery country name from delivery country id
-     * (Call getDelCountry())
-     * @var null|string
-     */
-    protected $_sDelCountryTitle=null;
-
+    
     /**
      * Class constructor, initiates parent constructor (parent::oxBase()).
      */
@@ -1950,11 +1936,13 @@ class Order extends \OxidEsales\Eshop\Core\Model\BaseModel
      */
     public function getBillCountry()
     {
-        if ($this->_sBillCountryTitle === null) {
-            $this->_sBillCountryTitle = new \OxidEsales\Eshop\Core\Field($this->getCountryTitle($this->oxorder__oxbillcountryid->value));
+        $sLongFieldName = $this->getFieldLongName('oxbillcountry');
+        if (!property_exists($this, $sLongFieldName)) {
+            $countryTitle = $this->getCountryTitle($this->getFieldData('oxbillcountryid'));
+            $this->setFieldData('oxbillcountry', $countryTitle);
         }
 
-        return $this->_sBillCountryTitle;
+        return $this->$sLongFieldName;
     }
 
     /**
@@ -1964,11 +1952,13 @@ class Order extends \OxidEsales\Eshop\Core\Model\BaseModel
      */
     public function getDelCountry()
     {
-        if ($this->_sDelCountryTitle === null) {
-            $this->_sDelCountryTitle = new \OxidEsales\Eshop\Core\Field($this->getCountryTitle($this->oxorder__oxdelcountryid->value));
+        $sLongFieldName = $this->getFieldLongName('oxdelcountry');
+        if (!property_exists($this, $sLongFieldName)) {
+            $countryTitle = $this->getCountryTitle($this->getFieldData('oxdelcountryid'));
+            $this->setFieldData('oxdelcountry', $countryTitle);
         }
 
-        return $this->_sDelCountryTitle;
+        return $this->$sLongFieldName;
     }
 
     /**

--- a/source/Application/Model/Order.php
+++ b/source/Application/Model/Order.php
@@ -237,6 +237,20 @@ class Order extends \OxidEsales\Eshop\Core\Model\BaseModel
     protected $_oOrderBasket = null;
 
     /**
+     * Billing country name from billing country id
+     * (Call getBillCountry())
+     * @var null|string
+     */
+    protected $_sBillCountryTitle=null;
+
+    /**
+     * Delivery country name from delivery country id
+     * (Call getDelCountry())
+     * @var null|string
+     */
+    protected $_sDelCountryTitle=null;
+
+    /**
      * Class constructor, initiates parent constructor (parent::oxBase()).
      */
     public function __construct()
@@ -257,15 +271,15 @@ class Order extends \OxidEsales\Eshop\Core\Model\BaseModel
      */
     public function __get($sName)
     {
-        if ($sName == 'oDelSet') {
+        if ($sName === 'oDelSet') {
             return $this->getDelSet();
         }
 
-        if ($sName == 'oxorder__oxbillcountry') {
+        if ($sName === 'oxorder__oxbillcountry') {
             return $this->getBillCountry();
         }
 
-        if ($sName == 'oxorder__oxdelcountry') {
+        if ($sName === 'oxorder__oxdelcountry') {
             return $this->getDelCountry();
         }
     }
@@ -1936,11 +1950,11 @@ class Order extends \OxidEsales\Eshop\Core\Model\BaseModel
      */
     public function getBillCountry()
     {
-        if (!$this->oxorder__oxbillcountry->value) {
-            $this->oxorder__oxbillcountry = new \OxidEsales\Eshop\Core\Field($this->getCountryTitle($this->oxorder__oxbillcountryid->value));
+        if ($this->_sBillCountryTitle === null) {
+            $this->_sBillCountryTitle = new \OxidEsales\Eshop\Core\Field($this->getCountryTitle($this->oxorder__oxbillcountryid->value));
         }
 
-        return $this->oxorder__oxbillcountry;
+        return $this->_sBillCountryTitle;
     }
 
     /**
@@ -1950,11 +1964,11 @@ class Order extends \OxidEsales\Eshop\Core\Model\BaseModel
      */
     public function getDelCountry()
     {
-        if (!$this->oxorder__oxdelcountry->value) {
-            $this->oxorder__oxdelcountry = new \OxidEsales\Eshop\Core\Field($this->getCountryTitle($this->oxorder__oxdelcountryid->value));
+        if ($this->_sDelCountryTitle === null) {
+            $this->_sDelCountryTitle = new \OxidEsales\Eshop\Core\Field($this->getCountryTitle($this->oxorder__oxdelcountryid->value));
         }
 
-        return $this->oxorder__oxdelcountry;
+        return $this->_sDelCountryTitle;
     }
 
     /**


### PR DESCRIPTION
(Accessed from e.g. order_owner.tpl)

The__get()-call for 'oxorder__oxbillcountry' calls getBillCountry(), but getBillCountry() again accesses oxorder__oxbillcountry with: if (!$this->oxorder__oxbillcountry->value) {
which creates an 'undefined property' warning (would create an endless loop if php did not have special handling for magic getters)

This patch introduces $this->_sBillCountryTitle for use in getBillCountry() and does no longer check $this->oxorder__oxbillcountry->value. And __get('oxorder__oxbillcountry') now always calls getBillCountry(). 
The same applies for 'oxorder__oxdelcountry'