### PR TITLE
Centralize article SEO std-url context parameters and keep them on save

### DIFF
--- a/source/Application/Controller/Admin/ArticleSeo.php
+++ b/source/Application/Controller/Admin/ArticleSeo.php
@@ -307,6 +307,66 @@ class ArticleSeo extends \OxidEsales\Eshop\Application\Controller\Admin\ObjectSe
     }
 
     /**
+     * Returns the article std url including the currently selected
+     * category / vendor / manufacturer context.
+     *
+     * ObjectSeo::getStdUrl() only returns the context-less base link
+     * (Article::getBaseStdLink()), so saving the SEO tab would drop the
+     * cnid/mnid the entry was generated with. This override mirrors the
+     * std-url parameters used on initial generation in SeoEncoderArticle.
+     *
+     * @param string $sOxid object id
+     *
+     * @return string
+     */
+    protected function getStdUrl($sOxid)
+    {
+        $oArticle = oxNew(\OxidEsales\Eshop\Application\Model\Article::class);
+        if (!$oArticle->load($sOxid)) {
+            return '';
+        }
+
+        $sStdUrl = $oArticle->getBaseStdLink($this->getEditLang(), true, false);
+
+        if ($aParams = $this->getContextStdParams()) {
+            $sStdUrl = \OxidEsales\Eshop\Core\Registry::getUtilsUrl()->appendUrl($sStdUrl, $aParams);
+        }
+
+        return $sStdUrl;
+    }
+
+    /**
+     * Builds the std-url parameters for the SEO context currently selected in
+     * the editor, reusing the same parameter definitions the encoder uses on
+     * initial generation.
+     *
+     * @return array
+     */
+    protected function getContextStdParams()
+    {
+        $oEncoder = $this->getEncoder();
+
+        switch ($this->getActCatType()) {
+            case 'oxvendor':
+                if ($oVendor = $this->getActVendor()) {
+                    return $oEncoder->getVendorStdParameters($oVendor->getId(), $this->getListType());
+                }
+                break;
+            case 'oxmanufacturer':
+                if ($oManufacturer = $this->getActManufacturer()) {
+                    return $oEncoder->getManufacturerStdParameters($oManufacturer->getId(), $this->getListType());
+                }
+                break;
+            default:
+                if ($sCatId = $this->getActCatId()) {
+                    return $oEncoder->getCategoryStdParameters($sCatId);
+                }
+        }
+
+        return [];
+    }
+
+    /**
      * Returns current object type seo encoder object
      *
      * @return \OxidEsales\Eshop\Application\Model\SeoEncoderArticle

--- a/source/Application/Model/SeoEncoderArticle.php
+++ b/source/Application/Model/SeoEncoderArticle.php
@@ -134,6 +134,44 @@ class SeoEncoderArticle extends \OxidEsales\Eshop\Core\SeoEncoder
     }
 
     /**
+     * Returns the std url parameters that bind an article detail link to a category.
+     *
+     * @param string $sCategoryId category id
+     *
+     * @return array
+     */
+    public function getCategoryStdParameters($sCategoryId)
+    {
+        return ['cnid' => $sCategoryId];
+    }
+
+    /**
+     * Returns the std url parameters that bind an article detail link to a vendor.
+     *
+     * @param string      $sVendorId vendor id
+     * @param string|null $sListType list type to use
+     *
+     * @return array
+     */
+    public function getVendorStdParameters($sVendorId, $sListType)
+    {
+        return ['cnid' => 'v_' . $sVendorId, 'listtype' => $sListType];
+    }
+
+    /**
+     * Returns the std url parameters that bind an article detail link to a manufacturer.
+     *
+     * @param string      $sManufacturerId manufacturer id
+     * @param string|null $sListType       list type to use
+     *
+     * @return array
+     */
+    public function getManufacturerStdParameters($sManufacturerId, $sListType)
+    {
+        return ['mnid' => $sManufacturerId, 'listtype' => $sListType];
+    }
+
+    /**
      * create article uri for given category and save it
      *
      * @param \OxidEsales\Eshop\Application\Model\Article  $oArticle  article object
@@ -162,7 +200,7 @@ class SeoEncoderArticle extends \OxidEsales\Eshop\Core\SeoEncoder
             $oArticle->getId(),
             \OxidEsales\Eshop\Core\Registry::getUtilsUrl()->appendUrl(
                 $oArticle->getBaseStdLink($iLang),
-                ['cnid' => $sCatId]
+                $this->getCategoryStdParameters($sCatId)
             ),
             $sSeoUri,
             $iLang,
@@ -388,7 +426,7 @@ class SeoEncoderArticle extends \OxidEsales\Eshop\Core\SeoEncoder
                 $sSeoUri = \OxidEsales\Eshop\Core\Registry::get(\OxidEsales\Eshop\Application\Model\SeoEncoderVendor::class)->getVendorUri($oVendor, $iLang);
                 $sSeoUri = $this->processSeoUrl($sSeoUri . $sTitle, $oArticle->getId(), $iLang);
 
-                $aStdParams = ['cnid' => "v_" . $oVendor->getId(), 'listtype' => $this->getListType()];
+                $aStdParams = $this->getVendorStdParameters($oVendor->getId(), $this->getListType());
                 $this->saveToDb(
                     'oxarticle',
                     $oArticle->getId(),
@@ -465,7 +503,7 @@ class SeoEncoderArticle extends \OxidEsales\Eshop\Core\SeoEncoder
                 $sSeoUri = \OxidEsales\Eshop\Core\Registry::get(\OxidEsales\Eshop\Application\Model\SeoEncoderManufacturer::class)->getManufacturerUri($oManufacturer, $iLang);
                 $sSeoUri = $this->processSeoUrl($sSeoUri . $sTitle, $oArticle->getId(), $iLang);
 
-                $aStdParams = ['mnid' => $oManufacturer->getId(), 'listtype' => $this->getListType()];
+                $aStdParams = $this->getManufacturerStdParameters($oManufacturer->getId(), $this->getListType());
                 $this->saveToDb(
                     'oxarticle',
                     $oArticle->getId(),

--- a/tests/Unit/Application/Controller/Admin/ArticleSeoTest.php
+++ b/tests/Unit/Application/Controller/Admin/ArticleSeoTest.php
@@ -1,0 +1,108 @@
+<?php
+
+/**
+ * Copyright © OXID eSales AG. All rights reserved.
+ * See LICENSE file for license details.
+ */
+
+declare(strict_types=1);
+
+namespace OxidEsales\EshopCommunity\Tests\Unit\Application\Controller\Admin;
+
+use OxidEsales\Eshop\Application\Controller\Admin\ArticleSeo;
+use OxidEsales\Eshop\Application\Model\Manufacturer;
+use OxidEsales\Eshop\Application\Model\SeoEncoderArticle;
+use OxidEsales\Eshop\Application\Model\Vendor;
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
+use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+use ReflectionMethod;
+
+/**
+ * @internal
+ */
+#[AllowMockObjectsWithoutExpectations]
+class ArticleSeoTest extends TestCase
+{
+    public function testCategoryContextAddsCnid(): void
+    {
+        $controller = $this->createControllerMock(['getActCatType', 'getActCatId']);
+        $controller->method('getActCatType')->willReturn('oxcategory');
+        $controller->method('getActCatId')->willReturn('catid123');
+
+        $this->assertSame(['cnid' => 'catid123'], $this->invokeGetContextStdParams($controller));
+    }
+
+    public function testVendorContextAddsPrefixedCnidAndListType(): void
+    {
+        $vendor = $this->getMockBuilder(Vendor::class)
+            ->disableOriginalConstructor()->onlyMethods(['getId'])->getMock();
+        $vendor->method('getId')->willReturn('vendor123');
+
+        $controller = $this->createControllerMock(['getActCatType', 'getActVendor', 'getListType']);
+        $controller->method('getActCatType')->willReturn('oxvendor');
+        $controller->method('getActVendor')->willReturn($vendor);
+        $controller->method('getListType')->willReturn('vendor');
+
+        $this->assertSame(
+            ['cnid' => 'v_vendor123', 'listtype' => 'vendor'],
+            $this->invokeGetContextStdParams($controller)
+        );
+    }
+
+    public function testManufacturerContextAddsMnidAndListType(): void
+    {
+        $manufacturer = $this->getMockBuilder(Manufacturer::class)
+            ->disableOriginalConstructor()->onlyMethods(['getId'])->getMock();
+        $manufacturer->method('getId')->willReturn('man123');
+
+        $controller = $this->createControllerMock(['getActCatType', 'getActManufacturer', 'getListType']);
+        $controller->method('getActCatType')->willReturn('oxmanufacturer');
+        $controller->method('getActManufacturer')->willReturn($manufacturer);
+        $controller->method('getListType')->willReturn('manufacturer');
+
+        $this->assertSame(
+            ['mnid' => 'man123', 'listtype' => 'manufacturer'],
+            $this->invokeGetContextStdParams($controller)
+        );
+    }
+
+    public function testNoSelectedCategoryReturnsEmptyArray(): void
+    {
+        $controller = $this->createControllerMock(['getActCatType', 'getActCatId']);
+        $controller->method('getActCatType')->willReturn('oxcategory');
+        $controller->method('getActCatId')->willReturn(false);
+
+        $this->assertSame([], $this->invokeGetContextStdParams($controller));
+    }
+
+    public function testVendorContextWithoutVendorReturnsEmptyArray(): void
+    {
+        $controller = $this->createControllerMock(['getActCatType', 'getActVendor']);
+        $controller->method('getActCatType')->willReturn('oxvendor');
+        $controller->method('getActVendor')->willReturn(null);
+
+        $this->assertSame([], $this->invokeGetContextStdParams($controller));
+    }
+
+    private function createControllerMock(array $methods): ArticleSeo
+    {
+        $methods[] = 'getEncoder';
+        $controller = $this->getMockBuilder(ArticleSeo::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(array_values(array_unique($methods)))
+            ->getMock();
+        $controller->method('getEncoder')
+            ->willReturn((new ReflectionClass(SeoEncoderArticle::class))->newInstanceWithoutConstructor());
+
+        return $controller;
+    }
+
+    private function invokeGetContextStdParams(ArticleSeo $controller): array
+    {
+        $method = new ReflectionMethod(ArticleSeo::class, 'getContextStdParams');
+        $method->setAccessible(true);
+
+        return $method->invoke($controller);
+    }
+}

--- a/tests/Unit/Application/Model/SeoEncoderArticleStdParametersTest.php
+++ b/tests/Unit/Application/Model/SeoEncoderArticleStdParametersTest.php
@@ -1,0 +1,46 @@
+<?php
+
+/**
+ * Copyright © OXID eSales AG. All rights reserved.
+ * See LICENSE file for license details.
+ */
+
+declare(strict_types=1);
+
+namespace OxidEsales\EshopCommunity\Tests\Unit\Application\Model;
+
+use OxidEsales\Eshop\Application\Model\SeoEncoderArticle;
+use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+
+/**
+ * @internal
+ */
+class SeoEncoderArticleStdParametersTest extends TestCase
+{
+    public function testCategoryStdParameters(): void
+    {
+        $this->assertSame(['cnid' => 'cat1'], $this->encoder()->getCategoryStdParameters('cat1'));
+    }
+
+    public function testVendorStdParametersPrefixesIdAndKeepsListType(): void
+    {
+        $this->assertSame(
+            ['cnid' => 'v_vend1', 'listtype' => 'vendor'],
+            $this->encoder()->getVendorStdParameters('vend1', 'vendor')
+        );
+    }
+
+    public function testManufacturerStdParameters(): void
+    {
+        $this->assertSame(
+            ['mnid' => 'man1', 'listtype' => 'manufacturer'],
+            $this->encoder()->getManufacturerStdParameters('man1', 'manufacturer')
+        );
+    }
+
+    private function encoder(): SeoEncoderArticle
+    {
+        return (new ReflectionClass(SeoEncoderArticle::class))->newInstanceWithoutConstructor();
+    }
+}


### PR DESCRIPTION
## Problem

Same as the companion minimal-fix PR: saving an article's SEO entry in the admin drops the `cnid`/`mnid` from `oxseo.oxstdurl`, so a non-main category's SEO URL resolves to the main category. Reported in the OXID bug tracker, entry 0007952 (`bugs.oxid-esales.com/view.php?id=7952`).

## Fix + refactor

In addition to fixing the save path (new `ArticleSeo::getStdUrl()` override), this variant **centralizes** the std-url parameter definitions, which were previously inlined in `SeoEncoderArticle` for category, vendor and manufacturer. They are now provided by:

- `SeoEncoderArticle::getCategoryStdParameters($categoryId)`
- `SeoEncoderArticle::getVendorStdParameters($vendorId, $listType)`
- `SeoEncoderArticle::getManufacturerStdParameters($manufacturerId, $listType)`

Both the encoder (on initial generation) and the editor (`ArticleSeo::getStdUrl()`) reuse these, so the parameter structure is defined in one place. The `listtype` source stays with the caller (passed in), so encoder output is byte-identical to before.

## Tests

- `tests/Unit/Application/Model/SeoEncoderArticleStdParametersTest.php` — the centralized parameter helpers.
- `tests/Unit/Application/Controller/Admin/ArticleSeoTest.php` — `getStdUrl()` context delegation.

## Note

This is the **centralized / refactor** variant. The companion PR #1000 contains the same behavioral fix without the encoder refactor, for a smaller, lower-risk change. The two PRs are alternatives.
