### PR TITLE
Fixed PHPUnit's deprecation notices about old methods

### DIFF
--- a/tests/Unit/Internal/Domain/Contact/From/ContactFormMessageBuilderTest.php
+++ b/tests/Unit/Internal/Domain/Contact/From/ContactFormMessageBuilderTest.php
@@ -27,11 +27,9 @@ class ContactFormMessageBuilderTest extends \PHPUnit\Framework\TestCase
         $shopAdapter = $this->getMockBuilder(ShopAdapterInterface::class)->getMock();
         $shopAdapter
             ->method('translateString')
-            ->will(
-                $this->returnCallback(function ($arg) {
-                    return $arg;
-                })
-            );
+            ->willReturnCallback(function ($arg) {
+                return $arg;
+            });
         $contactFormMessageBuilder = new ContactFormMessageBuilder($shopAdapter);
 
         $this->assertStringContainsString(

--- a/tests/Unit/Internal/Framework/Logger/Validator/PsrLoggerConfigurationValidatorTest.php
+++ b/tests/Unit/Internal/Framework/Logger/Validator/PsrLoggerConfigurationValidatorTest.php
@@ -25,7 +25,7 @@ class PsrLoggerConfigurationValidatorTest extends PHPUnit\Framework\TestCase
         $configurationMock
             ->expects($this->any())
             ->method('getLogLevel')
-            ->will($this->returnValue($logLevel));
+            ->willReturn($logLevel);
 
         $validator = new PsrLoggerConfigurationValidator();
         $validator->validate($configurationMock);
@@ -57,7 +57,7 @@ class PsrLoggerConfigurationValidatorTest extends PHPUnit\Framework\TestCase
         $configurationMock
             ->expects($this->any())
             ->method('getLogLevel')
-            ->will($this->returnValue($logLevel));
+            ->willReturn($logLevel);
 
         $validator = new PsrLoggerConfigurationValidator();
         $validator->validate($configurationMock);

--- a/tests/Unit/Internal/Framework/Templating/Locator/AdminTemplateFileLocatorTest.php
+++ b/tests/Unit/Internal/Framework/Templating/Locator/AdminTemplateFileLocatorTest.php
@@ -33,7 +33,7 @@ final class AdminTemplateFileLocatorTest extends TestCase
         $config->expects($this->any())
             ->method('getTemplatePath')
             ->with($templateName, true)
-            ->will($this->returnValue('pathToTpl/' . $templateName));
+            ->willReturn('pathToTpl/' . $templateName);
 
         return $config;
     }

--- a/tests/Unit/Internal/Framework/Templating/Locator/TemplateFileLocatorTest.php
+++ b/tests/Unit/Internal/Framework/Templating/Locator/TemplateFileLocatorTest.php
@@ -33,7 +33,7 @@ final class TemplateFileLocatorTest extends TestCase
         $config->expects($this->any())
             ->method('getTemplatePath')
             ->with($templateName, false)
-            ->will($this->returnValue('pathToTpl/' . $templateName));
+            ->willReturn('pathToTpl/' . $templateName);
 
         return $config;
     }


### PR DESCRIPTION
PHPUnit 11.1.3

