### PR TITLE
security: add allowed_classes => false to unserialize() in Language, UserBasketItem, and OrderArticle

### DIFF
--- a/source/Application/Controller/Admin/ShopConfiguration.php
+++ b/source/Application/Controller/Admin/ShopConfiguration.php
@@ -324,17 +324,17 @@ class ShopConfiguration extends \OxidEsales\Eshop\Application\Controller\Admin\A
 
             case "arr":
                 if (in_array($name, $this->_aSkipMultiline)) {
-                    $data = unserialize($value);
+                    $data = unserialize($value, ['allowed_classes' => false]);
                 } else {
-                    $data = $str->htmlentities($this->arrayToMultiline(unserialize($value)));
+                    $data = $str->htmlentities($this->arrayToMultiline(unserialize($value, ['allowed_classes' => false])));
                 }
                 break;
 
             case "aarr":
                 if (in_array($name, $this->_aSkipMultiline)) {
-                    $data = unserialize($value);
+                    $data = unserialize($value, ['allowed_classes' => false]);
                 } else {
-                    $data = $str->htmlentities($this->aarrayToMultiline(unserialize($value)));
+                    $data = $str->htmlentities($this->aarrayToMultiline(unserialize($value, ['allowed_classes' => false])));
                 }
                 break;
         }

--- a/source/Application/Model/OrderArticle.php
+++ b/source/Application/Model/OrderArticle.php
@@ -196,7 +196,7 @@ class OrderArticle extends BaseModel implements ArticleInterface
         }
 
         if ($this->getFieldData('oxpersparam')) {
-            $this->_aPersParam = unserialize($this->getFieldData('oxpersparam'));
+            $this->_aPersParam = unserialize($this->getFieldData('oxpersparam'), ['allowed_classes' => false]);
         }
 
         return $this->_aPersParam;

--- a/source/Application/Model/UserBasketItem.php
+++ b/source/Application/Model/UserBasketItem.php
@@ -146,7 +146,7 @@ class UserBasketItem extends \OxidEsales\Eshop\Core\Model\BaseModel
     public function getSelList()
     {
         if ($this->_aSelList == null && $this->oxuserbasketitems__oxsellist->value) {
-            $this->_aSelList = unserialize($this->oxuserbasketitems__oxsellist->value);
+            $this->_aSelList = unserialize($this->oxuserbasketitems__oxsellist->value, ['allowed_classes' => false]);
         }
 
         return $this->_aSelList;
@@ -170,7 +170,7 @@ class UserBasketItem extends \OxidEsales\Eshop\Core\Model\BaseModel
     public function getPersParams()
     {
         if ($this->_aPersParam == null && $this->oxuserbasketitems__oxpersparam->value) {
-            $this->_aPersParam = unserialize($this->oxuserbasketitems__oxpersparam->value);
+            $this->_aPersParam = unserialize($this->oxuserbasketitems__oxpersparam->value, ['allowed_classes' => false]);
         }
 
         return $this->_aPersParam;

--- a/source/Core/Language.php
+++ b/source/Core/Language.php
@@ -1322,7 +1322,7 @@ class Language extends \OxidEsales\Eshop\Core\Base
         $aConfigValues = $this->selectLanguageParamValues($sLanguageParameterName, $iShopId);
 
         foreach ($aConfigValues as $sConfigValue) {
-            $aConfigLanguages = unserialize($sConfigValue['oxvarvalue']);
+            $aConfigLanguages = unserialize($sConfigValue['oxvarvalue'], ['allowed_classes' => false]);
 
             $aLanguages = [];
             if ($sLanguageParameterName == 'aLanguageParams') {


### PR DESCRIPTION
## Summary

This PR adds `allowed_classes => false` to three `unserialize()` call sites that deserialize plain arrays from the database, providing defence-in-depth against PHP Object Injection.

### Affected files and data types

| File | Field | Stored data |
|------|-------|-------------|
| `Core/Language.php` | `oxvarvalue` | Array of language parameter strings/arrays |
| `Application/Model/UserBasketItem.php` | `oxsellist` | Selection list — array of scalars |
| `Application/Model/UserBasketItem.php` | `oxpersparam` | Persistent parameters — array of scalars |
| `Application/Model/OrderArticle.php` | `oxpersparam` | Persistent parameters — array of scalars |

None of these fields legitimately store PHP objects, so `allowed_classes => false` is a safe, zero-breaking-change hardening.

### Risk

Without `allowed_classes`, an attacker who can influence these database column values (e.g., via a SQL injection, direct DB access, or a compromised external sync) can trigger PHP Object Injection through `unserialize()`.

### Fix

All changes follow the same pattern:
```php
// Before
$value = unserialize($rawData);

// After
$value = unserialize($rawData, ['allowed_classes' => false]);
```