### PR TITLE
Replace doc-comments with attributes to fix PHPUnit's deprecation messages

### DIFF
--- a/tests/Unit/Internal/Domain/Contact/Form/ContactFormMessageBuilderTest.php
+++ b/tests/Unit/Internal/Domain/Contact/Form/ContactFormMessageBuilderTest.php
@@ -13,12 +13,11 @@ use OxidEsales\EshopCommunity\Internal\Transition\Adapter\ShopAdapterInterface;
 use OxidEsales\EshopCommunity\Internal\Framework\Form\Form;
 use OxidEsales\EshopCommunity\Internal\Framework\Form\FormField;
 use OxidEsales\EshopCommunity\Internal\Domain\Contact\Form\ContactFormMessageBuilder;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class ContactFormMessageBuilderTest extends \PHPUnit\Framework\TestCase
 {
-    /**
-     * @dataProvider fieldsProvider
-     */
+    #[DataProvider('fieldsProvider')]
     public function testContentGetter($name, $value)
     {
         $form = $this->getContactForm();

--- a/tests/Unit/Internal/Domain/Email/EmailValidatorServiceTest.php
+++ b/tests/Unit/Internal/Domain/Email/EmailValidatorServiceTest.php
@@ -10,13 +10,11 @@ declare(strict_types=1);
 namespace OxidEsales\EshopCommunity\Tests\Unit\Internal\Domain\Email;
 
 use OxidEsales\EshopCommunity\Internal\Utility\Email\EmailValidatorService;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
-/**
- * Class EmailValidatorServiceTest
- *
- * @covers \OxidEsales\EshopCommunity\Internal\Utility\Email\EmailValidatorService
- */
+#[CoversClass(EmailValidatorService::class)]
 class EmailValidatorServiceTest extends TestCase
 {
     public static function providerEmailsToValidate(): array
@@ -37,9 +35,7 @@ class EmailValidatorServiceTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider providerEmailsToValidate
-     */
+    #[DataProvider('providerEmailsToValidate')]
     public function testValidateEmailWithValidEmail(string $email, bool $validMail): void
     {
         $mailValidator = new EmailValidatorService();

--- a/tests/Unit/Internal/Domain/Review/Dao/ProductRatingDaoTest.php
+++ b/tests/Unit/Internal/Domain/Review/Dao/ProductRatingDaoTest.php
@@ -13,12 +13,11 @@ use OxidEsales\EshopCommunity\Internal\Framework\Database\QueryBuilderFactoryInt
 use OxidEsales\EshopCommunity\Internal\Domain\Review\Dao\ProductRatingDao;
 use OxidEsales\EshopCommunity\Internal\Domain\Review\DataMapper\ProductRatingDataMapperInterface;
 use \OxidEsales\EshopCommunity\Internal\Framework\Dao\InvalidObjectIdDaoException;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class ProductRatingDaoTest extends \PHPUnit\Framework\TestCase
 {
-    /**
-     * @dataProvider invalidProductIdsProvider
-     */
+    #[DataProvider('invalidProductIdsProvider')]
     public function testGetProductByIdWithInvalidId($invalidProductId)
     {
         $this->expectException(InvalidObjectIdDaoException::class);

--- a/tests/Unit/Internal/Framework/Database/Logger/QueryFilterTest.php
+++ b/tests/Unit/Internal/Framework/Database/Logger/QueryFilterTest.php
@@ -10,13 +10,10 @@ declare(strict_types=1);
 namespace OxidEsales\EshopCommunity\Tests\Unit\Internal\Framework\Database\Logger;
 
 use OxidEsales\EshopCommunity\Internal\Framework\Database\Logger\QueryFilter;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class QueryFilterTest extends \PHPUnit\Framework\TestCase
 {
-
-    /**
-     * @return array
-     */
     public static function providerTestFiltering(): array
     {
         return [
@@ -79,13 +76,7 @@ class QueryFilterTest extends \PHPUnit\Framework\TestCase
         ];
     }
 
-    /**
-     * @param string $query
-     * @param array  $skipLogTags
-     * @param bool   $expected
-     *
-     * @dataProvider providerTestFiltering
-     */
+    #[DataProvider('providerTestFiltering')]
     public function testFiltering(string $query, array $skipLogTags, bool $expected)
     {
         $queryFilter = new QueryFilter();

--- a/tests/Unit/Internal/Framework/Logger/Validator/PsrLoggerConfigurationValidatorTest.php
+++ b/tests/Unit/Internal/Framework/Logger/Validator/PsrLoggerConfigurationValidatorTest.php
@@ -12,17 +12,16 @@ namespace OxidEsales\EshopCommunity\Tests\Unit\Internal\Framework\Logger\Validat
 use InvalidArgumentException;
 use OxidEsales\EshopCommunity\Internal\Framework\Logger\Configuration\PsrLoggerConfigurationInterface;
 use OxidEsales\EshopCommunity\Internal\Framework\Logger\Validator\PsrLoggerConfigurationValidator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\DoesNotPerformAssertions;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LogLevel;
 
 class PsrLoggerConfigurationValidatorTest extends TestCase
 {
-
-    /**
-     * @dataProvider dataProviderValidLogLevels
-     * @doesNotPerformAssertions
-     */
+    #[DataProvider('dataProviderValidLogLevels')]
+    #[DoesNotPerformAssertions]
     public function testValidLogLevelValidation($logLevel)
     {
         /** @var MockObject|PsrLoggerConfigurationInterface $configurationMock */
@@ -50,9 +49,7 @@ class PsrLoggerConfigurationValidatorTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider dataProviderInvalidLogLevels
-     */
+    #[DataProvider('dataProviderInvalidLogLevels')]
     public function testInvalidLogLevelValidation($logLevel)
     {
         $this->expectException(InvalidArgumentException::class);

--- a/tests/Unit/Internal/Framework/Logger/Wrapper/LoggerWrapperTest.php
+++ b/tests/Unit/Internal/Framework/Logger/Wrapper/LoggerWrapperTest.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 namespace OxidEsales\EshopCommunity\Tests\Unit\Internal\Framework\Logger\Wrapper;
 
 use OxidEsales\EshopCommunity\Internal\Framework\Logger\Wrapper\LoggerWrapper;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Psr\Log\LoggerInterface;
 
 /**
@@ -19,26 +20,21 @@ use Psr\Log\LoggerInterface;
  */
 class LoggerWrapperTest extends \PHPUnit\Framework\TestCase
 {
-
-    /**
-     * @dataProvider dataProviderPsrInterfaceMethods
-     *
-     * @param string $methodName The name of the method to test
-     */
-    public function testAllInterfaceMethodsExceptLogAreHandled($methodName)
+    #[DataProvider('dataProviderPsrInterfaceMethods')]
+    public function testAllInterfaceMethodsExceptLogAreHandled(string $methodNameToTest)
     {
         $messageToLog = "The message is {myMessage}";
         $contextToLog = ['myMessage' => 'Hello World!'];
         $loggerMock = $this->getLoggerMock();
         $loggerMock->expects($this->once())
-            ->method($methodName)
+            ->method($methodNameToTest)
             ->with(
                 $this->equalTo($messageToLog),
                 $this->equalTo($contextToLog)
             );
 
         $loggerServiceWrapper = new LoggerWrapper($loggerMock);
-        $loggerServiceWrapper->$methodName($messageToLog, $contextToLog);
+        $loggerServiceWrapper->$methodNameToTest($messageToLog, $contextToLog);
     }
 
     /**
@@ -77,10 +73,7 @@ class LoggerWrapperTest extends \PHPUnit\Framework\TestCase
         $loggerServiceWrapper->log($levelToLog, $messageToLog, $contextToLog);
     }
 
-    /**
-     * @return LoggerInterface
-     */
-    private function getLoggerMock()
+    private function getLoggerMock(): LoggerInterface
     {
         $loggerMock = $this
             ->getMockBuilder(LoggerInterface::class)

--- a/tests/Unit/Internal/Framework/Module/Configuration/Cache/ClassPropertyModuleConfigurationCacheTest.php
+++ b/tests/Unit/Internal/Framework/Module/Configuration/Cache/ClassPropertyModuleConfigurationCacheTest.php
@@ -12,6 +12,7 @@ namespace OxidEsales\EshopCommunity\Tests\Unit\Internal\Framework\Module\Configu
 use OxidEsales\EshopCommunity\Internal\Framework\Module\Configuration\Cache\ClassPropertyModuleConfigurationCache;
 use OxidEsales\EshopCommunity\Internal\Framework\Module\Configuration\DataObject\ModuleConfiguration;
 use OxidEsales\EshopCommunity\Internal\Framework\Module\Configuration\DataObject\ShopConfiguration;
+use PHPUnit\Framework\Attributes\DoesNotPerformAssertions;
 use PHPUnit\Framework\TestCase;
 
 final class ClassPropertyModuleConfigurationCacheTest extends TestCase
@@ -41,9 +42,7 @@ final class ClassPropertyModuleConfigurationCacheTest extends TestCase
         $this->assertTrue($cache->exists('test',1));
     }
 
-    /**
-     * @doesNotPerformAssertions
-     */
+    #[DoesNotPerformAssertions]
     public function testNotExistentEvict(): void
     {
         $cache = new ClassPropertyModuleConfigurationCache();

--- a/tests/Unit/Internal/Framework/Module/Configuration/DataMapper/ModuleConfigurationDataMapperTest.php
+++ b/tests/Unit/Internal/Framework/Module/Configuration/DataMapper/ModuleConfigurationDataMapperTest.php
@@ -16,21 +16,14 @@ use OxidEsales\EshopCommunity\Internal\Framework\Module\Configuration\DataMapper
 use OxidEsales\EshopCommunity\Internal\Framework\Module\Configuration\DataMapper\ModuleConfigurationDataMapperInterface;
 use OxidEsales\EshopCommunity\Internal\Framework\Module\Configuration\DataObject\ModuleConfiguration;
 use OxidEsales\EshopCommunity\Tests\ContainerTrait;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
-/**
- * @internal
- */
 class ModuleConfigurationDataMapperTest extends TestCase
 {
     use ContainerTrait;
 
-    /**
-     * @dataProvider moduleConfigurationDataProvider
-     *
-     * @param array                                  $data
-     * @param ModuleConfigurationDataMapperInterface $dataMapper
-     */
+    #[DataProvider('moduleConfigurationDataProvider')]
     public function testToDataAndFromData(array $data, ModuleConfigurationDataMapperInterface $dataMapper)
     {
 

--- a/tests/Unit/Internal/Framework/Module/Configuration/DataObject/ClassExtensionsChainTest.php
+++ b/tests/Unit/Internal/Framework/Module/Configuration/DataObject/ClassExtensionsChainTest.php
@@ -10,12 +10,11 @@ declare(strict_types=1);
 namespace OxidEsales\EshopCommunity\Tests\Unit\Internal\Framework\Module\Configuration\DataObject;
 
 use OxidEsales\EshopCommunity\Internal\Framework\Module\Configuration\DataObject\ClassExtensionsChain;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use OxidEsales\EshopCommunity\Internal\Framework\Module\Configuration\DataObject\ModuleConfiguration\ClassExtension;
 use OxidEsales\EshopCommunity\Internal\Framework\Module\Configuration\Exception\ExtensionNotInChainException;
-/**
- * @internal
- */
+
 class ClassExtensionsChainTest extends TestCase
 {
     public function testAddExtensionsIfChainIsEmpty()
@@ -137,12 +136,7 @@ class ClassExtensionsChainTest extends TestCase
         );
     }
 
-    /**
-     * @dataProvider invalidExtensionProvider
-     *
-     * @param ClassExtension $extension
-     *
-     */
+    #[DataProvider('invalidExtensionProvider')]
     public function testRemoveExtensionThrowsExceptionIfClassNotExistsInChain(ClassExtension $extension)
     {
         $this->expectException(ExtensionNotInChainException::class);

--- a/tests/Unit/Internal/Framework/Module/Install/Service/BootstrapModuleInstallerTest.php
+++ b/tests/Unit/Internal/Framework/Module/Install/Service/BootstrapModuleInstallerTest.php
@@ -13,6 +13,7 @@ use OxidEsales\EshopCommunity\Internal\Framework\Module\Install\DataObject\OxidE
 use OxidEsales\EshopCommunity\Internal\Framework\Module\Install\Service\BootstrapModuleInstaller;
 use OxidEsales\EshopCommunity\Internal\Framework\Module\Install\Service\ModuleConfigurationInstallerInterface;
 use OxidEsales\EshopCommunity\Internal\Framework\Module\Install\Service\ModuleFilesInstallerInterface;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 class BootstrapModuleInstallerTest extends TestCase
@@ -39,9 +40,7 @@ class BootstrapModuleInstallerTest extends TestCase
         $moduleInstaller->install($package);
     }
 
-    /**
-     * @dataProvider moduleInstallMatrixDataProvider
-     */
+    #[DataProvider('moduleInstallMatrixDataProvider')]
     public function testIsInstalled(bool $filesInstalled, bool $projectConfigurationInstalled, bool $moduleInstalled)
     {
         $moduleFilesInstaller = $this->getMockBuilder(ModuleFilesInstallerInterface::class)->getMock();

--- a/tests/Unit/Internal/Framework/Module/MetaData/Converter/MetaDataConverterAggregateTest.php
+++ b/tests/Unit/Internal/Framework/Module/MetaData/Converter/MetaDataConverterAggregateTest.php
@@ -11,11 +11,10 @@ namespace OxidEsales\EshopCommunity\Tests\Unit\Internal\Framework\Module\Convert
 
 use OxidEsales\EshopCommunity\Internal\Framework\Module\MetaData\Converter\MetaDataConverterInterface;
 use OxidEsales\EshopCommunity\Internal\Framework\Module\MetaData\Converter\MetaDataConverterAggregate;
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 
-/**
- * @covers \OxidEsales\EshopCommunity\Internal\Framework\Module\MetaData\Converter\MetaDataConverterAggregate
- */
+#[CoversClass(MetaDataConverterAggregate::class)]
 class MetaDataConverterAggregateTest extends TestCase
 {
     public function testConvert(): void

--- a/tests/Unit/Internal/Framework/Module/MetaData/Converter/ModuleSettingsBooleanConverterTest.php
+++ b/tests/Unit/Internal/Framework/Module/MetaData/Converter/ModuleSettingsBooleanConverterTest.php
@@ -11,6 +11,7 @@ namespace OxidEsales\EshopCommunity\Tests\Unit\Internal\Framework\Module\MetaDat
 
 use OxidEsales\EshopCommunity\Internal\Framework\Module\MetaData\Converter\ModuleSettingsBooleanConverter;
 use OxidEsales\EshopCommunity\Internal\Framework\Module\MetaData\Dao\MetaDataProvider;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 class ModuleSettingsBooleanConverterTest extends TestCase
@@ -26,9 +27,7 @@ class ModuleSettingsBooleanConverterTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider convertToTrueDataProvider
-     */
+    #[DataProvider('convertToTrueDataProvider')]
     public function testConvertToTrue($value): void
     {
         $metaData =
@@ -56,9 +55,7 @@ class ModuleSettingsBooleanConverterTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider convertToFalseDataProvider
-     */
+    #[DataProvider('convertToFalseDataProvider')]
     public function testConvertToFalse($value): void
     {
         $metaData =
@@ -91,9 +88,7 @@ class ModuleSettingsBooleanConverterTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider whenNothingToConvertDataProvider
-     */
+    #[DataProvider('whenNothingToConvertDataProvider')]
     public function testWhenNothingToConvert(array $metaData): void
     {
         $converter = new ModuleSettingsBooleanConverter();

--- a/tests/Unit/Internal/Framework/Module/MetaData/Dao/MetaDataNormalizerTest.php
+++ b/tests/Unit/Internal/Framework/Module/MetaData/Dao/MetaDataNormalizerTest.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 namespace OxidEsales\EshopCommunity\Tests\Unit\Internal\Framework\Module\MetaData\Dao;
 
 use OxidEsales\EshopCommunity\Internal\Framework\Module\MetaData\Dao\MetaDataNormalizer;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 class MetaDataNormalizerTest extends TestCase
@@ -60,9 +61,7 @@ class MetaDataNormalizerTest extends TestCase
         );
     }
 
-    /**
-     * @dataProvider multiLanguageFieldDataProvider
-     */
+    #[DataProvider('multiLanguageFieldDataProvider')]
     public function testNormalizerConvertsMultiLanguageFieldToArrayWithDefaultLanguageIfItIsString(string $fieldName, string $value)
     {
         $metadata = [
@@ -79,9 +78,7 @@ class MetaDataNormalizerTest extends TestCase
         );
     }
 
-    /**
-     * @dataProvider multiLanguageFieldDataProvider
-     */
+    #[DataProvider('multiLanguageFieldDataProvider')]
     public function testNormalizerConvertsMultiLanguageFieldToArrayWithCustomLanguageIfItIsStringAndLangOptionIsSet(string $fieldName, string $value)
     {
         $metadata = [

--- a/tests/Unit/Internal/Framework/Module/MetaData/Validator/MetaDataSchemaValidatorTest.php
+++ b/tests/Unit/Internal/Framework/Module/MetaData/Validator/MetaDataSchemaValidatorTest.php
@@ -15,6 +15,7 @@ use OxidEsales\EshopCommunity\Internal\Framework\Module\MetaData\Dao\MetaDataSch
 use OxidEsales\EshopCommunity\Internal\Framework\Module\MetaData\Exception\UnsupportedMetaDataValueTypeException;
 use OxidEsales\EshopCommunity\Internal\Framework\Module\MetaData\Exception\UnsupportedMetaDataVersionException;
 use OxidEsales\EshopCommunity\Internal\Framework\Module\MetaData\Validator\MetaDataSchemaValidator;
+use PHPUnit\Framework\Attributes\DoesNotPerformAssertions;
 use PHPUnit\Framework\TestCase;
 
 class MetaDataSchemaValidatorTest extends TestCase
@@ -78,8 +79,8 @@ class MetaDataSchemaValidatorTest extends TestCase
 
     /**
      * This test covers metaData sections like 'extend', or 'templates', which have their custom subKeys
-     * @doesNotPerformAssertions
      */
+    #[DoesNotPerformAssertions]
     public function testExcludedSectionItemValidation()
     {
         $metaDataToValidate = [
@@ -144,9 +145,7 @@ class MetaDataSchemaValidatorTest extends TestCase
         $validator->validate('path/to/metadata.php', '2.0', $metaDataToValidate);
     }
 
-    /**
-     * @doesNotPerformAssertions
-     */
+    #[DoesNotPerformAssertions]
     public function testValidateThrowsNoExceptionOnIncompleteFirstLevel()
     {
         $metaDataToValidate = [
@@ -165,9 +164,7 @@ class MetaDataSchemaValidatorTest extends TestCase
         $validator->validate('path/to/metadata.php', '2.0', $metaDataToValidate);
     }
 
-    /**
-     * @doesNotPerformAssertions
-     */
+    #[DoesNotPerformAssertions]
     public function testValidateThrowsNoExceptionOnIncompleteSecondLevel()
     {
         $metaDataToValidate = [

--- a/tests/Unit/Internal/Framework/Module/MetaData/Validator/MetaDataValidatorAggregateTest.php
+++ b/tests/Unit/Internal/Framework/Module/MetaData/Validator/MetaDataValidatorAggregateTest.php
@@ -11,11 +11,10 @@ namespace OxidEsales\EshopCommunity\Tests\Unit\Internal\Framework\Module\Convert
 
 use OxidEsales\EshopCommunity\Internal\Framework\Module\MetaData\Validator\MetaDataValidatorAggregate;
 use OxidEsales\EshopCommunity\Internal\Framework\Module\MetaData\Validator\MetaDataValidatorInterface;
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 
-/**
- * @covers \OxidEsales\EshopCommunity\Internal\Framework\Module\MetaData\Validator\MetaDataValidatorAggregate
- */
+#[CoversClass(MetaDataValidatorAggregate::class)]
 class MetaDataValidatorAggregateTest extends TestCase
 {
     public function testValidate(): void

--- a/tests/Unit/Internal/Framework/Module/MetaData/Validator/ModuleIdValidatorTest.php
+++ b/tests/Unit/Internal/Framework/Module/MetaData/Validator/ModuleIdValidatorTest.php
@@ -12,17 +12,16 @@ namespace OxidEsales\EshopCommunity\Tests\Unit\Internal\Framework\Module\MetaDat
 use OxidEsales\EshopCommunity\Internal\Framework\Module\MetaData\Exception\ModuleIdNotValidException;
 use OxidEsales\EshopCommunity\Internal\Framework\Module\MetaData\Dao\MetaDataProvider;
 use OxidEsales\EshopCommunity\Internal\Framework\Module\MetaData\Validator\ModuleIdValidator;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\DoesNotPerformAssertions;
 use PHPUnit\Framework\TestCase;
 
-/**
- * @covers \OxidEsales\EshopCommunity\Internal\Framework\Module\MetaData\Validator\ModuleIdValidator
- */
+#[CoversClass(ModuleIdValidator::class)]
 class ModuleIdValidatorTest extends TestCase
 {
 
-    /**
-     * @doesNotPerformAssertions
-     */
+    #[DoesNotPerformAssertions]
     public function testValidateWhenValid(): void
     {
         $metaData = [
@@ -41,10 +40,7 @@ class ModuleIdValidatorTest extends TestCase
         ];
     }
 
-    /**
-     * @param mixed $moduleId
-     * @dataProvider validateInvalidIdProvidedDataProvider
-     */
+    #[DataProvider('validateInvalidIdProvidedDataProvider')]
     public function testValidateWhenInvalidIdProvided($moduleId): void
     {
         $this->expectException(ModuleIdNotValidException::class);

--- a/tests/Unit/Internal/Framework/Module/MetaData/Validator/SchemaValidatorTest.php
+++ b/tests/Unit/Internal/Framework/Module/MetaData/Validator/SchemaValidatorTest.php
@@ -15,6 +15,7 @@ use OxidEsales\EshopCommunity\Internal\Framework\Module\MetaData\Exception\Unsup
 use OxidEsales\EshopCommunity\Internal\Framework\Module\MetaData\Exception\UnsupportedMetaDataValueTypeException;
 use OxidEsales\EshopCommunity\Internal\Framework\Module\MetaData\Exception\UnsupportedMetaDataVersionException;
 use OxidEsales\EshopCommunity\Internal\Framework\Module\MetaData\Validator\MetaDataSchemaValidator;
+use PHPUnit\Framework\Attributes\DoesNotPerformAssertions;
 use PHPUnit\Framework\TestCase;
 
 final class SchemaValidatorTest extends TestCase
@@ -31,9 +32,7 @@ final class SchemaValidatorTest extends TestCase
         ],
     ];
 
-    /**
-     * @doesNotPerformAssertions
-     */
+    #[DoesNotPerformAssertions]
     public function testValidateWithMinimalValidStructure(): void
     {
         $this->getValidator()->validate('', '2.1', []);
@@ -80,9 +79,7 @@ final class SchemaValidatorTest extends TestCase
         $this->getValidator()->validate('', '2.1', $metadata);
     }
 
-    /**
-     * @doesNotPerformAssertions
-     */
+    #[DoesNotPerformAssertions]
     public function testValidateWithSectionExcludedFromValidation(): void
     {
         $sectionExcludedFromValidation = MetaDataProvider::METADATA_EXTEND;

--- a/tests/Unit/Internal/Framework/Module/MetaData/Validator/ShopModuleSettingBooleanValidatorTest.php
+++ b/tests/Unit/Internal/Framework/Module/MetaData/Validator/ShopModuleSettingBooleanValidatorTest.php
@@ -12,11 +12,12 @@ namespace OxidEsales\EshopCommunity\Tests\Unit\Internal\Framework\Module\MetaDat
 use OxidEsales\EshopCommunity\Internal\Framework\Module\MetaData\Exception\SettingNotValidException;
 use OxidEsales\EshopCommunity\Internal\Framework\Module\MetaData\Dao\MetaDataProvider;
 use OxidEsales\EshopCommunity\Internal\Framework\Module\MetaData\Validator\ModuleSettingBooleanValidator;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\DoesNotPerformAssertions;
 use PHPUnit\Framework\TestCase;
 
-/**
- * @covers \OxidEsales\EshopCommunity\Internal\Framework\Module\MetaData\Validator\ModuleSettingBooleanValidator
- */
+#[CoversClass(ModuleSettingBooleanValidator::class)]
 class ShopModuleSettingBooleanValidatorTest extends TestCase
 {
     public static function validationPassWithDataProvider(): array
@@ -33,14 +34,11 @@ class ShopModuleSettingBooleanValidatorTest extends TestCase
     }
 
     /**
-     * @dataProvider validationPassWithDataProvider
-     *
-     * @param $value
-     *
-     * @doesNotPerformAssertions
      * @deprecated   since v6.4.0 (2019-06-10);This is not recommended values for use,
      *               only boolean values should be used.
      */
+    #[DataProvider('validationPassWithDataProvider')]
+    #[DoesNotPerformAssertions]
     public function testValidationPassWithBackwardsCompatibleValues($value)
     {
         $this->executeValidationForBoolSetting($value);
@@ -54,11 +52,8 @@ class ShopModuleSettingBooleanValidatorTest extends TestCase
         ];
     }
 
-    /**
-     * @param bool $value
-     * @dataProvider validationPassDataProvider
-     * @doesNotPerformAssertions
-     */
+    #[DataProvider('validationPassDataProvider')]
+    #[DoesNotPerformAssertions]
     public function testValidationPass(bool $value)
     {
         $this->executeValidationForBoolSetting($value);
@@ -73,19 +68,14 @@ class ShopModuleSettingBooleanValidatorTest extends TestCase
         ];
     }
 
-    /**
-     * @param mixed $value
-     * @dataProvider validationFailsDataProvider
-     */
-    public function testValidationFails($value)
+    #[DataProvider('validationFailsDataProvider')]
+    public function testValidationFails(mixed $value)
     {
         $this->expectException(SettingNotValidException::class);
         $this->executeValidationForBoolSetting($value);
     }
 
-    /**
-     * @doesNotPerformAssertions
-     */
+    #[DoesNotPerformAssertions]
     public function testWhenStringTypeProvided()
     {
         $settings =
@@ -102,9 +92,7 @@ class ShopModuleSettingBooleanValidatorTest extends TestCase
         $validator->validate($settings);
     }
 
-    /**
-     * @doesNotPerformAssertions
-     */
+    #[DoesNotPerformAssertions]
     public function testWhenNoTypeProvided()
     {
         $settings =

--- a/tests/Unit/Internal/Framework/Module/Setup/Validator/ControllersValidatorTest.php
+++ b/tests/Unit/Internal/Framework/Module/Setup/Validator/ControllersValidatorTest.php
@@ -13,18 +13,14 @@ use OxidEsales\EshopCommunity\Internal\Framework\Module\State\ModuleStateService
 use OxidEsales\EshopCommunity\Internal\Transition\Adapter\ShopAdapterInterface;
 use OxidEsales\EshopCommunity\Internal\Framework\Module\Configuration\DataObject\ModuleConfiguration;
 use OxidEsales\EshopCommunity\Internal\Framework\Module\Setup\Validator\ControllersValidator;
+use PHPUnit\Framework\Attributes\DoesNotPerformAssertions;
 use PHPUnit\Framework\TestCase;
 use OxidEsales\EshopCommunity\Internal\Framework\Module\Configuration\DataObject\ModuleConfiguration\Controller;
 use Psr\Log\LoggerInterface;
 
-/**
- * @internal
- */
 final class ControllersValidatorTest extends TestCase
 {
-    /**
-     * @doesNotPerformAssertions
-     */
+    #[DoesNotPerformAssertions]
     public function testValidationWithCorrectSetting(): void
     {
         $shopAdapter = $this->getMockBuilder(ShopAdapterInterface::class)->getMock();

--- a/tests/Unit/Internal/Framework/Module/Setup/Validator/EventsModuleSettingValidatorTest.php
+++ b/tests/Unit/Internal/Framework/Module/Setup/Validator/EventsModuleSettingValidatorTest.php
@@ -13,15 +13,15 @@ use OxidEsales\EshopCommunity\Internal\Transition\Adapter\ShopAdapter;
 use OxidEsales\EshopCommunity\Internal\Framework\Module\Configuration\DataObject\ModuleConfiguration;
 use OxidEsales\EshopCommunity\Internal\Framework\Module\Setup\Validator\EventsValidator;
 use OxidEsales\EshopCommunity\Tests\Integration\Internal\Framework\Module\TestData\TestModule\ModuleEvents;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\DoesNotPerformAssertions;
 use PHPUnit\Framework\TestCase;
 use OxidEsales\EshopCommunity\Internal\Framework\Module\Configuration\DataObject\ModuleConfiguration\Event;
 use OxidEsales\EshopCommunity\Internal\Framework\Module\Setup\Exception\ModuleSettingNotValidException;
 
 class EventsModuleSettingValidatorTest extends TestCase
 {
-    /**
-     * @doesNotPerformAssertions
-     */
+    #[DoesNotPerformAssertions]
     public function testValidate()
     {
         $validator = $this->createValidator();
@@ -47,15 +47,11 @@ class EventsModuleSettingValidatorTest extends TestCase
     }
 
     /**
-     * @dataProvider invalidEventsProvider
-     *
-     * @param Event $invalidEvent
-     *
-     * @doesNotPerformAssertions
-     *
      * @throws \OxidEsales\EshopCommunity\Internal\Framework\Module\Setup\Exception\ModuleSettingNotValidException
      */
-    public function testValidateDoesNotValidateSyntax($invalidEvent)
+    #[DataProvider('invalidEventsProvider')]
+    #[DoesNotPerformAssertions]
+    public function testValidateDoesNotValidateSyntax(Event $invalidEvent)
     {
         $validator = $this->createValidator();
 
@@ -73,9 +69,6 @@ class EventsModuleSettingValidatorTest extends TestCase
         ];
     }
 
-    /**
-     * @return EventsValidator
-     */
     private function createValidator(): EventsValidator
     {
         return new EventsValidator();

--- a/tests/Unit/Internal/Framework/Templating/Locator/EditionMenuFileLocatorTest.php
+++ b/tests/Unit/Internal/Framework/Templating/Locator/EditionMenuFileLocatorTest.php
@@ -10,20 +10,19 @@ declare(strict_types=1);
 namespace OxidEsales\EshopCommunity\Tests\Unit\Internal\Framework\Templating\Locator;
 
 use org\bovigo\vfs\vfsStream;
+use org\bovigo\vfs\vfsStreamDirectory;
 use OxidEsales\EshopCommunity\Internal\Framework\Templating\Locator\EditionMenuFileLocator;
 use OxidEsales\EshopCommunity\Internal\Framework\Theme\Bridge\AdminThemeBridgeInterface;
 use OxidEsales\EshopCommunity\Tests\Unit\Internal\BasicContextStub;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Filesystem\Filesystem;
 
 final class EditionMenuFileLocatorTest extends TestCase
 {
-    /** @var vfsStream */
-    private $vfsStreamDirectory;
+    private vfsStreamDirectory $vfsStreamDirectory;
 
-    /**
-     * @dataProvider dataProviderTestLocate
-     */
+    #[DataProvider('dataProviderTestLocate')]
     public function testLocate($edition)
     {
         $this->createModuleStructure($edition);
@@ -49,10 +48,7 @@ final class EditionMenuFileLocatorTest extends TestCase
         ];
     }
 
-    /**
-     * @return AdminThemeBridgeInterface
-     */
-    private function getAdminThemeMock()
+    private function getAdminThemeMock(): AdminThemeBridgeInterface
     {
         $adminTheme = $this->getMockBuilder(AdminThemeBridgeInterface::class)->getMock();
         $adminTheme->method('getActiveTheme')->willReturn('admin');
@@ -60,12 +56,7 @@ final class EditionMenuFileLocatorTest extends TestCase
         return $adminTheme;
     }
 
-    /**
-     * @param string $edition
-     *
-     * @return BasicContextStub
-     */
-    private function getContext(string $edition)
+    private function getContext(string $edition): BasicContextStub
     {
         $context = new BasicContextStub();
         $context->setEdition($edition);

--- a/tests/Unit/Internal/Framework/Templating/Locator/EditionUserFileLocatorTest.php
+++ b/tests/Unit/Internal/Framework/Templating/Locator/EditionUserFileLocatorTest.php
@@ -10,20 +10,19 @@ declare(strict_types=1);
 namespace OxidEsales\EshopCommunity\Tests\Unit\Internal\Framework\Templating\Locator;
 
 use org\bovigo\vfs\vfsStream;
+use org\bovigo\vfs\vfsStreamDirectory;
 use OxidEsales\EshopCommunity\Internal\Framework\Templating\Locator\EditionUserFileLocator;
 use OxidEsales\EshopCommunity\Internal\Framework\Theme\Bridge\AdminThemeBridgeInterface;
 use OxidEsales\EshopCommunity\Tests\Unit\Internal\BasicContextStub;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Filesystem\Filesystem;
 
 final class EditionUserFileLocatorTest extends TestCase
 {
-    /** @var vfsStream */
-    private $vfsStreamDirectory;
+    private vfsStreamDirectory $vfsStreamDirectory;
 
-    /**
-     * @dataProvider dataProviderTestLocate
-     */
+    #[DataProvider('dataProviderTestLocate')]
     public function testLocate($edition)
     {
         $this->createModuleStructure($edition);
@@ -49,10 +48,7 @@ final class EditionUserFileLocatorTest extends TestCase
         ];
     }
 
-    /**
-     * @return AdminThemeBridgeInterface
-     */
-    private function getAdminThemeMock()
+    private function getAdminThemeMock(): AdminThemeBridgeInterface
     {
         $adminTheme = $this->getMockBuilder(AdminThemeBridgeInterface::class)->getMock();
         $adminTheme->method('getActiveTheme')->willReturn('admin');
@@ -60,12 +56,7 @@ final class EditionUserFileLocatorTest extends TestCase
         return $adminTheme;
     }
 
-    /**
-     * @param string $edition
-     *
-     * @return BasicContextStub
-     */
-    private function getContext(string $edition)
+    private function getContext(string $edition): BasicContextStub
     {
         $context = new BasicContextStub();
         $context->setEdition($edition);

--- a/tests/Unit/Internal/Framework/Templating/Resolver/TemplateFileResolverTest.php
+++ b/tests/Unit/Internal/Framework/Templating/Resolver/TemplateFileResolverTest.php
@@ -11,6 +11,7 @@ namespace OxidEsales\EshopCommunity\Tests\Unit\Internal\Framework\Templating\Res
 
 use OxidEsales\EshopCommunity\Internal\Framework\Templating\Exception\InvalidTemplateNameException;
 use OxidEsales\EshopCommunity\Internal\Framework\Templating\Resolver\TemplateFileResolver;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 final class TemplateFileResolverTest extends TestCase
@@ -22,7 +23,7 @@ final class TemplateFileResolverTest extends TestCase
         (new TemplateFileResolver('tpl'))->getFilename('');
     }
 
-    /** @dataProvider smartyTemplateNameFileDataProvider */
+    #[DataProvider('smartyTemplateNameFileDataProvider')]
     public function testGetFilenameSmartyTemplate($templateName, $expectedFilename): void
     {
         $filename = (new TemplateFileResolver('tpl'))->getFilename($templateName);
@@ -30,7 +31,7 @@ final class TemplateFileResolverTest extends TestCase
         $this->assertEquals($expectedFilename, $filename);
     }
 
-    /** @dataProvider twigTemplateNameFileDataProvider */
+    #[DataProvider('twigTemplateNameFileDataProvider')]
     public function testGetFilenameTwigTemplate($templateName, $expectedFilename): void
     {
         $filename = (new TemplateFileResolver('html.twig'))->getFilename($templateName);

--- a/tests/Unit/Internal/Framework/Templating/TemplateRendererTest.php
+++ b/tests/Unit/Internal/Framework/Templating/TemplateRendererTest.php
@@ -12,6 +12,7 @@ namespace OxidEsales\EshopCommunity\Tests\Unit\Internal\Framework\Templating;
 use OxidEsales\EshopCommunity\Internal\Framework\Templating\TemplateEngineInterface;
 use OxidEsales\EshopCommunity\Internal\Framework\Templating\TemplateRenderer;
 use OxidEsales\EshopCommunity\Internal\Transition\Utility\ContextInterface;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 final class TemplateRendererTest extends TestCase
@@ -31,7 +32,7 @@ final class TemplateRendererTest extends TestCase
         $this->assertSame($response, $renderer->renderTemplate($templateName, []));
     }
 
-    /** @dataProvider twigTemplateNameFileDataProvider */
+    #[DataProvider('twigTemplateNameFileDataProvider')]
     public function testRenderTemplateFilenameExtension($filename, $expectedFilename): void
     {
         $engine = $this->getEngineMock();

--- a/tests/Unit/Internal/Setup/ConfigFile/ConfigFileDaoTest.php
+++ b/tests/Unit/Internal/Setup/ConfigFile/ConfigFileDaoTest.php
@@ -13,6 +13,7 @@ use OxidEsales\EshopCommunity\Internal\Setup\ConfigFile\ConfigFileDao;
 use OxidEsales\EshopCommunity\Internal\Setup\ConfigFile\ConfigFileNotFoundException;
 use OxidEsales\EshopCommunity\Internal\Setup\ConfigFile\FileNotEditableException;
 use OxidEsales\EshopCommunity\Internal\Transition\Utility\BasicContextInterface;
+use PHPUnit\Framework\Attributes\DoesNotPerformAssertions;
 use PHPUnit\Framework\TestCase;
 use Prophecy\PhpUnit\ProphecyTrait;
 
@@ -94,7 +95,7 @@ final class ConfigFileDaoTest extends TestCase
         $configFileDao->checkIsEditable();
     }
 
-    /** @doesNotPerformAssertions */
+    #[DoesNotPerformAssertions]
     public function testCheckIsEditableWithValidFile(): void
     {
         $basicContext = $this->prophesize(BasicContextInterface::class);

--- a/tests/Unit/Internal/Transition/Adapter/Configuration/Utility/ShopSettingEncoderTest.php
+++ b/tests/Unit/Internal/Transition/Adapter/Configuration/Utility/ShopSettingEncoderTest.php
@@ -10,17 +10,14 @@ declare(strict_types=1);
 namespace OxidEsales\EshopCommunity\Tests\Unit\Internal\Transition\Adapter\Configuration\Utility;
 
 use OxidEsales\EshopCommunity\Internal\Framework\Config\Exception\InvalidShopSettingValueException;
+use PHPUnit\Framework\Attributes\DataProvider;
 use OxidEsales\EshopCommunity\Internal\Framework\Config\Utility\ShopSettingEncoder;
 use PHPUnit\Framework\TestCase;
 
-/**
- * @internal
- */
+
 class ShopSettingEncoderTest extends TestCase
 {
-    /**
-     * @dataProvider settingDataProvider
-     */
+    #[DataProvider('settingDataProvider')]
     public function testEncoding($value, $encodedValue, string $encodingType)
     {
         $shopSettingEncoder = new ShopSettingEncoder();
@@ -31,9 +28,7 @@ class ShopSettingEncoderTest extends TestCase
         );
     }
 
-    /**
-     * @dataProvider settingDataProvider
-     */
+    #[DataProvider('settingDataProvider')]
     public function testDecoding($value, $encodedValue, string $encodingType)
     {
         $shopSettingEncoder = new ShopSettingEncoder();

--- a/tests/Unit/Internal/Transition/Adapter/TemplateLogic/DateFormatHelperTest.php
+++ b/tests/Unit/Internal/Transition/Adapter/TemplateLogic/DateFormatHelperTest.php
@@ -8,14 +8,13 @@
 namespace OxidEsales\EshopCommunity\Tests\Unit\Internal\Transition\Adapter\TemplateLogic;
 
 use OxidEsales\EshopCommunity\Internal\Transition\Adapter\TemplateLogic\DateFormatHelper;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
+#[CoversClass(DateFormatHelper::class, 'fixWindowsTimeFormat')]
 class DateFormatHelperTest extends TestCase
 {
-
-    /**
-     * @return array
-     */
     public static function provider(): array
     {
         return [
@@ -29,14 +28,7 @@ class DateFormatHelperTest extends TestCase
         ];
     }
 
-    /**
-     * @param string $format
-     * @param int    $timestamp
-     * @param string $expectedFormat
-     *
-     * @dataProvider provider
-     * @covers       \OxidEsales\EshopCommunity\Internal\Transition\Adapter\TemplateLogic\DateFormatHelper::fixWindowsTimeFormat
-     */
+    #[DataProvider('provider')]
     public function testFixWindowsTimeFormat($format, $timestamp, $expectedFormat)
     {
         $dateFormatHelper = new DateFormatHelper();

--- a/tests/Unit/Internal/Transition/Adapter/TemplateLogic/IncludeDynamicLogicTest.php
+++ b/tests/Unit/Internal/Transition/Adapter/TemplateLogic/IncludeDynamicLogicTest.php
@@ -8,49 +8,32 @@
 namespace OxidEsales\EshopCommunity\Tests\Unit\Internal\Transition\Adapter\TemplateLogic;
 
 use OxidEsales\EshopCommunity\Internal\Transition\Adapter\TemplateLogic\IncludeDynamicLogic;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
-/**
- * Class IncludeDynamicLogicTest
- *
- * @covers \OxidEsales\EshopCommunity\Internal\Transition\Adapter\TemplateLogic\IncludeDynamicLogic
- */
+#[CoversClass(IncludeDynamicLogic::class)]
 class IncludeDynamicLogicTest extends TestCase
 {
-
-    /** @var IncludeDynamicLogic */
-    private $includeDynamicLogic;
+    private IncludeDynamicLogic $includeDynamicLogic;
 
     public function setup(): void
     {
         $this->includeDynamicLogic = new IncludeDynamicLogic();
     }
 
-    /**
-     * @param array $parameters
-     * @param array $expected
-     *
-     * @dataProvider getIncludeDynamicPrefixTests
-     */
+    #[DataProvider('getIncludeDynamicPrefixTests')]
     public function testIncludeDynamicPrefix(array $parameters, array $expected): void
     {
         $this->assertEquals($this->includeDynamicLogic->includeDynamicPrefix($parameters), $expected);
     }
 
-    /**
-     * @param array  $parameters
-     * @param string $expected
-     *
-     * @dataProvider getRenderForCacheTests
-     */
+    #[DataProvider('getRenderForCacheTests')]
     public function testRenderForCache(array $parameters, string $expected): void
     {
         $this->assertEquals($this->includeDynamicLogic->renderForCache($parameters), $expected);
     }
 
-    /**
-     * @return array
-     */
     public static function getIncludeDynamicPrefixTests(): array
     {
         return [
@@ -63,9 +46,6 @@ class IncludeDynamicLogicTest extends TestCase
         ];
     }
 
-    /**
-     * @return array
-     */
     public static function getRenderForCacheTests(): array
     {
         return [

--- a/tests/Unit/Internal/Utility/Authentication/Policy/PasswordPolicyTest.php
+++ b/tests/Unit/Internal/Utility/Authentication/Policy/PasswordPolicyTest.php
@@ -11,6 +11,8 @@ namespace OxidEsales\EshopCommunity\Tests\Unit\Internal\Utility\Authentication\P
 
 use OxidEsales\EshopCommunity\Internal\Utility\Authentication\Exception\PasswordPolicyException;
 use OxidEsales\EshopCommunity\Internal\Utility\Authentication\Policy\PasswordPolicy;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\DoesNotPerformAssertions;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -18,9 +20,7 @@ use PHPUnit\Framework\TestCase;
  */
 class PasswordPolicyTest extends TestCase
 {
-    /**
-     * @doesNotPerformAssertions
-     */
+    #[DoesNotPerformAssertions]
     public function testPasswordPolicyAcceptsUtf8EncodedStrings()
     {
         $passwordUtf8 = 'äääää';
@@ -30,9 +30,9 @@ class PasswordPolicyTest extends TestCase
     }
 
     /**
-     * @dataProvider unsupportedEncodingDataProvider
      * @throws PasswordPolicyException
      */
+    #[DataProvider('unsupportedEncodingDataProvider')]
     public function testPasswordPolicyRejectsStringNonUtf8Encoding(string $unsupportedEncoding)
     {
         $this->expectException(PasswordPolicyException::class);

--- a/tests/Unit/Internal/Utility/Hash/BcryptPasswordHashServiceTest.php
+++ b/tests/Unit/Internal/Utility/Hash/BcryptPasswordHashServiceTest.php
@@ -13,6 +13,7 @@ use OxidEsales\EshopCommunity\Internal\Utility\Hash\Exception\PasswordHashExcept
 use OxidEsales\EshopCommunity\Internal\Utility\Hash\Service\BcryptPasswordHashService;
 use OxidEsales\EshopCommunity\Internal\Utility\Hash\Service\PasswordHashServiceInterface;
 use OxidEsales\EshopCommunity\Internal\Utility\Authentication\Policy\PasswordPolicyInterface;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -89,9 +90,7 @@ class BcryptPasswordHashServiceTest extends TestCase
         $this->assertSame(4, $info['options']['cost']);
     }
 
-    /**
-     * @dataProvider invalidCostOptionDataProvider
-     */
+    #[DataProvider('invalidCostOptionDataProvider')]
     public function testHashWithInvalidCostOptionValueThrowsPasswordHashException($invalidCostOption)
     {
         $this->expectException(PasswordHashException::class);

--- a/tests/Unit/Internal/Utility/Url/UrlParserTest.php
+++ b/tests/Unit/Internal/Utility/Url/UrlParserTest.php
@@ -10,15 +10,12 @@ declare(strict_types=1);
 namespace OxidEsales\EshopCommunity\Tests\Unit\Internal\Utility\Url;
 
 use OxidEsales\EshopCommunity\Internal\Utility\Url\UrlParser;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 final class UrlParserTest extends TestCase
 {
-    /**
-     * @dataProvider getPathWithoutTrailingSlashDataProvider
-     * @param $url
-     * @param $exp
-     */
+    #[DataProvider('getPathWithoutTrailingSlashDataProvider')]
     public function testGetPathWithoutTrailingSlashWithDataProvider(string $url, string $exp): void
     {
         $act = (new UrlParser())->getPathWithoutTrailingSlash($url);


### PR DESCRIPTION
Please note that I did not rebase after pushing the changes of https://github.com/OXID-eSales/oxideshop_ce/pull/970. So I had to revert that commit for this pull request. Therefore this pull request contains 3 instead of 1 commit.

Fixed messages (message too long, therefore cut down to at least deliver the idea)
```
1) Metadata found in doc-comment for method Integration\Application\Controller\Admin\ManufacturerPictureTest::testRender(). Metadata in doc-comments is deprecated and will no longer be supported in PHPUnit 12. Update your test code to use attributes instead.

2) Metadata found in doc-comment for class Integration\Application\Controller\Admin\ManufacturerPictureTest. Metadata in doc-comments is deprecated and will no longer be supported in PHPUnit 12. Update your test code to use attributes instead.

3) Metadata found in doc-comment for method Integration\Application\Controller\Admin\ManufacturerPictureTest::testSaveShouldThrowAnExceptionInDemoShopMode(). Metadata in doc-comments is deprecated and will no longer be supported in PHPUnit 12. Update your test code to use attributes instead.

[...]

283) Metadata found in doc-comment for method OxidEsales\EshopCommunity\Tests\Integration\Core\SessionTest::testSidNeededForDifferentUrls(). Metadata in doc-comments is deprecated and will no longer be supported in PHPUnit 12. Update your test code to use attributes instead.
```


