### PR TITLE
Fix artifact handling and slack titles for nightlies

### DIFF
--- a/.github/oxid-esales/shop_ce.yml
+++ b/.github/oxid-esales/shop_ce.yml
@@ -15,4 +15,4 @@ sonarcloud:
     testplan: '["-","~/sonarcloud_oxideshop_ce_internal.yml"]'
 
 finish:
-  slack_title: 'Full matrix CE ({{ .Data.global.git.shop_ref }}) on {{ .Github.Repository }} by {{ .Github.Actor }}'
+  slack_title: 'Shop CE ({{ .Data.global.git.shop_ref }}) on {{ .Github.Repository }} by {{ .Github.Actor }}'

--- a/.github/oxid-esales/shop_ce_70x.yml
+++ b/.github/oxid-esales/shop_ce_70x.yml
@@ -17,4 +17,4 @@ sonarcloud:
     testplan: '["-","~/sonarcloud_oxideshop_ce_internal.yml"]'
 
 finish:
-  slack_title: 'Full matrix CE ({{ .Data.global.git.shop_ref }}) on {{ .Github.Repository }} by {{ .Github.Actor }}'
+  slack_title: 'Shop CE ({{ .Data.global.git.shop_ref }}) on {{ .Github.Repository }} by {{ .Github.Actor }}'

--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -14,6 +14,11 @@ jobs:
       runs_on: '"ubuntu-latest"'
       defaults: 'v4'
       plan_folder: '.github/oxid-esales'
+      custom_testplan_yaml: |
+        global:
+          title: '7.1.x-nightly'
+        finish:
+          slack_title: 'Nightly Shop CE 7.1.x on {{ .Github.Repository }}'
     secrets:
       DOCKER_HUB_USER: ${{ secrets.DOCKER_HUB_USER }}
       DOCKER_HUB_TOKEN: ${{ secrets.DOCKER_HUB_TOKEN }}
@@ -33,6 +38,11 @@ jobs:
       runs_on: '"ubuntu-latest"'
       defaults: 'v4'
       plan_folder: '.github/oxid-esales'
+      custom_testplan_yaml: |
+        global:
+          title: '7.2.x-nightly'
+        finish:
+          slack_title: 'Nightly Shop CE 7.2.x on {{ .Github.Repository }}'  
     secrets:
       DOCKER_HUB_USER: ${{ secrets.DOCKER_HUB_USER }}
       DOCKER_HUB_TOKEN: ${{ secrets.DOCKER_HUB_TOKEN }}
@@ -52,6 +62,11 @@ jobs:
       runs_on: '"ubuntu-latest"'
       defaults: 'v4'
       plan_folder: '.github/oxid-esales'
+      custom_testplan_yaml: |
+        global:
+          title: '8.0.x-nightly'
+        finish:
+          slack_title: 'Nightly Shop CE 8.0.x on {{ .Github.Repository }}'
     secrets:
       DOCKER_HUB_USER: ${{ secrets.DOCKER_HUB_USER }}
       DOCKER_HUB_TOKEN: ${{ secrets.DOCKER_HUB_TOKEN }}


### PR DESCRIPTION
FIX: As the Github contest is the same for all 3 nightlies, the artifact names collide. This sets a unique title for each run. It also sets a shorter unique title for the slack notification.