Fixed:
```
24 tests triggered 24 PHPUnit deprecations:

1) OxidEsales\EshopCommunity\Tests\Unit\Internal\Domain\Contact\Form\ContactFormMessageBuilderTest::testContentGetter with data set #0 ('email', 'marina.ginesta@bcn.cat')
returnCallback() is deprecated and will be removed in PHPUnit 12. Use $double->willReturnCallback() instead of $double->will($this->returnCallback())

/var/www/vendor/oxid-esales/oxideshop-ce/tests/Unit/Internal/Domain/Contact/From/ContactFormMessageBuilderTest.php:22

2) OxidEsales\EshopCommunity\Tests\Unit\Internal\Domain\Contact\Form\ContactFormMessageBuilderTest::testContentGetter with data set #1 ('firstName', 'Marina')
returnCallback() is deprecated and will be removed in PHPUnit 12. Use $double->willReturnCallback() instead of $double->will($this->returnCallback())

/var/www/vendor/oxid-esales/oxideshop-ce/tests/Unit/Internal/Domain/Contact/From/ContactFormMessageBuilderTest.php:22

3) OxidEsales\EshopCommunity\Tests\Unit\Internal\Domain\Contact\Form\ContactFormMessageBuilderTest::testContentGetter with data set #2 ('lastName', 'Ginestà')
returnCallback() is deprecated and will be removed in PHPUnit 12. Use $double->willReturnCallback() instead of $double->will($this->returnCallback())

/var/www/vendor/oxid-esales/oxideshop-ce/tests/Unit/Internal/Domain/Contact/From/ContactFormMessageBuilderTest.php:22

4) OxidEsales\EshopCommunity\Tests\Unit\Internal\Domain\Contact\Form\ContactFormMessageBuilderTest::testContentGetter with data set #3 ('salutation', 'MRS')
returnCallback() is deprecated and will be removed in PHPUnit 12. Use $double->willReturnCallback() instead of $double->will($this->returnCallback())

/var/www/vendor/oxid-esales/oxideshop-ce/tests/Unit/Internal/Domain/Contact/From/ContactFormMessageBuilderTest.php:22

5) OxidEsales\EshopCommunity\Tests\Unit\Internal\Domain\Contact\Form\ContactFormMessageBuilderTest::testContentGetter with data set #4 ('message', 'I'm standing on the rooftop')
returnCallback() is deprecated and will be removed in PHPUnit 12. Use $double->willReturnCallback() instead of $double->will($this->returnCallback())

/var/www/vendor/oxid-esales/oxideshop-ce/tests/Unit/Internal/Domain/Contact/From/ContactFormMessageBuilderTest.php:22






7) PsrLoggerConfigurationValidatorTest::testValidLogLevelValidation with data set #0 ('debug')
returnValue() is deprecated and will be removed in PHPUnit 12. Use $double->willReturn() instead of $double->will($this->returnValue())

/var/www/vendor/oxid-esales/oxideshop-ce/tests/Unit/Internal/Framework/Logger/Validator/PsrLoggerConfigurationValidatorTest.php:21

8) PsrLoggerConfigurationValidatorTest::testValidLogLevelValidation with data set #1 ('info')
returnValue() is deprecated and will be removed in PHPUnit 12. Use $double->willReturn() instead of $double->will($this->returnValue())

/var/www/vendor/oxid-esales/oxideshop-ce/tests/Unit/Internal/Framework/Logger/Validator/PsrLoggerConfigurationValidatorTest.php:21

9) PsrLoggerConfigurationValidatorTest::testValidLogLevelValidation with data set #2 ('notice')
returnValue() is deprecated and will be removed in PHPUnit 12. Use $double->willReturn() instead of $double->will($this->returnValue())

/var/www/vendor/oxid-esales/oxideshop-ce/tests/Unit/Internal/Framework/Logger/Validator/PsrLoggerConfigurationValidatorTest.php:21

10) PsrLoggerConfigurationValidatorTest::testValidLogLevelValidation with data set #3 ('warning')
returnValue() is deprecated and will be removed in PHPUnit 12. Use $double->willReturn() instead of $double->will($this->returnValue())

/var/www/vendor/oxid-esales/oxideshop-ce/tests/Unit/Internal/Framework/Logger/Validator/PsrLoggerConfigurationValidatorTest.php:21

11) PsrLoggerConfigurationValidatorTest::testValidLogLevelValidation with data set #4 ('error')
returnValue() is deprecated and will be removed in PHPUnit 12. Use $double->willReturn() instead of $double->will($this->returnValue())

/var/www/vendor/oxid-esales/oxideshop-ce/tests/Unit/Internal/Framework/Logger/Validator/PsrLoggerConfigurationValidatorTest.php:21

12) PsrLoggerConfigurationValidatorTest::testValidLogLevelValidation with data set #5 ('critical')
returnValue() is deprecated and will be removed in PHPUnit 12. Use $double->willReturn() instead of $double->will($this->returnValue())

/var/www/vendor/oxid-esales/oxideshop-ce/tests/Unit/Internal/Framework/Logger/Validator/PsrLoggerConfigurationValidatorTest.php:21

13) PsrLoggerConfigurationValidatorTest::testValidLogLevelValidation with data set #6 ('alert')
returnValue() is deprecated and will be removed in PHPUnit 12. Use $double->willReturn() instead of $double->will($this->returnValue())

/var/www/vendor/oxid-esales/oxideshop-ce/tests/Unit/Internal/Framework/Logger/Validator/PsrLoggerConfigurationValidatorTest.php:21

14) PsrLoggerConfigurationValidatorTest::testValidLogLevelValidation with data set #7 ('emergency')
returnValue() is deprecated and will be removed in PHPUnit 12. Use $double->willReturn() instead of $double->will($this->returnValue())

/var/www/vendor/oxid-esales/oxideshop-ce/tests/Unit/Internal/Framework/Logger/Validator/PsrLoggerConfigurationValidatorTest.php:21

15) PsrLoggerConfigurationValidatorTest::testInvalidLogLevelValidation with data set #0 (null)
returnValue() is deprecated and will be removed in PHPUnit 12. Use $double->willReturn() instead of $double->will($this->returnValue())

/var/www/vendor/oxid-esales/oxideshop-ce/tests/Unit/Internal/Framework/Logger/Validator/PsrLoggerConfigurationValidatorTest.php:51

16) PsrLoggerConfigurationValidatorTest::testInvalidLogLevelValidation with data set #1 (false)
returnValue() is deprecated and will be removed in PHPUnit 12. Use $double->willReturn() instead of $double->will($this->returnValue())

/var/www/vendor/oxid-esales/oxideshop-ce/tests/Unit/Internal/Framework/Logger/Validator/PsrLoggerConfigurationValidatorTest.php:51

17) PsrLoggerConfigurationValidatorTest::testInvalidLogLevelValidation with data set #2 (true)
returnValue() is deprecated and will be removed in PHPUnit 12. Use $double->willReturn() instead of $double->will($this->returnValue())

/var/www/vendor/oxid-esales/oxideshop-ce/tests/Unit/Internal/Framework/Logger/Validator/PsrLoggerConfigurationValidatorTest.php:51

18) PsrLoggerConfigurationValidatorTest::testInvalidLogLevelValidation with data set #3 ('string')
returnValue() is deprecated and will be removed in PHPUnit 12. Use $double->willReturn() instead of $double->will($this->returnValue())

/var/www/vendor/oxid-esales/oxideshop-ce/tests/Unit/Internal/Framework/Logger/Validator/PsrLoggerConfigurationValidatorTest.php:51

19) PsrLoggerConfigurationValidatorTest::testInvalidLogLevelValidation with data set #4 (0)
returnValue() is deprecated and will be removed in PHPUnit 12. Use $double->willReturn() instead of $double->will($this->returnValue())

/var/www/vendor/oxid-esales/oxideshop-ce/tests/Unit/Internal/Framework/Logger/Validator/PsrLoggerConfigurationValidatorTest.php:51

20) PsrLoggerConfigurationValidatorTest::testInvalidLogLevelValidation with data set #5 (1.0)
returnValue() is deprecated and will be removed in PHPUnit 12. Use $double->willReturn() instead of $double->will($this->returnValue())

/var/www/vendor/oxid-esales/oxideshop-ce/tests/Unit/Internal/Framework/Logger/Validator/PsrLoggerConfigurationValidatorTest.php:51

21) PsrLoggerConfigurationValidatorTest::testInvalidLogLevelValidation with data set #6 (stdClass Object ())
returnValue() is deprecated and will be removed in PHPUnit 12. Use $double->willReturn() instead of $double->will($this->returnValue())

/var/www/vendor/oxid-esales/oxideshop-ce/tests/Unit/Internal/Framework/Logger/Validator/PsrLoggerConfigurationValidatorTest.php:51

22) PsrLoggerConfigurationValidatorTest::testInvalidLogLevelValidation with data set #7 (['array'])
returnValue() is deprecated and will be removed in PHPUnit 12. Use $double->willReturn() instead of $double->will($this->returnValue())

/var/www/vendor/oxid-esales/oxideshop-ce/tests/Unit/Internal/Framework/Logger/Validator/PsrLoggerConfigurationValidatorTest.php:51

23) OxidEsales\EshopCommunity\Tests\Unit\Internal\Framework\Templating\Locator\AdminTemplateFileLocatorTest::testLocate
returnValue() is deprecated and will be removed in PHPUnit 12. Use $double->willReturn() instead of $double->will($this->returnValue())

/var/www/vendor/oxid-esales/oxideshop-ce/tests/Unit/Internal/Framework/Templating/Locator/AdminTemplateFileLocatorTest.php:18

24) OxidEsales\EshopCommunity\Tests\Unit\Internal\Framework\Templating\Locator\TemplateFileLocatorTest::testLocate
returnValue() is deprecated and will be removed in PHPUnit 12. Use $double->willReturn() instead of $double->will($this->returnValue())

/var/www/vendor/oxid-esales/oxideshop-ce/tests/Unit/Internal/Framework/Templating/Locator/TemplateFileLocatorTest.php:18
```

Except
```
6) OxidEsales\EshopCommunity\Tests\Unit\Internal\Framework\Console\CommandsProvider\ServicesCommandsProviderTest::testGetCommandsWhenServiceExtendsSymfonyCommandClass
getMockForAbstractClass() is deprecated and will be removed in PHPUnit 12 without replacement.

/var/www/vendor/oxid-esales/oxideshop-ce/tests/Unit/Internal/Framework/Console/CommandsProvider/ServicesCommandsProviderTest.php:19
```