### PR TITLE
Fix testplan for oxdev-7631

### DIFF
--- a/.github/workflows/dispatch_dev_matrix_ce.yml
+++ b/.github/workflows/dispatch_dev_matrix_ce.yml
@@ -8,7 +8,7 @@ on:
         type: string
         required: true
         description: 'URL/PATH of the testplan to run'
-        default: 'tests/github_actions/full_matrix_ce.yml'
+        default: 'tests/github_actions/defaults/7.0.x.yml,tests/github_actions/oxdev_7631.yml'
       runs_on:
         type: string
         description: 'JSON string/array describing the runner'

--- a/tests/Codeception/acceptance.suite.yml
+++ b/tests/Codeception/acceptance.suite.yml
@@ -3,8 +3,6 @@
 # Suite for acceptance tests.
 # Perform tests in browser using the WebDriver or PhpBrowser.
 # If you need both WebDriver and PHPBrowser tests - create a separate suite.
-codeception:
-    suite: 'Acceptance'
 actor: AcceptanceTester
 bootstrap: _bootstrap.php
 modules:

--- a/tests/Codeception/acceptanceSetup.suite.yml
+++ b/tests/Codeception/acceptanceSetup.suite.yml
@@ -1,5 +1,3 @@
-codeception:
-  suite: 'AcceptanceSetup'
 actor: AcceptanceSetupTester
 modules:
   enabled:

--- a/tests/full_matrix_ce.yml
+++ b/tests/full_matrix_ce.yml
@@ -1,0 +1,18 @@
+# This config depends on the defaults.yml testplan
+# Only diverging settings are defined here
+
+codeception:
+  # Running on public runners, this should pose no problem
+  max_parallel: &codeception_max_parallel 4
+
+phpcs_tests:
+  # Check all files in the full check
+  diff_only: false
+  filter: '^\./source/Internal/.*\.php$'
+
+sonarcloud:
+  matrix:
+    testplan: '["-","tests/github_actions/sonarcloud_oxideshop_ce_internal.yml"]'
+
+finish:
+  slack_title: 'Full matrix CE ({{ .Data.global.git.shop_ref }}) on {{ .Github.Repository }} by {{ .Github.Actor }}'

--- a/tests/github_actions/codeception_acceptanceSetup_7x.yml
+++ b/tests/github_actions/codeception_acceptanceSetup_7x.yml
@@ -1,0 +1,14 @@
+codeception:
+  title: shop_setup
+  load_shop: {{ .Data.prepare_shop.cache.prefix }}
+  container:
+    # yamllint disable-line rule:line-length
+    options: '-e SELENIUM_SERVER_HOST=selenium -e BROWSER_NAME=chrome -e DB_NAME=setup_test -e DB_USERNAME=root -e DB_PASSWORD=root -e DB_HOST=mysql -e DB_PORT=3306 -e SHOP_URL=http://localhost.local/ -e SHOP_SOURCE_PATH=/var/www/source/'
+  suite: 'acceptanceSetup'
+  additional_options: ''
+  logfile:
+    prefix: 'shop_setup'
+  output:
+    prefix: 'shop_setup-artifacts'
+  coverage:
+    path: ''

--- a/tests/github_actions/codeception_acceptance_7x.yml
+++ b/tests/github_actions/codeception_acceptance_7x.yml
@@ -1,0 +1,10 @@
+codeception:
+  title: codeception
+  suite: 'acceptance'
+  additional_options: '--coverage-xml=/var/www/codeception_coverage.xml'
+  logfile:
+    prefix: 'codeception'
+  output:
+    prefix: 'codeception-artifacts'
+  coverage:
+    path: 'source/codeception_coverage.xml'

--- a/tests/github_actions/full_matrix_ce_7.x.yml
+++ b/tests/github_actions/full_matrix_ce_7.x.yml
@@ -1,0 +1,16 @@
+# This config depends on the defaults.yml testplan
+# Only diverging settings are defined here
+
+codeception:
+  matrix:
+    testplan: '["tests/github_actions/codeception_acceptance_7x.yml","tests/github_actions/codeception_acceptanceSetup_7x.yml"]'
+  # Running on public runners, this should pose no problem
+  max_parallel: &codeception_max_parallel 4
+
+phpcs_tests:
+  # Check all files in the full check
+  diff_only: false
+  filter: '^\./source/Internal/.*\.php$'
+
+finish:
+  slack_title: 'Full matrix CE on {{ .Github.Repository }} by {{ .Github.Actor }}'

--- a/tests/github_actions/oxdev_7631.yml
+++ b/tests/github_actions/oxdev_7631.yml
@@ -7,7 +7,7 @@ prepare_shop:
 
 codeception:
   matrix:
-    testplan: '["tests/github_actions/defaults/codeception_acceptance_7x.yml","tests/github_actions/defaults/codeception_acceptanceSetup_7x.yml"]'
+    testplan: '["tests/github_actions/codeception_acceptance_7x.yml","tests/github_actions/codeception_acceptanceSetup_7x.yml"]'
   # Running on public runners, this should pose no problem
   max_parallel: &codeception_max_parallel 4
 

--- a/tests/github_actions/oxdev_7631.yml
+++ b/tests/github_actions/oxdev_7631.yml
@@ -6,6 +6,8 @@ global:
       install: 'twig-component twig-admin-theme apex-theme:dev-b-7.0.x-fix-page-objects-OXDEV-7631'
 
 codeception:
+  matrix:
+    testplan: '["tests/github_actions/codeception_acceptance_7x.yml","tests/github_actions/codeception_acceptanceSetup_7x.yml"]'
   # Running on public runners, this should pose no problem
   max_parallel: &codeception_max_parallel 4
 

--- a/tests/github_actions/oxdev_7631.yml
+++ b/tests/github_actions/oxdev_7631.yml
@@ -1,13 +1,13 @@
 # This config depends on the defaults.yml testplan
 # Only diverging settings are defined here
-global:
+prepare_shop:
   composer:
     require:
       install: 'twig-component twig-admin-theme apex-theme:dev-b-7.0.x-fix-page-objects-OXDEV-7631'
 
 codeception:
   matrix:
-    testplan: '["tests/github_actions/codeception_acceptance_7x.yml","tests/github_actions/codeception_acceptanceSetup_7x.yml"]'
+    testplan: '["tests/github_actions/defaults/codeception_acceptance_7x.yml","tests/github_actions/defaults/codeception_acceptanceSetup_7x.yml"]'
   # Running on public runners, this should pose no problem
   max_parallel: &codeception_max_parallel 4
 


### PR DESCRIPTION
I have restored the original full_matrix files and moved your configuration to a dedicated yaml file
"oxdev_7631.yml". This reduces the chance of accidentally overwriting things when merging or creating unnneeded merge conflicts.

I set up a few configurations to support the 7x versions better (also for our nightlies). I've added those and they contain the suite entries I mentioned in the chat.

I also modified the dispatch_dev_matrix_ce starter that it uses the 7.0x template and the oxdev_7631.yml by default. Before merging back, you should change that back to "full_matrix_ce.yml" though.
