### PR TITLE
Increase bcrypt cost and deprecate Argon2IPassword…

### DIFF
--- a/CHANGELOG-7.6.md
+++ b/CHANGELOG-7.6.md
@@ -4,7 +4,11 @@
 
 ### Added
 
+### Changed
+- Increased bcrypt password hashing cost from 10 to 12 to improve resistance against brute-force attacks; existing password hashes will be transparently rehashed on next login.
+
 ### Deprecated
+- `Argon2IPasswordHashService` is deprecated and will be removed in a future major version; use `BcryptPasswordHashService` instead.
 
 ### Fixed
 

--- a/source/Internal/Utility/Hash/Service/Argon2IPasswordHashService.php
+++ b/source/Internal/Utility/Hash/Service/Argon2IPasswordHashService.php
@@ -14,6 +14,9 @@ use OxidEsales\EshopCommunity\Internal\Utility\Authentication\Policy\PasswordPol
 
 /**
  * Hashes with the ARGON2I algorithm
+ *
+ * @deprecated 7.6.0 Not used. Use BcryptPasswordHashService instead.
+ * @see BcryptPasswordHashService
  */
 class Argon2IPasswordHashService implements PasswordHashServiceInterface
 {

--- a/source/Internal/Utility/Hash/services.yaml
+++ b/source/Internal/Utility/Hash/services.yaml
@@ -1,5 +1,6 @@
 parameters:
-  oxid_esales.utility.hash.service.password_hash.bcrypt.cost: 10
+  oxid_esales.utility.hash.service.password_hash.bcrypt.cost: 12
+  # @deprecated 7.6.0 Argon2IPasswordHashService is deprecated and will be removed in a future major version.
   oxid_esales.utility.hash.service.password_hash.argon2.memory_cost: 1024
   oxid_esales.utility.hash.service.password_hash.argon2.time_cost: 2
   oxid_esales.utility.hash.service.password_hash.argon2.threads: 2


### PR DESCRIPTION
Increased bcrypt password hashing cost from 10 to 12
`Argon2IPasswordHashService` is deprecated