### PR TITLE
This proposes to introduce a random number generator class

### DIFF
--- a/source/Core/Autoload/UnifiedNameSpaceClassMap.php
+++ b/source/Core/Autoload/UnifiedNameSpaceClassMap.php
@@ -2865,6 +2865,12 @@ return [
         'isInterface'      => false,
         'isDeprecated'     => false
     ],
+    'OxidEsales\Eshop\Core\RandomNumberGenerator'                                => [
+        'editionClassName' => \OxidEsales\EshopCommunity\Core\RandomNumberGenerator::class,
+        'isAbstract'       => false,
+        'isInterface'      => false,
+        'isDeprecated'     => false
+    ],
     'OxidEsales\Eshop\Core\Registry'                                             => [
         'editionClassName' => \OxidEsales\EshopCommunity\Core\Registry::class,
         'isAbstract'       => false,

--- a/source/Core/OpenSSLFunctionalityChecker.php
+++ b/source/Core/OpenSSLFunctionalityChecker.php
@@ -7,8 +7,10 @@
 
 namespace OxidEsales\EshopCommunity\Core;
 
+
 /**
  * Class is responsible for openSSL functionality availability checking.
+ * @deprecated Use RandomNumberGenerator class
  */
 class OpenSSLFunctionalityChecker
 {

--- a/source/Core/RandomNumberGenerator.php
+++ b/source/Core/RandomNumberGenerator.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace OxidEsales\EshopCommunity\Core;
+
+/**
+ * Provides cryptographically secure random number generator
+ * Currently uses PHPs random_bytes() and random_int()
+ */
+class RandomNumberGenerator
+{
+    /** Returns cryptographically secure random bytes
+     * @param int $length The length of the random string that should be returned in bytes; must be 1 or greater.
+     * @return string A string containing the requested number of cryptographically secure random bytes.
+     * @throws \Exception Exception if thrown if the random number generator is not working
+     */
+    public function getRandomBytes(int $length): string
+    {
+        if ($length < 1) {
+            throw new \Exception('length must must be 1 or greater');
+        }
+
+        return random_bytes($length);
+    }
+
+    /** Calls getRandomBytes() and passes the result through bin2hex()
+     * @param int $length The length of the returned string; must be 1 or greater.
+     * @return string
+     * @throws \Exception Exception if thrown if the random number generator is not working
+     */
+    public function getRandomHexString(int $length): string
+    {
+        if ($length < 1) {
+            throw new \Exception('length must be 1 or greater');
+        }
+
+        $randomBytesLength = ceil($length / 2);
+        $hexStr = bin2hex($this->getRandomBytes($randomBytesLength));
+        return substr($hexStr, 0, $length);
+    }
+
+    /**
+     * @param int $min The lowest value to be returned.
+     * @param int $max The highest value to be returned.
+     * @return int A cryptographically secure, uniformly selected integer from the closed interval [min, max]. Both min and max are possible return values.
+     * @throws \Exception Exception if thrown if the random number generator is not working
+     */
+    public function getRandomInt(int $min, int $max): int
+    {
+        return random_int($min, $max);
+    }
+}

--- a/source/Core/Registry.php
+++ b/source/Core/Registry.php
@@ -431,4 +431,14 @@ class Registry
 
         return self::$instances[$className];
     }
+
+    /**
+     * Returns RandomNumberGenerator
+     *
+     * @return \OxidEsales\Eshop\Core\RandomNumberGenerator
+     */
+    public static function getRandomNumberGenerator()
+    {
+        return self::getObject(\OxidEsales\Eshop\Core\RandomNumberGenerator::class);
+    }
 }

