### PR TITLE
fix missing backend startup checks

### DIFF
--- a/source/Application/Controller/Admin/NavigationController.php
+++ b/source/Application/Controller/Admin/NavigationController.php
@@ -49,7 +49,7 @@ class NavigationController extends \OxidEsales\Eshop\Application\Controller\Admi
             //checking requirements if this is not nav frame reload
             if (!Registry::getRequest()->getRequestEscapedParameter("navReload")) {
                 // #661 execute stuff we run each time when we start admin once
-                if ('home' == $sItem) {
+                if (in_array($sItem, ['home.tpl', 'home.html.twig'])) {
                     $this->_aViewData['aMessage'] = $this->doStartUpChecks();
                 }
             } else {


### PR DESCRIPTION
"home" item condition fails in every case, because dependend on template renderer item has a file extension like ".tpl" or ".html.twig"