### PR TITLE
Keep category/vendor/manufacturer context in article SEO std url on save

### DIFF
--- a/source/Application/Controller/Admin/ArticleSeo.php
+++ b/source/Application/Controller/Admin/ArticleSeo.php
@@ -307,6 +307,65 @@ class ArticleSeo extends \OxidEsales\Eshop\Application\Controller\Admin\ObjectSe
     }
 
     /**
+     * Returns the article std url including the currently selected
+     * category / vendor / manufacturer context.
+     *
+     * ObjectSeo::getStdUrl() only returns the context-less base link
+     * (Article::getBaseStdLink()), so saving the SEO tab would drop the
+     * cnid/mnid the entry was generated with. This override mirrors the
+     * std-url parameters used on initial generation in SeoEncoderArticle.
+     *
+     * @param string $sOxid object id
+     *
+     * @return string
+     */
+    protected function getStdUrl($sOxid)
+    {
+        $oArticle = oxNew(\OxidEsales\Eshop\Application\Model\Article::class);
+        if (!$oArticle->load($sOxid)) {
+            return '';
+        }
+
+        $sStdUrl = $oArticle->getBaseStdLink($this->getEditLang(), true, false);
+
+        if ($aParams = $this->getContextStdParams()) {
+            $sStdUrl = \OxidEsales\Eshop\Core\Registry::getUtilsUrl()->appendUrl($sStdUrl, $aParams);
+        }
+
+        return $sStdUrl;
+    }
+
+    /**
+     * Builds the std-url parameters for the SEO context currently selected in
+     * the editor, matching the parameters used on initial generation
+     * (SeoEncoderArticle::createArticleCategoryUri/getArticleVendorUri/
+     * getArticleManufacturerUri).
+     *
+     * @return array
+     */
+    protected function getContextStdParams()
+    {
+        switch ($this->getActCatType()) {
+            case 'oxvendor':
+                if ($oVendor = $this->getActVendor()) {
+                    return ['cnid' => 'v_' . $oVendor->getId(), 'listtype' => $this->getListType()];
+                }
+                break;
+            case 'oxmanufacturer':
+                if ($oManufacturer = $this->getActManufacturer()) {
+                    return ['mnid' => $oManufacturer->getId(), 'listtype' => $this->getListType()];
+                }
+                break;
+            default:
+                if ($sCatId = $this->getActCatId()) {
+                    return ['cnid' => $sCatId];
+                }
+        }
+
+        return [];
+    }
+
+    /**
      * Returns current object type seo encoder object
      *
      * @return \OxidEsales\Eshop\Application\Model\SeoEncoderArticle

--- a/tests/Unit/Application/Controller/Admin/ArticleSeoTest.php
+++ b/tests/Unit/Application/Controller/Admin/ArticleSeoTest.php
@@ -1,0 +1,101 @@
+<?php
+
+/**
+ * Copyright © OXID eSales AG. All rights reserved.
+ * See LICENSE file for license details.
+ */
+
+declare(strict_types=1);
+
+namespace OxidEsales\EshopCommunity\Tests\Unit\Application\Controller\Admin;
+
+use OxidEsales\Eshop\Application\Controller\Admin\ArticleSeo;
+use OxidEsales\Eshop\Application\Model\Manufacturer;
+use OxidEsales\Eshop\Application\Model\Vendor;
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
+use PHPUnit\Framework\TestCase;
+use ReflectionMethod;
+
+/**
+ * @internal
+ */
+#[AllowMockObjectsWithoutExpectations]
+class ArticleSeoTest extends TestCase
+{
+    public function testCategoryContextAddsCnid(): void
+    {
+        $controller = $this->createControllerMock(['getActCatType', 'getActCatId']);
+        $controller->method('getActCatType')->willReturn('oxcategory');
+        $controller->method('getActCatId')->willReturn('catid123');
+
+        $this->assertSame(['cnid' => 'catid123'], $this->invokeGetContextStdParams($controller));
+    }
+
+    public function testVendorContextAddsPrefixedCnidAndListType(): void
+    {
+        $vendor = $this->getMockBuilder(Vendor::class)
+            ->disableOriginalConstructor()->onlyMethods(['getId'])->getMock();
+        $vendor->method('getId')->willReturn('vendor123');
+
+        $controller = $this->createControllerMock(['getActCatType', 'getActVendor', 'getListType']);
+        $controller->method('getActCatType')->willReturn('oxvendor');
+        $controller->method('getActVendor')->willReturn($vendor);
+        $controller->method('getListType')->willReturn('vendor');
+
+        $this->assertSame(
+            ['cnid' => 'v_vendor123', 'listtype' => 'vendor'],
+            $this->invokeGetContextStdParams($controller)
+        );
+    }
+
+    public function testManufacturerContextAddsMnidAndListType(): void
+    {
+        $manufacturer = $this->getMockBuilder(Manufacturer::class)
+            ->disableOriginalConstructor()->onlyMethods(['getId'])->getMock();
+        $manufacturer->method('getId')->willReturn('man123');
+
+        $controller = $this->createControllerMock(['getActCatType', 'getActManufacturer', 'getListType']);
+        $controller->method('getActCatType')->willReturn('oxmanufacturer');
+        $controller->method('getActManufacturer')->willReturn($manufacturer);
+        $controller->method('getListType')->willReturn('manufacturer');
+
+        $this->assertSame(
+            ['mnid' => 'man123', 'listtype' => 'manufacturer'],
+            $this->invokeGetContextStdParams($controller)
+        );
+    }
+
+    public function testNoSelectedCategoryReturnsEmptyArray(): void
+    {
+        $controller = $this->createControllerMock(['getActCatType', 'getActCatId']);
+        $controller->method('getActCatType')->willReturn('oxcategory');
+        $controller->method('getActCatId')->willReturn(false);
+
+        $this->assertSame([], $this->invokeGetContextStdParams($controller));
+    }
+
+    public function testVendorContextWithoutVendorReturnsEmptyArray(): void
+    {
+        $controller = $this->createControllerMock(['getActCatType', 'getActVendor']);
+        $controller->method('getActCatType')->willReturn('oxvendor');
+        $controller->method('getActVendor')->willReturn(null);
+
+        $this->assertSame([], $this->invokeGetContextStdParams($controller));
+    }
+
+    private function createControllerMock(array $methods): ArticleSeo
+    {
+        return $this->getMockBuilder(ArticleSeo::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods($methods)
+            ->getMock();
+    }
+
+    private function invokeGetContextStdParams(ArticleSeo $controller): array
+    {
+        $method = new ReflectionMethod(ArticleSeo::class, 'getContextStdParams');
+        $method->setAccessible(true);
+
+        return $method->invoke($controller);
+    }
+}


### PR DESCRIPTION
## Problem

When an article's SEO entry is saved in the admin SEO tab, the context (`cnid`/`mnid`) disappears from `oxseo.oxstdurl`. The entry is generated with context (e.g. `index.php?cl=details&anid=...&cnid=<catId>`), but after saving it becomes `index.php?cl=details&anid=...`.

As a result, the SEO URL of a **non-main** category resolves to the article's **main** category instead of the selected one. With single-category articles the effect is masked by the main-category fallback, which is why it can look "as expected".

Reported in the OXID bug tracker, entry 0007952 (`bugs.oxid-esales.com/view.php?id=7952`).

### Root cause

`ObjectSeo::save()` rebuilds the std url via `ObjectSeo::getStdUrl()`, which calls `Article::getBaseStdLink()` — that never appends `cnid`/`mnid`. `ArticleSeo` is context-aware otherwise (it writes the correct `oxparams` via `processParam()` and overrides `getEntryUri()` per `getActCatType()`), but it does **not** override `getStdUrl()`, so the stored std url loses the context the entry was generated with. `oxparams` is not used when resolving a SEO URL (`SeoDecoder::decodeUrl()` reads only `oxstdurl`), so the context is genuinely lost.

## Fix

`ArticleSeo` now overrides `getStdUrl()` and appends the std-url parameters of the selected category/vendor/manufacturer, mirroring the parameters used on initial generation in `SeoEncoderArticle`:

- category → `['cnid' => catId]`
- vendor → `['cnid' => 'v_'.vendorId, 'listtype' => 'vendor']`
- manufacturer → `['mnid' => manufId, 'listtype' => 'manufacturer']`

## Tests

`tests/Unit/Application/Controller/Admin/ArticleSeoTest.php` covering the category / vendor / manufacturer / no-context cases.

## Note

This is the **minimal, local** variant. The companion PR #1001 implements the same fix but additionally centralizes the parameter definitions in `SeoEncoderArticle` (shared by encoder and editor) to remove the duplication. The two PRs are alternatives — pick whichever fits the release strategy.
