### PR TITLE
Allow oe-console oe:setup:shop to use an existing empty dabase

### DIFF
--- a/source/Internal/Setup/Database/SetupDbConnectionValidator.php
+++ b/source/Internal/Setup/Database/SetupDbConnectionValidator.php
@@ -32,7 +32,7 @@ class SetupDbConnectionValidator implements SetupDbConnectionValidatorInterface
             );
         }
         $this->canConnectToServer($databaseConfiguration);
-        $this->databaseDoesNotExist($databaseConfiguration);
+        $this->databaseDoesNotExistOrIsEmpty($databaseConfiguration);
     }
 
     private function canConnectToServer(DatabaseConfiguration $databaseConfiguration): void
@@ -41,15 +41,19 @@ class SetupDbConnectionValidator implements SetupDbConnectionValidatorInterface
         $connection->close();
     }
 
-    private function databaseDoesNotExist(DatabaseConfiguration $databaseConfiguration): void
+    private function databaseDoesNotExistOrIsEmpty(DatabaseConfiguration $databaseConfiguration): void
     {
         try {
-            $this->databaseConnectionFactory->getDatabaseConnection($databaseConfiguration);
+            $dbConn = $this->databaseConnectionFactory->getDatabaseConnection($databaseConfiguration);
+            $tables = $dbConn->createSchemaManager()->listTables();
+            if (count($tables) === 0) {
+                return; // Allow empty database
+            }
         } catch (ConnectionException) {
             return;
         }
         throw new DatabaseAlreadyExistsException(
-            "Database `{$databaseConfiguration->getName()}` already exists!"
+            "Database `{$databaseConfiguration->getName()}` already exists and is not empty!"
         );
     }
 }

--- a/source/Internal/Setup/Database/ShopDbManager.php
+++ b/source/Internal/Setup/Database/ShopDbManager.php
@@ -41,7 +41,14 @@ class ShopDbManager implements ShopDbManagerInterface
         $connection = $this->databaseConnectionFactory->getServerConnection($this->databaseConfiguration);
         $connection->executeStatement(
             sprintf(
-                'CREATE DATABASE `%s` CHARACTER SET utf8 COLLATE utf8_general_ci;',
+                'CREATE DATABASE IF NOT EXISTS `%s` CHARACTER SET utf8 COLLATE utf8_general_ci;',
+                $this->databaseConfiguration->getName()
+            )
+        );
+        // If existing empty database is used: Update character set and collation
+        $connection->executeStatement(
+            sprintf(
+                'ALTER DATABASE `%s` CHARACTER SET utf8 COLLATE utf8_general_ci;',
                 $this->databaseConfiguration->getName()
             )
         );


### PR DESCRIPTION
This allows the setup to use an existing database if it is still empty.
(For cases where the database has to be created via an administration interface at the hoster, for example)