### PR TITLE
Fixing null issues and ignoring Smarty errors in PHP 8+

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - SeoDecoder undefined array key oxtype
 - SystemRequirements non-numeric error on getBytes() 
 - Reading booling in VariantHandler Model
+- Unset property on the order object
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - BaseModel::getLanguage() isset check on property
 - UtilsUrl::stringToParamsArray() isset check after explode()
 - UtilsView::filterTemplateBlocks() null coalesce array variables
+- ShopConfiguration::_arrayToMultiline() fix implode error with multidimensional array
+- ShopList::render() updatenav check in _aViewData
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - UtilsView::filterTemplateBlocks() null coalesce array variables
 - ShopConfiguration::_arrayToMultiline() fix implode error with multidimensional array
 - ShopList::render() updatenav check in _aViewData
+- SeoDecoder undefined array key oxtype
+- SystemRequirements non-numeric error on getBytes() 
+- Reading booling in VariantHandler Model
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
-- Error handler to LegacySmartyEngine for ignoring PHP 8+ warnings when config option `iDebug != 0`
+- Error handler to LegacySmartyEngine for ignoring PHP 8+ warnings for the frontend
 - Links to CHANGELOG for 6.14.2-6.14.3 and unreleased
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,41 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+
+### Added
+
+- Error handler to LegacySmartyEngine for ignoring PHP 8+ warnings when config option `iDebug != 0`
+- Links to CHANGELOG for 6.14.2-6.14.3 and unreleased
+
+### Fixed
+
+- UserComponent::changeUserWithoutRedirect() undefined `oxuser__oxusername`
+- AdminListController::_setListNavigationParams() `actpage` default to 0
+- SystemInfoController::render() `shop` key null coalesce check
+- ThemeConfiguration::render() null coalesce check
+- ArticleListController::getTemplateName() null coalesce check
+- ForgotPasswordController::isExpiredLink() expired default to null
+- PaymentController::getCheckedPaymentId() isset check for $sCheckedId and null coalesce check on $_SERVER vars
+- ThankYouController::getOrder() null check
+- Article::updateSoldAmount default $rs to false
+- Basket::getPriceForPayment() isset check on oxdelivery
+- NewsSubscribed::getOptInStatus null coalesce on oxid oxboptin value
+- Order::finalizeOrder() null checks on order number and oxremark
+- Order::_updateNoticeList() null check
+- Order::getPaymentType() isset check on order
+- OrderArticle::getPersParams() isset check
+- Payment::delete() is_string and isset check on EOF
+- User::getNewsSubscription() isset and null coalescence on news subscriptions
+- InputValidator::checkLogin() isset check
+- BaseModel::getLanguage() isset check on property
+- UtilsUrl::stringToParamsArray() isset check after explode()
+- UtilsView::filterTemplateBlocks() null coalesce array variables
+
+### Removed
+
+- function.oxinputhelp.php unused $blAdmin parameter (no backward compat break - not used)
+
 ## [6.14.3] - 2024-11-04
 
 ### Changed
@@ -1309,6 +1344,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [6.0-beta.1] - 2016-11-30
 
+
+[Unreleased]: https://github.com/OXID-eSales/oxideshop_ce/compare/v6.14.3...b-6.5.x
+[6.14.3]: https://github.com/OXID-eSales/oxideshop_ce/compare/v6.14.2...v6.14.3
+[6.14.2]: https://github.com/OXID-eSales/oxideshop_ce/compare/v6.14.1...v6.14.2
 [6.14.1]: https://github.com/OXID-eSales/oxideshop_ce/compare/v6.14.0...v6.14.1
 [6.14.0]: https://github.com/OXID-eSales/oxideshop_ce/compare/v6.13.0...v6.14.0
 [6.13.0]: https://github.com/OXID-eSales/oxideshop_ce/compare/v6.12.0...v6.13.0

--- a/source/Application/Component/UserComponent.php
+++ b/source/Application/Component/UserComponent.php
@@ -715,7 +715,7 @@ class UserComponent extends \OxidEsales\Eshop\Core\Controller\BaseController
                 $blOptin = $oUser->getNewsSubscription()->getOptInStatus();
             }
             // check if email address changed, if so, force check newsletter subscription settings.
-            $sBillingUsername = $aInvAdress['oxuser__oxusername'];
+            $sBillingUsername = isset($aInvAdress['oxuser__oxusername']) ? $aInvAdress['oxuser__oxusername'] : null;
             $blForceCheckOptIn = ($sBillingUsername !== null && $sBillingUsername !== $sUserName);
             $blEmailParam = $this->getConfig()->getConfigParam('blOrderOptInEmail');
             $this->_blNewsSubscriptionStatus = $oUser->setNewsSubscription($blOptin, $blEmailParam, $blForceCheckOptIn);

--- a/source/Application/Controller/Admin/AdminListController.php
+++ b/source/Application/Controller/Admin/AdminListController.php
@@ -659,6 +659,7 @@ class AdminListController extends \OxidEsales\Eshop\Application\Controller\Admin
             // yes, we need to build the navigation object
             $pageNavigation = new stdClass();
             $pageNavigation->pages = round((($this->_iListSize - 1) / $adminListSize) + 0.5, 0);