--- a/source/Core/Session.php
+++ b/source/Core/Session.php
@@ -795,8 +795,7 @@ class Session extends \OxidEsales\Eshop\Core\Base
     {
         $sToken = $this->getVariable('_rtoken');
         if (!$sToken && $blGenerateNew) {
-            $sToken = md5(rand() . $this->getId());
-            $sToken = substr($sToken, 0, 8);
+            $sToken = Registry::getRandomNumberGenerator()->getRandomHexString(8);
             $this->setVariable('_rtoken', $sToken);
         }
 

--- a/source/Core/ShopControl.php
+++ b/source/Core/ShopControl.php
@@ -574,7 +574,7 @@ class ShopControl extends \OxidEsales\Eshop\Core\Base
             $debugLevel = Registry::getConfig()->getConfigParam('iDebug');
             $debugInfo = oxNew(\OxidEsales\Eshop\Core\DebugInfo::class);
 
-            $logId = md5(time() . rand() . rand());
+            $logId = Registry::getUtilsObject()->generateUId();
             $header = $debugInfo->formatGeneralInfo();
             $display = ($debugLevel == -1) ? 'none' : 'block';
             $monitorMessage = $this->formMonitorMessage($view);

--- a/source/Core/SystemEventHandler.php
+++ b/source/Core/SystemEventHandler.php
@@ -251,9 +251,9 @@ class SystemEventHandler
     {
         $checkTime = Registry::getConfig()->getSystemConfigParameter('sOnlineLicenseCheckTime');
         if (!$checkTime) {
-            $hourToCheck = rand(8, 23);
-            $minuteToCheck = rand(0, 59);
-            $secondToCheck = rand(0, 59);
+            $hourToCheck = Registry::getRandomNumberGenerator()->getRandomInt(8, 23);
+            $minuteToCheck = Registry::getRandomNumberGenerator()->getRandomInt(0, 59);
+            $secondToCheck = Registry::getRandomNumberGenerator()->getRandomInt(0, 59);
 
             $checkTime = $hourToCheck . ':' . $minuteToCheck . ':' . $secondToCheck;
             Registry::getConfig()->saveSystemConfigParameter('str', 'sOnlineLicenseCheckTime', $checkTime);

--- a/source/Core/UniversallyUniqueIdGenerator.php
+++ b/source/Core/UniversallyUniqueIdGenerator.php
@@ -24,14 +24,11 @@ class UniversallyUniqueIdGenerator
      */
     public function __construct(\OxidEsales\Eshop\Core\OpenSSLFunctionalityChecker $openSSLChecker = null)
     {
-        if (is_null($openSSLChecker)) {
-            $openSSLChecker = oxNew(\OxidEsales\Eshop\Core\OpenSSLFunctionalityChecker::class);
-        }
         $this->_openSSLChecker = $openSSLChecker;
     }
 
     /**
-     * Generates UUID based on either openSSL's openssl_random_pseudo_bytes or mt_rand.
+     * Generates UUID (using RandomNumberGenerator-class)
      *
      * @return string
      */
@@ -49,11 +46,11 @@ class UniversallyUniqueIdGenerator
      */
     public function generateV4()
     {
-        if ($this->getOpenSSLChecker()->isOpenSslRandomBytesGeneratorAvailable()) {
-            return $this->generateBasedOnOpenSSL();
-        }
+        $sRandomData = \OxidEsales\Eshop\Core\Registry::getRandomNumberGenerator()->getRandomBytes(16);
+        $sRandomData[6] = chr(ord($sRandomData[6]) & 0x0f | 0x40); // set version to 0100
+        $sRandomData[8] = chr(ord($sRandomData[8]) & 0x3f | 0x80); // set bits 6-7 to 10
 
-        return $this->generateBasedOnMtRand();
+        return vsprintf('%s%s-%s-%s-%s-%s%s%s', str_split(bin2hex($sRandomData), 4));
     }
 
     /**
@@ -68,7 +65,7 @@ class UniversallyUniqueIdGenerator
     {
         $sSeed = str_replace(['-', '{', '}'], '', $sSeed);
         $sBinarySeed = '';
-        for ($i = 0; $i < strlen($sSeed); $i += 2) {
+        for ($i = 0, $iMax = strlen($sSeed); $i < $iMax; $i += 2) {
             $sBinarySeed .= chr(hexdec($sSeed[$i] . $sSeed[$i + 1]));
         }
         $sHash = sha1($sBinarySeed . $sSalt);
@@ -88,43 +85,36 @@ class UniversallyUniqueIdGenerator
      * gets open SSL checker.
      *
      * @return \OxidEsales\Eshop\Core\OpenSSLFunctionalityChecker
+     * @deprecated Use RandomNumberGenerator class
      */
     protected function getOpenSSLChecker()
     {
+        if (is_null($this->_openSSLChecker)) {
+            $this->_openSSLChecker = oxNew(\OxidEsales\Eshop\Core\OpenSSLFunctionalityChecker::class);
+        }
         return $this->_openSSLChecker;
     }
 
     /**
      * Generates UUID based on OpenSSL's openssl_random_pseudo_bytes.
+     * Deprecated, now only an alias for generateV4()
      *
      * @return string
+     * @deprecated
      */
     protected function generateBasedOnOpenSSL()
     {
-        $sRandomData = openssl_random_pseudo_bytes(16);
-        $sRandomData[6] = chr(ord($sRandomData[6]) & 0x0f | 0x40); // set version to 0100
-        $sRandomData[8] = chr(ord($sRandomData[8]) & 0x3f | 0x80); // set bits 6-7 to 10
-
-        return vsprintf('%s%s-%s-%s-%s-%s%s%s', str_split(bin2hex($sRandomData), 4));
+        return $this->generateV4();
     }
 
     /**
      * Generates UUID based on mt_rand.
      *
      * @return string
+     * Deprecated, now only an alias for generateV4()
      */
     protected function generateBasedOnMtRand()
     {
-        return sprintf(
-            '%04x%04x-%04x-%04x-%04x-%04x%04x%04x',
-            mt_rand(0, 0xffff),
-            mt_rand(0, 0xffff),
-            mt_rand(0, 0xffff),
-            mt_rand(0, 0x0fff) | 0x4000,
-            mt_rand(0, 0x3fff) | 0x8000,
-            mt_rand(0, 0xffff),
-            mt_rand(0, 0xffff),
-            mt_rand(0, 0xffff)
-        );
+        return $this->generateV4();
     }
 }

--- a/source/Core/UtilsObject.php
+++ b/source/Core/UtilsObject.php
@@ -205,7 +205,7 @@ class UtilsObject
      */
     public function generateUId()
     {
-        return md5(uniqid('', true) . '|' . microtime());
+        return \OxidEsales\Eshop\Core\Registry::getRandomNumberGenerator()->getRandomHexString(32);
     }
 
     /**

--- a/source/Core/ViewConfig.php
+++ b/source/Core/ViewConfig.php
@@ -747,7 +747,7 @@ class ViewConfig extends \OxidEsales\Eshop\Core\Base
     public function getPopupIdentRand()
     {
         if (($sValue = $this->getViewConfigParam('popupidentrand')) === null) {
-            $sValue = md5(time());
+            $sValue = Registry::getUtilsObject()->generateUId();
             $this->setViewConfigParam('popupidentrand', $sValue);
         }
 

--- a/source/Setup/Utilities.php
+++ b/source/Setup/Utilities.php
@@ -59,7 +59,7 @@ class Utilities extends Core
      */
     public function generateUID()
     {
-        return md5(uniqid(rand(), true));
+        return bin2hex(random_bytes(16));
     }
 
     /**


### PR DESCRIPTION
This proposes to introduce a random number generator class which can follow the state of the art for random number generation) and to change source code places that work with random numbers to use this class. Also deprecates older mechanisms.
Currently only acts as a wrapper arround random_bytes() and random_int()
Places that don't actually require cryptographically-secure randomness are also changed, as they would otherwise appear as false positives in pentests.

Related:
https://php.watch/articles/testing-php-rand-functions 
https://github.com/matomo-org/matomo/pull/15263/files