### PR TITLE
Patch 11

### DIFF
--- a/source/Application/translations/de/lang.php
+++ b/source/Application/translations/de/lang.php
@@ -712,7 +712,6 @@ $aLang = [
 'DETAILS_VPE_MESSAGE'                                         => 'Dieser Artikel kann nur in Verpackungseinheiten zu je %s erworben werden.',
 'DETAILS_CHOOSEVARIANT'                                       => 'Bitte wählen Sie eine Variante',
 'INVITE_TO_SHOP'                                              => 'Eine Einladung von %s %s zu besuchen.',
-'PAYMENT_INFO_OFF'                                            => 'BEZAHLINFORMATIONEN AUSGESCHALTET - um diese einzuschalten, bitte Application/views/[theme]/tpl/email/html/order_owner und plain/order_owner ändern.',
 'DISTRIBUTORS'                                                => 'Lieferanten',
 'MANUFACTURERS'                                               => 'Marken',
 'SERVICES'                                                    => 'Service',

--- a/source/Application/translations/en/lang.php
+++ b/source/Application/translations/en/lang.php
@@ -711,7 +711,6 @@ $aLang = [
 'DETAILS_VPE_MESSAGE'                                         => 'This product can only be ordered in packaging units of %s',
 'DETAILS_CHOOSEVARIANT'                                       => 'Please select a variant',
 'INVITE_TO_SHOP'                                              => 'An invitation from %s to visit %s',
-'PAYMENT_INFO_OFF'                                            => 'PAYMENT INFORMATION SWITCHED OFF - to switch it on please edit Application/views/[theme]/tpl/email/html/order_owner and plain/order_owner.',
 'DISTRIBUTORS'                                                => 'Distributors',
 'MANUFACTURERS'                                               => 'Brands',
 'SERVICES'                                                    => 'Service',


### PR DESCRIPTION
Removed translation PAYMENT_INFO_OFF from both english and german translation file as it is no longer in use since flow). Also see: https://bugs.oxid-esales.com/view.php?id=6426