### PR TITLE
inactive articles are shown in the detail page

### DIFF
--- a/CHANGELOG-7.1.md
+++ b/CHANGELOG-7.1.md
@@ -11,5 +11,8 @@
 - Private Sales Invite functionality is outdated.
 - `getContainer()` and `dispatchEvent()` methods in Core classes
 
+### Fixed
+- Inactive articles are shown in the detail page under some conditions [PR-911](https://github.com/OXID-eSales/oxideshop_ce/pull/911) [#0007476](https://bugs.oxid-esales.com/view.php?id=7476)
+
 ### Removed
 - PHP v8.0 support

--- a/source/Application/Model/Article.php
+++ b/source/Application/Model/Article.php
@@ -1045,6 +1045,7 @@ class Article extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
         if (
             !$this->oxarticles__oxactive->value &&
             (
+                !Registry::getConfig()->getConfigParam('blUseTimeCheck') ||
                 $this->oxarticles__oxactivefrom->value > $sNow ||
                 $this->oxarticles__oxactiveto->value < $sNow
             )


### PR DESCRIPTION
If an article is inactive but has an (unused) from-to date, its detail page is shown.

PR for https://bugs.oxid-esales.com/view.php?id=7476