### PR TITLE
Adjust seo decoder to handle sub folder shops

### DIFF
--- a/source/Core/SeoDecoder.php
+++ b/source/Core/SeoDecoder.php
@@ -61,9 +61,14 @@ class SeoDecoder extends \OxidEsales\Eshop\Core\Base
     {
         $stringObject = Str::getStr();
         $baseUrl = \OxidEsales\Eshop\Core\Registry::getConfig()->getShopURL();
+        $basePath = parse_url($baseUrl, PHP_URL_PATH);
+
         if ($stringObject->strpos($seoUrl, $baseUrl) === 0) {
             $seoUrl = $stringObject->substr($seoUrl, $stringObject->strlen($baseUrl));
+        } elseif ($stringObject->strpos($seoUrl, $basePath) === 0) {
+            $seoUrl = $stringObject->substr($seoUrl, $stringObject->strlen($basePath));
         }
+
         $seoUrl = rawurldecode($seoUrl);
 
         //extract page number from seo url


### PR DESCRIPTION
Currently it's not possible to configure a sub shop on a folder based domain, since the seo decoder can't handle this. With this change it's possible to setup sub shops with a domain like https://www.mydomain.com/subshop