### PR TITLE
OXDEV-7864 Nightlies use new scheduled.yml template

### DIFF
--- a/.github/workflows/nightly_matrix_full_ce_70x.yml
+++ b/.github/workflows/nightly_matrix_full_ce_70x.yml
@@ -9,7 +9,7 @@ jobs:
   oxideshop_ce_70x_nightly:
     uses: oxid-eSales/github-actions/.github/workflows/call-universal_test_workflow.yml@v3
     with:
-      testplan: 'tests/github_actions/defaults/7.0.x.yml,tests/github_actions/full_matrix_ce_70x.yml'
+      testplan: 'tests/github_actions/defaults/7.0.x.yml,tests/github_actions/defaults/scheduled.yml,tests/github_actions/full_matrix_ce_70x.yml'
       runs_on: '"ubuntu-latest"'
       defaults: 'v3'
     secrets:

--- a/.github/workflows/nightly_matrix_full_ce_71x.yml
+++ b/.github/workflows/nightly_matrix_full_ce_71x.yml
@@ -9,7 +9,7 @@ jobs:
   oxideshop_ce_71x_nightly:
     uses: oxid-eSales/github-actions/.github/workflows/call-universal_test_workflow.yml@v3
     with:
-      testplan: 'tests/github_actions/defaults/7.1.x.yml,tests/github_actions/full_matrix_ce.yml'
+      testplan: 'tests/github_actions/defaults/7.1.x.yml,tests/github_actions/defaults/scheduled.yml,tests/github_actions/full_matrix_ce.yml'
       runs_on: '"ubuntu-latest"'
       defaults: 'v3'
     secrets:

--- a/.github/workflows/nightly_smarty_70x.yml
+++ b/.github/workflows/nightly_smarty_70x.yml
@@ -9,7 +9,7 @@ jobs:
   oxideshop_ce_smarty_70x_nightly:
     uses: oxid-eSales/github-actions/.github/workflows/call-universal_test_workflow.yml@v3
     with:
-      testplan: 'tests/github_actions/defaults/7.0.x.yml,tests/github_actions/smarty_7.0.x.yml'
+      testplan: 'tests/github_actions/defaults/7.0.x.yml,tests/github_actions/defaults/scheduled.yml,tests/github_actions/smarty_7.0.x.yml'
       runs_on: '"ubuntu-latest"'
       defaults: 'v3'
     secrets:


### PR DESCRIPTION
This uses the new scheduled.yml template introduced with 3.9.1. Merge after releasing github-actions v3.9.1