### PR TITLE
$this->_oUserData not existing

### DIFF
--- a/source/Application/Controller/ContactController.php
+++ b/source/Application/Controller/ContactController.php
@@ -124,11 +124,11 @@ class ContactController extends \OxidEsales\Eshop\Application\Controller\Fronten
      */
     public function getUserData()
     {
-        if ($this->_oUserData === null) {
-            $this->_oUserData = Registry::getRequest()->getRequestEscapedParameter('editval');
+        if ($this->_aUserData === null) {
+            $this->_aUserData = Registry::getRequest()->getRequestEscapedParameter('editval');
         }
 
-        return $this->_oUserData;
+        return $this->_aUserData;
     }
 
     /**


### PR DESCRIPTION
The correct naming is "_aUserData", because variable is an array.
Property "_oUserData" doesn't exist. Property "_aUserData" is defined for this: `protected $_aUserData = null;`

Stops PHP warning: "Undefined property"