+            $pageNavigation->actpage = 0;
             $pageNavigation->actpage = ($pageNavigation->actpage > $pageNavigation->pages) ? $pageNavigation->pages : round(
                 ($this->_iCurrListPos / $adminListSize) + 0.5,
                 0

--- a/source/Application/Controller/Admin/OrderOverview.php
+++ b/source/Application/Controller/Admin/OrderOverview.php
@@ -45,7 +45,9 @@ class OrderOverview extends \OxidEsales\Eshop\Application\Controller\Admin\Admin
             $this->_aViewData["paymentType"] = $this->_getPaymentType($oOrder);
             $this->_aViewData["deliveryType"] = $oOrder->getDelSet();
             $sTsProtectsField = 'oxorder__oxtsprotectcosts';
-            if ($oOrder->$sTsProtectsField->value) {
+            if (isset($oOrder->$sTsProtectsField)
+                && isset($oOrder->$sTsProtectsField->value)
+                && $oOrder->$sTsProtectsField->value) {
                 $this->_aViewData["tsprotectcosts"] = $oLang->formatCurrency($oOrder->$sTsProtectsField->value, $oCur);
             }
         }

--- a/source/Application/Controller/Admin/ShopConfiguration.php
+++ b/source/Application/Controller/Admin/ShopConfiguration.php
@@ -399,7 +399,14 @@ class ShopConfiguration extends \OxidEsales\Eshop\Application\Controller\Admin\A
      */
     protected function _arrayToMultiline($input) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
-        return implode("\n", (array) $input);
+        $array = array_values((array) $input);
+        // implode does not work with multidimensional lines
+        foreach ($array as $key => $value) {
+            if (is_array($value)) {
+                unset($array[$key]);
+            }
+        }
+        return implode("\n", $array);
     }
 
     /**
@@ -441,7 +448,7 @@ class ShopConfiguration extends \OxidEsales\Eshop\Application\Controller\Admin\A
                 if ($multiline) {
                     $multiline .= "\n";
                 }
-                $multiline .= $key . " => " . $value;
+                $multiline .= $key . " => " . ((is_array($value)) ? 'Array' : $value);
             }
 
             return $multiline;

--- a/source/Application/Controller/Admin/ShopList.php
+++ b/source/Application/Controller/Admin/ShopList.php
@@ -76,7 +76,7 @@ class ShopList extends \OxidEsales\Eshop\Application\Controller\Admin\AdminListC
 
         $this->updateNavigation();
 
-        if ($this->_aViewData['updatenav']) {
+        if (isset($this->_aViewData['updatenav'])) {
             //skipping requirements checking when reloading nav frame
             \OxidEsales\Eshop\Core\Registry::getSession()->setVariable("navReload", true);
         }

--- a/source/Application/Controller/Admin/SystemInfoController.php
+++ b/source/Application/Controller/Admin/SystemInfoController.php
@@ -53,7 +53,7 @@ class SystemInfoController extends \OxidEsales\Eshop\Application\Controller\Admi
             $context = [
                 "oViewConf" => $this->_aViewData["oViewConf"],
                 "oView" => $this->_aViewData["oView"],
-                "shop" => $this->_aViewData["shop"],
+                "shop" => $this->_aViewData["shop"] ?? '',
                 "isdemo" => $myConfig->isDemoShop(),
                 "aSystemInfo" => $aSystemInfo
             ];

--- a/source/Application/Controller/Admin/ThemeConfiguration.php
+++ b/source/Application/Controller/Admin/ThemeConfiguration.php
@@ -48,7 +48,7 @@ class ThemeConfiguration extends \OxidEsales\Eshop\Application\Controller\Admin\
                 $this->_aViewData["var_constraints"] = $aDbVariables['constraints'];
                 $this->_aViewData["var_grouping"] = $aDbVariables['grouping'];
                 foreach ($this->_aConfParams as $sType => $sParam) {
-                    $this->_aViewData[$sParam] = $aDbVariables['vars'][$sType];
+                    $this->_aViewData[$sParam] = $aDbVariables['vars'][$sType] ?? null;
                 }
             } catch (\OxidEsales\Eshop\Core\Exception\StandardException $oEx) {
                 \OxidEsales\Eshop\Core\Registry::getUtilsView()->addErrorToDisplay($oEx);

--- a/source/Application/Controller/ArticleListController.php
+++ b/source/Application/Controller/ArticleListController.php
@@ -687,7 +687,7 @@ class ArticleListController extends \OxidEsales\Eshop\Application\Controller\Fro
         // assign template name
         if (($templateName = basename(Registry::getConfig()->getRequestParameter('tpl')))) {
             $this->_sThisTemplate = 'custom/' . $templateName;
-        } elseif (($category = $this->getActiveCategory()) && $category->oxcategories__oxtemplate->value) {
+        } elseif (($category = $this->getActiveCategory()) && isset($category->oxcategories__oxtemplate) && $category->oxcategories__oxtemplate->value) {
             $this->_sThisTemplate = $category->oxcategories__oxtemplate->value;
         }
 

--- a/source/Application/Controller/ForgotPasswordController.php
+++ b/source/Application/Controller/ForgotPasswordController.php
@@ -158,6 +158,7 @@ class ForgotPasswordController extends \OxidEsales\Eshop\Application\Controller\
      */
     public function isExpiredLink()
     {
+        $blExpired = null;
         if (($sKey = $this->getUpdateId())) {
             $blExpired = oxNew(\OxidEsales\Eshop\Application\Model\User::class)->isExpiredUpdateId($sKey);
         }

--- a/source/Application/Controller/PaymentController.php
+++ b/source/Application/Controller/PaymentController.php
@@ -685,9 +685,9 @@ class PaymentController extends \OxidEsales\Eshop\Application\Controller\Fronten
         }
 
         if (
-            !$this->_checkArrValuesEmpty($_REQUEST["dynvalue"], $aFields) ||
-            !$this->_checkArrValuesEmpty($_POST["dynvalue"], $aFields) ||
-            !$this->_checkArrValuesEmpty($_GET["dynvalue"], $aFields)
+            !$this->_checkArrValuesEmpty($_REQUEST["dynvalue"] ?? [], $aFields) ||
+            !$this->_checkArrValuesEmpty($_POST["dynvalue"] ?? [], $aFields) ||
+            !$this->_checkArrValuesEmpty($_GET["dynvalue"] ?? [], $aFields)
         ) {
             $this->_blDynDataFiltered = true;
         }

