### PR TITLE
Fix new basket item twig adapter

### DIFF
--- a/CHANGELOG-7.2.md
+++ b/CHANGELOG-7.2.md
@@ -10,6 +10,7 @@
 
 ### Fixed
 - User registration in the Private Sales mode
+- New item in basket message display [#0007548](https://bugs.oxid-esales.com/view.php?id=7548) [PR-964](https://github.com/OXID-eSales/oxideshop_ce/pull/964)
 
 ### Changed
 -  

--- a/source/Internal/Transition/Adapter/TemplateLogic/InsertNewBasketItemLogicTwig.php
+++ b/source/Internal/Transition/Adapter/TemplateLogic/InsertNewBasketItemLogicTwig.php
@@ -8,6 +8,8 @@
 namespace OxidEsales\EshopCommunity\Internal\Transition\Adapter\TemplateLogic;
 
 use OxidEsales\Eshop\Application\Model\Article;
+use OxidEsales\Eshop\Core\Registry;
+use OxidEsales\Eshop\Core\ViewConfig;
 use Twig\Environment;
 
 class InsertNewBasketItemLogicTwig extends AbstractInsertNewBasketItemLogic
@@ -30,13 +32,13 @@ class InsertNewBasketItemLogicTwig extends AbstractInsertNewBasketItemLogic
     {
         // loading article object here because on some system passing article by session causes problems
         $newItem->oArticle = oxNew(Article::class);
-        $newItem->oArticle->Load($newItem->sId);
+        $newItem->oArticle->load($newItem->sId);
 
         // passing variable to template with unique name
-        $templateEngine->addGlobal('_newitem', $newItem);
+        $templateEngine->addGlobal('_newitem', clone $newItem);
 
         // deleting article object data
-        \OxidEsales\Eshop\Core\Registry::getSession()->deleteVariable('_newitem');
+        Registry::getSession()->deleteVariable('_newitem');
     }
 
     /**
@@ -55,7 +57,9 @@ class InsertNewBasketItemLogicTwig extends AbstractInsertNewBasketItemLogic
     public function getGlobals(): array
     {
         return [
-            '_newitem' => null
+            '_newitem' => null,
+            'oViewConf' => oxNew(ViewConfig::class),
+            'oxcmp_basket' => Registry::getSession()->getBasket(),
         ];
     }
 }


### PR DESCRIPTION
- Add oxcmp_basket and oViewConf globals (apex theme uses this globals)
- Clone newItem object to prevent the deletion (because of call by reference)
- Write `load` call lowercase

Bug with globals is reproduced and bug entry is accepted: [https://bugs.oxid-esales.com/view.php?id=7548](https://bugs.oxid-esales.com/view.php?id=7548)