### PR TITLE
Deal with case where $_SERVER['HTTP_ACCEPT_LANGUAGE'] is not defined

### DIFF
--- a/source/Application/Controller/Admin/LoginController.php
+++ b/source/Application/Controller/Admin/LoginController.php
@@ -216,6 +216,6 @@ class LoginController extends \OxidEsales\Eshop\Application\Controller\Admin\Adm
      */
     protected function getBrowserLanguage()
     {
-        return strtolower(substr($_SERVER['HTTP_ACCEPT_LANGUAGE'], 0, 2));
+        return @strtolower(substr($_SERVER['HTTP_ACCEPT_LANGUAGE'], 0, 2));
     }
 }


### PR DESCRIPTION
There is some case where the `$_SERVER` has no 'HTTP_ACCEPT_LANGUAGE' key.