--- a/source/Application/Controller/PaymentController.php
+++ b/source/Application/Controller/PaymentController.php
@@ -549,6 +549,8 @@ class PaymentController extends \OxidEsales\Eshop\Application\Controller\Fronten
      */
     public function getCheckedPaymentId()
     {
+        $sCheckedId = null;
+
         if ($this->_sCheckedPaymentId === null) {
             if (!($sPaymentID = Registry::getConfig()->getRequestParameter('paymentid'))) {
                 $sPaymentID = Registry::getSession()->getVariable('paymentid');
@@ -574,7 +576,7 @@ class PaymentController extends \OxidEsales\Eshop\Application\Controller\Fronten
 
             // #646
             $oPaymentList = $this->getPaymentList();
-            if (isset($oPaymentList) && $oPaymentList && !isset($oPaymentList[$sCheckedId])) {
+            if (isset($oPaymentList) && $oPaymentList && isset($sCheckedId) && !isset($oPaymentList[$sCheckedId])) {
                 end($oPaymentList);
                 $sCheckedId = key($oPaymentList);
             }

--- a/source/Application/Controller/ThankYouController.php
+++ b/source/Application/Controller/ThankYouController.php
@@ -281,7 +281,7 @@ class ThankYouController extends \OxidEsales\Eshop\Application\Controller\Fronte
      */
     public function getOrder()
     {
-        if ($this->_oOrder === null) {
+        if (!isset($this->_oOrder)) {
             $this->_oOrder = oxNew(\OxidEsales\Eshop\Application\Model\Order::class);
             // loading order sometimes needed in template
             if ($sOrderId = $this->getBasket()->getOrderId()) {

--- a/source/Application/Model/Article.php
+++ b/source/Application/Model/Article.php
@@ -2266,6 +2266,7 @@ class Article extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel implements
      */
     public function updateSoldAmount($dAmount = 0)
     {
+        $rs = false;
         if (!$dAmount) {
             return;
         }

--- a/source/Application/Model/Basket.php
+++ b/source/Application/Model/Basket.php
@@ -2711,7 +2711,7 @@ class Basket extends \OxidEsales\Eshop\Core\Base
         }
 
         // adding delivery price to final price
-        if ($oDeliveryPrice = $this->_aCosts['oxdelivery']) {
+        if (isset($this->_aCosts['oxdelivery']) && $oDeliveryPrice = $this->_aCosts['oxdelivery']) {
             $dPrice += $oDeliveryPrice->getBruttoPrice();
         }
 

--- a/source/Application/Model/NewsSubscribed.php
+++ b/source/Application/Model/NewsSubscribed.php
@@ -170,7 +170,9 @@ class NewsSubscribed extends \OxidEsales\Eshop\Core\Model\BaseModel
      */
     public function getOptInStatus()
     {
-        return $this->oxnewssubscribed__oxdboptin->value;
+        return isset($this->oxnewssubscribed__oxdboptin) && isset($this->oxnewssubscribed__oxdboptin->value)
+            ? $this->oxnewssubscribed__oxdboptin->value
+            : null;
     }
 
     /**

--- a/source/Application/Model/Order.php
+++ b/source/Application/Model/Order.php
@@ -689,7 +689,7 @@ class Order extends \OxidEsales\Eshop\Core\Model\BaseModel
         }
 
         // user remark
-        if (!isset($this->oxorder__oxremark)) {
+        if (!isset($this->oxorder__oxremark) || !$this->oxorder__oxremark) {
             $this->oxorder__oxremark = new \OxidEsales\Eshop\Core\Field(\OxidEsales\Eshop\Core\Registry::getSession()->getVariable('ordrem'), \OxidEsales\Eshop\Core\Field::T_RAW);
         }
 

--- a/source/Application/Model/Order.php
+++ b/source/Application/Model/Order.php
@@ -689,7 +689,7 @@ class Order extends \OxidEsales\Eshop\Core\Model\BaseModel
         }
 
         // user remark
-        if (!isset($this->oxorder__oxremark) || $this->oxorder__oxremark->value === null) {
+        if (!isset($this->oxorder__oxremark)) {
             $this->oxorder__oxremark = new \OxidEsales\Eshop\Core\Field(\OxidEsales\Eshop\Core\Registry::getSession()->getVariable('ordrem'), \OxidEsales\Eshop\Core\Field::T_RAW);
         }
 
@@ -1823,7 +1823,7 @@ class Order extends \OxidEsales\Eshop\Core\Model\BaseModel
      */
     public function getPaymentType()
     {
-        if ($this->oxorder__oxpaymentid->value && $this->_oPaymentType === null) {
+        if (isset($this->oxorder__oxpaymentid->value) && $this->oxorder__oxpaymentid->value && $this->_oPaymentType === null) {
             $this->_oPaymentType = false;
             $oPaymentType = oxNew(\OxidEsales\Eshop\Application\Model\UserPayment::class);
             if ($oPaymentType->load($this->oxorder__oxpaymentid->value)) {

--- a/source/Application/Model/Order.php
+++ b/source/Application/Model/Order.php
@@ -535,7 +535,7 @@ class Order extends \OxidEsales\Eshop\Core\Model\BaseModel
             }
         }
 
-        if (!$this->oxorder__oxordernr->value) {
+        if (!isset($this->oxorder__oxordernr) || !isset($this->oxorder__oxordernr->value)) {
             $this->_setNumber();
         } else {
             oxNew(\OxidEsales\Eshop\Core\Counter::class)->update($this->_getCounterIdent(), $this->oxorder__oxordernr->value);
@@ -1095,7 +1095,7 @@ class Order extends \OxidEsales\Eshop\Core\Model\BaseModel
          * If no then it was just created and will cause a new row in oxuserbaskets without content in oxuserbasketitems.
          * Also it will prevent creating a row for guests.
          */
-        if ($oUser->getBasket('noticelist')->oxuserbaskets__oxid->value === null) {
+        if (!isset($oUser->getBasket('noticelist')->oxuserbaskets__oxid->value)) {
             return;
         }
 

--- a/source/Application/Model/OrderArticle.php
+++ b/source/Application/Model/OrderArticle.php
@@ -196,7 +196,7 @@ class OrderArticle extends \OxidEsales\Eshop\Core\Model\BaseModel implements Art
             return $this->_aPersParam;
         }
 
-        if ($this->oxorderarticles__oxpersparam->value) {
+        if (isset($this->oxorderarticles__oxpersparam->value)) {
             $this->_aPersParam = unserialize($this->oxorderarticles__oxpersparam->value);
         }
 

--- a/source/Application/Model/Payment.php
+++ b/source/Application/Model/Payment.php
@@ -396,7 +396,10 @@ class Payment extends \OxidEsales\Eshop\Core\Model\MultiLanguageModel
                 ':oxpaymentid' => $sOxId
             ]);
 
-            return $rs->EOF;
+            if (isset($rs->EOF) && is_string($rs->EOF)) {
+                return $rs->EOF;
+            }
+
         }
 
         return false;

--- a/source/Application/Model/User.php
+++ b/source/Application/Model/User.php
@@ -277,9 +277,19 @@ class User extends \OxidEsales\Eshop\Core\Model\BaseModel
                 // no subscription defined yet - creating one
                 $this->_oNewsSubscription->oxnewssubscribed__oxuserid = new \OxidEsales\Eshop\Core\Field($this->getId(), \OxidEsales\Eshop\Core\Field::T_RAW);
                 $this->_oNewsSubscription->oxnewssubscribed__oxemail = new \OxidEsales\Eshop\Core\Field($this->oxuser__oxusername->value, \OxidEsales\Eshop\Core\Field::T_RAW);
-                $this->_oNewsSubscription->oxnewssubscribed__oxsal = new \OxidEsales\Eshop\Core\Field($this->oxuser__oxsal->value, \OxidEsales\Eshop\Core\Field::T_RAW);
-                $this->_oNewsSubscription->oxnewssubscribed__oxfname = new \OxidEsales\Eshop\Core\Field($this->oxuser__oxfname->value, \OxidEsales\Eshop\Core\Field::T_RAW);
-                $this->_oNewsSubscription->oxnewssubscribed__oxlname = new \OxidEsales\Eshop\Core\Field($this->oxuser__oxlname->value, \OxidEsales\Eshop\Core\Field::T_RAW);
+
+                $this->_oNewsSubscription->oxnewssubscribed__oxsal = new \OxidEsales\Eshop\Core\Field(
+                    isset($this->oxuser__oxsal) && isset($this->oxuser__oxsal->value) ? $this->oxuser__oxsal->value : null,
+                    \OxidEsales\Eshop\Core\Field::T_RAW
+                );
+                $this->_oNewsSubscription->oxnewssubscribed__oxfname = new \OxidEsales\Eshop\Core\Field(
+                    isset($this->oxuser__oxfname) && isset($this->oxuser__oxfname->value) ? $this->oxuser__oxfname->value : null,
+                    \OxidEsales\Eshop\Core\Field::T_RAW
+                );
+                $this->_oNewsSubscription->oxnewssubscribed__oxlname = new \OxidEsales\Eshop\Core\Field(
+                    isset($this->oxuser__oxlname) && isset($this->oxuser__oxlname->value) ? $this->oxuser__oxlname->value : null,
+                    \OxidEsales\Eshop\Core\Field::T_RAW
+                );
             }
         }
 

--- a/source/Application/Model/VariantHandler.php
+++ b/source/Application/Model/VariantHandler.php
@@ -290,11 +290,12 @@ class VariantHandler extends \OxidEsales\Eshop\Core\Base
     public function isMdVariant($oArticle)
     {
         if ($this->getConfig()->getConfigParam('blUseMultidimensionVariants')) {
-            if (strpos($oArticle->oxarticles__oxvarselect->value, trim($this->_sMdSeparator)) !== false) {
-                return true;
+            if (is_object($oArticle) && isset($oArticle->oxarticles__oxvarselect)) {
+                if (strpos($oArticle->oxarticles__oxvarselect->value, trim($this->_sMdSeparator)) !== false) {
+                    return true;
+                }
             }
         }
-
         return false;
     }
 

--- a/source/Core/InputValidator.php
+++ b/source/Core/InputValidator.php
@@ -140,7 +140,7 @@ class InputValidator extends \OxidEsales\Eshop\Core\Base
 
         // check only for users with password during registration
         // if user wants to change user name - we must check if passwords are ok before changing
-        if ($user->oxuser__oxpassword->value && $login != $user->oxuser__oxusername->value) {
+        if (isset($user->oxuser__oxpassword->value) && $user->oxuser__oxpassword->value && $login != $user->oxuser__oxusername->value) {
             // on this case password must be taken directly from request
             $newPassword = (isset($invAddress['oxuser__oxpassword']) && $invAddress['oxuser__oxpassword']) ? $invAddress['oxuser__oxpassword'] : \OxidEsales\Eshop\Core\Registry::getConfig()->getRequestParameter('user_password');
             if (!$newPassword) {

--- a/source/Core/InputValidator.php
+++ b/source/Core/InputValidator.php
@@ -623,7 +623,9 @@ class InputValidator extends \OxidEsales\Eshop\Core\Base
      */
     protected function _hasRequiredParametersForVatInCheck($invAddress) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
-        return $invAddress['oxuser__oxustid'] && $invAddress['oxuser__oxcountryid'] && $invAddress['oxuser__oxcompany'];
+        return isset($invAddress['oxuser__oxustid']) && $invAddress['oxuser__oxustid']
+            && isset($invAddress['oxuser__oxcountryid']) && $invAddress['oxuser__oxcountryid']
+            && isset($invAddress['oxuser__oxcompany']) && $invAddress['oxuser__oxcompany'];
     }
 
     /**

--- a/source/Core/Model/BaseModel.php
+++ b/source/Core/Model/BaseModel.php
@@ -1635,7 +1635,7 @@ class BaseModel extends \OxidEsales\Eshop\Core\Base
      */
     public function isPropertyLoaded($name)
     {
-        return property_exists($this, $name) && $this->$name !== null;
+        return property_exists($this, $name) && isset($this->$name) && $this->$name !== null;
     }
 
     /**

--- a/source/Core/SeoDecoder.php
+++ b/source/Core/SeoDecoder.php
@@ -183,7 +183,7 @@ class SeoDecoder extends \OxidEsales\Eshop\Core\Base
             ':oxshopid' => $iShopId,
         ]);
 
-        if ('oxarticle' == $aInfo['oxtype']) {
+        if (isset($aInfo['oxtype']) && 'oxarticle' == $aInfo['oxtype']) {
             $sMainCatId = $oDb->getOne("select oxcatnid from " . getViewName("oxobject2category") . " where oxobjectid = :oxobjectid order by oxtime", [
                 ':oxobjectid' => $sObjectId
             ]);
@@ -200,7 +200,7 @@ class SeoDecoder extends \OxidEsales\Eshop\Core\Base
             }
         }
 
-        return $aInfo['oxseourl'];
+        return $objectInfo['oxseourl'] ?? null;
     }
 
     /**

--- a/source/Core/Smarty/Plugin/function.oxinputhelp.php
+++ b/source/Core/Smarty/Plugin/function.oxinputhelp.php
@@ -24,7 +24,7 @@ function smarty_function_oxinputhelp($params, &$smarty)
     $iLang  = $oLang->getTplLanguage();
 
     try {
-        $sTranslation = $oLang->translateString($sIdent, $iLang, $blAdmin);
+        $sTranslation = $oLang->translateString($sIdent, $iLang, null);
     } catch (\OxidEsales\Eshop\Core\Exception\LanguageException $oEx) {
         // is thrown in debug mode and has to be caught here, as smarty hangs otherwise!
     }

--- a/source/Core/SystemRequirements.php
+++ b/source/Core/SystemRequirements.php
@@ -1064,25 +1064,30 @@ class SystemRequirements
      */
     protected function _getBytes($sBytes) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
-        $sBytes = trim($sBytes);
-        $sLast = strtolower($sBytes[strlen($sBytes) - 1]);
-        switch ($sLast) {
-            // The 'G' modifier is available since PHP 5.1.0
-            // gigabytes
-            case 'g':
-                $sBytes *= 1024;
-            // megabytes
-            // no break
-            case 'm':
-                $sBytes *= 1024;
-            // kilobytes
-            // no break
-            case 'k':
-                $sBytes *= 1024;
-                break;
-        }
+        $sBytes = trim(strtolower($sBytes));
 
-        return $sBytes;
+        if (preg_match('/^(\d+)([k|m|g]?)$/', $sBytes, $matches)) {
+            $size = (int)$matches[1]; // Use int for size
+            $unit = $matches[2];
+
+            switch ($unit) {
+                case 'g':
+                    $size *= 1024 * 1024 * 1024;
+                    break;
+                case 'm':
+                    $size *= 1024 * 1024;
+                    break;
+                case 'k':
+                    $size *= 1024;
+                    break;
+                // No case needed for bytes (no unit)
+            }
+            return $size;
+
+        } else {
+            // Handle invalid input
+            return 0;
+        }
     }
 
     /**

--- a/source/Core/UtilsUrl.php
+++ b/source/Core/UtilsUrl.php
@@ -476,7 +476,9 @@ class UtilsUrl extends \OxidEsales\Eshop\Core\Base
         $aParams = [];
         foreach ($aNavParams as $sValue) {
             $exp = explode("=", $sValue);
-            $aParams[$exp[0]] = $exp[1];
+            if (isset($exp[1])) {
+                $aParams[$exp[0]] = $exp[1];
+            }
         }
 
         return $aParams;

--- a/source/Core/UtilsView.php
+++ b/source/Core/UtilsView.php
@@ -689,11 +689,11 @@ class UtilsView extends \OxidEsales\Eshop\Core\Base
 
         $templateBlocksToExchange = $this->formListOfDuplicatedBlocks($activeBlockTemplates);
 
-        if ($templateBlocksToExchange['theme']) {
+        if ($templateBlocksToExchange['theme'] ?? false) {
             $templateBlocks = $this->removeDefaultBlocks($activeBlockTemplates, $templateBlocksToExchange);
         }
 
-        if ($templateBlocksToExchange['custom_theme']) {
+        if ($templateBlocksToExchange['custom_theme'] ?? false) {
             $templateBlocks = $this->removeParentBlocks($templateBlocks, $templateBlocksToExchange);
         }
 
@@ -812,7 +812,7 @@ class UtilsView extends \OxidEsales\Eshop\Core\Base
 
         foreach ($blockTemplates as $activeBlockTemplate) {
             try {
-                if (!is_array($templateBlocksWithContent[$activeBlockTemplate['OXBLOCKNAME']])) {
+                if (array_key_exists($activeBlockTemplate['OXBLOCKNAME'], $templateBlocksWithContent) && !is_array($templateBlocksWithContent[$activeBlockTemplate['OXBLOCKNAME']])) {
                     $templateBlocksWithContent[$activeBlockTemplate['OXBLOCKNAME']] = [];
                 }
                 $templateBlocksWithContent[$activeBlockTemplate['OXBLOCKNAME']][] = $this->_getTemplateBlock($activeBlockTemplate['OXMODULE'], $activeBlockTemplate['OXFILE']);

--- a/source/Core/UtilsView.php
+++ b/source/Core/UtilsView.php
@@ -689,11 +689,11 @@ class UtilsView extends \OxidEsales\Eshop\Core\Base
 
         $templateBlocksToExchange = $this->formListOfDuplicatedBlocks($activeBlockTemplates);
 
-        if ($templateBlocksToExchange['theme'] ?? false) {
+        if ($templateBlocksToExchange['theme']) {
             $templateBlocks = $this->removeDefaultBlocks($activeBlockTemplates, $templateBlocksToExchange);
         }
 
-        if ($templateBlocksToExchange['custom_theme'] ?? false) {
+        if ($templateBlocksToExchange['custom_theme']) {
             $templateBlocks = $this->removeParentBlocks($templateBlocks, $templateBlocksToExchange);
         }
 
@@ -713,7 +713,7 @@ class UtilsView extends \OxidEsales\Eshop\Core\Base
         $customThemeId = $this->getConfig()->getConfigParam('sCustomTheme');
 
         foreach ($activeBlockTemplates as $activeBlockTemplate) {
-            if ($activeBlockTemplate['OXTHEME'] ?? false) {
+            if ($activeBlockTemplate['OXTHEME']) {
                 if ($customThemeId && $customThemeId === $activeBlockTemplate['OXTHEME']) {
                     $templateBlocksToExchange['custom_theme'][] = $this->prepareBlockKey($activeBlockTemplate);
                 } else {
@@ -812,7 +812,7 @@ class UtilsView extends \OxidEsales\Eshop\Core\Base
 
         foreach ($blockTemplates as $activeBlockTemplate) {
             try {
-                if (array_key_exists($activeBlockTemplate['OXBLOCKNAME'], $templateBlocksWithContent) && !is_array($templateBlocksWithContent[$activeBlockTemplate['OXBLOCKNAME']])) {
+                if (!is_array($templateBlocksWithContent[$activeBlockTemplate['OXBLOCKNAME']])) {
                     $templateBlocksWithContent[$activeBlockTemplate['OXBLOCKNAME']] = [];
                 }
                 $templateBlocksWithContent[$activeBlockTemplate['OXBLOCKNAME']][] = $this->_getTemplateBlock($activeBlockTemplate['OXMODULE'], $activeBlockTemplate['OXFILE']);

--- a/source/Core/UtilsView.php
+++ b/source/Core/UtilsView.php
@@ -689,11 +689,11 @@ class UtilsView extends \OxidEsales\Eshop\Core\Base
 
         $templateBlocksToExchange = $this->formListOfDuplicatedBlocks($activeBlockTemplates);
 
-        if ($templateBlocksToExchange['theme']) {
+        if ($templateBlocksToExchange['theme'] ?? false) {
             $templateBlocks = $this->removeDefaultBlocks($activeBlockTemplates, $templateBlocksToExchange);
         }
 
-        if ($templateBlocksToExchange['custom_theme']) {
+        if ($templateBlocksToExchange['custom_theme'] ?? false) {
             $templateBlocks = $this->removeParentBlocks($templateBlocks, $templateBlocksToExchange);
         }
 
@@ -713,7 +713,7 @@ class UtilsView extends \OxidEsales\Eshop\Core\Base
         $customThemeId = $this->getConfig()->getConfigParam('sCustomTheme');
 
         foreach ($activeBlockTemplates as $activeBlockTemplate) {
-            if ($activeBlockTemplate['OXTHEME']) {
+            if ($activeBlockTemplate['OXTHEME'] ?? false) {
                 if ($customThemeId && $customThemeId === $activeBlockTemplate['OXTHEME']) {
                     $templateBlocksToExchange['custom_theme'][] = $this->prepareBlockKey($activeBlockTemplate);
                 } else {
@@ -812,7 +812,7 @@ class UtilsView extends \OxidEsales\Eshop\Core\Base
 
         foreach ($blockTemplates as $activeBlockTemplate) {
             try {
-                if (!is_array($templateBlocksWithContent[$activeBlockTemplate['OXBLOCKNAME']])) {
+                if (array_key_exists($activeBlockTemplate['OXBLOCKNAME'], $templateBlocksWithContent) && !is_array($templateBlocksWithContent[$activeBlockTemplate['OXBLOCKNAME']])) {
                     $templateBlocksWithContent[$activeBlockTemplate['OXBLOCKNAME']] = [];
                 }
                 $templateBlocksWithContent[$activeBlockTemplate['OXBLOCKNAME']][] = $this->_getTemplateBlock($activeBlockTemplate['OXMODULE'], $activeBlockTemplate['OXFILE']);

--- a/source/Internal/Framework/Smarty/ErrorHandler.php
+++ b/source/Internal/Framework/Smarty/ErrorHandler.php
@@ -15,25 +15,18 @@ namespace OxidEsales\EshopCommunity\Internal\Framework\Smarty;
  */
 class ErrorHandler
 {
-    /**
-     * Allows {$foo->propName} where propName is undefined.
-     * @var bool
-     */
-    public $allowUndefinedProperties = true;
-
-    /**
-     * Allows {$foo.bar} where bar is unset and {$foo.bar1.bar2} where either bar1 or bar2 is unset.
-     * @var bool
-     */
-    public $allowUndefinedArrayKeys = true;
-
-    /**
-     * Allows {$foo->bar} where bar is not an object (e.g. null or false).
-     * @var bool
-     */
-    public $allowDereferencingNonObjects = true;
 
     private $previousErrorHandler = null;
+
+    /**
+     * @var bool $debug set to true if you want to see smarty errors
+     */
+    private bool $debug;
+
+    public function __construct($debug = false)
+    {
+        $this->debug = $debug;
+    }
 
     /**
      * Enable error handler to intercept errors
@@ -51,7 +44,9 @@ class ErrorHandler
             Of particular note is that this value will be 0 if the statement that caused the error was
             prepended by the @ error-control operator.
         */
-        $this->previousErrorHandler = set_error_handler([$this, 'handleError']);
+        if ($this->debug) {
+            $this->previousErrorHandler = set_error_handler([$this, 'handleError']);
+        }
     }
 
     /**
@@ -59,8 +54,10 @@ class ErrorHandler
      */
     public function deactivate()
     {
-        restore_error_handler();
-        $this->previousErrorHandler = null;
+        if ($this->debug) {
+            restore_error_handler();
+            $this->previousErrorHandler = null;
+        }
     }
 
     /**
@@ -78,30 +75,15 @@ class ErrorHandler
      */
     public function handleError($errno, $errstr, $errfile, $errline, $errcontext = [])
     {
-        if (
-            $this->allowUndefinedProperties && preg_match(
-                '/^(Undefined property)/',
-                $errstr
-            )
-        ) {
+        if (preg_match('/^(Undefined property)/', $errstr)) {
             return; // suppresses this error
         }
 
-        if (
-            $this->allowUndefinedArrayKeys && preg_match(
-                '/^(Undefined index|Undefined array key|Trying to access array offset on)/',
-                $errstr
-            )
-        ) {
+        if (preg_match('/^(Undefined index|Undefined array key|Trying to access array offset on)/', $errstr)) {
             return; // suppresses this error
         }
 
-        if (
-            $this->allowDereferencingNonObjects && preg_match(
-                '/^Attempt to read property ".+?" on/',
-                $errstr
-            )
-        ) {
+        if (preg_match('/^Attempt to read property ".+?" on/', $errstr)) {
             return; // suppresses this error
         }
 

--- a/source/Internal/Framework/Smarty/ErrorHandler.php
+++ b/source/Internal/Framework/Smarty/ErrorHandler.php
@@ -1,0 +1,112 @@
+<?php
+
+/**
+ * Copyright © OXID eSales AG. All rights reserved.
+ * See LICENSE file for license details.
+ */
+
+declare(strict_types=1);
+
+namespace OxidEsales\EshopCommunity\Internal\Framework\Smarty;
+
+/**
+ * Class SmartyEngine
+ * @internal
+ */
+class ErrorHandler
+{
+    /**
+     * Allows {$foo->propName} where propName is undefined.
+     * @var bool
+     */
+    public $allowUndefinedProperties = true;
+
+    /**
+     * Allows {$foo.bar} where bar is unset and {$foo.bar1.bar2} where either bar1 or bar2 is unset.
+     * @var bool
+     */
+    public $allowUndefinedArrayKeys = true;
+
+    /**
+     * Allows {$foo->bar} where bar is not an object (e.g. null or false).
+     * @var bool
+     */
+    public $allowDereferencingNonObjects = true;
+
+    private $previousErrorHandler = null;
+
+    /**
+     * Enable error handler to intercept errors
+     */
+    public function activate()
+    {
+        /*
+            Error muting is done because some people implemented custom error_handlers using
+            https://php.net/set_error_handler and for some reason did not understand the following paragraph:
+
+            It is important to remember that the standard PHP error handler is completely bypassed for the
+            error types specified by error_types unless the callback function returns FALSE.
+            error_reporting() settings will have no effect and your error handler will be called regardless -
+            however you are still able to read the current value of error_reporting and act appropriately.
+            Of particular note is that this value will be 0 if the statement that caused the error was
+            prepended by the @ error-control operator.
+        */
+        $this->previousErrorHandler = set_error_handler([$this, 'handleError']);
+    }
+
+    /**
+     * Disable error handler
+     */
+    public function deactivate()
+    {
+        restore_error_handler();
+        $this->previousErrorHandler = null;
+    }
+
+    /**
+     * Error Handler to mute expected messages
+     *
+     * @link https://php.net/set_error_handler
+     *
+     * @param integer $errno Error level
+     * @param         $errstr
+     * @param         $errfile
+     * @param         $errline
+     * @param         $errcontext
+     *
+     * @return bool
+     */
+    public function handleError($errno, $errstr, $errfile, $errline, $errcontext = [])
+    {
+        if (
+            $this->allowUndefinedProperties && preg_match(
+                '/^(Undefined property)/',
+                $errstr
+            )
+        ) {
+            return; // suppresses this error
+        }
+
+        if (
+            $this->allowUndefinedArrayKeys && preg_match(
+                '/^(Undefined index|Undefined array key|Trying to access array offset on)/',
+                $errstr
+            )
+        ) {
+            return; // suppresses this error
+        }
+
+        if (
+            $this->allowDereferencingNonObjects && preg_match(
+                '/^Attempt to read property ".+?" on/',
+                $errstr
+            )
+        ) {
+            return; // suppresses this error
+        }
+
+        // pass all other errors through to the previous error handler or to the default PHP error handler
+        return $this->previousErrorHandler ?
+            call_user_func($this->previousErrorHandler, $errno, $errstr, $errfile, $errline, $errcontext) : false;
+    }
+}

--- a/source/Internal/Framework/Smarty/ErrorHandler.php
+++ b/source/Internal/Framework/Smarty/ErrorHandler.php
@@ -19,13 +19,13 @@ class ErrorHandler
     private $previousErrorHandler = null;
 
     /**
-     * @var bool $debug set to true if you want to see smarty errors
+     * @var bool $hideErrors set to true if you want to see smarty errors
      */
-    private bool $debug;
+    private bool $hideErrors;
 
-    public function __construct($debug = false)
+    public function __construct($hideErrors = false)
     {
-        $this->debug = $debug;
+        $this->hideErrors = $hideErrors;
     }
 
     /**
@@ -44,7 +44,7 @@ class ErrorHandler
             Of particular note is that this value will be 0 if the statement that caused the error was
             prepended by the @ error-control operator.
         */
-        if ($this->debug) {
+        if ($this->hideErrors) {
             $this->previousErrorHandler = set_error_handler([$this, 'handleError']);
         }
     }
@@ -54,7 +54,7 @@ class ErrorHandler
      */
     public function deactivate()
     {
-        if ($this->debug) {
+        if ($this->hideErrors) {
             restore_error_handler();
             $this->previousErrorHandler = null;
         }

--- a/source/Internal/Framework/Smarty/ErrorHandler.php
+++ b/source/Internal/Framework/Smarty/ErrorHandler.php
@@ -1,33 +1,32 @@
 <?php
-
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
-
 declare(strict_types=1);
-
 namespace OxidEsales\EshopCommunity\Internal\Framework\Smarty;
-
 /**
  * Class SmartyEngine
  * @internal
  */
 class ErrorHandler
 {
-
-    private $previousErrorHandler = null;
-
     /**
-     * @var bool $hideErrors set to true if you want to see smarty errors
+     * Allows {$foo->propName} where propName is undefined.
+     * @var bool
      */
-    private bool $hideErrors;
-
-    public function __construct($hideErrors = false)
-    {
-        $this->hideErrors = $hideErrors;
-    }
-
+    public $allowUndefinedProperties = true;
+    /**
+     * Allows {$foo.bar} where bar is unset and {$foo.bar1.bar2} where either bar1 or bar2 is unset.
+     * @var bool
+     */
+    public $allowUndefinedArrayKeys = true;
+    /**
+     * Allows {$foo->bar} where bar is not an object (e.g. null or false).
+     * @var bool
+     */
+    public $allowDereferencingNonObjects = true;
+    private $previousErrorHandler = null;
     /**
      * Enable error handler to intercept errors
      */
@@ -36,7 +35,6 @@ class ErrorHandler
         /*
             Error muting is done because some people implemented custom error_handlers using
             https://php.net/set_error_handler and for some reason did not understand the following paragraph:
-
             It is important to remember that the standard PHP error handler is completely bypassed for the
             error types specified by error_types unless the callback function returns FALSE.
             error_reporting() settings will have no effect and your error handler will be called regardless -
@@ -44,22 +42,16 @@ class ErrorHandler
             Of particular note is that this value will be 0 if the statement that caused the error was
             prepended by the @ error-control operator.
         */
-        if ($this->hideErrors) {
-            $this->previousErrorHandler = set_error_handler([$this, 'handleError']);
-        }
+        $this->previousErrorHandler = set_error_handler([$this, 'handleError']);
     }
-
     /**
      * Disable error handler
      */
     public function deactivate()
     {
-        if ($this->hideErrors) {
-            restore_error_handler();
-            $this->previousErrorHandler = null;
-        }
+        restore_error_handler();
+        $this->previousErrorHandler = null;
     }
-
     /**
      * Error Handler to mute expected messages
      *
@@ -75,18 +67,30 @@ class ErrorHandler
      */
     public function handleError($errno, $errstr, $errfile, $errline, $errcontext = [])
     {
-        if (preg_match('/^(Undefined property)/', $errstr)) {
+        if (
+            $this->allowUndefinedProperties && preg_match(
+                '/^(Undefined property)/',
+                $errstr
+            )
+        ) {
             return; // suppresses this error
         }
-
-        if (preg_match('/^(Undefined index|Undefined array key|Trying to access array offset on)/', $errstr)) {
+        if (
+            $this->allowUndefinedArrayKeys && preg_match(
+                '/^(Undefined index|Undefined array key|Trying to access array offset on)/',
+                $errstr
+            )
+        ) {
             return; // suppresses this error
         }
-
-        if (preg_match('/^Attempt to read property ".+?" on/', $errstr)) {
+        if (
+            $this->allowDereferencingNonObjects && preg_match(
+                '/^Attempt to read property ".+?" on/',
+                $errstr
+            )
+        ) {
             return; // suppresses this error
         }
-
         // pass all other errors through to the previous error handler or to the default PHP error handler
         return $this->previousErrorHandler ?
             call_user_func($this->previousErrorHandler, $errno, $errstr, $errfile, $errline, $errcontext) : false;

--- a/source/Internal/Framework/Smarty/Legacy/LegacySmartyEngine.php
+++ b/source/Internal/Framework/Smarty/Legacy/LegacySmartyEngine.php
@@ -51,7 +51,7 @@ class LegacySmartyEngine implements LegacySmartyEngineInterface, TemplateEngineI
     {
         $this->engine = $engine;
         $this->bridge = $bridge;
-        $debug = Registry::get(ConfigFile::class)->getVar('iDebug') != 0;
+        $debug = Registry::get(ConfigFile::class)->getVar('iDebug') == 0;
         $this->errorHandler = new ErrorHandler($debug);
     }
 

--- a/source/Internal/Framework/Smarty/Legacy/LegacySmartyEngine.php
+++ b/source/Internal/Framework/Smarty/Legacy/LegacySmartyEngine.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 namespace OxidEsales\EshopCommunity\Internal\Framework\Smarty\Legacy;
 
 use OxidEsales\EshopCommunity\Internal\Framework\Smarty\Bridge\SmartyEngineBridgeInterface;
+use OxidEsales\EshopCommunity\Internal\Framework\Smarty\ErrorHandler;
 use OxidEsales\EshopCommunity\Internal\Framework\Templating\TemplateEngineInterface;
 
 /**
@@ -62,10 +63,18 @@ class LegacySmartyEngine implements LegacySmartyEngineInterface, TemplateEngineI
         foreach ($context as $key => $value) {
             $this->engine->assign($key, $value);
         }
+
+        $errorHandler = new ErrorHandler();
+        $errorHandler->activate();
         if (isset($context['oxEngineTemplateId'])) {
-            return $this->engine->fetch($name, $context['oxEngineTemplateId']);
+            $return = $this->engine->fetch($name, $context['oxEngineTemplateId']);
+        } else {
+            $return = $this->engine->fetch($name);
         }
-        return $this->engine->fetch($name);
+
+        $errorHandler->deactivate();
+
+        return $return;
     }
 
     /**

--- a/source/Internal/Framework/Smarty/Legacy/LegacySmartyEngine.php
+++ b/source/Internal/Framework/Smarty/Legacy/LegacySmartyEngine.php
@@ -9,6 +9,8 @@ declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Framework\Smarty\Legacy;
 
+use OxidEsales\Eshop\Core\ConfigFile;
+use OxidEsales\Eshop\Core\Registry;
 use OxidEsales\EshopCommunity\Internal\Framework\Smarty\Bridge\SmartyEngineBridgeInterface;
 use OxidEsales\EshopCommunity\Internal\Framework\Smarty\ErrorHandler;
 use OxidEsales\EshopCommunity\Internal\Framework\Templating\TemplateEngineInterface;
@@ -37,6 +39,7 @@ class LegacySmartyEngine implements LegacySmartyEngineInterface, TemplateEngineI
      * @var array
      */
     private $globals = [];
+    private ErrorHandler $errorHandler;
 
     /**
      * Constructor.
@@ -48,6 +51,8 @@ class LegacySmartyEngine implements LegacySmartyEngineInterface, TemplateEngineI
     {
         $this->engine = $engine;
         $this->bridge = $bridge;
+        $debug = Registry::get(ConfigFile::class)->getVar('iDebug') != 0;
+        $this->errorHandler = new ErrorHandler($debug);
     }
 
     /**
@@ -64,15 +69,11 @@ class LegacySmartyEngine implements LegacySmartyEngineInterface, TemplateEngineI
             $this->engine->assign($key, $value);
         }
 
-        $errorHandler = new ErrorHandler();
-        $errorHandler->activate();
-        if (isset($context['oxEngineTemplateId'])) {
-            $return = $this->engine->fetch($name, $context['oxEngineTemplateId']);
-        } else {
-            $return = $this->engine->fetch($name);
-        }
+        $engineTemplateId = $context['oxEngineTemplateId'] ?? null;
 
-        $errorHandler->deactivate();
+        $this->errorHandler->activate();
+        $return = $this->engine->fetch($name, $engineTemplateId);
+        $this->errorHandler->deactivate();
 
         return $return;
     }

--- a/source/Internal/Framework/Smarty/Legacy/LegacySmartyEngine.php
+++ b/source/Internal/Framework/Smarty/Legacy/LegacySmartyEngine.php
@@ -9,8 +9,6 @@ declare(strict_types=1);
 
 namespace OxidEsales\EshopCommunity\Internal\Framework\Smarty\Legacy;
 
-use OxidEsales\Eshop\Core\ConfigFile;
-use OxidEsales\Eshop\Core\Registry;
 use OxidEsales\EshopCommunity\Internal\Framework\Smarty\Bridge\SmartyEngineBridgeInterface;
 use OxidEsales\EshopCommunity\Internal\Framework\Smarty\ErrorHandler;
 use OxidEsales\EshopCommunity\Internal\Framework\Templating\TemplateEngineInterface;
@@ -51,8 +49,6 @@ class LegacySmartyEngine implements LegacySmartyEngineInterface, TemplateEngineI
     {
         $this->engine = $engine;
         $this->bridge = $bridge;
-        $debug = Registry::get(ConfigFile::class)->getVar('iDebug') == 0;
-        $this->errorHandler = new ErrorHandler($debug);
     }
 
     /**
@@ -71,9 +67,10 @@ class LegacySmartyEngine implements LegacySmartyEngineInterface, TemplateEngineI
 
         $engineTemplateId = $context['oxEngineTemplateId'] ?? null;
 
-        $this->errorHandler->activate();
+        $errorHandler = new ErrorHandler();
+        $errorHandler->activate();
         $return = $this->engine->fetch($name, $engineTemplateId);
-        $this->errorHandler->deactivate();
+        $errorHandler->deactivate();
 
         return $return;
     }


### PR DESCRIPTION
PHP 8 changes undefined notices to warnings. This causes Smarty 2 to complain a lot and make a very verbose log. This PR mainly address that issues along with the other changes I documented in the CHANGELOG. 

Here is a list of the changes as well (note this is all found in the changelog)

### Added

- Error handler to LegacySmartyEngine for ignoring PHP 8+ warnings for the frontend
- Links to CHANGELOG for 6.14.2-6.14.3 and unreleased

### Fixed

- UserComponent::changeUserWithoutRedirect() undefined `oxuser__oxusername`
- AdminListController::_setListNavigationParams() `actpage` default to 0
- SystemInfoController::render() `shop` key null coalesce check
- ThemeConfiguration::render() null coalesce check
- ArticleListController::getTemplateName() null coalesce check
- ForgotPasswordController::isExpiredLink() expired default to null
- PaymentController::getCheckedPaymentId() isset check for $sCheckedId and null coalesce check on $_SERVER vars
- ThankYouController::getOrder() null check
- Article::updateSoldAmount default $rs to false
- Basket::getPriceForPayment() isset check on oxdelivery
- NewsSubscribed::getOptInStatus null coalesce on oxid oxboptin value
- Order::finalizeOrder() null checks on order number and oxremark
- Order::_updateNoticeList() null check
- Order::getPaymentType() isset check on order
- OrderArticle::getPersParams() isset check
- Payment::delete() is_string and isset check on EOF
- User::getNewsSubscription() isset and null coalescence on news subscriptions
- InputValidator::checkLogin() isset check
- BaseModel::getLanguage() isset check on property
- UtilsUrl::stringToParamsArray() isset check after explode()
- UtilsView::filterTemplateBlocks() null coalesce array variables
- ShopConfiguration::_arrayToMultiline() fix implode error with multidimensional array
- ShopList::render() updatenav check in _aViewData

### Removed

- function.oxinputhelp.php unused $blAdmin parameter (no backward compat break - not used)