### PR TITLE
Class-Alias for 'attribute' conflicts with PHP8

### DIFF
--- a/source/Core/Autoload/BackwardsCompatibilityClassMap.php
+++ b/source/Core/Autoload/BackwardsCompatibilityClassMap.php
@@ -95,7 +95,6 @@ return [
     'article_variant' => 'OxidEsales\\Eshop\\Application\\Controller\\Admin\\ArticleVariant',
     'attribute_category' => 'OxidEsales\\Eshop\\Application\\Controller\\Admin\\AttributeCategory',
     'attribute_category_ajax' => 'OxidEsales\\Eshop\\Application\\Controller\\Admin\\AttributeCategoryAjax',
-    'attribute' => 'OxidEsales\\Eshop\\Application\\Controller\\Admin\\AttributeController',
     'attribute_list' => 'OxidEsales\\Eshop\\Application\\Controller\\Admin\\AttributeList',
     'attribute_main' => 'OxidEsales\\Eshop\\Application\\Controller\\Admin\\AttributeMain',
     'attribute_main_ajax' => 'OxidEsales\\Eshop\\Application\\Controller\\Admin\\AttributeMainAjax',


### PR DESCRIPTION
PHP8 introduced an 'Attribute'-class (https://www.php.net/manual/en/class.attribute.php) and OXIDs unified-namespace-generator creates a class_alias()-line for 'attribute' and that causes (as class names in php are case-insensitive): PHP Warning:  Cannot declare class attribute, because the name is already in use in /vendor/oxid-esales/oxideshop-unified-namespace-generator/generated/OxidEsales/Eshop/Application/Controller/Admin/AttributeController.php on line 45 (warning gets logged when the attributes are opened in /admin/)

This suggests to simply remove the 'attribute'-mapping from the BackwardsCompatibilityClassMap.php, as the controller-key 'attribute' is still resolved by ShopControllerMapProvider and the class_alias() for 'attribute' is not working with PHP8 anyway.

(Maybe the whole BackwardsCompatibilityClassMap-stuff could get removed with OXID 7, as existing modules must be converted for OXID 7 anyway and its no big effort to convert oxNew()-calls with old class-names to the newer namespaced class names)