### PR TITLE
Remove sTitle from Attribute and set/get field data directly

### DIFF
--- a/source/Application/Model/Attribute.php
+++ b/source/Application/Model/Attribute.php
@@ -34,13 +34,6 @@ class Attribute extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel
     protected $_sActiveValue = null;
 
     /**
-     * Attribute title
-     *
-     * @var string
-     */
-    protected $_sTitle = null;
-
-    /**
      * Attribute values
      *
      * @var array
@@ -210,7 +203,7 @@ class Attribute extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel
      */
     public function setTitle($sTitle)
     {
-        $this->_sTitle = Str::getStr()->htmlspecialchars($sTitle);
+        $this->setFieldData('oxtitle', Str::getStr()->htmlspecialchars($sTitle));
     }
 
     /**
@@ -220,7 +213,7 @@ class Attribute extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel
      */
     public function getTitle()
     {
-        return $this->_sTitle;
+        return $this->getFieldData('oxtitle');
     }
 
     /**


### PR DESCRIPTION
This multiple handling of `oxtitle` and the field data (`oxattributes__oxtitle`) causes in some cases. For example
in [\OxidEsales\EshopCommunity\Core\Model\ListModel::assignArray()](https://github.com/OXID-eSales/oxideshop_ce/blob/eecc980420498980e7d3908a863d1a8395bc8d27/source/Application/Model/AttributeList.php#L150) we assign the field data to the object. But in [\OxidEsales\EshopCommunity\Application\Model\AttributeList::getCategoryAttributes()](https://github.com/OXID-eSales/oxideshop_ce/blob/eecc980420498980e7d3908a863d1a8395bc8d27/source/Application/Model/AttributeList.php#L198) we use `setTitle()` which doesn't use the field data but sTitle.

Therefore sTitle should be removed and only `oxattributes__oxtitle`-field will be used for handling title in `setTitle` and `getTitle`.